### PR TITLE
Make AMA event store parsing robust to corrupted / obsolete JSONs

### DIFF
--- a/Unity.README.md
+++ b/Unity.README.md
@@ -74,7 +74,9 @@ You can also do this configuration in a script
 			<namespace fullname="System.Security.Cryptography" preserve="all"/>
    		</assembly>
 
-		<assembly fullname="AWSSDK.Core" preserve="all"/>
+		<assembly fullname="AWSSDK.Core" preserve="all">
+			<namespace fullname="Amazon.Util.Internal.PlatformServices" preserve="all"/>
+		</assembly>
    		<assembly fullname="AWSSDK.CognitoIdentity" preserve="all"/>
    		<assembly fullname="AWSSDK.SecurityToken" preserve="all"/>
 		add more services that you need here... 

--- a/sdk/src/Services/MobileAnalytics/Custom/Delivery/DeliveryClient.cs
+++ b/sdk/src/Services/MobileAnalytics/Custom/Delivery/DeliveryClient.cs
@@ -137,10 +137,15 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
                 submitEventsLength += eventString.Length;
                 if (submitEventsLength < _maConfig.MaxRequestSize)
                 {
-                    Amazon.MobileAnalytics.Model.Event _analyticsEvent = JsonMapper.ToObject<Amazon.MobileAnalytics.Model.Event>(eventString);
+                    try {
+                        Amazon.MobileAnalytics.Model.Event _analyticsEvent = JsonMapper.ToObject<Amazon.MobileAnalytics.Model.Event>(eventString);
+                        submitEventsList.Add(_analyticsEvent);
+                    } catch (JsonException e) {
+                        _logger.Error(e, "Could not load event from event store, discarding.");
+                    }
 
                     submitEventsIdList.Add(eventData["id"].ToString());
-                    submitEventsList.Add(_analyticsEvent);
+                    
                 }
                 else
                 {


### PR DESCRIPTION
When upgrading from the old aws-sdk-unity to the new aws-sdk-net with unity support, some of the json formats change. This causes the delivery client to not be able to deliver ANY events, because it fails to convert the old jsons to the new Event model.

This renders AMA nonfunctional for users who will upgrade to our new version. The suggested fix catches these errors, writes to the log and discards the event so the rest of the pipeline will be able to continue functioning.