### PR TITLE
Issue #240 Revisit signing issues for endpoints with a path component in light of WP 8.1 regression

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS3Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS3Signer.cs
@@ -129,7 +129,9 @@ namespace Amazon.Runtime.Internal.Auth
             }
             else
             {
-                Uri url = AmazonServiceClient.ComposeUrl(request);
+                Uri url = request.Endpoint;
+                if (!string.IsNullOrEmpty(request.ResourcePath))
+                    url = new Uri(request.Endpoint, request.ResourcePath);
 
                 stringToSign = request.HttpMethod + "\n"
                     + GetCanonicalizedResourcePath(url) + "\n"

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -539,7 +539,7 @@ namespace Amazon.Runtime.Internal.Auth
         {
             var canonicalRequest = new StringBuilder();
             canonicalRequest.AppendFormat("{0}\n", httpMethod);
-            canonicalRequest.AppendFormat("{0}\n", CanonicalizeResourcePath(resourcePath));
+            canonicalRequest.AppendFormat("{0}\n", AWSSDKUtils.CanonicalizeResourcePath(resourcePath));
             canonicalRequest.AppendFormat("{0}\n", canonicalQueryString);
 
             canonicalRequest.AppendFormat("{0}\n", CanonicalizeHeaders(sortedHeaders));
@@ -557,34 +557,6 @@ namespace Amazon.Runtime.Internal.Auth
             }
 
             return canonicalRequest.ToString();
-        }
-
-        /// <summary>
-        /// Returns the canonicalized resource path for the service endpoint
-        /// </summary>
-        /// <param name="resourcePath">Resource path for the request</param>
-        /// <remarks>
-        /// If resourcePath begins or ends with slash, the resulting canonicalized
-        /// path will follow suit.
-        /// </remarks>
-        /// <returns>Canonicalized resource path for the endpoint</returns>
-        protected static string CanonicalizeResourcePath(string resourcePath)
-        {
-            if (string.IsNullOrEmpty(resourcePath))
-                return "/";
-
-            // split path at / into segments
-            var pathSegments = resourcePath.Split(new char[] { '/' }, StringSplitOptions.None);
-            
-            // url encode the segments
-            var encodedSegments = pathSegments
-                .Select(segment => AWSSDKUtils.UrlEncode(segment, false))
-                .ToArray();
-            
-            // join the encoded segments with /
-            var canonicalizedResourcePath = string.Join("/", encodedSegments);
-
-            return canonicalizedResourcePath;
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -135,7 +135,8 @@ namespace Amazon.Runtime.Internal.Auth
             var bodyHash = SetRequestBodyHash(request);
             var sortedHeaders = SortHeaders(request.Headers);
             
-            var canonicalRequest = CanonicalizeRequest(request.ResourcePath,
+            var canonicalRequest = CanonicalizeRequest(request.Endpoint,
+                                                       request.ResourcePath,
                                                        request.HttpMethod,
                                                        sortedHeaders,
                                                        canonicalParameters,
@@ -522,6 +523,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// <summary>
         /// Computes and returns the canonical request
         /// </summary>
+        /// <param name="endpoint">The endpoint URL</param>
         /// <param name="resourcePath">the path of the resource being operated on</param>
         /// <param name="httpMethod">The http method used for the request</param>
         /// <param name="sortedHeaders">The full request headers, sorted into canonical order</param>
@@ -531,7 +533,8 @@ namespace Amazon.Runtime.Internal.Auth
         /// will look for the hash as a header on the request.
         /// </param>
         /// <returns>Canonicalised request as a string</returns>
-        protected static string CanonicalizeRequest(string resourcePath,
+        protected static string CanonicalizeRequest(Uri endpoint,
+                                                    string resourcePath,
                                                     string httpMethod,
                                                     IDictionary<string, string> sortedHeaders,
                                                     string canonicalQueryString,
@@ -539,7 +542,7 @@ namespace Amazon.Runtime.Internal.Auth
         {
             var canonicalRequest = new StringBuilder();
             canonicalRequest.AppendFormat("{0}\n", httpMethod);
-            canonicalRequest.AppendFormat("{0}\n", AWSSDKUtils.CanonicalizeResourcePath(resourcePath));
+            canonicalRequest.AppendFormat("{0}\n", AWSSDKUtils.CanonicalizeResourcePath(endpoint, resourcePath));
             canonicalRequest.AppendFormat("{0}\n", canonicalQueryString);
 
             canonicalRequest.AppendFormat("{0}\n", CanonicalizeHeaders(sortedHeaders));
@@ -942,7 +945,8 @@ namespace Amazon.Runtime.Internal.Auth
 
             var canonicalQueryParams = CanonicalizeQueryParameters(parametersToCanonicalize);
 
-            var canonicalRequest = CanonicalizeRequest(request.ResourcePath,
+            var canonicalRequest = CanonicalizeRequest(request.Endpoint,
+                                                       request.ResourcePath,
                                                        request.HttpMethod,
                                                        sortedHeaders,
                                                        canonicalQueryParams,

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -41,6 +41,9 @@ namespace Amazon.Util
         internal const string DefaultRegion = "us-east-1";
         internal const string DefaultGovRegion = "us-gov-west-1";
 
+        private const char SlashChar = '/';
+        private const string Slash = "/";
+
         internal const int DefaultMaxRetry = 3;
         private const int DefaultConnectionLimit = 50;
         private const int DefaultMaxIdleTime = 50 * 1000; // 50 seconds
@@ -249,19 +252,35 @@ namespace Amazon.Util
         /// <summary>
         /// Returns the canonicalized resource path for the service endpoint
         /// </summary>
+        /// <param name="endpoint">Endpoint URL for the request</param>
         /// <param name="resourcePath">Resource path for the request</param>
         /// <remarks>
         /// If resourcePath begins or ends with slash, the resulting canonicalized
         /// path will follow suit.
         /// </remarks>
         /// <returns>Canonicalized resource path for the endpoint</returns>
-        public static string CanonicalizeResourcePath(string resourcePath)
+        public static string CanonicalizeResourcePath(Uri endpoint, string resourcePath)
         {
+            if (endpoint != null)
+            {
+                var path = endpoint.AbsolutePath;
+                if (string.IsNullOrEmpty(path) || string.Equals(path, Slash, StringComparison.Ordinal))
+                    path = string.Empty;
+
+                if (!string.IsNullOrEmpty(resourcePath) && resourcePath.StartsWith(Slash, StringComparison.Ordinal))
+                    resourcePath = resourcePath.Substring(1);
+
+                if (!string.IsNullOrEmpty(resourcePath))
+                    path = path + Slash + resourcePath;
+
+                resourcePath = path;
+            }
+
             if (string.IsNullOrEmpty(resourcePath))
-                return "/";
+                return Slash;
 
             // split path at / into segments
-            var pathSegments = resourcePath.Split(new char[] { '/' }, StringSplitOptions.None);
+            var pathSegments = resourcePath.Split(new char[] { SlashChar }, StringSplitOptions.None);
 
             // url encode the segments
             var encodedSegments = pathSegments
@@ -269,7 +288,7 @@ namespace Amazon.Util
                 .ToArray();
 
             // join the encoded segments with /
-            var canonicalizedResourcePath = string.Join("/", encodedSegments);
+            var canonicalizedResourcePath = string.Join(Slash, encodedSegments);
 
             return canonicalizedResourcePath;
         }

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -247,6 +247,34 @@ namespace Amazon.Util
         }
 
         /// <summary>
+        /// Returns the canonicalized resource path for the service endpoint
+        /// </summary>
+        /// <param name="resourcePath">Resource path for the request</param>
+        /// <remarks>
+        /// If resourcePath begins or ends with slash, the resulting canonicalized
+        /// path will follow suit.
+        /// </remarks>
+        /// <returns>Canonicalized resource path for the endpoint</returns>
+        public static string CanonicalizeResourcePath(string resourcePath)
+        {
+            if (string.IsNullOrEmpty(resourcePath))
+                return "/";
+
+            // split path at / into segments
+            var pathSegments = resourcePath.Split(new char[] { '/' }, StringSplitOptions.None);
+
+            // url encode the segments
+            var encodedSegments = pathSegments
+                .Select(segment => AWSSDKUtils.UrlEncode(segment, false))
+                .ToArray();
+
+            // join the encoded segments with /
+            var canonicalizedResourcePath = string.Join("/", encodedSegments);
+
+            return canonicalizedResourcePath;
+        }
+
+        /// <summary>
         /// Returns a new string created by joining each of the strings in the
         /// specified list together, with a comma between them.
         /// </summary>

--- a/sdk/test/UnitTests/Custom/Runtime/SignerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/SignerTests.cs
@@ -70,6 +70,31 @@ namespace AWSSDK.UnitTests
             Assert.AreEqual("us-west-2", AWSSDKUtils.DetermineRegion("https://streams.dynamodb.us-west-2.amazonaws.com/"));
         }
 
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestCanonicalizeResourcePath()
+        {
+            Assert.AreEqual("/", AWSSDKUtils.CanonicalizeResourcePath(null, null));
+            Assert.AreEqual("/", AWSSDKUtils.CanonicalizeResourcePath(null, string.Empty));
+            Assert.AreEqual("/", AWSSDKUtils.CanonicalizeResourcePath(new Uri("https://ec2.us-west-1.amazonaws.com"), null));
+            Assert.AreEqual("/", AWSSDKUtils.CanonicalizeResourcePath(new Uri("https://ec2.us-west-1.amazonaws.com"), string.Empty));
+            Assert.AreEqual("/custompath", AWSSDKUtils.CanonicalizeResourcePath(new Uri("https://customhost/custompath"), null));
+            Assert.AreEqual("/custompath", AWSSDKUtils.CanonicalizeResourcePath(new Uri("https://customhost/custompath"), string.Empty));
+
+            Assert.AreEqual(
+                "/vx_folder/1.0%5Cdatafiles%5Cfile.json",
+                AWSSDKUtils.CanonicalizeResourcePath(null, @"/vx_folder/1.0\datafiles\file.json"));
+
+            Assert.AreEqual(
+                "/vx_folder/1.0%5Cdatafiles%5Cfile.json",
+                AWSSDKUtils.CanonicalizeResourcePath(new Uri("https://s3-eu-west-1.amazonaws.com/"), @"/vx_folder/1.0\datafiles\file.json"));
+
+            Assert.AreEqual(
+                "/custompath/vx_folder/1.0%5Cdatafiles%5Cfile.json",
+                AWSSDKUtils.CanonicalizeResourcePath(new Uri("https://customhost/custompath"), @"/vx_folder/1.0\datafiles\file.json"));
+        }
+
 #if BCL45
         [TestMethod][TestCategory("UnitTest")]
         [TestCategory("Runtime")]


### PR DESCRIPTION
The original implementation regressed a use case for Windows Phone 8.1 Silverlight (see issue #259)

The intent was to sign the request with the same URL that was to be used to make the request by calling  `AmazonServiceClient.ComposeUrl()`  to ensure parity between the contents of the signature and the URL the server will ultimately use to recreate the signature.  `AmazonServiceClient.ComposeUrl() ` ends up calling  `AmazonServiceClient.DontUnescapePathDotsAndSlashes()`  in an attempt to smooth over differences in the way the Uri class behaves across .NET versions; clearly this is a no-op on WP 8.1 and of course for WP 8.1 the Uri class behaves in the "old" way by unescaping the slashes.

Instead, use the suggestion by @PavelSafronov to have `CanonicalizeResourcePath()` take the endpoint URL as a parameter in order to accommodate endpoints with path components.

Added unit test to document the intent.