### PR TITLE
UseChunkEncoding property for PutObjectRequest, UploadPartRequest - a way to disable chunked uploading

### DIFF
--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutObjectRequestMarshaller.cs
@@ -95,7 +95,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 // Wrap the stream in a stream that has a length
                 var streamWithLength = GetStreamWithLength(putObjectRequest.InputStream, putObjectRequest.Headers.ContentLength);
                 if (streamWithLength.Length > 0)
-                    request.UseChunkEncoding = true;
+                    request.UseChunkEncoding = putObjectRequest.UseChunkEncoding;
                 var length = streamWithLength.Length - streamWithLength.Position;
                 if (!request.Headers.ContainsKey(HeaderKeys.ContentLengthHeader))
                     request.Headers.Add(HeaderKeys.ContentLengthHeader, length.ToString(CultureInfo.InvariantCulture));

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/UploadPartRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/UploadPartRequestMarshaller.cs
@@ -72,7 +72,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 // Wrap input stream in partial wrapper (to upload only part of the stream)
                 var partialStream = new PartialWrapperStream(uploadPartRequest.InputStream, uploadPartRequest.PartSize);
                 if (partialStream.Length > 0)
-                    request.UseChunkEncoding = true;
+                    request.UseChunkEncoding = uploadPartRequest.UseChunkEncoding;
                 if (!request.Headers.ContainsKey(HeaderKeys.ContentLengthHeader))
                     request.Headers.Add(HeaderKeys.ContentLengthHeader, partialStream.Length.ToString(CultureInfo.InvariantCulture));
 

--- a/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
@@ -133,7 +133,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// If this value is set to true then the request payload will be transfered in multiple chunks (AWS Signature Version 4).
+        /// If this value is set to true then a chunked encoding upload will be used for the request.
         /// Default: true.
         /// </summary>
         public bool UseChunkEncoding

--- a/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
@@ -48,6 +48,7 @@ namespace Amazon.S3.Model
         private string contentBody;
         private bool autoCloseStream = true;
         private bool autoResetStreamPosition = true;
+        private bool useChunkEncoding = true;
         private RequestPayer requestPayer;
 
         private string md5Digest;
@@ -129,6 +130,16 @@ namespace Amazon.S3.Model
         {
             get { return this.autoResetStreamPosition; }
             set { this.autoResetStreamPosition = value; }
+        }
+
+        /// <summary>
+        /// If this value is set to true then the request payload will be transfered in multiple chunks (AWS Signature Version 4).
+        /// Default: true.
+        /// </summary>
+        public bool UseChunkEncoding
+        {
+            get { return this.useChunkEncoding; }
+            set { this.useChunkEncoding = value; }
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
@@ -52,6 +52,7 @@ namespace Amazon.S3.Model
 
         private string filePath;
         private long? filePosition;
+        private bool useChunkEncoding = true;
 
         private bool lastPart;
         private RequestPayer requestPayer;
@@ -268,6 +269,16 @@ namespace Amazon.S3.Model
         {
             get { return this.filePosition.GetValueOrDefault(); }
             set { this.filePosition = value; }
+        }
+
+        /// <summary>
+        /// If this value is set to true then the request payload will be transfered in multiple chunks (AWS Signature Version 4).
+        /// Default: true.
+        /// </summary>
+        public bool UseChunkEncoding
+        {
+            get { return this.useChunkEncoding; }
+            set { this.useChunkEncoding = value; }
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
@@ -272,7 +272,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// If this value is set to true then the request payload will be transfered in multiple chunks (AWS Signature Version 4).
+        /// If this value is set to true then a chunked encoding upload will be used for the request.
         /// Default: true.
         /// </summary>
         public bool UseChunkEncoding

--- a/sdk/test/CoreCLR/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
+++ b/sdk/test/CoreCLR/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
@@ -97,15 +97,18 @@ namespace Amazon.DNXCore.IntegrationTests.S3
             );
         }
 
