### PR TITLE
Fixes to target NET Standard 1.3

### DIFF
--- a/sdk/src/Core/Amazon.Util/Internal/_coreclr/TypeWrapper.coreclr.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/_coreclr/TypeWrapper.coreclr.cs
@@ -55,17 +55,17 @@ namespace Amazon.Util.Internal
 
             public override IEnumerable<PropertyInfo> GetProperties()
             {
-                return this._typeInfo.GetProperties();
+                return this._type.GetProperties();
             }
 
             public override IEnumerable<FieldInfo> GetFields()
             {
-                return this._typeInfo.GetFields();
+                return this._type.GetFields();
             }
 
             public override FieldInfo GetField(string name)
             {
-                return this._typeInfo.GetField(name);
+                return this._type.GetField(name);
             }
 
             public override MemberInfo[] GetMembers()
@@ -125,7 +125,7 @@ namespace Amazon.Util.Internal
 
             public override MethodInfo GetMethod(string name)
             {
-                return this._typeInfo.GetMethod(name);
+                return this._type.GetMethod(name);
             }
 
             public override bool ContainsGenericParameters
@@ -162,12 +162,12 @@ namespace Amazon.Util.Internal
                 for (int i = 0; i < paramTypes.Length; i++)
                     types[i] = ((AbstractTypeInfo)paramTypes[i]).Type;
 
-                return this._typeInfo.GetMethod(name, types);
+                return this._type.GetMethod(name, types);
             }
 
             public override PropertyInfo GetProperty(string name)
             {
-                return this._typeInfo.GetProperty(name);
+                return this._type.GetProperty(name);
             }
 
             public override bool IsAssignableFrom(ITypeInfo typeInfo)
@@ -224,7 +224,7 @@ namespace Amazon.Util.Internal
                 for (int i = 0; i < paramTypes.Length; i++)
                     types[i] = ((AbstractTypeInfo)paramTypes[i]).Type;
 
-                return this._typeInfo.GetConstructor(types);
+                return this._type.GetConstructor(types);
             }
         }
     }

--- a/sdk/src/Core/project.json
+++ b/sdk/src/Core/project.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.0-*",
-  "description": "",
-  "authors": [ "" ],
-  "tags": [ "" ],
-  "projectUrl": "",
-  "licenseUrl": "",
+    "version": "1.0.0-*",
+    "description": "",
+    "authors": [ "" ],
+    "tags": [ "" ],
+    "projectUrl": "",
+    "licenseUrl": "",
 
 
   "dependencies": {
@@ -38,32 +38,32 @@
     "xmlDoc": true
   },
 
-  "frameworks": {
-    "netstandard1.5": {
-      "buildOptions": {
-        "define": [ "ADD_SUPPORT_IORDERED_DICTIONARY", "ADD_SUPPORT_ICLONEABLE" ]
-      },
-      "dependencies": {
-        "System.Collections": "4.0.11-rc2-24027",
-        "System.Collections.NonGeneric": "4.0.1-rc2-24027",
-        "System.Console": "4.0.0-rc2-24027",
-        "System.Diagnostics.Tools": "4.0.1-rc2-24027",
-        "System.IO.FileSystem": "4.0.1-rc2-24027",
-        "System.Linq": "4.1.0-rc2-24027",
-        "System.Net.Http": "4.0.1-rc2-24027",
-        "System.Net.Requests": "4.0.11-rc2-24027",
-        "System.Reflection.Extensions": "4.0.1-rc2-24027",
-        "System.Runtime.Extensions": "4.1.0-rc2-24027",
-        "System.Runtime.InteropServices": "4.1.0-rc2-24027",
-        "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-24027",
-        "System.Security.Cryptography.Algorithms": "4.1.0-rc2-24027",
-        "System.Text.Encoding.Extensions": "4.0.11-rc2-24027",
-        "System.Text.RegularExpressions": "4.0.12-rc2-24027",
-        "System.Threading": "4.0.11-rc2-24027",
-        "System.Threading.Thread": "4.0.0-rc2-24027",
-        "System.Xml.XDocument": "4.0.11-rc2-24027",
-        "Microsoft.CSharp": "4.0.1-rc2-24027"
-      }
+    "frameworks": {
+        "netstandard1.3": {
+            "buildOptions": {
+                "define": [ "ADD_SUPPORT_IORDERED_DICTIONARY", "ADD_SUPPORT_ICLONEABLE" ]
+            },
+            "dependencies": {
+                "System.Collections": "4.0.11-rc2-24027",
+                "System.Collections.NonGeneric": "4.0.1-rc2-24027",
+                "System.Console": "4.0.0-rc2-24027",
+                "System.Diagnostics.Tools": "4.0.1-rc2-24027",
+                "System.IO.FileSystem": "4.0.1-rc2-24027",
+                "System.Linq": "4.1.0-rc2-24027",
+                "System.Net.Http": "4.0.1-rc2-24027",
+                "System.Net.Requests": "4.0.11-rc2-24027",
+                "System.Reflection.Extensions": "4.0.1-rc2-24027",
+                "System.Reflection.TypeExtensions": "4.1.0-rc2-24027",
+                "System.Runtime.Extensions": "4.1.0-rc2-24027",
+                "System.Runtime.InteropServices": "4.1.0-rc2-24027",
+                "System.Security.Cryptography.Algorithms": "4.1.0-rc2-24027",
+                "System.Text.Encoding.Extensions": "4.0.11-rc2-24027",
+                "System.Text.RegularExpressions": "4.0.12-rc2-24027",
+                "System.Threading": "4.0.11-rc2-24027",
+                "System.Threading.Thread": "4.0.0-rc2-24027",
+                "System.Xml.XDocument": "4.0.11-rc2-24027",
+                "Microsoft.CSharp": "4.0.1-rc2-24027"
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
1.5 is a bit too high.  I think everything can target 1.3.

I haven't fixed all the libraries but I thought I'd ask before moving on.  Is this viable?