### PR TITLE
S3 DownloadDirectory infinite block - Released the Semaphore when key ends with "/"

### DIFF
--- a/AWSSDK_DotNet45/Amazon.S3/Transfer/Internal/DownloadDirectoryCommand.async.bcl45.cs
+++ b/AWSSDK_DotNet45/Amazon.S3/Transfer/Internal/DownloadDirectoryCommand.async.bcl45.cs
@@ -75,6 +75,9 @@ namespace Amazon.S3.Transfer.Internal
                 var pendingTasks = new List<Task>();
                 foreach (S3Object s3o in objs)
                 {
+                    if (s3o.Key.EndsWith("/", StringComparison.Ordinal))
+                        continue;
+
                     await asyncThrottler.WaitAsync(cancellationToken).
                             ConfigureAwait(continueOnCapturedContext: false);
 
@@ -87,9 +90,6 @@ namespace Amazon.S3.Transfer.Internal
                         // responses and throw the original exception.
                         break;
                     }
-
-                    if (s3o.Key.EndsWith("/", StringComparison.Ordinal))
-                        continue;
 
                     // Valid for serial uploads when
                     // TransferUtilityDownloadDirectoryRequest.DownloadFilesConcurrently is set to false.


### PR DESCRIPTION
Problem:
The `TransferUtility.DownloadDirectory()` will hang if you have too many keys in S3 that ends with "/".

Solution:
It seems the Semaphore is being filled and never released when the S3 Key ends with "/". I have added a Release() to fix the issue.

I am no expert on Semaphore, hopefully this doesn't break anything else. 
If there's a better way to prevent infinite wait on the  `await asyncThrottler.WaitAsync(cancellationToken).ConfigureAwait(continueOnCapturedContext: false);` in this particular scenario, let me know and I'll glady send another pull request.
