### PR TITLE
Adding support for Unity WebGL

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -118,7 +118,12 @@ namespace Amazon.Runtime
 
         #region Private/protected credential update methods
 
-        private void UpdateToGeneratedCredentials(CredentialsRefreshState state)
+#if UNITY
+        protected
+#else
+        private
+#endif
+        void UpdateToGeneratedCredentials(CredentialsRefreshState state)
         {
             // Check if the new credentials are already expired
             if (ShouldUpdate)
@@ -150,7 +155,12 @@ namespace Amazon.Runtime
         }
 
         // Test credentials existence and expiration time
-        private bool ShouldUpdate
+#if UNITY
+        protected
+#else
+        private
+#endif
+        bool ShouldUpdate
         {
             get
             {

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/_unity/Dispatcher.unity.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/_unity/Dispatcher.unity.cs
@@ -1,0 +1,158 @@
+﻿/*
+ * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Amazon.Runtime.Internal.Util
+{
+    /// <summary>
+    /// Class to perform actions on a background thread.
+    /// Uses a single background thread and performs actions
+    /// on it in the order the data was sent through the instance.
+    /// </summary>
+    internal class CoroutineDispatcher<T> : IDisposable
+    {
+        #region Properties
+
+        private bool isDisposed = false;
+        private Action<T> action;
+        private Queue<T> queue;
+        private Coroutine coroutine;
+        private bool shouldStop;
+        public bool IsRunning { get; private set; }
+
+        #endregion
+
+
+        #region Constructor/destructor
+
+        public CoroutineDispatcher(Action<T> action)
+        {
+            if (action == null)
+                throw new ArgumentNullException("action");
+
+            queue = new Queue<T>();
+            shouldStop = false;
+            this.action = action;
+
+            coroutine = UnityInitializer.Instance.StartCoroutine(Run());
+        }
+
+        ~CoroutineDispatcher()
+        {
+            Stop();
+            this.Dispose();
+        }
+
+        #endregion
+
+
+        #region Dispose Pattern Implementation
+
+
+        /// <summary>
+        /// Disposes of all managed and unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+
+
+        #region Public Methods
+
+        const int MAX_QUEUE_SIZE = 100;
+        public void Dispatch(T data)
+        {
+            if (queue.Count < MAX_QUEUE_SIZE) 
+            {
+                lock (queue) 
+                {
+                    if (queue.Count < MAX_QUEUE_SIZE)
+                        queue.Enqueue(data);
+                }
+            }
+        }
+
+        public void Stop()
+        {
+            shouldStop = true;
+            UnityInitializer.Instance.StopCoroutine(coroutine);
+            coroutine = null;
+        }
+
+        #endregion
+
+
+        #region Private methods
+
+        private IEnumerator Run()
+        {
+            IsRunning = true;
+            while (!shouldStop) 
+            {
+                HandleInvoked();
+                yield return new WaitForEndOfFrame();
+            }
+            HandleInvoked();
+            IsRunning = false;
+        }
+
+        private void HandleInvoked()
+        {
+            while (true) 
+            {
+                bool dataPresent = false;
+                T data = default(T);
+                lock (queue) 
+                {
+                    if (queue.Count > 0) 
+                    {
+                        data = queue.Dequeue();
+                        dataPresent = true;
+                    }
+                }
+
+                if (!dataPresent)
+                    break;
+
+                try 
+                {
+                    action(data);
+                }
+                catch { }
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Class to invoke actions on a coroutine.
+    /// Uses a single coroutine and invokes actions
+    /// on it in the order they were invoked through the instance.
+    /// </summary>
+    internal class CoroutineInvoker : CoroutineDispatcher<Action>
+    {
+        public CoroutineInvoker()
+            : base(action => action())
+        {
+        }
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
@@ -277,7 +277,11 @@ namespace Amazon.Runtime.Internal
 
         private void GetRequestStreamCallback(IAsyncResult result)
         {
+#if UNITY
+            if (result.CompletedSynchronously && UnityEngine.Application.platform != UnityEngine.RuntimePlatform.WebGLPlayer)
+#else
             if (result.CompletedSynchronously)
+#endif
             {
                 System.Threading.ThreadPool.QueueUserWorkItem(GetRequestStreamCallbackHelper, result);
             }
@@ -316,7 +320,11 @@ namespace Amazon.Runtime.Internal
 
         private void GetResponseCallback(IAsyncResult result)
         {
+#if UNITY
+            if (result.CompletedSynchronously && UnityEngine.Application.platform != UnityEngine.RuntimePlatform.WebGLPlayer)
+#else
             if (result.CompletedSynchronously)
+#endif
             {
                 System.Threading.ThreadPool.QueueUserWorkItem(GetResponseCallbackHelper, result);
             }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/_unity/UnityMainThreadDispatcher.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/_unity/UnityMainThreadDispatcher.cs
@@ -222,13 +222,13 @@ namespace Amazon.Runtime.Internal
                 // Invoke the callback method for the request on the thread pool
                 // after the web request is executed. This callback triggers the 
                 // post processing of the response from the server.
-                ThreadPool.QueueUserWorkItem((state) =>
+                if(Application.platform == RuntimePlatform.WebGLPlayer) 
                 {
-                    try
+                    try 
                     {
                         request.Callback(request.AsyncResult);
                     }
-                    catch (Exception exception)
+                    catch (Exception exception) 
                     {
                         // The callback method (HttpHandler.GetResponseCallback) and 
                         // subsequent calls to handler callbacks capture any exceptions
@@ -241,7 +241,28 @@ namespace Amazon.Runtime.Internal
                     + "UnityMainThreadDispatcher.InvokeRequest method.");
 
                     }
-                });
+                }
+                else
+                    ThreadPool.QueueUserWorkItem((state) =>
+                    {
+                        try
+                        {
+                            request.Callback(request.AsyncResult);
+                        }
+                        catch (Exception exception)
+                        {
+                            // The callback method (HttpHandler.GetResponseCallback) and 
+                            // subsequent calls to handler callbacks capture any exceptions
+                            // thrown from the runtime pipeline during post processing.
+
+                            // Log the exception, in case we get an unhandled exception 
+                            // from the callback.
+                            _logger.Error(exception,
+                        "An exception was thrown from the callback method executed from"
+                        + "UnityMainThreadDispatcher.InvokeRequest method.");
+
+                        }
+                    });
             }
         }
 

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -521,7 +521,14 @@ namespace Amazon.Util
                 var eventHandler = ((EventHandler<T>)call);
                 if (eventHandler != null)
                 {
+#if UNITY
+                    if(UnityEngine.Application.platform == UnityEngine.RuntimePlatform.WebGLPlayer)
+                        CoroutineDispatcher.Dispatch(() => eventHandler(sender, args));
+                    else
+                        Dispatcher.Dispatch(() => eventHandler(sender, args));
+#else
                     Dispatcher.Dispatch(() => eventHandler(sender, args));
+#endif
                 }
             }
         }
@@ -540,6 +547,20 @@ namespace Amazon.Util
                 return _dispatcher;
             }
         }
+
+#if UNITY
+        private static CoroutineInvoker _coroutineDispatcher;
+
+        private static CoroutineInvoker CoroutineDispatcher {
+            get {
+                if (_coroutineDispatcher == null) {
+                    _coroutineDispatcher = new CoroutineInvoker();
+                }
+
+                return _coroutineDispatcher;
+            }
+        }
+#endif
 
         /// <summary>
         /// Parses a query string of a URL and returns the parameters as a string-to-string dictionary.

--- a/sdk/src/Core/Amazon.Util/Internal/_unity/InternalSDKUtils.unity.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/_unity/InternalSDKUtils.unity.cs
@@ -78,7 +78,7 @@ namespace Amazon.Util.Internal
 
         public static void AsyncExecutor(Action action, AsyncOptions options)
         {
-            if (options.ExecuteCallbackOnMainThread)
+            if (options.ExecuteCallbackOnMainThread || Application.platform == RuntimePlatform.WebGLPlayer)
             {
                 if (UnityInitializer.IsMainThread())
                 {

--- a/sdk/src/Services/CognitoIdentity/Custom/CognitoAWSCredentials.cs
+++ b/sdk/src/Services/CognitoIdentity/Custom/CognitoAWSCredentials.cs
@@ -666,6 +666,18 @@ namespace Amazon.CognitoIdentity
         /// <returns></returns>
         protected override CredentialsRefreshState GenerateNewCredentials()
         {
+#if UNITY
+            if (UnityEngine.Application.platform == UnityEngine.RuntimePlatform.WebGLPlayer)
+                throw new PlatformNotSupportedException("Unity WebGL is not supported. Please use GenerateNewCredentialsWebGL instead.");
+            else
+                return GenerateNewCredentialsInternal();
+#else
+            return GenerateNewCredentialsInternal();
+#endif
+        }
+
+        private CredentialsRefreshState GenerateNewCredentialsInternal()
+        {
             CredentialsRefreshState credentialsState;
 
             // Pick role to use, depending on Logins

--- a/sdk/src/Services/CognitoIdentity/Custom/_unity/CognitoAWSCredentials.unity.cs
+++ b/sdk/src/Services/CognitoIdentity/Custom/_unity/CognitoAWSCredentials.unity.cs
@@ -64,6 +64,212 @@ namespace Amazon.CognitoIdentity
 
         #endregion
 
+        #region private methods (WebGL)
+
+        private void GetIdentityIdWebGL(RefreshIdentityOptions options, Action<string> callback)
+        {
+            // Locking so that concurrent calls do not make separate network calls,
+            // and instead wait for the first caller to cache the Identity ID.
+            lock (refreshIdLock) 
+            {
+                if (!IsIdentitySet || options == RefreshIdentityOptions.Refresh) 
+                {
+                    RefreshIdentityWebGL(IdentityState => 
+                    {
+                        _identityState = IdentityState;
+
+                        if (!string.IsNullOrEmpty(_identityState.LoginProvider)) 
+                        {
+                            Logins[_identityState.LoginProvider] = _identityState.LoginToken;
+                        }
+                        UpdateIdentity(_identityState.IdentityId);
+
+                        callback(identityId);
+                    });
+                }
+                else
+                    callback(identityId);
+            }
+        }
+        
+        private void RefreshIdentityWebGL(Action<IdentityState> callback)
+        {
+            bool isCached = true;
+            if (!IsIdentitySet) 
+            {
+                var getIdRequest = new GetIdRequest 
+                {
+                    AccountId = AccountId,
+                    IdentityPoolId = IdentityPoolId,
+                    Logins = Logins
+                };
+
+                cib.GetIdAsync(getIdRequest, result => 
+                {
+                    isCached = false;
+                    UpdateIdentity(result.Response.IdentityId);
+
+                    callback(new IdentityState(identityId, isCached));
+                });
+            }
+            else
+                callback(new IdentityState(identityId, isCached));
+        }
+        
+        private void GenerateNewCredentialsWebGL(Action<CredentialsRefreshState> callback)
+        {
+            Action<CredentialsRefreshState> handleCredentials = credentialsState => 
+            {
+                CacheCredentials(credentialsState);
+
+                // Return new refresh state (credentials and expiration)
+                callback(credentialsState);
+            };
+
+            // Pick role to use, depending on Logins
+            string roleArn = UnAuthRoleArn;
+            if (Logins.Count > 0)
+                roleArn = AuthRoleArn;
+            bool roleSpecified = !string.IsNullOrEmpty(roleArn);
+
+            // Get credentials from determined role or from identity pool
+            if (roleSpecified)
+                GetCredentialsForRoleWebGL(roleArn, handleCredentials);
+            else
+                GetPoolCredentialsWebGL(handleCredentials);
+        }
+        
+        private void GetPoolCredentialsWebGL(Action<CredentialsRefreshState> callback)
+        {
+            CredentialsRefreshState credentialsState;
+            this.GetIdentityIdWebGL(RefreshIdentityOptions.Refresh, identity => 
+            {
+                var getCredentialsRequest = new GetCredentialsForIdentityRequest { IdentityId = identity };
+
+                if (Logins.Count > 0)
+                    getCredentialsRequest.Logins = Logins;
+
+                //incase its BYOI provider override the logins dictionary with the new instance and set the values for cognito-identity provider
+                if (_identityState != null && !string.IsNullOrEmpty(_identityState.LoginToken)) 
+                {
+                    getCredentialsRequest.Logins = new Dictionary<string, string>();
+                    getCredentialsRequest.Logins["cognito-identity.amazonaws.com"] = _identityState.LoginToken;
+                }
+
+                GetCredentialsForIdentityWebGL(getCredentialsRequest, (response, e) => 
+                {
+                    bool retry = false;
+
+                    if (e is AmazonCognitoIdentityException) 
+                    {
+                        if (ShouldRetry(e as AmazonCognitoIdentityException))
+                            retry = true;
+                        else
+                            throw e;
+                    }
+
+                    if (retry) 
+                    {
+                        GetPoolCredentialsWebGL(callback);
+                        return;
+                    }
+
+                    // IdentityId may have changed, save the new value
+                    UpdateIdentity(response.IdentityId);
+
+                    var credentials = response.Credentials;
+                    credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration);
+                    callback(credentialsState);
+                });
+            });
+        }
+        
+        private void GetCredentialsForRoleWebGL(string roleArn, Action<CredentialsRefreshState> callback)
+        {
+            CredentialsRefreshState credentialsState;
+            // Retrieve Open Id Token
+            // (Reuses existing IdentityId or creates a new one)
+            this.GetIdentityIdWebGL(RefreshIdentityOptions.Refresh, identity => 
+            {
+                var getTokenRequest = new GetOpenIdTokenRequest { IdentityId = identity };
+                // If logins are set, pass them to the GetOpenId call
+                if (Logins.Count > 0)
+                    getTokenRequest.Logins = Logins;
+
+                GetOpenIdWebGL(getTokenRequest, (getTokenResult, e) => 
+                {
+                    bool retry = false;
+
+                    if (e is AmazonCognitoIdentityException) 
+                    {
+                        if (ShouldRetry(e as AmazonCognitoIdentityException))
+                            retry = true;
+                        else
+                            throw e;
+                    }
+
+                    if (retry) 
+                    {
+                        GetCredentialsForRoleWebGL(roleArn, callback);
+                        return;
+                    }
+
+                    string token = getTokenResult.Token;
+
+                    // IdentityId may have changed, save the new value
+                    UpdateIdentity(getTokenResult.IdentityId);
+
+                    // Assume role with Open Id Token
+                    var assumeRequest = new AssumeRoleWithWebIdentityRequest 
+                    {
+                        WebIdentityToken = token,
+                        RoleArn = roleArn,
+                        RoleSessionName = "NetProviderSession",
+                        DurationSeconds = DefaultDurationSeconds
+                    };
+                    var credentials = GetStsCredentials(assumeRequest);
+
+                    credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration);
+                    callback(credentialsState);
+                });
+            });
+        }
+
+        private void GetCredentialsForIdentityWebGL(GetCredentialsForIdentityRequest getCredentialsRequest, Action<GetCredentialsForIdentityResponse, Exception> callback)
+        {
+            cib.GetCredentialsForIdentityAsync(getCredentialsRequest, result => 
+            {
+                callback(result.Response, result.Exception);
+            });
+        }
+
+        private void GetOpenIdWebGL(GetOpenIdTokenRequest getTokenRequest, Action<GetOpenIdTokenResponse, Exception> callback)
+        {
+            cib.GetOpenIdTokenAsync(getTokenRequest, result => 
+            {
+                callback(result.Response, result.Exception);
+            });
+        }
+
+        private void GetCredentialsWebGL(Action<ImmutableCredentials> callback)
+        {
+            // If credentials are expired, update
+            if (ShouldUpdate) 
+                {
+                GenerateNewCredentialsWebGL(state => 
+                {
+                    currentState = state;
+                    UpdateToGeneratedCredentials(currentState);
+
+                    callback(currentState.Credentials.Copy());
+                });
+            }
+            else
+                callback(currentState.Credentials.Copy());
+        }
+
+        #endregion
+
         #region Overrides
 
         /// <summary>
@@ -147,12 +353,23 @@ namespace Amazon.CognitoIdentity
         /// <param name="options">Options for executing asynchronous operation</param>
         public void GetCredentialsAsync(AmazonCognitoIdentityCallback<ImmutableCredentials> callback, AsyncOptions options = null)
         {
-            options = options == null ? new AsyncOptions() : options;
-
-            CognitoIdentityAsyncExecutor.ExecuteAsync<ImmutableCredentials>(() =>
+            if(UnityEngine.Application.platform == UnityEngine.RuntimePlatform.WebGLPlayer) 
             {
-                return GetCredentials();
-            }, options, callback);
+                GetCredentialsWebGL(credentials => 
+                {
+                    var result = new AmazonCognitoIdentityResult<ImmutableCredentials>(credentials);
+                    callback(result);
+                });
+            }
+            else {
+                options = options == null ? new AsyncOptions() : options;
+
+                CognitoIdentityAsyncExecutor.ExecuteAsync<ImmutableCredentials>(() =>
+                {
+                    return GetCredentials();
+                }, options, callback);
+            }
+           
         }
 
         #endregion

--- a/sdk/src/Services/MobileAnalytics/Custom/Delivery/_unity/DeliveryClient.unity.cs
+++ b/sdk/src/Services/MobileAnalytics/Custom/Delivery/_unity/DeliveryClient.unity.cs
@@ -55,7 +55,7 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
             _appID = clientContext.AppID;
             _maConfig = maConfig;
             _maManager = maManager;
-            _eventStore = new SQLiteEventStore(maConfig);
+            _eventStore = UnityEngine.Application.platform == UnityEngine.RuntimePlatform.WebGLPlayer ? (IEventStore)new FileEventStore(maConfig) : new SQLiteEventStore(maConfig);
             _deliveryPolicies = new List<IDeliveryPolicy>();
             _deliveryPolicies.Add(_policyFactory.NewConnectivityPolicy());
         }

--- a/sdk/src/Services/MobileAnalytics/Custom/Delivery/_unity/FileEventStore.cs
+++ b/sdk/src/Services/MobileAnalytics/Custom/Delivery/_unity/FileEventStore.cs
@@ -1,0 +1,535 @@
+using Amazon.Util.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+
+using ThirdParty.Json.LitJson;
+
+using Logger = Amazon.Runtime.Internal.Util.Logger;
+
+namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
+{
+    internal class FileConnection
+    {
+        const string DataSetName = "FileDataSet";
+        
+        string Path { get; }
+
+        public DataSet Sql { get; }
+
+        public DataTableCollection Tables => Sql.Tables;
+
+        public FileConnection(string connection)
+        {
+            if (!connection.Contains("URI=file:"))
+                throw new InvalidOperationException();
+
+            Path = connection.Replace("URI=file:", "");
+            Sql = new DataSet(DataSetName);
+        }
+
+        internal void Dispose()
+        {
+            Sql.Dispose();
+        }
+
+        internal void Save()
+        {
+            foreach (DataTable table in Tables)
+                table.AcceptChanges();
+            Sql.AcceptChanges();
+
+            Sql.WriteXml(Path, XmlWriteMode.WriteSchema);
+        }
+
+        internal void Open()
+        {
+            Sql.ReadXml(Path, XmlReadMode.ReadSchema);
+
+            Sql.AcceptChanges();
+            foreach (DataTable table in Tables)
+                table.AcceptChanges();
+        }
+
+        internal static void CreateFile(string dBfileFullPath)
+        {
+            File.Create(dBfileFullPath).Close();
+
+            var sql = new DataSet(DataSetName);
+            sql.WriteXml(dBfileFullPath, XmlWriteMode.WriteSchema);
+            sql.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Implementation of <see cref="Amazon.MobileAnalytics.MobileAnalyticsManager.Internal.IEventStore"/>.
+    /// The object stores Mobile Analytic events in file database.
+    /// </summary>
+    [System.Security.SecuritySafeCritical]
+    public partial class FileEventStore : IEventStore
+    {
+        private Logger _logger = Logger.GetLogger(typeof(FileEventStore));
+        private const String TABLE_NAME = "ma_events";
+        private const String EVENT_COLUMN_NAME = "ma_event";
+        private const String EVENT_ID_COLUMN_NAME = "ma_event_id";
+        private const String EVENT_DELIVERY_ATTEMPT_COUNT_COLUMN_NAME = "ma_delivery_attempt_count";
+        private const String MA_APP_ID_COLUMN_NAME = "ma_app_id";
+        private const String TABLE_ROWID = "ROWID";
+        private const String DB_SIZE_KEY = "MAX_DB_SIZE";
+        private const String DB_WARNING_THRESHOLD_KEY = "DB_WARNING_THRESHOLD";
+        private const String dbFileName = "mobile_analytic_event.db";
+
+        // platform specific db file path
+        private static object _lock = new object();
+        private MobileAnalyticsManagerConfig _maConfig;
+
+#pragma warning disable 414
+        private bool _isDisposed;
+#pragma warning restore 414
+        
+        private bool keepOnlyOneConnection = true;
+
+        private FileConnection connection;
+
+        /// <summary>
+        /// Constructor of <see cref="Amazon.MobileAnalytics.MobileAnalyticsManager.Internal.FileEventStore"/>
+        /// </summary>
+        /// <param name="maConfig">Mobile Analytics Manager Configuration.</param>
+        public FileEventStore(MobileAnalyticsManagerConfig maConfig)
+        {
+            _maConfig = maConfig;
+            SetupSQLiteEventStore();
+        }
+
+        /// <summary>
+        /// Get the SQLite Event Store's database file full path.
+        /// </summary>
+        /// <returns> The database file full path. </returns>
+        public string DBfileFullPath {
+            get;
+            internal set;
+        }
+
+
+        /// <summary>
+        /// Disposes of all managed and unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Implements the Dispose pattern
+        /// </summary>
+        /// <param name="disposing">Whether this object is being disposed via a call to Dispose
+        /// or garbage collected.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this._isDisposed)
+            {
+                if (disposing)
+                {
+                    if (connection != null)
+                    {
+                        connection.Save();
+                        connection.Dispose();
+                    }
+                }
+                this._isDisposed = true;
+            }
+        }
+
+
+        private void CreateOrOpenDatabase()
+        {
+            lock (_lock)
+            {
+                this.DBfileFullPath = System.IO.Path.Combine(AmazonHookedPlatformInfo.Instance.PersistentDataPath, dbFileName);
+
+                if (!File.Exists(this.DBfileFullPath))
+                {
+                    string directory = Path.GetDirectoryName(this.DBfileFullPath);
+                    if (!Directory.Exists(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                    }
+                    FileConnection.CreateFile(this.DBfileFullPath);
+                }
+                try
+                {
+                    if (!keepOnlyOneConnection || connection == null)
+                    {
+                        connection = new FileConnection("URI=file:" + this.DBfileFullPath);
+                        connection.Open();
+                    }
+
+                    if (!connection.Tables.Contains(TABLE_NAME))
+                    {
+                        var table = new DataTable(TABLE_NAME);
+                        table.AcceptChanges();
+
+                        var eventColumn = new DataColumn
+                        {
+                            ColumnName = EVENT_COLUMN_NAME,
+                            DataType = typeof(string),
+                            AllowDBNull = false
+                        };
+                        var eventIdColumn = new DataColumn
+                        {
+                            ColumnName = EVENT_ID_COLUMN_NAME,
+                            DataType = typeof(string),
+                            AllowDBNull = false,
+                            Unique = true
+                        };
+                        var maAppIdColumn = new DataColumn
+                        {
+                            ColumnName = MA_APP_ID_COLUMN_NAME,
+                            DataType = typeof(string),
+                            AllowDBNull = false
+                        };
+                        var eventDeiliveryAttemptCountColumn = new DataColumn
+                        {
+                            ColumnName = EVENT_DELIVERY_ATTEMPT_COUNT_COLUMN_NAME,
+                            DataType = typeof(int),
+                            AllowDBNull = false,
+                            DefaultValue = 0
+                        };
+
+                        table.Columns.Add(eventColumn);
+                        table.Columns.Add(eventIdColumn);
+                        table.Columns.Add(maAppIdColumn);
+                        table.Columns.Add(eventDeiliveryAttemptCountColumn);
+                        table.AcceptChanges();
+
+                        connection.Tables.Add(table);
+                    }
+
+                    connection.Sql.AcceptChanges();
+                }
+                finally
+                {
+                    if (!keepOnlyOneConnection && connection != null)
+                    {
+                        connection.Save();
+                        connection.Dispose();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets up database.
+        /// </summary>
+        private void SetupSQLiteEventStore()
+        {
+            CreateOrOpenDatabase();
+        }
+
+
+        /// <summary>
+        /// Add an event to the store.
+        /// </summary>
+        /// <returns><c>true</c>, if event was put, <c>false</c> otherwise.</returns>
+        public void PutEvent(string eventString, string appId)
+        {
+            bool proceedToInsert = false;
+            long currentDatabaseSize = DatabaseSize;
+
+            if (string.IsNullOrEmpty(appId))
+                throw new ArgumentNullException("AppId");
+
+            if (currentDatabaseSize >= _maConfig.MaxDBSize)
+            {
+                proceedToInsert = false;
+
+                InvalidOperationException e = new InvalidOperationException();
+                _logger.Error(e, "The database size has exceeded the threshold limit. Unable to insert any new events");
+            }
+            else if ((double)currentDatabaseSize / (double)_maConfig.MaxDBSize >= _maConfig.DBWarningThreshold)
+            {
+                proceedToInsert = true;
+                _logger.InfoFormat("The database size is almost full");
+            }
+            else
+            {
+                proceedToInsert = true;
+            }
+
+            //keep the lock as short as possible
+            if (proceedToInsert)
+            {
+                lock (_lock)
+                {
+                    try
+                    {
+                        if (!keepOnlyOneConnection || connection == null)
+                        {
+                            connection = new FileConnection("URI=file:" + this.DBfileFullPath);
+                            connection.Open();
+                        }
+
+                        var eventRow = connection.Tables[TABLE_NAME].NewRow();
+                        eventRow[EVENT_COLUMN_NAME] = eventString;
+                        eventRow[EVENT_ID_COLUMN_NAME] = Guid.NewGuid().ToString();
+                        eventRow[MA_APP_ID_COLUMN_NAME] = appId;
+
+                        connection.Tables[TABLE_NAME].Rows.Add(eventRow);
+
+                        connection.Sql.AcceptChanges();
+                    }
+                    finally
+                    {
+                        if (!keepOnlyOneConnection && connection != null)
+                        {
+                            connection.Save();
+                            connection.Dispose();
+                        }
+                    }
+                }
+            }
+
+        }
+
+        /// <summary>
+        /// Deletes a list of events.
+        /// </summary>
+        /// <returns><c>true</c>, if events was deleted, <c>false</c> otherwise.</returns>
+        /// <param name="rowIds">Row identifiers.</param>
+        public void DeleteEvent(List<string> rowIds)
+        {
+            lock (_lock)
+            {
+                try
+                {
+                    if (!keepOnlyOneConnection || connection == null)
+                    {
+                        connection = new FileConnection("URI=file:" + this.DBfileFullPath);
+                        connection.Open();
+                    }
+
+                    List<DataRow> rows = new List<DataRow>();
+                    foreach (var rowId in rowIds)
+                    {
+                        var matchingRows = connection.Tables[TABLE_NAME].Select($"{EVENT_ID_COLUMN_NAME} = '{rowId}'");
+                        if (matchingRows != null && matchingRows.Length > 0)
+                            rows.AddRange(matchingRows);
+                    }
+                    rows = rows.Distinct().ToList();
+
+                    for (var i = 0; i < rows.Count; i++)
+                        connection.Tables[TABLE_NAME].Rows.Remove(rows[i]);
+
+                    connection.Sql.AcceptChanges();
+                }
+                finally
+                {
+                    if (!keepOnlyOneConnection && connection != null)
+                    {
+                        connection.Save();
+                        connection.Dispose();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get All event from the Event Store
+        /// </summary>
+        /// <param name="appID">Appid.</param>
+        /// <param name="maxAllowed">maximum number of events to fetch</param>
+        /// <returns>All the events as a List of <see cref="ThirdParty.Json.LitJson.JsonData"/>.</returns>
+        public List<JsonData> GetEvents(string appID, int maxAllowed)
+        {
+            List<JsonData> eventList = new List<JsonData>();
+            lock (_lock)
+            {
+                try
+                {
+                    if (!keepOnlyOneConnection || connection == null)
+                    {
+                        connection = new FileConnection("URI=file:" + this.DBfileFullPath);
+                        connection.Open();
+                    }
+
+                    var events = connection.Tables[TABLE_NAME].Select($"{MA_APP_ID_COLUMN_NAME} = '{appID}'").OrderBy(r => r[EVENT_DELIVERY_ATTEMPT_COUNT_COLUMN_NAME]).Take(maxAllowed);
+                    foreach (var eventRow in events)
+                    {
+                        JsonData data = new JsonData();
+                        data["id"] = eventRow[EVENT_ID_COLUMN_NAME].ToString();
+                        data["event"] = eventRow[EVENT_COLUMN_NAME].ToString();
+                        data["appId"] = eventRow[MA_APP_ID_COLUMN_NAME].ToString();
+                        eventList.Add(data);
+                    }
+
+                    connection.Sql.AcceptChanges();
+                }
+                finally
+                {
+                    if (!keepOnlyOneConnection && connection != null)
+                    {
+                        connection.Save();
+                        connection.Dispose();
+                    }
+                }
+            }
+
+            return eventList;
+        }
+
+        /// <summary>
+        /// Gets Numbers the of events.
+        /// </summary>
+        /// <returns>The number of events.</returns>
+        public long NumberOfEvents(string appID)
+        {
+            long count = 0;
+            lock (_lock)
+            {
+
+                try
+                {
+                    if (!keepOnlyOneConnection || connection == null)
+                    {
+                        connection = new FileConnection("URI=file:" + this.DBfileFullPath);
+                        connection.Open();
+                    }
+
+                    count = connection.Tables[TABLE_NAME].Select($"{MA_APP_ID_COLUMN_NAME} = '{appID}'").Count();
+                    UnityEngine.Debug.Log(string.Format("count = {0}", count));
+
+                    connection.Sql.AcceptChanges();
+                }
+                finally
+                {
+                    if (!keepOnlyOneConnection && connection != null)
+                    {
+                        connection.Save();
+                        connection.Dispose();
+                    }
+                }
+            }
+
+            return count;
+        }
+
+        /// <summary>
+        /// Increments the delivery attempt.
+        /// </summary>
+        /// <returns>Success of operation</returns>
+        /// <param name="rowIds">Row identifiers.</param>
+        public bool IncrementDeliveryAttempt(List<string> rowIds)
+        {
+            bool success = false;
+            lock (_lock)
+            {
+                try
+                {
+                    if (!keepOnlyOneConnection || connection == null)
+                    {
+                        connection = new FileConnection("URI=file:" + this.DBfileFullPath);
+                        connection.Open();
+                    }
+
+                    List<DataRow> rows = new List<DataRow>();
+                    foreach (var rowId in rowIds)
+                    {
+                        var matchingRows = connection.Tables[TABLE_NAME].Select($"{EVENT_ID_COLUMN_NAME} = '{rowId}'");
+                        if (matchingRows != null && matchingRows.Length > 0)
+                            rows.AddRange(matchingRows);
+                    }
+                    rows = rows.Distinct().ToList();
+
+                    for (var i = 0; i < rows.Count; i++)
+                        rows[i][EVENT_DELIVERY_ATTEMPT_COUNT_COLUMN_NAME] = (int)rows[i][EVENT_DELIVERY_ATTEMPT_COUNT_COLUMN_NAME] + 1;
+
+                    connection.Sql.AcceptChanges();
+                }
+                finally
+                {
+                    if (!keepOnlyOneConnection && connection != null)
+                    {
+                        connection.Save();
+                        connection.Dispose();
+                    }
+                }
+                return success;
+            }
+        }
+
+        /// <summary>
+        /// Gets the size of the database.
+        /// </summary>
+        /// <returns>The database size.</returns>
+        public long DatabaseSize
+        {
+            get
+            {
+                long sizeInKb = 0;
+                lock (_lock)
+                {
+                    try
+                    {
+                        if (!keepOnlyOneConnection || connection == null)
+                        {
+                            connection = new FileConnection("URI=file:" + this.DBfileFullPath);
+                            connection.Open();
+                        }
+
+                        var memoryStream = new MemoryStream();
+                        var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+
+                        binaryFormatter.Serialize(memoryStream, connection.Sql);
+                        sizeInKb = memoryStream.Length;
+
+                        binaryFormatter = null;
+                        memoryStream.Dispose();
+
+                        connection.Sql.AcceptChanges();
+                    }
+                    finally
+                    {
+                        if (!keepOnlyOneConnection && connection != null)
+                        {
+                            connection.Save();
+                            connection.Dispose();
+                        }
+                    }
+                }
+                return sizeInKb;
+            }
+        }
+
+        /// <summary>
+        /// Saves the database.
+        /// </summary>
+        public void SaveDatabase()
+        {
+            lock (_lock)
+            {
+                try
+                {
+                    if (!keepOnlyOneConnection || connection == null)
+                    {
+                        connection = new FileConnection("URI=file:" + this.DBfileFullPath);
+                        connection.Open();
+                    }
+
+                    connection.Save();
+                }
+                finally
+                {
+                    if (!keepOnlyOneConnection && connection != null)
+                    {
+                        connection.Save();
+                        connection.Dispose();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk/src/Services/MobileAnalytics/Custom/MobileAnalyticsManager.cs
+++ b/sdk/src/Services/MobileAnalytics/Custom/MobileAnalyticsManager.cs
@@ -36,6 +36,9 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager
         private static IDictionary<string, MobileAnalyticsManager> _instanceDictionary = new Dictionary<string, MobileAnalyticsManager>();
         private Logger _logger = Logger.GetLogger(typeof(MobileAnalyticsManager));
         private static BackgroundRunner _backgroundRunner = new BackgroundRunner();
+#if UNITY
+        private static CoroutineRunner _coroutineRunner = new CoroutineRunner();
+#endif
 
         #region constructor
 
@@ -135,7 +138,18 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager
                 managerInstance.Session.Start();
             }
 
+#if UNITY
+            if(UnityEngine.Application.platform == UnityEngine.RuntimePlatform.WebGLPlayer)
+            {
+                _coroutineRunner.StartWork();
+            }
+            else 
+            {
+                _backgroundRunner.StartWork();
+            }
+#else
             _backgroundRunner.StartWork();
+#endif
 
             return managerInstance;
         }

--- a/sdk/src/Services/MobileAnalytics/Custom/_unity/CoroutineRunner.unity.cs
+++ b/sdk/src/Services/MobileAnalytics/Custom/_unity/CoroutineRunner.unity.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+using Logger = Amazon.Runtime.Internal.Util.Logger;
+
+namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
+{
+    /// <summary>
+    /// Amazon Mobile Analytics coroutine runner.
+    /// Coroutine runner periodically calls delivery client to send events to server.
+    /// </summary>
+    public partial class CoroutineRunner
+    {
+        private Logger _logger = Logger.GetLogger(typeof(CoroutineRunner));
+
+        /// <summary>
+        /// Coroutine wait time. Coroutine will yield for the interval mention. Value is in Seconds.
+        /// Default 60 seconds.
+        /// </summary>
+        public const int BackgroundSubmissionWaitTime = 60;
+    
+        private static Coroutine _coroutine = null;
+        private static bool _shouldStop;
+
+        /// <summary>
+        /// Starts the Mobile Analytics Manager coroutine.
+        /// </summary>
+        public void StartWork()
+        {
+            if(_coroutine == null) 
+            {
+                _shouldStop = false;
+                _coroutine = UnityInitializer.Instance.StartCoroutine(DoWork());
+            }
+        }
+
+        /// <summary>
+        /// Aborts the coroutine.
+        /// </summary>
+        public static void StopCoroutine()
+        {
+            if (_coroutine != null) 
+            {
+                _shouldStop = true;
+                UnityInitializer.Instance.StopCoroutine(_coroutine);
+                _coroutine = null;
+            }
+        }
+
+        /// <summary>
+        /// Sends Mobile Analytics events to server on coroutine.
+        /// </summary>
+        private IEnumerator DoWork()
+        {
+            while (!_shouldStop) 
+            {
+                try 
+                {
+                    _logger.InfoFormat("Mobile Analytics Manager is trying to deliver events in background thread.");
+
+                    IDictionary<string, MobileAnalyticsManager> instanceDictionary = MobileAnalyticsManager.CopyOfInstanceDictionary;
+                    foreach (string appId in instanceDictionary.Keys) 
+                    {
+                        MobileAnalyticsManager manager = null;
+                        try 
+                        {
+                            manager = MobileAnalyticsManager.GetInstance(appId);
+                            manager.BackgroundDeliveryClient.AttemptDelivery();
+                        }
+                        catch (System.Exception e) 
+                        {
+                            _logger.Error(e, "An exception occurred in Mobile Analytics Delivery Client : {0}", e.ToString());
+
+                            if (null != manager) 
+                            {
+                                MobileAnalyticsErrorEventArgs eventArgs = new MobileAnalyticsErrorEventArgs(this.GetType().Name, "An exception occurred when deliverying events to Amazon Mobile Analytics.", e, new List<Amazon.MobileAnalytics.Model.Event>());
+                                manager.OnRaiseErrorEvent(eventArgs);
+                            }
+                        }
+                    }
+                }
+                catch (System.Exception e) 
+                {
+                    _logger.Error(e, "An exception occurred in Mobile Analytics Manager.");
+                }
+
+                yield return new WaitForSeconds(BackgroundSubmissionWaitTime);
+            }            
+        }
+    }
+}


### PR DESCRIPTION
-BackgroundInvoker replaced by CoroutineInvoker on UnityWebGL
-BackgroundRunner replaced by CoroutineRunner on UnityWebGL
-ThreadPool usage removed on UnityWebGL
-Cognito Identity support for GetCredentialsAsync() on UnityWebGL
-Mobile Analytics support for UnityWebGL with a FileEventStore instead of SQLiteEventStore

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Right at the start: My changes do not cover all services and all functions of the aws.sdk.net, mostly only the services we are using for our unity game (core, Cognito identity, mobile analytics). I can't guarantee that this is covering 100% (surely it is not), but at least it is something to start working with (maybe for a special Unity3D WebGL branch?).
The most of the code changes within unity only sections, but nevertheless, it should not affect non-WebGL builds. Only WebGL builds should use the changed methods/classes.

I added CoroutineRunner/CoroutineDispatcher like you have a BackgroundRunner/Dispatcher, which is basically running on coroutines on the unity main thread.
Calls which were related to Threading has been replaced by Unity Main Thread calls (for unity webgl only).
CognitoIdendity mostly used Synchronous methods, which I had to change in order to make it work for WebGL.
Also because SQLite is not supported in WebGL, I added a FileEventStore, which is based on System.Data.DataStore, in order to track mobile analytic events for WebGL builds. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, it is at least partially possible to use the aws.sdk.net inside Unity for WebGL builds.
<!--- If it fixes an open [issue][issues], please link to the issue here -->
https://github.com/aws/aws-sdk-net/issues/326
## Testing
<!--- Please describe in detail how you tested your changes -->
I ran tests of your SDK and also we are using the changes I did for our released facebook WebGL game, where we use different tools to keep an eye on every exception which happens in our special WebGL-only aws.sdk.net
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tried to minimize the impact on non-Unity related target frameworks with using unity define flags whenever I changed something, which is not directly part of a unity subfolder.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement