### PR TITLE
Do not use parent directory of "My Documents" folder to locate User directory in DetermineCredentialsFilePath()

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
@@ -376,8 +376,8 @@ namespace Amazon.Runtime
             else
             {
                 return Path.Combine(
-                    Directory.GetParent(System.Environment.GetFolderPath(System.Environment.SpecialFolder.Personal)).FullName,
-                    ".aws/credentials");
+                    System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
+                    @".aws\credentials");
             }
         }
 

--- a/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
@@ -376,8 +376,8 @@ namespace Amazon.Runtime
             else
             {
                 return Path.Combine(
-                    System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
-                    @".aws\credentials");
+                    System.Environment.GetEnvironmentVariable("HOME"),
+                    ".aws/credentials");
             }
         }
 


### PR DESCRIPTION
Use HOME Environment Variable to locate the User directory in case "My Documents" folder has been moved.

If the user has moved their "My Documents" folder, then its "parent" directory will not be the correct location of the aws credentials.