-        [Fact]
-        public async Task SimplePutObjectTest()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SimplePutObjectTest(bool useChunkEncoding)
         {
             PutObjectRequest request = new PutObjectRequest()
             {
                 BucketName = bucketName,
                 Key = "contentBodyPut" + random.Next(),
                 ContentBody = testContent,
-                CannedACL = S3CannedACL.AuthenticatedRead
+                CannedACL = S3CannedACL.AuthenticatedRead,
+                UseChunkEncoding = useChunkEncoding
             };
             PutObjectResponse response = await Client.PutObjectAsync(request);
 
@@ -113,34 +116,43 @@ namespace Amazon.DNXCore.IntegrationTests.S3
             Assert.True(response.ETag.Length > 0);
         }
 
-        [Fact]
-        public async Task SimplePathPutObjectTest()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SimplePathPutObjectTest(bool useChunkEncoding)
         {
             PutObjectRequest request = new PutObjectRequest()
             {
                 BucketName = bucketName,
                 FilePath = filePath,
-                CannedACL = S3CannedACL.AuthenticatedRead
+                CannedACL = S3CannedACL.AuthenticatedRead,
+                UseChunkEncoding = useChunkEncoding
             };
             PutObjectResponse response = await Client.PutObjectAsync(request);
 
             Console.WriteLine("S3 generated ETag: {0}", response.ETag);
             Assert.True(response.ETag.Length > 0);
-        }
-
-        [Fact]
-        public async Task GzipTest()
+        } 
+         
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GzipTest(bool useChunkEncoding)
         {
             var request = CreatePutObjectRequest();
+            request.UseChunkEncoding = useChunkEncoding;
             request.Headers.ContentEncoding = "gzip";
 
             await TestPutAndGet(request);
         }
 
-        [Fact]
-        public async Task PutObjectWithContentEncoding()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task PutObjectWithContentEncoding(bool useChunkEncoding)
         {
             var request = CreatePutObjectRequest();
+            request.UseChunkEncoding = useChunkEncoding;
             request.Headers.ContentEncoding = "gzip";
             request.Headers.ContentDisposition = "disposition";
 
@@ -148,10 +160,14 @@ namespace Amazon.DNXCore.IntegrationTests.S3
             Assert.Equal("disposition", headers.ContentDisposition);
             Assert.Equal("gzip", headers.ContentEncoding);
         }
-        [Fact]
-        public async Task PutObjectWithContentEncodingIdentity()
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task PutObjectWithContentEncodingIdentity(bool useChunkEncoding)
         {
             var request = CreatePutObjectRequest();
+            request.UseChunkEncoding = useChunkEncoding;
             request.Headers.ContentEncoding = "identity";
             request.Headers.ContentDisposition = "disposition";
 
@@ -159,10 +175,14 @@ namespace Amazon.DNXCore.IntegrationTests.S3
             Assert.Equal("disposition", headers.ContentDisposition);
             Assert.Equal("identity", headers.ContentEncoding);
         }
-        [Fact]
-        public async Task PutObjectWithoutContentEncoding()
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task PutObjectWithoutContentEncoding(bool useChunkEncoding)
         {
             var request = CreatePutObjectRequest();
+            request.UseChunkEncoding = useChunkEncoding;
             request.Headers.ContentDisposition = "disposition";
 
             var headers = await TestPutAndGet(request);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added `UseChunkEncoding` property to `PutObjectRequest`, `UploadPartRequest` so that chunked encoding upload could be optionally disabled for the request.

## Motivation and Context
Our S3-compatible storage doesn't work very well for some edge-cases with chunked encoding upload, but I could not find a way to disable it for aws-sdk-net.
There also could be minor performance improvement for small files - less network traffic.
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
* Integration tests (see PR)
* Manual tests to ensure payload is sent in appropriate way
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes _// I've modified existing tests, not sure if is's appropriate_
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement