### PR TITLE
TransferUtility: Removed cast to AmazonS3Client

### DIFF
--- a/sdk/src/Services/S3/Custom/_bcl+coreclr+pcl/Transfer/Internal/_async/DownloadCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/_bcl+coreclr+pcl/Transfer/Internal/_async/DownloadCommand.async.cs
@@ -35,7 +35,7 @@ namespace Amazon.S3.Transfer.Internal
             ValidateRequest();
             GetObjectRequest getRequest = ConvertToGetObjectRequest(this._request);
 
-            var maxRetries = ((AmazonS3Client)_s3Client).Config.MaxErrorRetry;
+            var maxRetries = _s3Client.Config.MaxErrorRetry;
             var retries = 0;
             bool shouldRetry = false;
             string mostRecentETag = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Casting the S3 client object to the concrete implementation of the `IAmazonS3` interface is not necessary to get the `MaxErrorRetry` value.

## Motivation and Context
We use a proxy object of the `IAmazonS3` interface to profiles all of the methods in the `AmazonS3Client` class. This cast prevents us from profiling the `TransferUtility` when uploading or downloading large objects from S3.

## Testing
<!--- Please describe in detail how you tested your changes -->
All of the Unit Tests pass with the change on Windows 10 with Visual Studio 2017 Professional.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement