### PR TITLE
Close HttpWebRequest's response stream on WebExceptions

### DIFF
--- a/AWSSDK_DotNet35/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
+++ b/AWSSDK_DotNet35/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
@@ -18,6 +18,7 @@ using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
 using System;
 using System.Globalization;
+using System.Net;
 using System.Reflection;
 using System.Text;
 
@@ -103,7 +104,14 @@ namespace Amazon.Runtime.Internal
                 {
                     response = httpRequest.GetResponse();
                 }
-                catch { }
+                catch(WebException webException)
+                {
+                    webException.Response.Close();
+                }
+                catch(HttpErrorResponseException httpErrorResponse)
+                {
+                    httpErrorResponse.Response.ResponseBody.Dispose();
+                }
                 finally
                 {
                     if (response != null && response.ResponseBody != null)

--- a/AWSSDK_DotNet35/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
+++ b/AWSSDK_DotNet35/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
@@ -61,7 +61,7 @@ namespace Amazon.Runtime.Internal
             try
             {
                 SetMetrics(executionContext.RequestContext);
-                IRequest wrappedRequest = executionContext.RequestContext.Request; 
+                IRequest wrappedRequest = executionContext.RequestContext.Request;
                 httpRequest = CreateWebRequest(executionContext.RequestContext);
                 httpRequest.SetRequestHeaders(wrappedRequest.Headers);
 
@@ -104,13 +104,14 @@ namespace Amazon.Runtime.Internal
                 {
                     response = httpRequest.GetResponse();
                 }
-                catch(WebException webException)
+                catch (WebException webException)
                 {
-                    webException.Response.Close();
+                    if (webException.Response != null) webException.Response.Close();
                 }
-                catch(HttpErrorResponseException httpErrorResponse)
+                catch (HttpErrorResponseException httpErrorResponse)
                 {
-                    httpErrorResponse.Response.ResponseBody.Dispose();
+                    if (httpErrorResponse.Response != null && httpErrorResponse.Response.ResponseBody != null)
+                        httpErrorResponse.Response.ResponseBody.Dispose();
                 }
                 finally
                 {
@@ -120,8 +121,8 @@ namespace Amazon.Runtime.Internal
             }
             catch { }
         }
-		
-#if AWS_ASYNC_API 
+
+#if AWS_ASYNC_API
 
         /// <summary>
         /// Issues an HTTP request for the current request context.
@@ -218,8 +219,8 @@ namespace Amazon.Runtime.Internal
                 {
                     // First call, initialize an async result.
                     executionContext.ResponseContext.AsyncResult =
-                        new RuntimeAsyncResult(executionContext.RequestContext.Callback, 
-                            executionContext.RequestContext.State);                    
+                        new RuntimeAsyncResult(executionContext.RequestContext.Callback,
+                            executionContext.RequestContext.State);
                 }
 
                 // Set request headers
@@ -233,7 +234,7 @@ namespace Amazon.Runtime.Internal
                 }
                 else
                 {
-                    
+
                     // Get response if there is no response body to send.
                     httpRequest.BeginGetResponse(new AsyncCallback(GetResponseCallback), executionContext);
                 }
@@ -250,7 +251,7 @@ namespace Amazon.Runtime.Internal
                 }
 
                 if (httpRequest != null)
-                {                    
+                {
                     httpRequest.Dispose();
                 }
 
@@ -274,8 +275,8 @@ namespace Amazon.Runtime.Internal
                 //var requestStream = httpRequest.EndSetRequestBody(result);                
                 httpRequest.BeginGetResponse(new AsyncCallback(GetResponseCallback), executionContext);
             }
-            catch(Exception exception)
-            {   
+            catch (Exception exception)
+            {
                 httpRequest.Dispose();
 
                 // Capture the exception and invoke outer handlers to 
@@ -298,7 +299,7 @@ namespace Amazon.Runtime.Internal
                 executionContext.ResponseContext.HttpResponse = httpResponse;
             }
             catch (Exception exception)
-            {   
+            {
                 // Capture the exception and invoke outer handlers to 
                 // process the exception.
                 executionContext.ResponseContext.AsyncResult.Exception = exception;
@@ -309,7 +310,7 @@ namespace Amazon.Runtime.Internal
                 httpRequest.Dispose();
                 base.InvokeAsyncCallback(executionContext);
             }
-        }       
+        }
 
 #endif
 
@@ -358,7 +359,7 @@ namespace Amazon.Runtime.Internal
                                                      wrappedRequest.AWS4SignerResult)
                     : originalStream;
 
-                httpRequest.WriteToRequestBody(requestContent, inputStream, 
+                httpRequest.WriteToRequestBody(requestContent, inputStream,
                     requestContext.Request.Headers, requestContext);
 
             }


### PR DESCRIPTION
If `httpRequest.GetResponse()` internally throws a `WebException` then there is still a response stream to close. I believe this is causing sockets to remain open and leading to #152 