### PR TITLE
Fix LruCache NullReferenceException

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/LruCache.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/LruCache.cs
@@ -160,6 +160,7 @@ namespace Amazon.Runtime.Internal.Util
                 }
                 else
                 {
+                    Head.Previous = item;
                     item.Next = Head;
                     item.Previous = null;
                     Head = item;

--- a/sdk/test/UnitTests/Custom/Runtime/LruCacheTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/LruCacheTests.cs
@@ -1,0 +1,30 @@
+﻿using Amazon;
+using Amazon.Runtime.Internal.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSSDK_DotNet35.UnitTests.Custom.Runtime
+{
+    [TestClass()]
+    public class LruCacheTests
+    {
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestLruCacheTryGetValue()
+        {
+            RegionEndpoint regionEndpoint;
+            var lru = new LruCache<string, RegionEndpoint>(5);
+
+            lru.AddOrUpdate("my-bucket-us-east-1", RegionEndpoint.USEast1);
+            lru.AddOrUpdate("my-bucket-us-west-2", RegionEndpoint.USWest2);
+            lru.AddOrUpdate("my-bucket-ap-northeast-2", RegionEndpoint.APNortheast2);
+            lru.AddOrUpdate("my-bucket-sa-east-1", RegionEndpoint.SAEast1);
+
+            lru.TryGetValue("my-bucket-us-west-2", out regionEndpoint);
+            Assert.AreEqual(RegionEndpoint.USWest2, regionEndpoint);
+
+            lru.TryGetValue("my-bucket-ap-northeast-2", out regionEndpoint);
+            Assert.AreEqual(RegionEndpoint.APNortheast2, regionEndpoint);
+        }
+    }
+}


### PR DESCRIPTION
The method `S3Signer.Sign()`, when using V4, uses the `LruCache` utility.
Found the utility fails to properly link the elements in the LRU list, causing a `NullReferenceException` whenever it tries to get any item in the middle of the list.
Here is the fix, with a unit test to verify it.