### PR TITLE
cross platform path separator check

### DIFF
--- a/AWSSDK/Amazon.S3/AmazonS3Client.cs
+++ b/AWSSDK/Amazon.S3/AmazonS3Client.cs
@@ -2218,9 +2218,8 @@ namespace Amazon.S3
 
                 if (!request.IsSetKey())
                 {
-                    string name = request.FilePath;
                     // Set the key to be the name of the file sans directories
-                    request.Key = name.Substring(name.LastIndexOf(@"\") + 1);
+                    request.Key = Path.GetFileName(request.FilePath);
                 }
             }
 


### PR DESCRIPTION
use Path.GetFileName() instead of searching for backslash -- this is cross platform.
