### PR TITLE
do not specify the encrypted flag if specifying a snapshot id

### DIFF
--- a/AWSSDK_DotNet35/Amazon.EC2/Model/Internal/MarshallTransformations/RunInstancesRequestMarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.EC2/Model/Internal/MarshallTransformations/RunInstancesRequestMarshaller.cs
@@ -143,7 +143,7 @@ namespace Amazon.EC2.Model.Internal.MarshallTransformations
                         {
                             request.Parameters.Add("BlockDeviceMapping." + blockDeviceMappingsListIndex + ".Ebs.Iops", StringUtils.FromInt(ebs.Iops));
                         }
-                        if (ebs != null && ebs.IsSetEncrypted())
+                        if (ebs != null && ebs.IsSetEncrypted() && !ebs.IsSetSnapshotId())
                         {
                             request.Parameters.Add("BlockDeviceMapping." + blockDeviceMappingsListIndex + ".Ebs.Encrypted", StringUtils.FromBool(ebs.Encrypted));
                         }


### PR DESCRIPTION
Otherwise, we get:
Amazon.EC2.AmazonEC2Exception: Parameter encrypted is invalid. You cannot specify the encrypted flag if specifying a snapshot id in a block device mapping. ---> System.Net.WebException: The remote server returned an error: (400) Bad Request.
   at System.Net.HttpWebRequest.GetResponse()
   at Amazon.Runtime.AmazonWebServiceClient.getResponseCallback(IAsyncResult result)
   --- End of inner exception stack trace ---
   at Amazon.Runtime.AmazonWebServiceClient.HandleHttpWebErrorResponse(AsyncResult asyncResult, WebException we)
   at Amazon.Runtime.AmazonWebServiceClient.getResponseCallback(IAsyncResult result)
   at Amazon.Runtime.AmazonWebServiceClient.endOperation[T](IAsyncResult result)

This exception happens on .NET SDK 2.1.1 and above, and it doesn't happen on 2.1.0 and below
Thanks.