### PR TITLE
Updating SQS constants for FIFO-related attributes.

### DIFF
--- a/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
+++ b/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
@@ -175,22 +175,38 @@ namespace Amazon.SQS.Model
         /// <summary>
         /// Whether or not the queue is a First-In-First-Out (FIFO) queue
         /// </summary>
-        public bool? FifoQueue
+        public bool FifoQueue
         {
             get
             {
-                return getAttributeValue(SQSConstants.ATTRIBUTE_FIFO_QUEUE)?.ToUpper().Equals("TRUE");
+                var attributeValue = getAttributeValue(SQSConstants.ATTRIBUTE_FIFO_QUEUE);
+
+                if (attributeValue == null || attributeValue.Trim() == string.Empty)
+                {
+                    return false;
+                }
+
+                bool result;
+                return bool.TryParse(attributeValue, out result);
             }
         }
 
         /// <summary>
         /// Whether or not the First-In-First-Out (FIFO) queue has content based deduplication enabled
         /// </summary>
-        public bool? ContentBasedDeduplication
+        public bool ContentBasedDeduplication
         {
             get
             {
-                return getAttributeValue(SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION)?.ToUpper().Equals("TRUE");
+                var attributeValue = getAttributeValue(SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION);
+
+                if (attributeValue == null || attributeValue.Trim() == string.Empty)
+                {
+                    return false;
+                }
+
+                bool result;
+                return bool.TryParse(attributeValue, out result);
             }
         }
 

--- a/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
+++ b/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
@@ -13,12 +13,7 @@
  * permissions and limitations under the License.
  */
 using System;
-using System.Collections.Generic;
-using System.Xml.Serialization;
-using System.Text;
-using System.IO;
 
-using Amazon.Runtime;
 using Amazon.SQS.Util;
 using Amazon.Util;
 
@@ -84,7 +79,6 @@ namespace Amazon.SQS.Model
                 return value;
             }
         }
-
 
         /// <summary>
         /// Gets the approximate number of messages from the Attributes collection.
@@ -175,6 +169,28 @@ namespace Amazon.SQS.Model
             get
             {
                 return getAttributeValue(SQSConstants.ATTRIBUTE_POLICY);
+            }
+        }
+
+        /// <summary>
+        /// Whether or not the queue is a First-In-First-Out (FIFO) queue
+        /// </summary>
+        public bool? FifoQueue
+        {
+            get
+            {
+                return getAttributeValue(SQSConstants.ATTRIBUTE_FIFO_QUEUE)?.ToUpper().Equals("TRUE");
+            }
+        }
+
+        /// <summary>
+        /// Whether or not the First-In-First-Out (FIFO) queue has content based deduplication enabled
+        /// </summary>
+        public bool? ContentBasedDeduplication
+        {
+            get
+            {
+                return getAttributeValue(SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION)?.ToUpper().Equals("TRUE");
             }
         }
 

--- a/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
+++ b/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
@@ -197,15 +197,10 @@ namespace Amazon.SQS.Model
             {
                 var attributeValue = getAttributeValue(SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION);
 
-                if (attributeValue == null || attributeValue.Trim() == string.Empty)
-                {
-                    return null;
-                }
-
                 bool result;
                 if (bool.TryParse(attributeValue, out result))
                     return result;
-                return false;
+                return null;
             }
         }
 

--- a/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
+++ b/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
@@ -181,13 +181,10 @@ namespace Amazon.SQS.Model
             {
                 var attributeValue = getAttributeValue(SQSConstants.ATTRIBUTE_FIFO_QUEUE);
 
-                if (attributeValue == null || attributeValue.Trim() == string.Empty)
-                {
-                    return false;
-                }
-
                 bool result;
-                return bool.TryParse(attributeValue, out result);
+                if (bool.TryParse(attributeValue, out result))
+                    return result;
+                return false;
             }
         }
 

--- a/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
+++ b/sdk/src/Services/SQS/Custom/Model/GetQueueAttributesResponse.extensions.cs
@@ -192,9 +192,9 @@ namespace Amazon.SQS.Model
         }
 
         /// <summary>
-        /// Whether or not the First-In-First-Out (FIFO) queue has content based deduplication enabled
+        /// Whether or not the First-In-First-Out (FIFO) queue has content based deduplication enabled. For non-FIFO queues this will return null.
         /// </summary>
-        public bool ContentBasedDeduplication
+        public bool? ContentBasedDeduplication
         {
             get
             {
@@ -202,11 +202,13 @@ namespace Amazon.SQS.Model
 
                 if (attributeValue == null || attributeValue.Trim() == string.Empty)
                 {
-                    return false;
+                    return null;
                 }
 
                 bool result;
-                return bool.TryParse(attributeValue, out result);
+                if (bool.TryParse(attributeValue, out result))
+                    return result;
+                return false;
             }
         }
 

--- a/sdk/src/Services/SQS/Custom/Util/SQSConstants.cs
+++ b/sdk/src/Services/SQS/Custom/Util/SQSConstants.cs
@@ -100,5 +100,15 @@ namespace Amazon.SQS.Util
         /// The parameters for dead letter queue functionality of the source queue. For more information about RedrivePolicy and dead letter queues, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html">Using Amazon SQS Dead Letter Queues</a> in the <i>Amazon SQS Developer Guide</i>.
         /// </summary>
         public const string ATTRIBUTE_REDRIVE_POLICY = "RedrivePolicy";
+		
+		/// <summary>
+        /// Enables content-based deduplication on a First-In-First-Out (FIFO) queue. For more information see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing">Exactly-Once Processing</a> in the <i>Amazon SQS Developer Guide</i>.
+        /// </summary>
+		public const string ATTRIBUTE_CONTENT_BASED_DEDUPLICATION = "ContentBasedDeduplication";
+		
+		/// <summary>
+        /// Specifies whether or not the queue is a First-In-First-Out (FIFO) queue.
+        /// </summary>
+		public const string ATTRIBUTE_FIFO_QUEUE = "FifoQueue";
     }
 }

--- a/sdk/src/Services/SQS/Custom/Util/SQSConstants.cs
+++ b/sdk/src/Services/SQS/Custom/Util/SQSConstants.cs
@@ -107,7 +107,7 @@ namespace Amazon.SQS.Util
         public const string ATTRIBUTE_CONTENT_BASED_DEDUPLICATION = "ContentBasedDeduplication";
 
         /// <summary>
-        /// Specifies whether or not the queue is a First-In-First-Out (FIFO) queue.
+        /// Designates a queue as a First-In-First-Out (FIFO) queue. You can provide this attribute only during queue creation. You can't change it for an existing queue. When you set this attribute, you must also provide the <code>MessageGroupId</code> for your messages explicitly.
         /// </summary>
         public const string ATTRIBUTE_FIFO_QUEUE = "FifoQueue";
     }

--- a/sdk/src/Services/SQS/Custom/Util/SQSConstants.cs
+++ b/sdk/src/Services/SQS/Custom/Util/SQSConstants.cs
@@ -100,15 +100,15 @@ namespace Amazon.SQS.Util
         /// The parameters for dead letter queue functionality of the source queue. For more information about RedrivePolicy and dead letter queues, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html">Using Amazon SQS Dead Letter Queues</a> in the <i>Amazon SQS Developer Guide</i>.
         /// </summary>
         public const string ATTRIBUTE_REDRIVE_POLICY = "RedrivePolicy";
-		
-		/// <summary>
+
+        /// <summary>
         /// Enables content-based deduplication on a First-In-First-Out (FIFO) queue. For more information see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing">Exactly-Once Processing</a> in the <i>Amazon SQS Developer Guide</i>.
         /// </summary>
-		public const string ATTRIBUTE_CONTENT_BASED_DEDUPLICATION = "ContentBasedDeduplication";
-		
-		/// <summary>
+        public const string ATTRIBUTE_CONTENT_BASED_DEDUPLICATION = "ContentBasedDeduplication";
+
+        /// <summary>
         /// Specifies whether or not the queue is a First-In-First-Out (FIFO) queue.
         /// </summary>
-		public const string ATTRIBUTE_FIFO_QUEUE = "FifoQueue";
+        public const string ATTRIBUTE_FIFO_QUEUE = "FifoQueue";
     }
 }

--- a/sdk/test/IntegrationTests/Tests/SQS.cs
+++ b/sdk/test/IntegrationTests/Tests/SQS.cs
@@ -242,11 +242,13 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             var attrResults = Client.GetQueueAttributes(new GetQueueAttributesRequest()
             {
                 QueueUrl = result.QueueUrl,
-                AttributeNames = new List<string>() { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT }
+                AttributeNames = new List<string>() { SQSConstants.ATTRIBUTE_ALL }
             });
 
-            Assert.AreEqual(1, attrResults.Attributes.Count);
+            Assert.AreEqual(11, attrResults.Attributes.Count);
             Assert.AreEqual(int.Parse(defaultTimeout), int.Parse(attrResults.Attributes[SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT]));
+            Assert.AreEqual(false, attrResults.FifoQueue);
+            Assert.AreEqual(false, attrResults.ContentBasedDeduplication);
 
             for (int i = 0; i < 30; i++)
             {
@@ -289,10 +291,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                     AttributeNames = new List<string>() { SQSConstants.ATTRIBUTE_FIFO_QUEUE, SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION }
                 });
 
-                Assert.AreEqual(true, attrResults.FifoQueue.HasValue);
                 Assert.AreEqual(true, attrResults.FifoQueue);
 
-                Assert.AreEqual(true, attrResults.ContentBasedDeduplication.HasValue);
                 Assert.AreEqual(true, attrResults.ContentBasedDeduplication);
             }
         }

--- a/sdk/test/IntegrationTests/Tests/SQS.cs
+++ b/sdk/test/IntegrationTests/Tests/SQS.cs
@@ -261,5 +261,40 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
 
             return "fail";
         }
+
+        [TestMethod]
+        [TestCategory("SQS")]
+        public void SQSFIFOTest()
+        {
+            string fifoQueueName = prefix + new Random().Next() + ".fifo";
+
+            var sqsClient = new AmazonSQSClient(RegionEndpoint.USEast2);
+            var result = sqsClient.CreateQueue(new CreateQueueRequest()
+            {
+                QueueName = fifoQueueName,
+                Attributes = new Dictionary<string, string>
+                {
+                    [SQSConstants.ATTRIBUTE_FIFO_QUEUE] = "true",
+                    [SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION] = "true"
+                }
+            });
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.QueueUrl);
+
+            var attrResults = sqsClient.GetQueueAttributes(new GetQueueAttributesRequest()
+            {
+                QueueUrl = result.QueueUrl,
+                AttributeNames = new List<string>() { SQSConstants.ATTRIBUTE_FIFO_QUEUE, SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION }
+            });
+
+            sqsClient.Dispose();
+
+            Assert.AreEqual(true, attrResults.FifoQueue.HasValue);
+            Assert.AreEqual(true, attrResults.FifoQueue);
+
+            Assert.AreEqual(true, attrResults.ContentBasedDeduplication.HasValue);
+            Assert.AreEqual(true, attrResults.ContentBasedDeduplication);
+        }
     }
 }

--- a/sdk/test/IntegrationTests/Tests/SQS.cs
+++ b/sdk/test/IntegrationTests/Tests/SQS.cs
@@ -248,7 +248,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             Assert.AreEqual(11, attrResults.Attributes.Count);
             Assert.AreEqual(int.Parse(defaultTimeout), int.Parse(attrResults.Attributes[SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT]));
             Assert.AreEqual(false, attrResults.FifoQueue);
-            Assert.AreEqual(false, attrResults.ContentBasedDeduplication);
+            Assert.AreEqual(false, attrResults.ContentBasedDeduplication.HasValue);
+            Assert.AreEqual(null, attrResults.ContentBasedDeduplication);
 
             for (int i = 0; i < 30; i++)
             {

--- a/sdk/test/IntegrationTests/Tests/SQS.cs
+++ b/sdk/test/IntegrationTests/Tests/SQS.cs
@@ -268,33 +268,33 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
         {
             string fifoQueueName = prefix + new Random().Next() + ".fifo";
 
-            var sqsClient = new AmazonSQSClient(RegionEndpoint.USEast2);
-            var result = sqsClient.CreateQueue(new CreateQueueRequest()
+            using (var sqsClient = new AmazonSQSClient(RegionEndpoint.USEast2))
             {
-                QueueName = fifoQueueName,
-                Attributes = new Dictionary<string, string>
+                var result = sqsClient.CreateQueue(new CreateQueueRequest()
                 {
-                    [SQSConstants.ATTRIBUTE_FIFO_QUEUE] = "true",
-                    [SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION] = "true"
-                }
-            });
+                    QueueName = fifoQueueName,
+                    Attributes = new Dictionary<string, string>
+                    {
+                        [SQSConstants.ATTRIBUTE_FIFO_QUEUE] = "true",
+                        [SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION] = "true"
+                    }
+                });
 
-            Assert.IsNotNull(result);
-            Assert.IsNotNull(result.QueueUrl);
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.QueueUrl);
 
-            var attrResults = sqsClient.GetQueueAttributes(new GetQueueAttributesRequest()
-            {
-                QueueUrl = result.QueueUrl,
-                AttributeNames = new List<string>() { SQSConstants.ATTRIBUTE_FIFO_QUEUE, SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION }
-            });
+                var attrResults = sqsClient.GetQueueAttributes(new GetQueueAttributesRequest()
+                {
+                    QueueUrl = result.QueueUrl,
+                    AttributeNames = new List<string>() { SQSConstants.ATTRIBUTE_FIFO_QUEUE, SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION }
+                });
 
-            sqsClient.Dispose();
+                Assert.AreEqual(true, attrResults.FifoQueue.HasValue);
+                Assert.AreEqual(true, attrResults.FifoQueue);
 
-            Assert.AreEqual(true, attrResults.FifoQueue.HasValue);
-            Assert.AreEqual(true, attrResults.FifoQueue);
-
-            Assert.AreEqual(true, attrResults.ContentBasedDeduplication.HasValue);
-            Assert.AreEqual(true, attrResults.ContentBasedDeduplication);
+                Assert.AreEqual(true, attrResults.ContentBasedDeduplication.HasValue);
+                Assert.AreEqual(true, attrResults.ContentBasedDeduplication);
+            }
         }
     }
 }

--- a/sdk/test/IntegrationTests/Tests/SQS.cs
+++ b/sdk/test/IntegrationTests/Tests/SQS.cs
@@ -261,40 +261,5 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
 
             return "fail";
         }
-
-        [TestMethod]
-        [TestCategory("SQS")]
-        public void SQSFIFOTest()
-        {
-            string fifoQueueName = prefix + new Random().Next() + ".fifo";
-
-            var sqsClient = new AmazonSQSClient(RegionEndpoint.USEast2);
-            var result = sqsClient.CreateQueue(new CreateQueueRequest()
-            {
-                QueueName = fifoQueueName,
-                Attributes = new Dictionary<string, string>
-                {
-                    [SQSConstants.ATTRIBUTE_FIFO_QUEUE] = "true",
-                    [SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION] = "true"
-                }
-            });
-
-            Assert.IsNotNull(result);
-            Assert.IsNotNull(result.QueueUrl);
-
-            var attrResults = sqsClient.GetQueueAttributes(new GetQueueAttributesRequest()
-            {
-                QueueUrl = result.QueueUrl,
-                AttributeNames = new List<string>() { SQSConstants.ATTRIBUTE_FIFO_QUEUE, SQSConstants.ATTRIBUTE_CONTENT_BASED_DEDUPLICATION }
-            });
-
-            sqsClient.Dispose();
-
-            Assert.AreEqual(true, attrResults.FifoQueue.HasValue);
-            Assert.AreEqual(true, attrResults.FifoQueue);
-
-            Assert.AreEqual(true, attrResults.ContentBasedDeduplication.HasValue);
-            Assert.AreEqual(true, attrResults.ContentBasedDeduplication);
-        }
     }
 }


### PR DESCRIPTION
Updating SQS constants for FIFO-related attributes.

## Description
Add constants to represent attributes; `FifoQueue` and `ContentBasedDeduplication`

## Motivation and Context
To keep consistency and to remove magic strings from consumers of the SQS API.

## Testing
~~I didn't.~~

Ran all related SQS tests

## Screenshots (if appropriate)
N/A

## Types of changes
Not sure if it is a new feature _technically_, but it's the closest category.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement