### PR TITLE
DynamoDb: No result when trying to call DescribeTable on a table with a Global Secondary Index

### DIFF
--- a/AWSSDK_DotNet35/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
+++ b/AWSSDK_DotNet35/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
@@ -21,314 +21,329 @@ using ThirdParty.Json.LitJson;
 
 namespace Amazon.Runtime.Internal.Transform
 {
-    /// <summary>
-    /// Wraps a json string for unmarshalling.
-    /// 
-    /// Each <c>Read()</c> operation gets the next token.
-    /// <c>TestExpression()</c> is used to match the current key-chain
-    /// to an xpath expression. The general pattern looks like this:
-    /// <code>
-    /// JsonUnmarshallerContext context = new JsonUnmarshallerContext(jsonString);
-    /// while (context.Read())
-    /// {
-    ///     if (context.IsKey)
-    ///     {
-    ///         if (context.TestExpresion("path/to/element"))
-    ///         {
-    ///             myObject.stringMember = stringUnmarshaller.GetInstance().Unmarshall(context);
-    ///             continue;
-    ///         }
-    ///     }
-    /// }
-    /// </code>
-    /// </summary>
-    public class JsonUnmarshallerContext : UnmarshallerContext
-    {
-        #region Private members
+	/// <summary>
+	/// Wraps a json string for unmarshalling.
+	/// 
+	/// Each <c>Read()</c> operation gets the next token.
+	/// <c>TestExpression()</c> is used to match the current key-chain
+	/// to an xpath expression. The general pattern looks like this:
+	/// <code>
+	/// JsonUnmarshallerContext context = new JsonUnmarshallerContext(jsonString);
+	/// while (context.Read())
+	/// {
+	///     if (context.IsKey)
+	///     {
+	///         if (context.TestExpresion("path/to/element"))
+	///         {
+	///             myObject.stringMember = stringUnmarshaller.GetInstance().Unmarshall(context);
+	///             continue;
+	///         }
+	///     }
+	/// }
+	/// </code>
+	/// </summary>
+	public class JsonUnmarshallerContext : UnmarshallerContext
+	{
+		#region Private members
 
-        private StreamReader streamReader = null;
-        private JsonReader jsonReader = null;
-        private Stack<string> stack = new Stack<string>();
-        private string stackString = "";
-        private string currentField;
-        private JsonToken? currentToken = null;
+		private StreamReader streamReader = null;
+		private JsonReader jsonReader = null;
+		private Stack<string> stack = new Stack<string>();
+		private string stackString = "";
+		private string currentField;
+		private JsonToken? currentToken = null;
+		private bool popEndTokens = false;
 
-        #endregion
+		#endregion
 
-        #region Constructors
+		#region Constructors
 
-        /// <summary>
-        /// Wrap the jsonstring for unmarshalling.
-        /// </summary>
-        /// <param name="responseStream">Stream that contains the JSON for unmarshalling</param>
-        /// <param name="responseData">Response data coming back from the request</param>
-        public JsonUnmarshallerContext(Stream responseStream, IWebResponseData responseData)
-        {
-            this.WebResponseData = responseData;
-            this.ResponseContents = null;
+		/// <summary>
+		/// Wrap the jsonstring for unmarshalling.
+		/// </summary>
+		/// <param name="responseStream">Stream that contains the JSON for unmarshalling</param>
+		/// <param name="responseData">Response data coming back from the request</param>
+		public JsonUnmarshallerContext(Stream responseStream, IWebResponseData responseData)
+		{
+			this.WebResponseData = responseData;
+			this.ResponseContents = null;
 
-            long contentLength;
-            if (long.TryParse(responseData.GetHeaderValue("Content-Length"), out contentLength))
-            {
-                base.SetupCRCStream(responseData, responseStream, contentLength);
-            }
+			long contentLength;
+			if (long.TryParse(responseData.GetHeaderValue("Content-Length"), out contentLength))
+			{
+				base.SetupCRCStream(responseData, responseStream, contentLength);
+			}
 
-            if (this.CrcStream != null)
-                streamReader = new StreamReader(this.CrcStream);
-            else
-                streamReader = new StreamReader(responseStream);
+			if (this.CrcStream != null)
+				streamReader = new StreamReader(this.CrcStream);
+			else
+				streamReader = new StreamReader(responseStream);
 
-            jsonReader = new JsonReader(streamReader);
-        }
+			jsonReader = new JsonReader(streamReader);
+		}
 
-        /// <summary>
-        /// Wrap the jsonstring for unmarshalling.
-        /// </summary>
-        /// <param name="responseBody">String that contains the JSON for unmarshalling</param>
-        /// <param name="responseData">Response data coming back from the request</param>
-        public JsonUnmarshallerContext(string responseBody, IWebResponseData responseData)
-        {
-            this.WebResponseData = responseData;
-            this.ResponseContents = responseBody;
+		/// <summary>
+		/// Wrap the jsonstring for unmarshalling.
+		/// </summary>
+		/// <param name="responseBody">String that contains the JSON for unmarshalling</param>
+		/// <param name="responseData">Response data coming back from the request</param>
+		public JsonUnmarshallerContext(string responseBody, IWebResponseData responseData)
+		{
+			this.WebResponseData = responseData;
+			this.ResponseContents = responseBody;
 
-            streamReader = new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(responseBody)));
-            jsonReader = new JsonReader(streamReader);
-        }
+			streamReader = new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(responseBody)));
+			jsonReader = new JsonReader(streamReader);
+		}
 
