### PR TITLE
Improve DataConflictException handling in case of partial local modification

### DIFF
--- a/sdk/src/Services/CognitoSync/Custom/SyncManager/Dataset.cs
+++ b/sdk/src/Services/CognitoSync/Custom/SyncManager/Dataset.cs
@@ -565,13 +565,13 @@ namespace Amazon.CognitoSync.SyncManager
 
             // push changes to remote
             List<Record> localChanges = this.ModifiedRecords;
-            long maxPatchSyncCount = 0;
+            long minPatchSyncCount = lastSyncCount;
             foreach (Record r in localChanges)
             {
                 //track the max sync count
-                if (r.SyncCount > maxPatchSyncCount)
+                if (r.SyncCount < minPatchSyncCount)
                 {
-                    maxPatchSyncCount = r.SyncCount;
+                    minPatchSyncCount = r.SyncCount;
                 }
             }
             if (localChanges.Count != 0)
@@ -630,9 +630,9 @@ namespace Amazon.CognitoSync.SyncManager
                     else
                     {
                         //it's possible there is a local dirty record with a stale sync count this will fix it
-                        if (lastSyncCount > maxPatchSyncCount)
+                        if (lastSyncCount > minPatchSyncCount)
                         {
-                            Local.UpdateLastSyncCount(IdentityId, DatasetName, maxPatchSyncCount);
+                            Local.UpdateLastSyncCount(IdentityId, DatasetName, minPatchSyncCount);
                         }
 #if BCL35
                         RunSyncOperation(--retry);


### PR DESCRIPTION
In the case where only some of the records in a patch are skipped by `ConditionallyPutRecords`, maxPatchSyncCount will not cause the dataset sync count to be reset sufficiently to correct the skipped records when they experience a `DataConflictException` on future sync attempts.  (Especially likely if multiple records are always updated together.)

Another possibility for this might be to have `ConditionallyPutRecords` return a flag for whether it skipped any records, and if it did, to not update the dataset sync count in the `DataConflictException` handler.

Attempts to address issue #391 