### PR TITLE
Fix download on Linux if filepath contains directory

### DIFF
--- a/AWSSDK_DotNet35/Amazon.S3/Transfer/Internal/DownloadDirectoryCommand.bcl.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Transfer/Internal/DownloadDirectoryCommand.bcl.cs
@@ -89,7 +89,7 @@ namespace Amazon.S3.Transfer.Internal
             var downloadRequest = new TransferUtilityDownloadRequest();
             downloadRequest.BucketName = this._request.BucketName;
             downloadRequest.Key = s3Object.Key;
-            var file = s3Object.Key.Substring(prefixLength).Replace('/','\\');
+            var file = s3Object.Key.Substring(prefixLength).Replace('/', Path.DirectorySeparatorChar);
             downloadRequest.FilePath = Path.Combine(this._request.LocalDirectory, file);
             downloadRequest.WriteObjectProgressEvent += downloadedProgressEventCallback;
 


### PR DESCRIPTION
This change fixes a problem on Linux with downloading files.

On Linux we shouldn't replace forward slashes with backslashes because the forward slash serves as directory separator. 