### PR TITLE
Fixed issue that caused ServiceURL to be always using https when RegionEndpoint is set

### DIFF
--- a/AWSSDK/Amazon.Runtime/ClientConfig.cs
+++ b/AWSSDK/Amazon.Runtime/ClientConfig.cs
@@ -136,7 +136,7 @@ namespace Amazon.Runtime
             else
             {
                 var endpoint = this.RegionEndpoint.GetEndpointForService(this.RegionEndpointServiceName);
-                string protocol = endpoint.HTTPS ? "https://" : "http://";
+                string protocol = this.ServiceURL.ToLower().StartsWith("http:") ? "http://" : "https://";
                 url = new Uri(string.Format("{0}{1}", protocol, endpoint.Hostname)).AbsoluteUri;
             }
 


### PR DESCRIPTION
Changes to Amazon.Runtime.ClientConfig class
