### PR TITLE
ISSUE #240: Fix signing issues for endpoints with a path component

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS3Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS3Signer.cs
@@ -129,9 +129,7 @@ namespace Amazon.Runtime.Internal.Auth
             }
             else
             {
-                Uri url = request.Endpoint;
-                if (!string.IsNullOrEmpty(request.ResourcePath))
-                    url = new Uri(request.Endpoint, request.ResourcePath);
+                Uri url = AmazonServiceClient.ComposeUrl(request);
 
                 stringToSign = request.HttpMethod + "\n"
                     + GetCanonicalizedResourcePath(url) + "\n"


### PR DESCRIPTION
In order to properly preserve the relationship between IRequest.Endpoint and IRequest.ResourcePath, have, AWS3Signer and AWS4Signer canonicalize the URL returned by AmazonServiceClient.ComposeUrl()