### PR TITLE
Don't allocate memory in UnmarshallerContext.TestExpression

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/UnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/UnmarshallerContext.cs
@@ -147,8 +147,10 @@ namespace Amazon.Runtime.Internal.Transform
                     startingStackDepth++;
                 }
             }
-            return (startingStackDepth == currentDepth
-                    && currentPath.EndsWith("/" + expression, StringComparison.OrdinalIgnoreCase));
+            return startingStackDepth == currentDepth
+                   && currentPath.Length > expression.Length
+                   && currentPath[currentPath.Length - expression.Length - 1] == '/'
+                   && currentPath.EndsWith(expression, StringComparison.OrdinalIgnoreCase);
         }
 
         #region Abstract members


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Improves performance and memory consumption of UnmarshallerContext.TestExpression(...)

## Motivation and Context
Performance profiling shows this as a hotspot in our dynamodb-heavy application.

## Testing
I ran the DynamoDB Integration tests.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/504266/28931275-658fe8be-782a-11e7-9cf6-6507f5cb3839.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement