### PR TITLE
Added TimeSpan? AWSConfigs.ManualClockCorrection property.

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/_bcl+coreclr/AWSCredentialsFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/_bcl+coreclr/AWSCredentialsFactory.cs
@@ -201,7 +201,7 @@ namespace Amazon.Runtime.CredentialManagement
 
                         }
 
-                        var roleSessionName = RoleSessionNamePrefix + DateTime.UtcNow.Ticks;
+                        var roleSessionName = RoleSessionNamePrefix + AWSSDKUtils.CorrectedUtcNow.Ticks;
                         var assumeRoleOptions = new AssumeRoleAWSCredentialsOptions()
                         {
                             ExternalId = options.ExternalID,

--- a/sdk/src/Core/Amazon.Runtime/Credentials/InstanceProfileAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/InstanceProfileAWSCredentials.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using Amazon.Runtime.Internal.Util;
+using Amazon.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -155,7 +156,7 @@ namespace Amazon.Runtime
         private CredentialsRefreshState GetEarlyRefreshState(CredentialsRefreshState state)
         {
             // New expiry time = Now + _refreshAttemptPeriod + PreemptExpiryTime
-            var newExpiryTime = DateTime.Now + _refreshAttemptPeriod + PreemptExpiryTime;
+            var newExpiryTime = AWSSDKUtils.CorrectedUtcNow.ToLocalTime() + _refreshAttemptPeriod + PreemptExpiryTime;
             // Use this only if the time is earlier than the default expiration time
             if (newExpiryTime.ToUniversalTime() > state.Expiration.ToUniversalTime())
                 newExpiryTime = state.Expiration;

--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using Amazon.Runtime.Internal.Util;
+using Amazon.Util;
 using System;
 using System.Globalization;
 
@@ -128,7 +129,7 @@ namespace Amazon.Runtime
                 else
                     errorMessage = string.Format(CultureInfo.InvariantCulture,
                         "The retrieved credentials have already expired: Now = {0}, Credentials expiration = {1}",
-                        DateTime.Now, state.Expiration);
+                        AWSSDKUtils.CorrectedUtcNow.ToLocalTime(), state.Expiration);
                 throw new AmazonClientException(errorMessage);
             }
 
@@ -142,7 +143,7 @@ namespace Amazon.Runtime
                 var logger = Logger.GetLogger(typeof(RefreshingAWSCredentials));
                 logger.InfoFormat(
                     "The preempt expiry time is set too high: Current time = {0}, Credentials expiry time = {1}, Preempt expiry time = {2}.",
-                    DateTime.Now,
+                    AWSSDKUtils.CorrectedUtcNow.ToLocalTime(),
                     currentState.Expiration,
                     PreemptExpiryTime);
             }
@@ -160,7 +161,7 @@ namespace Amazon.Runtime
                     return true;
 
                 //  it's past the expiration time
-                var now = DateTime.UtcNow;
+                var now = AWSSDKUtils.CorrectedUtcNow;
                 var exp = currentState.Expiration.ToUniversalTime();
                 return (now > exp);
             }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/SAMLImmutableCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/SAMLImmutableCredentials.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using Amazon.Runtime.Internal.Util;
+using Amazon.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -153,7 +154,7 @@ namespace Amazon.Runtime
                 // get the expiry first - if the credentials have expired we can then
                 // ignore the data
                 var expires = DateTime.Parse((string)o[ExpiresProperty], CultureInfo.InvariantCulture).ToUniversalTime();
-                if (expires <= DateTime.UtcNow)
+                if (expires <= AWSSDKUtils.CorrectedUtcNow)
                 {
                     Logger.GetLogger(typeof(SAMLImmutableCredentials)).InfoFormat("Skipping serialized credentials due to expiry.");
                     return null;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Console.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Console.cs
@@ -84,7 +84,7 @@ namespace Amazon.Runtime.Internal.Util
         {
             string formatted = null;
             long sequence = Interlocked.Increment(ref _sequanceId);
-            string dt = DateTime.Now.ToString(AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture);
+            string dt = AWSSDKUtils.CorrectedUtcNow.ToLocalTime().ToString(AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture);
             string asString = logLevel.ToString().ToUpper(CultureInfo.InvariantCulture);
 
             if (ex != null)

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Metrics.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Metrics.cs
@@ -534,7 +534,7 @@ namespace Amazon.Runtime.Internal.Util
         public MetricError(Metric metric, string messageFormat, params object[] args) : this(metric, null, messageFormat, args) { }
         public MetricError(Metric metric, Exception exception, string messageFormat, params object[] args)
         {
-            Time = DateTime.Now;
+            Time = AWSSDKUtils.CorrectedUtcNow.ToLocalTime();
             try
             {
                 Message = string.Format(CultureInfo.InvariantCulture, messageFormat, args);

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/SdkCache.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/SdkCache.cs
@@ -326,7 +326,7 @@ namespace Amazon.Runtime.Internal.Util
             lock (CacheLock)
             {
                 Contents.Clear();
-                LastCacheClean = DateTime.Now;
+                LastCacheClean = AWSSDKUtils.CorrectedUtcNow.ToLocalTime();
             }
         }
         public List<TKey> Keys
@@ -454,7 +454,7 @@ namespace Amazon.Runtime.Internal.Util
         {
             if (item == null)
                 return false;
-            var cutoff = DateTime.Now - this.MaximumItemLifespan;
+            var cutoff = AWSSDKUtils.CorrectedUtcNow.ToLocalTime() - this.MaximumItemLifespan;
             if (item.LastUseTime < cutoff)
                 return false;
 
@@ -462,13 +462,13 @@ namespace Amazon.Runtime.Internal.Util
         }
         private void RemoveOldItems_Locked()
         {
-            if (LastCacheClean + CacheClearPeriod > DateTime.Now)
+            if (LastCacheClean + CacheClearPeriod > AWSSDKUtils.CorrectedUtcNow.ToLocalTime())
                 return;
 
             // Remove all items that were not accessed since the cutoff.
             // Using a cutoff is more optimal than item.Age, as we only need
             // to do DateTime calculation once, not for each item.
-            var cutoff = DateTime.Now - MaximumItemLifespan;
+            var cutoff = AWSSDKUtils.CorrectedUtcNow.ToLocalTime() - MaximumItemLifespan;
 
             var keysToRemove = new List<TKey>();
             foreach (var kvp in Contents)
@@ -483,7 +483,7 @@ namespace Amazon.Runtime.Internal.Util
             foreach (var key in keysToRemove)
                 Contents.Remove(key);
 
-            LastCacheClean = DateTime.Now;
+            LastCacheClean = AWSSDKUtils.CorrectedUtcNow.ToLocalTime();
         }
 
         private class CacheItem<T>
@@ -494,7 +494,7 @@ namespace Amazon.Runtime.Internal.Util
             {
                 get
                 {
-                    LastUseTime = DateTime.Now;
+                    LastUseTime = AWSSDKUtils.CorrectedUtcNow.ToLocalTime();
                     return _value;
                 }
                 private set
@@ -507,7 +507,7 @@ namespace Amazon.Runtime.Internal.Util
             public CacheItem(T value)
             {
                 Value = value;
-                LastUseTime = DateTime.Now;
+                LastUseTime = AWSSDKUtils.CorrectedUtcNow.ToLocalTime();
             }
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/_pcl/Logger.File.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/_pcl/Logger.File.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.Util.Internal;
+﻿using Amazon.Util;
+using Amazon.Util.Internal;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -161,7 +162,7 @@ namespace Amazon.Runtime.Internal.Util
                     messageFormat = InfoMsgFormat;
                     break;
             }
-            string currentTime = DateTime.UtcNow
+            string currentTime = AWSSDKUtils.CorrectedUtcNow
                          .ToString(DATE_FORMAT);
             LogMessage msg = new LogMessage(CultureInfo.InvariantCulture, messageFormat, currentTime, message);
             Queue(msg);

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
@@ -173,7 +173,7 @@ namespace Amazon.Runtime
 
             if (isHead || isClockskewErrorCode)
             {
-                var realNow = DateTime.UtcNow;
+                var realNow = AWSConfigs.utcNowSource();
                 var correctedNow = AWSSDKUtils.CorrectedUtcNow;
 
                 DateTime serverTime;
@@ -199,7 +199,7 @@ namespace Amazon.Runtime
 
                         // Always set the correction, for informational purposes
                         AWSConfigs.ClockOffset = newCorrection;
-                        var shouldRetry = AWSConfigs.CorrectForClockSkew;
+                        var shouldRetry = AWSConfigs.CorrectForClockSkew && !AWSConfigs.ManualClockCorrection.HasValue;
 
                         // Only retry if clock skew correction is not disabled
                         if (shouldRetry)

--- a/sdk/src/Core/Amazon.Util/AWSPublicIpAddressRanges.cs
+++ b/sdk/src/Core/Amazon.Util/AWSPublicIpAddressRanges.cs
@@ -145,7 +145,7 @@ namespace Amazon.Util
                 catch (FormatException) { }
                 catch (ArgumentNullException) { }
 
-                instance.CreateDate = creationDateTime.GetValueOrDefault(DateTime.Now.ToUniversalTime());
+                instance.CreateDate = creationDateTime.GetValueOrDefault(AWSSDKUtils.CorrectedUtcNow);
 
                 // ipv4 and v6 addresses occupy different keys in the data file and can't easily be merged
                 // so process each subset separately

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -825,7 +825,9 @@ namespace Amazon.Util
         }
 
         /// <summary>
-        /// Returns DateTime.UtcNow + ClockOffset when
+        /// Returns DateTime.UtcNow + ManualClockCorrection when
+        /// <seealso cref="AWSConfigs.ManualClockCorrection"/> is set.
+        /// Otherwise returns DateTime.UtcNow + ClockOffset when
         /// <seealso cref="AWSConfigs.CorrectForClockSkew"/> is true.
         /// This value should be used when constructing requests, as it
         /// will represent accurate time w.r.t. AWS servers.
@@ -834,8 +836,10 @@ namespace Amazon.Util
         {
             get
             {
-                var now = DateTime.UtcNow;
-                if (AWSConfigs.CorrectForClockSkew)
+                var now = AWSConfigs.utcNowSource();
+                if (AWSConfigs.ManualClockCorrection.HasValue)
+                    now += AWSConfigs.ManualClockCorrection.Value;
+                else if (AWSConfigs.CorrectForClockSkew)
                     now += AWSConfigs.ClockOffset;
                 return now;
             }

--- a/sdk/src/Core/Amazon.Util/_bcl+coreclr/ProfileManager.cs
+++ b/sdk/src/Core/Amazon.Util/_bcl+coreclr/ProfileManager.cs
@@ -897,7 +897,7 @@ namespace Amazon.Util
             SAMLImmutableCredentials session = null;
             lock (_synclock)
             {
-                if (_session != null && _session.Expires <= DateTime.UtcNow)
+                if (_session != null && _session.Expires <= AWSSDKUtils.CorrectedUtcNow)
                 {
                     UpdateProfileSessionData(null);
                     _session = null;

--- a/sdk/src/Services/CognitoSync/Custom/SyncManager/Storage/SQLiteLocalStorage.cs
+++ b/sdk/src/Services/CognitoSync/Custom/SyncManager/Storage/SQLiteLocalStorage.cs
@@ -304,7 +304,7 @@ namespace Amazon.CognitoSync.SyncManager.Internal
                             DatasetColumns.LAST_MODIFIED_TIMESTAMP
                         });
 
-                    CreateDatasetHelper(query, identityId, datasetName, DateTime.Now, DateTime.Now);
+                    CreateDatasetHelper(query, identityId, datasetName, AWSSDKUtils.CorrectedUtcNow.ToLocalTime(), AWSSDKUtils.CorrectedUtcNow.ToLocalTime());
 
                 }
             }
@@ -544,8 +544,8 @@ namespace Amazon.CognitoSync.SyncManager.Internal
                     if (databaseRecord.SyncCount != oldDatabaseRecord.SyncCount
                         || !StringUtils.Equals(databaseRecord.LastModifiedBy, oldDatabaseRecord.LastModifiedBy))
                     {
-                        continue;
-                    }
+                    continue;
+                }
 
                     if (!StringUtils.Equals(databaseRecord.Value, oldDatabaseRecord.Value))
                     {
@@ -575,9 +575,9 @@ namespace Amazon.CognitoSync.SyncManager.Internal
                     }
                     else
                     {
-                        UpdateOrInsertRecord(identityId, datasetName, record);
-                    }
-                }
+                UpdateOrInsertRecord(identityId, datasetName, record);
+            }
+        }
                 else
                 {
                     UpdateOrInsertRecord(identityId, datasetName, record);
@@ -627,7 +627,7 @@ namespace Amazon.CognitoSync.SyncManager.Internal
                 Statement s2 = new Statement
                 {
                     Query = deleteDatasetQuery,
-                    Parameters = new object[] { DateTime.Now, -1, identityId, datasetName }
+                    Parameters = new object[] { AWSSDKUtils.CorrectedUtcNow.ToLocalTime(), -1, identityId, datasetName }
                 };
 
                 List<Statement> statementsToExecute = new List<Statement>() { s1, s2 };
@@ -728,7 +728,7 @@ namespace Amazon.CognitoSync.SyncManager.Internal
                     RecordColumns.IDENTITY_ID + " = @whereIdentityId AND " +
                     RecordColumns.DATASET_NAME + " = @whereDatasetName "
                 );
-                UpdateLastSyncCountHelper(query, lastSyncCount, DateTime.Now, identityId, datasetName);
+                UpdateLastSyncCountHelper(query, lastSyncCount, AWSSDKUtils.CorrectedUtcNow.ToLocalTime(), identityId, datasetName);
             }
         }
 
@@ -776,7 +776,7 @@ namespace Amazon.CognitoSync.SyncManager.Internal
                               + " WHERE " + DatasetColumns.IDENTITY_ID + " = @" + DatasetColumns.IDENTITY_ID
                               + " AND " + DatasetColumns.DATASET_NAME + " = @old" + DatasetColumns.DATASET_NAME + " ";
 
-                        string timestamp = AWSSDKUtils.ConvertToUnixEpochMilliSeconds(DateTime.UtcNow).ToString(CultureInfo.InvariantCulture);
+                        string timestamp = AWSSDKUtils.ConvertToUnixEpochMilliSeconds(AWSSDKUtils.CorrectedUtcNow).ToString(CultureInfo.InvariantCulture);
 
                         Statement updateDatasetStatement = new Statement()
                         {
@@ -956,7 +956,7 @@ namespace Amazon.CognitoSync.SyncManager.Internal
                     DatasetColumns.IDENTITY_ID + " = @whereIdentityId AND " +
                     DatasetColumns.DATASET_NAME + " = @whereDatasetName "
                 );
-                UpdateLastModifiedTimestampHelper(query, DateTime.Now, identityId, datasetName);
+                UpdateLastModifiedTimestampHelper(query, AWSSDKUtils.CorrectedUtcNow.ToLocalTime(), identityId, datasetName);
             }
         }
 
@@ -1025,7 +1025,7 @@ namespace Amazon.CognitoSync.SyncManager.Internal
                     string insertRecord = RecordColumns.BuildInsert();
                     ExecuteMultipleHelper(new List<Statement>{new Statement{
                     Query = insertRecord,
-                    Parameters = new object[]{identityId,datasetName,key,value,0,DateTime.Now,string.Empty,DateTime.Now,1}
+                    Parameters = new object[]{identityId,datasetName,key,value,0,AWSSDKUtils.CorrectedUtcNow.ToLocalTime(),string.Empty,AWSSDKUtils.CorrectedUtcNow.ToLocalTime(),1}
                     }});
                     return true;
                 }
@@ -1044,7 +1044,7 @@ namespace Amazon.CognitoSync.SyncManager.Internal
                     );
                     ExecuteMultipleHelper(new List<Statement>{new Statement{
                     Query = insertRecord,
-                    Parameters = new object[]{identityId,datasetName,key,value,1,record.SyncCount,DateTime.Now,identityId,datasetName,key}
+                    Parameters = new object[]{identityId,datasetName,key,value,1,record.SyncCount,AWSSDKUtils.CorrectedUtcNow.ToLocalTime(),identityId,datasetName,key}
                     }});
                     return true;
                 }

--- a/sdk/src/Services/MobileAnalytics/Custom/MobileAnalyticsManager.cs
+++ b/sdk/src/Services/MobileAnalytics/Custom/MobileAnalyticsManager.cs
@@ -279,7 +279,7 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager
             if (null == customEvent)
                 throw new ArgumentNullException("customEvent");
 
-            customEvent.Timestamp = DateTime.UtcNow;
+            customEvent.Timestamp = AWSSDKUtils.CorrectedUtcNow;
             Amazon.MobileAnalytics.Model.Event modelEvent = customEvent.ConvertToMobileAnalyticsModelEvent(this.Session);
 
             BackgroundDeliveryClient.EnqueueEventsForDelivery(modelEvent);

