### PR TITLE
Adds a "/" to request URI if required

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
+++ b/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
@@ -502,7 +502,10 @@ namespace Amazon.Runtime
                     "by System.Uri and thus cannot be handled by the .NET SDK.", resourcePath));
 
             var parameterizedPath = string.Concat(AWSSDKUtils.UrlEncode(resourcePath, true), sb);
-            var uri = new Uri(url.AbsoluteUri + parameterizedPath);
+            var hasSlash = url.AbsoluteUri.EndsWith("/") || parameterizedPath.StartsWith("/");
+            var uri = hasSlash
+                ? new Uri(url.AbsoluteUri + parameterizedPath)
+                : new Uri(url.AbsoluteUri + "/" + parameterizedPath);
             DontUnescapePathDotsAndSlashes(uri);
             return uri;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds a check when composing a request URL and includes an intervening "/" between the base URL and resource path if there is not one included in either of those values already.

## Motivation and Context
This change is a fix for a bug that arises when an S3 request has a ServiceURL containing a subdirectory specified,  ForcePathStyle set to true, and v4 signing enabled. 

The CanonicalResourcePath is created for the AWS4Signer  by combining the ServiceURL with the ResourcePath (the BucketName and the Key) using CanonicalizeResourcePath at AWSSDKUtils.cs:282. Here it is assumed that there is no trailing  "/" in the ServiceURL or leading "/" in the BucketName/ResourcePath as one is placed in between them during concatenation. 

When the same request is composing the url against which the request will be made, these same values (ServiceURL and ResourcePath beginning with BucketName) are combined at AmazonServiceClient.cs:505. Here it is assumed that an intervening "/" is already present, as the values are concatenated without a "/".

This results in either the CanonicalResoucePath being incorrect by having an extra "/" or the request URL being incorrect by lacking the "/" between the subdirectory of the ServiceURL and the beginning of the BucketName, depending on whether or not the "/" is included when these values are assigned.

## Testing
Perform a request through an AmazonS3Client with configuration values formatted like the following:

Client:
ServiceURL = "example.com/sub/directory"
ForcePathStyle = true
(in AWSConfig) useSignatureVersion4 = true

Request:
BucketName = "bucket"
Key = "resource/path/filename.ext"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed


## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement