### PR TITLE
Proposed fix for issue #375 to prevent v4 auth from being forced on GET object

### DIFF
--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
@@ -169,7 +169,7 @@ namespace Amazon.S3.Util
                 throw new ArgumentNullException("uri");
 
             var match = new Regex(EndpointPattern).Match(uri.Host);
-            if (uri.Host.EndsWith("amazonaws.com"))
+            if (uri.Host.EndsWith("amazonaws.com") || uri.Host.EndsWith("amazonaws.com.cn"))
             {
                 return match.Success;
             }

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
@@ -169,7 +169,15 @@ namespace Amazon.S3.Util
                 throw new ArgumentNullException("uri");
 
             var match = new Regex(EndpointPattern).Match(uri.Host);
-            return match.Success;
+            if (uri.Host.EndsWith("amazonaws.com"))
+            {
+                return match.Success;
+            }
+            else
+            {
+                return false;
+            }
+
         }
 
         /// <summary>

--- a/sdk/test/IntegrationTests/Tests/S3/KMSTests.cs
+++ b/sdk/test/IntegrationTests/Tests/S3/KMSTests.cs
@@ -216,6 +216,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 "http://bucketname.s3-us-west-2.amazonaws.com",
                 "http://s3.eu-central-1.amazonaws.com",
                 "http://bucketname.s3.eu-central-1.amazonaws.com",
+                "http://s3.cn-north-1.amazonaws.com.cn",
             };
 
             foreach (var uri in thirdPartyProviderUriExamples)

--- a/sdk/test/IntegrationTests/Tests/S3/KMSTests.cs
+++ b/sdk/test/IntegrationTests/Tests/S3/KMSTests.cs
@@ -204,6 +204,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             {
                 "http://storage.googleapis.com",
                 "http://bucket.storage.googleapis.com",
+                "http://s3.mycompany.com",
+                "http://storage.s3.company.com"
             };
 
             string[] s3UriExamples =


### PR DESCRIPTION
Proposed fix for issue #375  to prevent v4 auth from being forced on GET when using non s3 endpoint.  The use of v4 auth was being forced for endpoints that contain s3 and this is not necessarily a real AWS s3 endpoint - like s3.company.com.