### PR TITLE
Marked AmazonServiceException serializable

### DIFF
--- a/AWSSDK_DotNet35/Amazon.Runtime/AmazonServiceException.cs
+++ b/AWSSDK_DotNet35/Amazon.Runtime/AmazonServiceException.cs
@@ -26,6 +26,7 @@ namespace Amazon.Runtime
     /// may throw this exception if there is a problem which is caught in the core client code.
     /// </para>
     /// </summary>
+    [Serializable]
     public class AmazonServiceException : Exception
     {
         private ErrorType errorType;


### PR DESCRIPTION
Marked AmazonServiceException serializable to simplify transfer of this exception during remote calls