-        #endregion
+		#endregion
 
-        #region Overrides
+		#region Overrides
 
-        /// <summary>
-        /// Are we at the start of the json document.
-        /// </summary>
-        public override bool IsStartOfDocument
-        {
-            get
-            {
-                return (CurrentTokenType == JsonToken.None) && (!streamReader.EndOfStream);
-            }
-        }
+		/// <summary>
+		/// Are we at the start of the json document.
+		/// </summary>
+		public override bool IsStartOfDocument
+		{
+			get
+			{
+				return (CurrentTokenType == JsonToken.None) && (!streamReader.EndOfStream);
+			}
+		}
 
-        /// <summary>
-        /// Is the current token the end of an object
-        /// </summary>    
-        public override bool IsEndElement
-        {
-            get { return CurrentTokenType == JsonToken.ObjectEnd; }
-        }
+		/// <summary>
+		/// Is the current token the end of an object
+		/// </summary>    
+		public override bool IsEndElement
+		{
+			get { return CurrentTokenType == JsonToken.ObjectEnd; }
+		}
 
-        /// <summary>
-        /// Is the current token the start of an object
-        /// </summary>
-        public override bool IsStartElement
-        {
-            get { return CurrentTokenType == JsonToken.ObjectStart; }
-        }
+		/// <summary>
+		/// Is the current token the start of an object
+		/// </summary>
+		public override bool IsStartElement
+		{
+			get { return CurrentTokenType == JsonToken.ObjectStart; }
+		}
 
-        /// <summary>
-        ///     Returns the element depth of the parser's current position in the json
-        ///     document being parsed.
-        /// </summary>
-        public override int CurrentDepth
-        {
-            get
-            {
-                int depth = 0;
-                foreach (string s in stack)
-                {
-                    if (!
-                            (
-                            s.Equals(JsonToken.ObjectStart.ToString(), StringComparison.OrdinalIgnoreCase) ||
-                            s.Equals(JsonToken.ArrayStart.ToString(), StringComparison.OrdinalIgnoreCase)
-                            )
-                        )
-                    {
-                        depth++;
-                    }
-                }
-                if (currentField != null) depth++;
-                return depth;
-            }
-        }
+		/// <summary>
+		///     Returns the element depth of the parser's current position in the json
+		///     document being parsed.
+		/// </summary>
+		public override int CurrentDepth
+		{
+			get
+			{
+				int depth = 0;
+				foreach (string s in stack)
+				{
+					if (!
+							(
+							s.Equals(JsonToken.ObjectStart.ToString(), StringComparison.OrdinalIgnoreCase) ||
+							s.Equals(JsonToken.ArrayStart.ToString(), StringComparison.OrdinalIgnoreCase)
+							)
+						)
+					{
+						depth++;
+					}
+				}
+				if (currentField != null) depth++;
+				return depth;
+			}
+		}
 
-        /// <summary>
-        /// The current Json path that is being unmarshalled.
-        /// </summary>
-        public override string CurrentPath
-        {
-            get { return stackString; }
-        }
+		/// <summary>
+		/// The current Json path that is being unmarshalled.
+		/// </summary>
+		public override string CurrentPath
+		{
+			get { return stackString; }
+		}
 
-        /// <summary>
-        ///     Reads to the next token in the json document, and updates the context
-        ///     accordingly.
-        /// </summary>
-        /// <returns>
-        ///     True if a token was read, false if there are no more tokens to read./
-        /// </returns>
-        public override bool Read()
-        {
-            bool result = jsonReader.Read();
+		/// <summary>
+		///     Reads to the next token in the json document, and updates the context
+		///     accordingly.
+		/// </summary>
+		/// <returns>
+		///     True if a token was read, false if there are no more tokens to read./
+		/// </returns>
+		public override bool Read()
+		{
+			bool result = jsonReader.Read();
 
-            if (result)
-            {
-                currentToken = jsonReader.Token;
-                UpdateContext();
-            }
-            return result;
-        }
+			if (result)
+			{
+				currentToken = jsonReader.Token;
+				UpdateContext();
+			}
+			return result;
+		}
 
-        /// <summary>
-        ///     Returns the text contents of the current token being parsed.
-        /// </summary>
-        /// <returns>
-        ///     The text contents of the current token being parsed.
-        /// </returns>
-        public override string ReadText()
-        {
-            object data = jsonReader.Value;
-            string text;
-            switch (currentToken)
-            {
-                case JsonToken.Null:
-                    text = null;
-                    break;
-                case JsonToken.String:
-                case JsonToken.PropertyName:
-                    text = data as string;
-                    break;
-                case JsonToken.Boolean:
-                case JsonToken.Double:
-                case JsonToken.Int:
-                case JsonToken.Long:
-                    IFormattable iformattable = data as IFormattable;
-                    if (iformattable != null)
-                        text = iformattable.ToString(null, CultureInfo.InvariantCulture);
-                    else
-                        text = data.ToString();
-                    break;
-                default:
-                    throw new AmazonClientException(
-                            "We expected a VALUE token but got: " + currentToken);
-            }
-            return text;
-        }
+		/// <summary>
+		///     Returns the text contents of the current token being parsed.
+		/// </summary>
+		/// <returns>
+		///     The text contents of the current token being parsed.
+		/// </returns>
+		public override string ReadText()
+		{
+			object data = jsonReader.Value;
+			string text;
+			switch (currentToken)
+			{
+				case JsonToken.Null:
+					text = null;
+					break;
+				case JsonToken.String:
+				case JsonToken.PropertyName:
+					text = data as string;
+					break;
+				case JsonToken.Boolean:
+				case JsonToken.Double:
+				case JsonToken.Int:
+				case JsonToken.Long:
+					IFormattable iformattable = data as IFormattable;
+					if (iformattable != null)
+						text = iformattable.ToString(null, CultureInfo.InvariantCulture);
+					else
+						text = data.ToString();
+					break;
+				default:
+					throw new AmazonClientException(
+							"We expected a VALUE token but got: " + currentToken);
+			}
+			return text;
+		}
 
-        #endregion
+		#endregion
 
-        #region Internal methods/properties
+		#region Internal methods/properties
 
-        /// <summary>
-        /// Get the base stream of the jsonStream.
-        /// </summary>
-        internal Stream Stream
-        {
-            get { return streamReader.BaseStream; }
-        }
+		/// <summary>
+		/// Get the base stream of the jsonStream.
+		/// </summary>
+		internal Stream Stream
+		{
+			get
+			{
+				return streamReader.BaseStream;
+			}
+		}
 