--- a/sdk/src/Services/MobileAnalytics/Custom/Session/Session.cs
+++ b/sdk/src/Services/MobileAnalytics/Custom/Session/Session.cs
@@ -165,7 +165,7 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
                     return;
                 }
 
-                DateTime currentTime = DateTime.UtcNow;
+                DateTime currentTime = AWSSDKUtils.CorrectedUtcNow;
                 if (this.StopTime.Value < currentTime)
                 {
                     // new session 
@@ -192,8 +192,8 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
         private void NewSessionHelper()
         {
 
-            StartTime = DateTime.UtcNow;
-            PreStartTime = DateTime.UtcNow;
+            StartTime = AWSSDKUtils.CorrectedUtcNow;
+            PreStartTime = AWSSDKUtils.CorrectedUtcNow;
             StopTime = null;
             SessionId = Guid.NewGuid().ToString();
             Duration = 0;
@@ -208,7 +208,7 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
 
         private void StopSessionHelper()
         {
-            DateTime currentTime = DateTime.UtcNow;
+            DateTime currentTime = AWSSDKUtils.CorrectedUtcNow;
 
             // update session info
             StopTime = currentTime;
@@ -228,7 +228,7 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
 
         private void PauseSessionHelper()
         {
-            DateTime currentTime = DateTime.UtcNow;
+            DateTime currentTime = AWSSDKUtils.CorrectedUtcNow;
 
             // update session info
             StopTime = currentTime;
@@ -247,7 +247,7 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
 
         private void ResumeSessionHelper()
         {
-            DateTime currentTime = DateTime.UtcNow;
+            DateTime currentTime = AWSSDKUtils.CorrectedUtcNow;
 
             // update session info
             PreStartTime = currentTime;

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
@@ -567,7 +567,7 @@ namespace Amazon.S3.Util
             var request = new GetPreSignedUrlRequest
             {
                 BucketName = bucketName,
-                Expires = DateTime.Now.AddDays(1),
+                Expires = AWSSDKUtils.CorrectedUtcNow.ToLocalTime().AddDays(1),
                 Verb = HttpVerb.HEAD,
                 Protocol = Protocol.HTTP
             };

--- a/sdk/src/Services/S3/Custom/Util/BucketRegionDetector.cs
+++ b/sdk/src/Services/S3/Custom/Util/BucketRegionDetector.cs
@@ -121,7 +121,7 @@ namespace Amazon.S3.Util
             var request = new GetPreSignedUrlRequest
             {
                 BucketName = bucketName,
-                Expires = DateTime.Now.AddDays(1),
+                Expires = AWSSDKUtils.CorrectedUtcNow.ToLocalTime().AddDays(1),
                 Verb = HttpVerb.HEAD,
                 Protocol = Protocol.HTTP
             };

--- a/sdk/src/Services/S3/Custom/Util/_bcl/AmazonS3Util.Operations.cs
+++ b/sdk/src/Services/S3/Custom/Util/_bcl/AmazonS3Util.Operations.cs
@@ -66,7 +66,7 @@ namespace Amazon.S3.Util
             var request = new GetPreSignedUrlRequest
             {
                 BucketName = bucketName, 
-                Expires = DateTime.Now.AddDays(1), 
+                Expires = AWSSDKUtils.CorrectedUtcNow.ToLocalTime().AddDays(1), 
                 Verb = HttpVerb.HEAD, 
                 Protocol = Protocol.HTTP
             };

--- a/sdk/src/Services/S3/Custom/_bcl/IO/S3DirectoryInfo.cs
+++ b/sdk/src/Services/S3/Custom/_bcl/IO/S3DirectoryInfo.cs
@@ -1184,7 +1184,7 @@ namespace Amazon.S3.IO
         {
             int success = 0;
             bool currentState = false;
-            long start = DateTime.Now.Ticks;
+            var start = AWSSDKUtils.CorrectedUtcNow;
             do
             {
                 var buckets = this.S3Client.ListBuckets().Buckets;
@@ -1204,7 +1204,7 @@ namespace Amazon.S3.IO
 
                 Thread.Sleep(EVENTUAL_CONSISTENCY_POLLING_PERIOD);
 
-            } while (new TimeSpan(DateTime.Now.Ticks - start).TotalMilliseconds < EVENTUAL_CONSISTENCY_MAX_WAIT) ;
+            } while ((AWSSDKUtils.CorrectedUtcNow - start).TotalMilliseconds < EVENTUAL_CONSISTENCY_MAX_WAIT) ;
         }
     }
 

--- a/sdk/src/Services/S3/Custom/_unity/AmazonS3Client.unity.cs
+++ b/sdk/src/Services/S3/Custom/_unity/AmazonS3Client.unity.cs
@@ -158,13 +158,13 @@ namespace Amazon.S3
             int position = request.Key.LastIndexOf('/');
             if (position == -1)
             {
-                policyString = "{\"expiration\": \"" + DateTime.UtcNow.AddHours(24).ToString("yyyy-MM-ddTHH:mm:ssZ") + "\",\"conditions\": [{\"bucket\": \"" +
+                policyString = "{\"expiration\": \"" + AWSSDKUtils.CorrectedUtcNow.AddHours(24).ToString("yyyy-MM-ddTHH:mm:ssZ") + "\",\"conditions\": [{\"bucket\": \"" +
                     request.Bucket + "\"},[\"starts-with\", \"$key\", \"" + "\"],{\"acl\": \"" + request.CannedACL.Value + "\"},[\"eq\", \"$Content-Type\", " +
                     "\"" + request.Headers.ContentType + "\"" + "]" + metadataPolicy.ToString() + headersPolicy.ToString() + "]}";
             }
             else
             {
-                policyString = "{\"expiration\": \"" + DateTime.UtcNow.AddHours(24).ToString("yyyy-MM-ddTHH:mm:ssZ") + "\",\"conditions\": [{\"bucket\": \"" +
+                policyString = "{\"expiration\": \"" + AWSSDKUtils.CorrectedUtcNow.AddHours(24).ToString("yyyy-MM-ddTHH:mm:ssZ") + "\",\"conditions\": [{\"bucket\": \"" +
                     request.Bucket + "\"},[\"starts-with\", \"$key\", \"" + request.Key.Substring(0, position) + "/\"],{\"acl\": \"" + request.CannedACL.Value +
                     "\"},[\"eq\", \"$Content-Type\", " + "\"" + request.Headers.ContentType + "\"" + "]" + metadataPolicy.ToString() + headersPolicy.ToString() + "]}";
             }

--- a/sdk/src/Services/SecurityToken/Custom/_bcl/SAML/StoredProfileSAMLCredentials.cs
+++ b/sdk/src/Services/SecurityToken/Custom/_bcl/SAML/StoredProfileSAMLCredentials.cs
@@ -248,7 +248,7 @@ namespace Amazon.SecurityToken.SAML
                 using (var stsClient = new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials(), region))
                 {
                     var credentials = assertion.GetRoleCredentials(stsClient, ProfileData.RoleArn, credentialDuration);
-                    state = new CredentialsRefreshState(credentials, DateTime.UtcNow + credentialDuration);
+                    state = new CredentialsRefreshState(credentials, AWSSDKUtils.CorrectedUtcNow + credentialDuration);
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Workaround for exception "The retrieved credentials have already expired". This PR improves PR https://github.com/aws/aws-sdk-net/pull/404.
This allows using other DateTime source (NTP) instead of device time.

Usage:

```
private void OnApplicationReceivedReliableDate(DateTime reliableDate)
{
    AWSConfigs.ManualClockCorrection = reliableDate - DateTime.UtcNow;
}
```

Added public property `TimeSpan? AWSConfigs.ManualClockCorrection`. 
`AWSConfigs.ManualClockCorrection` has higher priority than `AWSConfigs.CorrectForClockSkew`.
Added test `General.TestManualClockCorrection`.
Fixed test `General.TestClockSkewCorrection`. This test was doing nothing because it could not find services in the core assembly.
Added internal field `Func<DateTime> AWSConfigs::utcNowSource`. This allows tests to simulate skewed client clock.
Replaced occurrences of `DateTime.UtcNow` to `AWSSDKUtils.CorrectedUtcNow`.

Related issues: https://github.com/aws/aws-sdk-net/issues/393 https://github.com/aws/aws-sdk-net/issues/402
