### PR TITLE
Fixing Glacier build

### DIFF
--- a/sdk/src/Services/Glacier/Custom/TreeHashGenerator.cs
+++ b/sdk/src/Services/Glacier/Custom/TreeHashGenerator.cs
@@ -114,9 +114,11 @@ namespace Amazon.Glacier
             if (hex.Length % 2 == 1)
                 throw new ArgumentOutOfRangeException("hex", "The binary key cannot have an odd number of digits");
 
-            byte[] arr = new byte[hex.Length >> 1];
+            int length = hex.Length >> 1;
 
-            for (int i = 0; i < hex.Length >> 1; ++i)
+            byte[] arr = new byte[length];
+
+            for (int i = 0; i < length; ++i)
             {
                 arr[i] = (byte)((getHexVal(hex[i << 1]) << 4) + (getHexVal(hex[(i << 1) + 1])));
             }


### PR DESCRIPTION
According to Visual Studio and msbuild the Glacier project doesn't build.

## Description
Pulled the bit shifted length into a variable and used that for the array size and for loop.

## Motivation and Context
Fresh checkout of my fork would always fail to build, and I presume other forks too.

## Testing
Running msbuild against AWSSDK.Glacier.Net35.csproj and AWSSDK.Glacier.Net45.csproj now passes without any errors.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement