### PR TITLE
Extend S3 signed URLs to allow for custom parameters that cannot be altered

### DIFF
--- a/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
@@ -223,6 +223,10 @@ namespace Amazon.S3
             if (!string.IsNullOrEmpty(responseHeaderOverrides.ContentEncoding))
                 queryParameters.Add("response-content-encoding", responseHeaderOverrides.ContentEncoding);
 
+            // Add custom parameters to be included and signed
+            foreach (string k in getPreSignedUrlRequest.Parameters.Keys)
+                queryParameters.Add(k, getPreSignedUrlRequest.Parameters[k]);
+
             request.ResourcePath = uriResourcePath.ToString();
             request.UseQueryString = true;
 

--- a/sdk/src/Services/S3/Custom/Model/GetPreSignedUrlRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetPreSignedUrlRequest.cs
@@ -50,8 +50,9 @@ namespace Amazon.S3.Model
         private string serverSideEncryptionKeyManagementServiceKeyId;
         private HeadersCollection headersCollection = new HeadersCollection();
         private MetadataCollection metadataCollection = new MetadataCollection();
+        private ParameterCollection parameterCollection = new ParameterCollection();
 
-        private ServerSideEncryptionCustomerMethod serverSideCustomerEncryption;
+    private ServerSideEncryptionCustomerMethod serverSideCustomerEncryption;
 
         #endregion
 
@@ -329,5 +330,23 @@ namespace Amazon.S3.Model
         }
 
         #endregion
-    }
+
+        #region Parameters
+
+        /// <summary>
+        /// Custom parameters to include in the signed request, so that they are tamper-proof.
+        /// </summary>
+        public ParameterCollection Parameters {
+            get {
+                if (this.parameterCollection == null)
+                    this.parameterCollection = new ParameterCollection();
+                return this.parameterCollection;
+            }
+            internal set {
+                this.parameterCollection = value;
+            }
+        }
+
+        #endregion
+  }
 }

--- a/sdk/src/Services/S3/Custom/Model/ParameterCollection.cs
+++ b/sdk/src/Services/S3/Custom/Model/ParameterCollection.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+using System.Text;
+using System.IO;
+using Amazon.Runtime;
+
+namespace Amazon.S3.Model {
+  /// <summary>
+  /// This class contains custom querystring parameters for an S3 object, which can then be signed as part of a Pre-signed URL request
+  /// </summary>
+  public sealed class ParameterCollection {
+
+    IDictionary<string, string> values = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets and sets parameters for the object. Parameter names must start with "x-". If the name passeed in as the indexer 
+    /// doesn't start with "x-" then it will be prepended.
+    /// </summary>
+    /// <param name="name">The name of the parameter.</param>
+    /// <returns>The value for the meta data</returns>
+    public string this[string name] {
+      get {
+        if (!name.StartsWith("x-", StringComparison.OrdinalIgnoreCase))
+          name = "x-" + name;
+
+        string value;
+        if (values.TryGetValue(name, out value))
+          return value;
+
+        return null;
+      }
+      set {
+        if (!name.StartsWith("x-", StringComparison.OrdinalIgnoreCase))
+          name = "x-" + name;
+
+        values[name] = value;
+      }
+    }
+
+    /// <summary>
+    /// Adds the parameter to the collection, if the name already exists it will be overwritten.
+    /// </summary>
+    /// <param name="name">The name of the parameter</param>
+    /// <param name="value">The value for the parameter</param>
+    public void Add(string name, string value) {
+      this[name] = value;
+    }
+
+    /// <summary>
+    /// Gets the count of parameters.
+    /// </summary>
+    public int Count {
+      get { return this.values.Count; }
+    }
+
+    /// <summary>
+    /// Gets the names of the parameter elements.
+    /// </summary>
+    public ICollection<string> Keys {
+      get { return values.Keys; }
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a Parameters property to GetPreSignedURLRequest, so that custom parameters can be included in an S3 request and logged, while assuring they can't be tampered with. See https://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html for logging "x-*" querystring parameters

## Motivation and Context
This allows additional metadata about the request to be logged in S3 request logs, with assurance that it remains unmodified from the value the application set it to. An example might be an application userid, sessionid, or similar identifier for auditing.

## Testing
Generated & retrieved a pre-signed URL both with and without the new property set, generated & retrieved a pre-signed URL with a property set, modified the parameter value and got a failure as expected, generated & retrieved a pre-signed URL with multiple properties set, modified parameter values and got failures as expected.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement