### PR TITLE
Hotfix - mixing synchronous with assynchronous should have ConfigureAwai...

### DIFF
--- a/AWSSDK_DotNet45/Amazon.Runtime/Internal/Transform/HttpClientResponseData.cs
+++ b/AWSSDK_DotNet45/Amazon.Runtime/Internal/Transform/HttpClientResponseData.cs
@@ -41,9 +41,12 @@ namespace Amazon.Runtime.Internal.Transform
 
         public Stream OpenResponse()
         {
-            var taskStream = this._response.Content.ReadAsStreamAsync();
-            taskStream.Wait();
-            return taskStream.Result;
+            return OpenResponseAsync().Result;
+        }
+        
+        public async Task<Stream> OpenResponseAsync()
+        {
+            return await this._response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         }
 
         public string ContentType


### PR DESCRIPTION
...t(false)

Mixing synchronous with assynchronous without ConfigureAwait(false) will cause threads deadlocks on ASP.NET applications.

This is just a hotfix. OpenResponse should not exist, only OpenResponseAsync.