-        /// <summary>
-        /// Peeks at the next (non-whitespace) character in the jsonStream.
-        /// </summary>
-        /// <returns>The next (non-whitespace) character in the jsonStream, or -1 if at the end.</returns>
-        internal int Peek()
-        {
-            while (Char.IsWhiteSpace((char)StreamPeek()))
-            {
-                streamReader.Read();
-            }
-            return StreamPeek();
+		/// <summary>
+		/// Peeks at the next (non-whitespace) character in the jsonStream.
+		/// </summary>
+		/// <returns>The next (non-whitespace) character in the jsonStream, or -1 if at the end.</returns>
+		internal int Peek()
+		{
+			while (Char.IsWhiteSpace((char)StreamPeek()))
+			{
+				streamReader.Read();
+			}
+			return StreamPeek();
 
-        }
+		}
 
-        /// <summary>
-        /// The type of the current token
-        /// </summary>
-        internal JsonToken CurrentTokenType
-        {
-            get { return currentToken.Value; }
-        }
+		/// <summary>
+		/// The type of the current token
+		/// </summary>
+		internal JsonToken CurrentTokenType
+		{
+			get { return currentToken.Value; }
+		}
 
-        #endregion
+		#endregion
 
-        #region Private methods
+		#region Private methods
 
-        /// <summary>
-        /// Peeks at the next character in the stream.
-        /// If the data isn't buffered into the StreamReader (Peek() returns -1),
-        /// we flush the buffered data and try one more time.
-        /// </summary>
-        /// <returns></returns>
-        private int StreamPeek()
-        {
-            int peek = streamReader.Peek();
-            if (peek == -1)
-            {
-                streamReader.DiscardBufferedData();
-                peek = streamReader.Peek();
-            }
-            return peek;
-        }
+		/// <summary>
+		/// Peeks at the next character in the stream.
+		/// If the data isn't buffered into the StreamReader (Peek() returns -1),
+		/// we flush the buffered data and try one more time.
+		/// </summary>
+		/// <returns></returns>
+		private int StreamPeek()
+		{
+			int peek = streamReader.Peek();
+			if (peek == -1)
+			{
+				streamReader.DiscardBufferedData();
+				peek = streamReader.Peek();
+			}
+			return peek;
+		}
 
-        private void UpdateContext()
-        {
-            if (!currentToken.HasValue) return;
+		private void UpdateContext()
+		{
+			if (popEndTokens)
+			{
+				stack.Pop();
+				stack.Pop();
+				popEndTokens = false;
+			}
 
-            if (currentToken.Value == JsonToken.ObjectStart || currentToken.Value == JsonToken.ArrayStart)
-            {
-                if (currentField != null)
-                {
-                    stack.Push(currentField);
-                    stack.Push(currentToken.ToString());
-                    currentField = null;
-                }
-            }
-            else if (currentToken.Value == JsonToken.ObjectEnd || currentToken.Value == JsonToken.ArrayEnd)
-            {
-                if (stack.Count > 0)
-                {
-                    bool squareBracketsMatch = currentToken.Value == JsonToken.ArrayEnd && stack.Peek().Equals(JsonToken.ArrayStart.ToString(), StringComparison.OrdinalIgnoreCase);
-                    bool curlyBracketsMatch = currentToken.Value == JsonToken.ObjectEnd && stack.Peek().Equals(JsonToken.ObjectStart.ToString(), StringComparison.OrdinalIgnoreCase);
-                    if (squareBracketsMatch || curlyBracketsMatch)
-                    {
-                        stack.Pop();
-                        stack.Pop();
-                    }
-                }
-                currentField = null;
-            }
-            else if (currentToken.Value == JsonToken.PropertyName)
-            {
-                string t = ReadText();
-                currentField = t;
-            }
+			if (!currentToken.HasValue) return;
 
-            RebuildStackString();
-        }
+			if (currentToken.Value == JsonToken.ObjectStart || currentToken.Value == JsonToken.ArrayStart)
+			{
+				if (currentField != null)
+				{
+					stack.Push(currentField);
+					stack.Push(currentToken.ToString());
+					currentField = null;
+				}
+			}
+			else if (currentToken.Value == JsonToken.ObjectEnd || currentToken.Value == JsonToken.ArrayEnd)
+			{
+				if (stack.Count > 0)
+				{
+					bool squareBracketsMatch = currentToken.Value == JsonToken.ArrayEnd && stack.Peek().Equals(JsonToken.ArrayStart.ToString(), StringComparison.OrdinalIgnoreCase);
+					bool curlyBracketsMatch = currentToken.Value == JsonToken.ObjectEnd && stack.Peek().Equals(JsonToken.ObjectStart.ToString(), StringComparison.OrdinalIgnoreCase);
 
-        private void RebuildStackString()
-        {
-            stackString = "";
+					if (squareBracketsMatch || curlyBracketsMatch)
+					{
+						// We need to pop both the end token and the property name, but we need to do it on the next Read otherwise the path and depth will be wrong.
+						popEndTokens = true;
+					}
+				}
+				currentField = null;
+			}
+			else if (currentToken.Value == JsonToken.PropertyName)
+			{
+				string t = ReadText();
+				currentField = t;
+			}
 
-            foreach (string s in stack)
-            {
-                if (
-                    !(
-                        s.Equals(JsonToken.ArrayStart.ToString(), StringComparison.OrdinalIgnoreCase) ||
-                        s.Equals(JsonToken.ObjectStart.ToString(), StringComparison.OrdinalIgnoreCase)))
-                {
-                    stackString += "/" + s;
-                }
-            }
+			RebuildStackString();
+		}
 
-            if (currentField != null)
-            {
-                stackString += "/" + currentField;
-            }
+		private void RebuildStackString()
+		{
+			stackString = "";
 
-            if (string.IsNullOrEmpty(stackString)) stackString = "/";
-        }
+			// We need the stack in reverse order otherwise the path doesn't make sense.
+			var arr = stack.ToArray();
+			for (var i = arr.Length - 1; i >= 0; i--)
+			{
+				var s = arr[i];
+				if (
+					!(
+						s.Equals(JsonToken.ArrayStart.ToString(), StringComparison.OrdinalIgnoreCase) ||
+						s.Equals(JsonToken.ObjectStart.ToString(), StringComparison.OrdinalIgnoreCase)))
+				{
+					stackString += "/" + s;
+				}
+			}
 
-        #endregion
-    }
+			if (currentField != null)
+			{
+				stackString += "/" + currentField;
+			}
+
+			if (string.IsNullOrEmpty(stackString)) stackString = "/";
+		}
+
+		#endregion
+	}
 }


### PR DESCRIPTION
I had an issue when calling DescribeTable on a table with a global secondary index.

I traced the issue to the way that the JSON is parsed in responses. I found two oddities:

The first is that the JsonUnmarshallerContext CurrentPath seems to reverse all but the last node (stack + currentField), whilst this doesn't actually make a difference to the code because it only cares about the last level it certainly confused me when I was trying to debug what was going on!

The second is that due to the fact that the DescribeTableResponseUnmarshaller doesn't currently handle the GlobalSecondaryIndexes node because it's new, everything after that point got ignored. I traced that to the way that ObjectEnd and ArrayEnd are handled; both ArrayEnd and ObjectEnd cause the stack to be popped twice, once to remove the Object/ArrayEnd token and once to remove the propertyName that it corresponds to.

This caused an issue because it resulted in the JsonUnmarshallerContext CurrentDepth property returning 1 even though there were more depth=2 properties to come at the point the Unmarshaller was at the Object/ArrayEnd token. This caused the TableDescriptionUnmarshaller to return before it was finished.

The fix may not be the best way around this but it seemed to work for my problem, basically I set a flag to pop the 2 items off the stack at the start of the next Read operation so that the path and depth are correct when the reader is at an ObjectEnd or ArrayEnd token.

This only happens if the particular Unmarshaller doesn't handle a specific property that's returned by the API, this is obviously an issue for any part of the SDK as it could happen any time that the API is updated and returns new properties.

Apologies for the whitespace (it's late) ?w=1 ftw
