### PR TITLE
Use Task.FromResult instead of Task.Run.

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AWSCredentials.cs
@@ -35,7 +35,7 @@ namespace Amazon.Runtime
 #if AWS_ASYNC_API
         public virtual System.Threading.Tasks.Task<ImmutableCredentials> GetCredentialsAsync()
         {
-            return System.Threading.Tasks.Task.Run<ImmutableCredentials>(() => this.GetCredentials());
+            return System.Threading.Tasks.Task.FromResult<ImmutableCredentials>(this.GetCredentials());
         }
 #endif
     }


### PR DESCRIPTION
## Description

Task.FromResult is the preferred mechanism to return a synchronous result from an async operations.

Fixes #690

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement