### PR TITLE
We should have the ability to convert DynamoDBNull to null, and return true(successfully convert).

### DIFF
--- a/AWSSDK_DotNet35/Amazon.DynamoDBv2/Conversion/DynamoDBEntryConversion.cs
+++ b/AWSSDK_DotNet35/Amazon.DynamoDBv2/Conversion/DynamoDBEntryConversion.cs
@@ -527,9 +527,12 @@ namespace Amazon.DynamoDBv2
             if (d != null && TryFrom(d, targetType, out value))
                 return true;
 
-            //var n = entry as DynamoDBNull;
-            //if (n != null)
-            //    return null;
+            var n = entry as DynamoDBNull;
+            if (n != null)
+            {
+                value = null;
+                return true;
+            }
 
             value = null;
             return false;


### PR DESCRIPTION
For example, when I deserialize a document which contain null for some filed. We should be able to call Context.FromDocument<T>(document) and deserialize it, not just throw an exception(unable to convert dynamoDBNull to system.string). Maybe I am wrong, just a thought~~ 