### PR TITLE
Make IDynamoDBContext interface public

### DIFF
--- a/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/IDynamoDBContext.Async.cs
+++ b/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/IDynamoDBContext.Async.cs
@@ -25,7 +25,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Context interface for using the DataModel mode of DynamoDB.
     /// Used to interact with the service, save/load objects, etc.
     /// </summary>
-    partial interface IDynamoDBContext
+    public partial interface IDynamoDBContext
     {
         #region Save async
 

--- a/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/IDynamoDBContext.Sync.cs
+++ b/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/IDynamoDBContext.Sync.cs
@@ -25,7 +25,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Context interface for using the DataModel mode of DynamoDB.
     /// Used to interact with the service, save/load objects, etc.
     /// </summary>
-    partial interface IDynamoDBContext
+    public partial interface IDynamoDBContext
     {
         #region Save/serialize
 

--- a/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/IDynamoDBContext.cs
+++ b/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/IDynamoDBContext.cs
@@ -25,7 +25,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Context interface for using the DataModel mode of DynamoDB.
     /// Used to interact with the service, save/load objects, etc.
     /// </summary>
-    partial interface IDynamoDBContext : IDisposable
+    public partial interface IDynamoDBContext : IDisposable
     {
         #region Save/serialize
 


### PR DESCRIPTION
Injecting the interface in our code permits mocking the DynamoDbContext and properly isolating the unit tests.
