### PR TITLE
Fix for issue #302 - Adding whitespace to keyValueSeparator

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
@@ -556,7 +556,7 @@ namespace Amazon.Runtime
             private static List<string> SplitData(string line)
             {
                 var split = line
-                    .Split(new string[] { keyValueSeparator }, 3, StringSplitOptions.None)
+                    .Split(new string[] { keyValueSeparator }, 2, StringSplitOptions.None)
                     .Select(s => s.Trim())
                     .Where(s => !string.IsNullOrEmpty(s))
                     .ToList();

--- a/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
@@ -504,7 +504,7 @@ namespace Amazon.Runtime
             private const string profileNamePrefix = "[";
             private const string profileNameSuffix = "]";
             private const string dataPrefix = "aws_";
-            private const string keyValueSeparator = "=";
+            private const string keyValueSeparator = " = ";
             private const string accessKeyName = "aws_access_key_id";
             private const string secretKeyName = "aws_secret_access_key";
             private const string tokenName = "aws_session_token";

--- a/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
@@ -504,7 +504,7 @@ namespace Amazon.Runtime
             private const string profileNamePrefix = "[";
             private const string profileNameSuffix = "]";
             private const string dataPrefix = "aws_";
-            private const string keyValueSeparator = " = ";
+            private const string keyValueSeparator = "=";
             private const string accessKeyName = "aws_access_key_id";
             private const string secretKeyName = "aws_secret_access_key";
             private const string tokenName = "aws_session_token";
@@ -556,7 +556,7 @@ namespace Amazon.Runtime
             private static List<string> SplitData(string line)
             {
                 var split = line
-                    .Split(new string[] { keyValueSeparator }, StringSplitOptions.None)
+                    .Split(new string[] { keyValueSeparator }, 3, StringSplitOptions.None)
                     .Select(s => s.Trim())
                     .Where(s => !string.IsNullOrEmpty(s))
                     .ToList();


### PR DESCRIPTION
Adding a space before and after the "=" string makes the split call on line 559 match exactly " = ". 
This prevents splitting of secret keys with "=" in the value.

**Note: This assumes that credentials files always match the AWS documentation for credentials files (note the space between "=" and the key values):**
aws_access_key_id = <key>
aws_secret_access_key = <key>


[Issue](https://github.com/aws/aws-sdk-net/issues/302)
[Credential file doc](http://docs.aws.amazon.com/AWSSdkDocsNET/latest/V2/DeveloperGuide/net-dg-config-creds.html)