### PR TITLE
Fix DescribeHostReservations always returning empty list

### DIFF
--- a/generator/ServiceModels/ec2/ec2-2016-11-15.normal.json
+++ b/generator/ServiceModels/ec2/ec2-2016-11-15.normal.json
@@ -10362,7 +10362,10 @@
     },
     "HostReservationSet":{
       "type":"list",
-      "member":{"shape":"HostReservation"}
+      "member":{
+        "shape":"HostReservation",
+        "locationName":"item"
+      }
     },
     "HostTenancy":{
       "type":"string",

--- a/sdk/src/Services/EC2/Generated/Model/Internal/MarshallTransformations/DescribeHostReservationsResponseUnmarshaller.cs
+++ b/sdk/src/Services/EC2/Generated/Model/Internal/MarshallTransformations/DescribeHostReservationsResponseUnmarshaller.cs
@@ -55,7 +55,7 @@ namespace Amazon.EC2.Model.Internal.MarshallTransformations
                 if (context.IsStartElement || context.IsAttribute)
                 {
 
-                    if (context.TestExpression("hostReservationSet/member", targetDepth))
+                    if (context.TestExpression("hostReservationSet/item", targetDepth))
                     {
                         var unmarshaller = HostReservationUnmarshaller.Instance;
                         var item = unmarshaller.Unmarshall(context);


### PR DESCRIPTION
EC2 service method `DescribeHostReservations()` always returns an empty list, regardless of parameters values.

Related Issue: #724

## Expected Behavior
Return Host Reservations.

## Current Behavior
Empty result list when there are Host Reservations in the account.

## Possible Solution
API is returning an XML like:
```
<?xml version="1.0" encoding="UTF-8"?>
<DescribeHostReservationsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
    <requestId></requestId>
    <hostReservationSet>
        <item>
            <upfrontPrice></upfrontPrice>
            <count></count>
            <start></start>
            <instanceFamily></instanceFamily>
            <offeringId></offeringId>
            <duration></duration>
            <paymentOption></paymentOption>
            <end></end>
            <hostReservationId></hostReservationId>
            <state></state>
            <hourlyPrice></hourlyPrice>
            <hostIdSet>
                <item></item>
            </hostIdSet>
        </item>
    </hostReservationSet>
</DescribeHostReservationsResponse>
```

Note each `HostReservation` is under `item`, and the unmarshaller is using `member`.

In the actual generated class there is the following if statement:
`if (context.TestExpression("hostReservationSet/member", targetDepth))`
