### PR TITLE
[S3] Fixing PutObject High Memory Usage

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ChunkedUploadWrapperStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ChunkedUploadWrapperStream.cs
@@ -37,7 +37,7 @@ namespace Amazon.Runtime.Internal.Util
     /// </summary>
     public class ChunkedUploadWrapperStream : WrapperStream
     {
-        public static readonly int DefaultChunkSize = 128*1024;
+        public static readonly int DefaultChunkSize = 81920;
 
         private const string CLRF = "\r\n";
         private const string CHUNK_STRING_TO_SIGN_PREFIX = "AWS4-HMAC-SHA256-PAYLOAD";


### PR DESCRIPTION
See https://github.com/aws/aws-sdk-net/issues/894 for detailed description

<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously, when invoking the constructor of `ChunkedUploadWrapperStream` it used to create two byte arrays each with a size of `131,072` (`128*1024`). From a memory aspect this is inefficient as objects over `85,000` bytes go straight into an area of memory known as the Large Object Heap (LOH). This area is never compacted by default (as compaction of the LOH is expensive), but is collected. Over a lifetime of an application it is possible to end up in a situation where the LOH has taken up most of the RAM.

Now, the byte arrays are still created but with a size of `81,920`. The reason for this number can be found here: https://referencesource.microsoft.com/#mscorlib/system/io/stream.cs,50. As `81,920` is under the `85,000` threshold the byte arrays in question go onto the Small Object Heap (SOH). This area of memory is collected **and** compacted by default.

## Motivation and Context
To reduce memory consumption of this call:-
https://github.com/aws/aws-sdk-net/blob/9814e245e0cd9c4435a17185e866813869d427da/sdk/src/Services/S3/Generated/_bcl45/AmazonS3Client.cs#L4421

| |Total | SOH | LOH
------------ | ------------- | ------------- | -------------
Before|114MB|64MB|50MB
After|98MB|98MB|0.4MB

## Testing
See https://github.com/aws/aws-sdk-net/issues/894 for benchmarks within a test harness for pre/post change.

## Screenshots (if appropriate)
See https://github.com/aws/aws-sdk-net/issues/894 for screenshots

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement