### PR TITLE
Support loading AccessKey and SecretKey from appsettings.json

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
@@ -128,6 +128,14 @@ namespace Microsoft.Extensions.Configuration
                 options.Region = RegionEndpoint.GetBySystemName(section["AWSRegion"]);
             }
 
+            if (!string.IsNullOrEmpty(section["AccessKeyId"]) && !string.IsNullOrEmpty(section["SecretAccessKey"]))
+            {
+                options.Credentials = new BasicAWSCredentials(
+                    section["AccessKeyId"],
+                    section["SecretAccessKey"]
+                );
+            }
+
             return options;
         }
     }


### PR DESCRIPTION
Since the "AWS_REGION" environment variable maps to "AWS:Region", the "AWS_ACCESS_KEY_ID" environment variable maps to "AWS:AccessKeyId" and the "AWS_SECRET_ACCESS_KEY" environment variable maps to "AWS:SecretAccessKey", like so:

```
"AWS": {
  "AccessKeyId": "abc",
  "SecretAccessKey": "xyz"
}
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
You can now add your access key and secret key directly to your appsettings.json instead of loading and registering profiles. The naming conventions have been inferred from the environment variable names. 

## Motivation and Context
Many developers including myself attempted to add their keys to the appsettings.json. This is a bit more straightforward that creating a custom profile, and this is more consistent with how the environment variables work. There are a few issues floating around that carry this sentiment including but not limited to https://github.com/aws/aws-sdk-net/issues/499.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement