### PR TITLE
Glacier: Allow setting retrieval tier using ArchiveTransferManager

### DIFF
--- a/sdk/src/Services/Glacier/Custom/_bcl+coreclr/Transfer/InitiateArchiveRetrievalOptions.cs
+++ b/sdk/src/Services/Glacier/Custom/_bcl+coreclr/Transfer/InitiateArchiveRetrievalOptions.cs
@@ -33,5 +33,18 @@ namespace Amazon.Glacier.Transfer
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets and sets the Glacier retrieval Tier. 
+        /// <para>
+        /// The retrieval option to use for the archive retrieval. Valid values are <code>Expedited</code>,
+        /// <code>Standard</code>, or <code>Bulk</code>. <code>Standard</code> is the default.
+        /// </para>
+        /// </summary>
+        public string Tier
+        {
+            get;
+            set;
+        }
     }
 }

--- a/sdk/src/Services/Glacier/Custom/_bcl+coreclr/Transfer/_async/ArchiveTransferManager.async.cs
+++ b/sdk/src/Services/Glacier/Custom/_bcl+coreclr/Transfer/_async/ArchiveTransferManager.async.cs
@@ -238,6 +238,7 @@ namespace Amazon.Glacier.Transfer
             {
                 jobRequest.AccountId = options.AccountId;
                 jobRequest.JobParameters.SNSTopic = options.SNSTopic;
+                jobRequest.JobParameters.Tier = options.Tier;
             }
 
             var glacierClientTask = await glacierClient.InitiateJobAsync(jobRequest).ConfigureAwait(false);

--- a/sdk/src/Services/Glacier/Custom/_bcl+coreclr/Transfer/_bcl/ArchiveTransferManager.bcl.cs
+++ b/sdk/src/Services/Glacier/Custom/_bcl+coreclr/Transfer/_bcl/ArchiveTransferManager.bcl.cs
@@ -245,6 +245,7 @@ namespace Amazon.Glacier.Transfer
             {
                 jobRequest.AccountId = options.AccountId;
                 jobRequest.JobParameters.SNSTopic = options.SNSTopic;
+                jobRequest.JobParameters.Tier = options.Tier;
             }
 
             var jobId = glacierClient.InitiateJob(jobRequest).JobId;


### PR DESCRIPTION
This introduces the Tier option from JobParameters into InitiateArchiveRetrievalOptions so the retrieval speed can be set.