### PR TITLE
Added DateTimeProvider property to RefreshingAWSCredentials.

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/AWSCredentials.cs
@@ -1145,6 +1145,8 @@ namespace Amazon.Runtime
             }
         }
 
+        public Func<DateTime> DateTimeProvider { get; set; }
+
         #endregion
 
         #region Override methods
@@ -1202,7 +1204,7 @@ namespace Amazon.Runtime
                 else
                     errorMessage = string.Format(CultureInfo.InvariantCulture,
                         "The retrieved credentials have already expired: Now = {0}, Credentials expiration = {1}",
-                        DateTime.Now, state.Expiration);
+                        GetDateTimeUtcNow().ToLocalTime(), state.Expiration);
                 throw new AmazonClientException(errorMessage);
             }
 
@@ -1216,7 +1218,7 @@ namespace Amazon.Runtime
                 var logger = Logger.GetLogger(typeof(RefreshingAWSCredentials));
                 logger.InfoFormat(
                     "The preempt expiry time is set too high: Current time = {0}, Credentials expiry time = {1}, Preempt expiry time = {2}.",
-                    DateTime.Now,
+                    GetDateTimeUtcNow().ToLocalTime(),
                     _currentState.Expiration,
                     PreemptExpiryTime);
             }
@@ -1234,10 +1236,15 @@ namespace Amazon.Runtime
                     return true;
 
                 //  it's past the expiration time
-                var now = DateTime.UtcNow;
+                var now = GetDateTimeUtcNow();
                 var exp = _currentState.Expiration.ToUniversalTime();
                 return (now > exp);
             }
+        }
+
+        private DateTime GetDateTimeUtcNow()
+        {
+            return DateTimeProvider != null ? DateTimeProvider() : DateTime.UtcNow;
         }
 
         /// <summary>


### PR DESCRIPTION
Workaround for exception "The retrieved credentials have already expired".
This allows using other DateTime source (NTP) instead of device time.

Usage:
```
    credentials = new CognitoAWSCredentials(poolId, region);
    credentials.DateTimeProvider = GetDateTime;

...

    private DateTime GetDateTime()
    {
        // Reading and writing DateTime is not thread safe
        lock (dateLock)
        {
            return reliableDate;
        }
    }
```

Related issues: https://github.com/aws/aws-sdk-net/issues/393 https://github.com/aws/aws-sdk-net/issues/402
