### PR TITLE
Support Mocking Query/Scan operations on DynamoDBContext

### DIFF
--- a/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/AsyncSearch.Async.cs
+++ b/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/AsyncSearch.Async.cs
@@ -38,7 +38,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// 
         /// <returns>An IAsyncResult that can be used to poll or wait for results, or both; this value is also needed when invoking EndGetNextSet
         ///         operation.</returns>
-        public IAsyncResult BeginGetNextSet(AsyncCallback callback, object state)
+        public virtual IAsyncResult BeginGetNextSet(AsyncCallback callback, object state)
         {
             return DynamoDBAsyncExecutor.BeginOperation(() =>
             {
@@ -52,7 +52,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Finishes the asynchronous execution of the BeginGetNextSet operation.
         /// </summary>
         /// <param name="asyncResult">The IAsyncResult returned by the call to BeginGetNextSet.</param>
-        public List<T> EndGetNextSet(IAsyncResult asyncResult)
+        public virtual List<T> EndGetNextSet(IAsyncResult asyncResult)
         {
             return DynamoDBAsyncExecutor.EndOperation<List<T>>(asyncResult) as List<T>;
         }
@@ -66,7 +66,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// 
         /// <returns>An IAsyncResult that can be used to poll or wait for results, or both; this value is also needed when invoking EndGetRemaining
         ///         operation.</returns>
-        public IAsyncResult BeginGetRemaining(AsyncCallback callback, object state)
+        public virtual IAsyncResult BeginGetRemaining(AsyncCallback callback, object state)
         {
             return DynamoDBAsyncExecutor.BeginOperation(() =>
             {
@@ -80,7 +80,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Finishes the asynchronous execution of the BeginGetRemaining operation.
         /// </summary>
         /// <param name="asyncResult">The IAsyncResult returned by the call to BeginGetNextSet.</param>
-        public List<T> EndGetRemaining(IAsyncResult asyncResult)
+        public virtual List<T> EndGetRemaining(IAsyncResult asyncResult)
         {
             return DynamoDBAsyncExecutor.EndOperation<List<T>>(asyncResult);
         }

--- a/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/AsyncSearch.cs
+++ b/AWSSDK_DotNet35/Amazon.DynamoDBv2/DataModel/AsyncSearch.cs
@@ -33,6 +33,11 @@ namespace Amazon.DynamoDBv2.DataModel
             Config = contextSearch.FlatConfig;
         }
 
+        /// <summary>
+        /// Default constructor to support mocks in unit testing
+        /// </summary>
+        public AsyncSearch() { }
+
         #endregion
 
         #region Private members
@@ -48,7 +53,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// Flag that, if true, indicates that the search is done
         /// </summary>
-        public bool IsDone
+        public virtual bool IsDone
         {
             get
             {

--- a/AWSSDK_DotNet45/Amazon.DynamoDBv2/DataModel/AsyncSearch.Async.cs
+++ b/AWSSDK_DotNet45/Amazon.DynamoDBv2/DataModel/AsyncSearch.Async.cs
@@ -41,7 +41,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// A Task that can be used to poll or wait for results, or both.
         /// Results will include the next set of result items from DynamoDB.
         /// </returns>
-        public Task<List<T>> GetNextSetAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<List<T>> GetNextSetAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return AsyncRunner.Run(() =>
             {
@@ -59,7 +59,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// A Task that can be used to poll or wait for results, or both.
         /// Results will include the remaining result items from DynamoDB.
         /// </returns>
-        public Task<List<T>> GetRemainingAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<List<T>> GetRemainingAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return AsyncRunner.Run(() =>
             {


### PR DESCRIPTION
Okay, I’ve had another bash at this:

* added a public default constructor on AsyncSearch
* all public members on AsyncSearch are now virtual

This allows mocking frameworks to generate mock AsyncSearch instances to test query & scan operations, without changing the context method signatures.