### PR TITLE
Fixed : KeyNotFoundException in Unity Editor

### DIFF
--- a/sdk/src/Services/CognitoSync/Custom/SyncManager/Storage/SQLiteLocalStorage.cs
+++ b/sdk/src/Services/CognitoSync/Custom/SyncManager/Storage/SQLiteLocalStorage.cs
@@ -530,7 +530,7 @@ namespace Amazon.CognitoSync.SyncManager.Internal
             foreach (Record record in records)
             {
                 Record databaseRecord = this.GetRecord(identityId, datasetName, record.Key);
-                Record oldDatabaseRecord = localRecordMap[record.Key];
+                Record oldDatabaseRecord = localRecordMap.ContainsKey(record.Key) ? localRecordMap[record.Key] : null;
                 if (databaseRecord != null && oldDatabaseRecord != null
                         && (!StringUtils.Equals(databaseRecord.Value, oldDatabaseRecord.Value)
                         || databaseRecord.SyncCount != oldDatabaseRecord.SyncCount


### PR DESCRIPTION
Fixes #352.

```
KeyNotFoundException: The given key was not present in the dictionary.
System.Collections.Generic.Dictionary`2[System.String,Amazon.CognitoSync.SyncManager.Record].get_Item (System.String key) (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Collections.Generic/Dictionary.cs:150)
Amazon.CognitoSync.SyncManager.Internal.SQLiteLocalStorage.ConditionallyPutRecords (System.String identityId, System.String datasetName, System.Collections.Generic.List`1 records, System.Collections.Generic.List`1 localRecords)
Amazon.CognitoSync.SyncManager.Dataset.RunSyncOperation (Int32 retry)
UnityEngine.Debug:LogException(Exception)
InfoDataset`1:HandleSyncFailure(Object, SyncFailureEventArgs) (at Assets/Scripts/AWS/InfoDataset.cs:408)
Amazon.CognitoSync.SyncManager.Dataset:FireSyncFailureEvent(Exception)
Amazon.CognitoSync.SyncManager.Dataset:RunSyncOperation(Int32)
Amazon.CognitoSync.SyncManager.Dataset:SynchornizeInternal()
Amazon.CognitoSync.SyncManager.Dataset:<SynchronizeHelperAsync>b__70_0()
Amazon.Util.Internal.InternalSDKUtils:SafeExecute(Action)
Amazon.Util.Internal.<>c__DisplayClass31_0:<AsyncExecutor>b__0(Object)
```