### PR TITLE
Adding support for third-party S3-compatible storage providers in GetObject request

### DIFF
--- a/AWSSDK_DotNet35/Amazon.S3/Internal/AmazonS3KmsHandler.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Internal/AmazonS3KmsHandler.cs
@@ -73,8 +73,8 @@ namespace Amazon.S3.Internal
 
         internal static void EvaluateIfSigV4Required(IRequest request)
         {
-            
-            if (request.OriginalRequest is S3.Model.GetObjectRequest)
+            // Skip this for S3-compatible storage provider endpoints
+            if ((request.OriginalRequest is S3.Model.GetObjectRequest) && (AmazonS3Uri.IsAmazonS3Endpoint(request.Endpoint)))
             {
                 var region = new AmazonS3Uri(request.Endpoint.OriginalString).Region;
                 if(region != RegionEndpoint.USEast1)

--- a/AWSSDK_DotNet35/Amazon.S3/Util/AmazonS3Uri.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Util/AmazonS3Uri.cs
@@ -146,6 +146,33 @@ namespace Amazon.S3.Util
         }
 
         /// <summary>
+        /// Checks whether the given URI is a Amazon S3 URI.
+        /// </summary>
+        /// <param name="uri">The S3 URI to be checked.</param>
+        /// <returns>true if the URI is a Amazon S3 URI, false; otherwise.</returns>
+        public static bool IsAmazonS3Endpoint(string uri)
+        {
+            if (uri == null)
+                throw new ArgumentNullException("uri");
+
+            return IsAmazonS3Endpoint(new Uri(uri));
+        }
+        
+        /// <summary>
+        /// Checks whether the given URI is a Amazon S3 URI.
+        /// </summary>
+        /// <param name="uri">The S3 URI to be checked.</param>
+        /// <returns>true if the URI is a Amazon S3 URI, false; otherwise.</returns>
+        public static bool IsAmazonS3Endpoint(Uri uri)
+        {
+            if (uri == null)
+                throw new ArgumentNullException("uri");
+
+            var match = new Regex(EndpointPattern).Match(uri.Host);
+            return match.Success;
+        }
+
+        /// <summary>
         /// Percent-decodes the given string, with a fast path for strings that are not
         /// percent-encoded.
         /// </summary>


### PR DESCRIPTION
A fix for [#197](https://github.com/aws/aws-sdk-net/issues/197).
`AmazonS3Uri.IsAmazonS3Endpoint` method is introduced to check if a URL is an Amazon S3 endpoint.
The method is used in `AmazonS3KmsHandler.EvaluateIfSigV4Required` to perform the evaluation only if a `GetObject` request endpoint is an Amazon S3 endpoint, and skip the evaluation for other providers.