### PR TITLE
Return from RunSyncOperation after dataset deletion

### DIFF
--- a/sdk/src/Services/CognitoSync/Custom/SyncManager/Dataset.cs
+++ b/sdk/src/Services/CognitoSync/Custom/SyncManager/Dataset.cs
@@ -404,6 +404,7 @@ namespace Amazon.CognitoSync.SyncManager
 #else
                 FireSyncSuccessEvent(new List<Record>());
 #endif
+                return;
             }
 
             // get latest modified records from remote


### PR DESCRIPTION
I've seen Null Pointer Exceptions on Unity when deleting a merged dataset after the deletion is complete.  All other instances of FireSyncSuccessEvent are followed by a return statement.

I don't think it makes sense to continue pulling updates, processing conflicts, and pushing local changes for a dataset that has been deleted remotely and locally.