### PR TITLE
Include WebExceptionStatus.Timeout in statuses to retry on

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/DefaultRetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/DefaultRetryPolicy.cs
@@ -62,12 +62,14 @@ namespace Amazon.Runtime.Internal
             WebExceptionStatus.NameResolutionFailure,
             WebExceptionStatus.ReceiveFailure,
             WebExceptionStatus.SendFailure,
+            WebExceptionStatus.Timeout,
 #else // WinRT does not expose the status as public enums so we hard code the status numbers.
             (WebExceptionStatus)8,
             (WebExceptionStatus)12,
             (WebExceptionStatus)1,
             (WebExceptionStatus)3,
             (WebExceptionStatus)4,
+            (WebExceptionStatus)14,
 #endif
         };
 

--- a/sdk/test/UnitTests/Custom/Runtime/RetryHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RetryHandlerTests.cs
@@ -73,6 +73,26 @@ namespace AWSSDK.UnitTests
             Assert.AreEqual(MAX_RETRIES + 1, Tester.CallCount);
         }
 
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void RetryForWebExceptionTimeout()
+        {
+            Tester.Reset();
+            Tester.Action = (int callCount) =>
+            {
+                throw new AmazonServiceException(new WebException("WebException", WebExceptionStatus.Timeout));
+            };
+
+            Utils.AssertExceptionExpected(() =>
+                {
+                    var request = CreateTestContext();
+                    RuntimePipeline.InvokeSync(request);
+                },
+                typeof(AmazonServiceException));
+            Assert.AreEqual(MAX_RETRIES + 1, Tester.CallCount);
+        }
+
         [TestMethod][TestCategory("UnitTest")]
         [TestCategory("Runtime")]
         public void RetryForHttpStatus500()
@@ -225,6 +245,27 @@ namespace AWSSDK.UnitTests
             Assert.AreEqual(MAX_RETRIES + 1, Tester.CallCount);
         }
 
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        [TestCategory(@"Runtime\Async45")]
+        public async Task RetryForWebExceptionTimeoutAsync()
+        {
+            Tester.Reset();
+            Tester.Action = (int callCount) =>
+            {
+                throw new AmazonServiceException(new WebException("WebException", WebExceptionStatus.Timeout));
+            };
+
+            await Utils.AssertExceptionExpectedAsync(() =>
+                {
+                    var request = CreateTestContext();
+                    return RuntimePipeline.InvokeAsync<AmazonWebServiceResponse>(request);
+                },
+                typeof(AmazonServiceException));
+            Assert.AreEqual(MAX_RETRIES + 1, Tester.CallCount);
+        }
+
         [TestMethod][TestCategory("UnitTest")]
         [TestCategory("Runtime")]
         [TestCategory(@"Runtime\Async45")]
@@ -275,6 +316,25 @@ namespace AWSSDK.UnitTests
             Tester.Action = (int callCount) =>
             {
                 throw new AmazonServiceException(new WebException("WebException", WebExceptionStatus.ConnectFailure));
+            };
+
+            var request = CreateAsyncTestContext();
+            var asyncResult = RuntimePipeline.InvokeAsync(request);
+            asyncResult.AsyncWaitHandle.WaitOne();
+
+            Assert.IsTrue(((RuntimeAsyncResult)asyncResult).Exception is AmazonServiceException);
+            Assert.AreEqual(MAX_RETRIES + 1, Tester.CallCount);
+        }
+
+        [TestMethod][TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        [TestCategory(@"Runtime\Async35")]
+        public void RetryForWebExceptionTimeoutAsync()
+        {
+            Tester.Reset();
+            Tester.Action = (int callCount) =>
+            {
+                throw new AmazonServiceException(new WebException("WebException", WebExceptionStatus.Timeout));
             };
 
             var request = CreateAsyncTestContext();


### PR DESCRIPTION
## Description
This change is to add WebExceptionStatus.Timeout to the collection of WebException statuses in the DefaultRetryPolicy so that it will retry on HTTP timeouts.

## Motivation and Context
We have had an ongoing issue with Dynamodb WebException timeouts. On further analysis we have determined that the cause of the problem is the SDK is not retrying requests that timeout regardless of the MaxErrorRetry value configured.

## Testing
- Unit tests have been added to RetryHandlerTests.cs in this pull request
- Further testing has been done by executing a test console app that queries AWS Dynamodb endpoints via a Fiddler proxy. The Fiddler proxy was configured to add a delay to certain requests to induce HTTP timeouts. Analysis of the AWS log output showed that the current Dynamodb client fails to retry on HTTP timeouts but does correctly after applying this pull request.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement