### PR TITLE
Fix: Cloudfront API calls failing from EC2 with IAM role

### DIFF
--- a/AWSSDK/Amazon.Runtime/AmazonWebServiceClient.cs
+++ b/AWSSDK/Amazon.Runtime/AmazonWebServiceClient.cs
@@ -825,7 +825,7 @@ namespace Amazon.Runtime
         private enum ClientProtocol { QueryStringProtocol, RestProtocol, Unknown }
         private static ClientProtocol DetermineProtocol(AbstractAWSSigner signer)
         {
-            if (signer is AWS3Signer || signer is AWS4Signer)
+            if (signer is AWS3Signer || signer is AWS4Signer || signer is CloudFrontSigner)
                 return ClientProtocol.RestProtocol;
             if (signer is QueryStringSigner)
                 return ClientProtocol.QueryStringProtocol;


### PR DESCRIPTION
AmazonWebServiceClient was failing to determine if the request should be signed for REST or QueryString protocol during signing because the DetermineProtocol method did not check the signer type against CloudFrontSigner in addition to AWS3Signer and AWS4Signer.
