### PR TITLE
Mobile implementation to allow to use a custom Http message handler, like ModernHttpClient. (Core and S3 Service)

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_mobile/HttpRequestMessageFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_mobile/HttpRequestMessageFactory.cs
@@ -163,7 +163,7 @@ namespace Amazon.Runtime
 
         private static HttpClient CreateHttpClient(IClientConfig clientConfig)
         {
-            var httpMessageHandler = new HttpClientHandler();
+            var httpMessageHandler = clientConfig.GetHttpMessageHandler() ?? new HttpClientHandler();
 #if CORECLR
             if (clientConfig.MaxConnectionsPerServer.HasValue)
                 httpMessageHandler.MaxConnectionsPerServer = clientConfig.MaxConnectionsPerServer.Value;

--- a/sdk/src/Core/Amazon.Runtime/_mobile/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/_mobile/ClientConfig.cs
@@ -27,6 +27,7 @@ namespace Amazon.Runtime
     /// </summary>    
     public abstract partial class ClientConfig
     {
+        private Func<HttpClientHandler> _httpClientHandler = null;
         private IWebProxy proxy = null;
         private string proxyHost;
         private int proxyPort = -1;
@@ -34,6 +35,23 @@ namespace Amazon.Runtime
         private static RegionEndpoint GetDefaultRegionEndpoint()
         {
             return FallbackRegionFactory.GetRegionEndpoint();
+        }
+
+        /// <summary>
+        /// Return a custom http message handle to use with HttpClient. (example: NativeMessageHandler from ModernHttpClient)
+        /// Default Http Message Handler used if null value returned
+        /// </summary>
+        public HttpClientHandler GetHttpMessageHandler()
+        {
+            return _httpClientHandler?.Invoke(); // Use the default Http client handler
+        }
+        /// <summary>
+        /// Update the Http Client handler to use
+        /// </summary>
+        /// <param name="httpClientHandler">A function that returns a new instance of the http client handler to use</param>
+        public void SetHttpMessageHandler(Func<HttpClientHandler> httpClientHandler)
+        {
+            this._httpClientHandler = httpClientHandler;
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/_mobile/IClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/_mobile/IClientConfig.cs
@@ -20,6 +20,7 @@ using System.Text;
 using Amazon.Util;
 
 using Amazon.Runtime.Internal.Auth;
+using System.Net.Http;
 
 namespace Amazon.Runtime
 {
@@ -41,5 +42,10 @@ namespace Amazon.Runtime
         /// </summary>
         IWebProxy GetWebProxy();
 
+        /// <summary>
+        /// Return a custom http message handle to use with HttpClient. (example: NativeMessageHandler from ModernHttpClient)
+        /// Default Http Message Handler used if null value returned
+        /// </summary>
+        HttpClientHandler GetHttpMessageHandler();
     }
 }

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3HttpUtil.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3HttpUtil.cs
@@ -68,19 +68,17 @@ namespace Amazon.S3
 
         private static HttpClient GetHttpClient(IClientConfig config)
         {
+            var handler = config.GetHttpMessageHandler();
             var proxy = GetProxyIfAvailableAndConfigured(config);
             if (proxy == null)
             {
-                return new HttpClient();
+                return new HttpClient(handler);
             }
             else
             {
-                return new HttpClient(
-                    new HttpClientHandler
-                    {
-                        Proxy = proxy,
-                        UseProxy = true
-                    });
+                handler.Proxy = proxy;
+                handler.UseProxy = true;
+                return new HttpClient(handler);
             }
         }
 #endif


### PR DESCRIPTION
The actual mobile implementation doesn't allow to use a custom Http message handler, like ModernHttpClient.
This will patch will affect the S3 service, but can be ported to other projects who internally create HttpClient object.

**Motivation and Context**
I have to use AWS SDK liberary in a mobile project. But I have to integrate Mobile Iron support, so I have to use a specific set of Http Client. In may case I have to use ModernHttpClient library.
Actually I have to use AWS source code directly, but it would be great if this request would be added directly to the AWS code.

**Testing**
S3 example:
var config = new AmazonS3Config();
config.SetHttpMessageHandler(new ModernHttpClient());
:
var s3 = new AmazonS3Client(credentials, config);