### PR TITLE
Expose Custom Logging

### DIFF
--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -605,6 +605,11 @@ namespace Amazon
         /// </summary>
         UnityLogger = 8
 #endif
+        ,
+        /// <summary>
+        /// Log using a custom provider specified in AWSConfigs.LoggingConfig.CustomLogger.
+        /// </summary>
+        Custom = 32
     }
 
     /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/BaseLogger.cs
+++ b/sdk/src/Core/Amazon.Runtime/BaseLogger.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace Amazon.Runtime
+{
+    /// <summary>
+    /// Abstract logger class, base for any custom/specific loggers.
+    /// </summary>
+    public abstract class BaseLogger
+    {
+        public Type DeclaringType { get; private set; }
+
+        public bool IsEnabled { get; set; }
+
+        public BaseLogger(Type declaringType)
+        {
+            DeclaringType = declaringType;
+            IsEnabled = true;
+        }
+
+        #region Logging methods
+
+        /// <summary>
+        /// Flushes the logger contents.
+        /// </summary>
+        public abstract void Flush();
+
+        /// <summary>
+        /// Simple wrapper around the log4net IsErrorEnabled property.
+        /// </summary>
+        public virtual bool IsErrorEnabled { get { return true; } }
+
+        /// <summary>
+        /// Simple wrapper around the log4net IsDebugEnabled property.
+        /// </summary>
+        public virtual bool IsDebugEnabled { get { return true; } }
+
+        /// <summary>
+        /// Simple wrapper around the log4net IsInfoEnabled property.
+        /// </summary>
+        public virtual bool IsInfoEnabled { get { return true; } }
+
+        /// <summary>
+        /// Simple wrapper around the log4net Error method.
+        /// </summary>
+        /// <param name="exception"></param>
+        /// <param name="messageFormat"></param>
+        /// <param name="args"></param>
+        public abstract void Error(Exception exception, string messageFormat, params object[] args);
+
+        /// <summary>
+        /// Simple wrapper around the log4net Debug method.
+        /// </summary>
+        /// <param name="exception"></param>
+        /// <param name="messageFormat"></param>
+        /// <param name="args"></param>
+        public abstract void Debug(Exception exception, string messageFormat, params object[] args);
+
+        /// <summary>
+        /// Simple wrapper around the log4net DebugFormat method.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="arguments"></param>
+        public abstract void DebugFormat(string message, params object[] arguments);
+
+        /// <summary>
+        /// Simple wrapper around the log4net InfoFormat method.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="arguments"></param>
+        public abstract void InfoFormat(string message, params object[] arguments);
+
+        #endregion
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Console.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Console.cs
@@ -9,7 +9,7 @@ using System.Threading;
 namespace Amazon.Runtime.Internal.Util
 {
 
-    internal class InternalConsoleLogger : InternalLogger
+    internal class InternalConsoleLogger : BaseLogger
     {
 		//mapped to android logcat
 		enum LogLevel

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
@@ -27,7 +27,7 @@ namespace Amazon.Runtime.Internal.Util
     /// <summary>
     /// Logger wrapper for reflected log4net logging methods.
     /// </summary>
-    internal class InternalLog4netLogger : InternalLogger
+    internal class InternalLog4netLogger : BaseLogger
     {
         enum LoadState { Uninitialized, Failed, Loading, Success };
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/_bcl/Logger.Diagnostic.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/_bcl/Logger.Diagnostic.cs
@@ -26,7 +26,7 @@ namespace Amazon.Runtime.Internal.Util
     /// <summary>
     /// Logger wrapper for System.Diagnostics.TraceSource logger.
     /// </summary>
-    internal class InternalSystemDiagnosticsLogger : InternalLogger
+    internal class InternalSystemDiagnosticsLogger : BaseLogger
     {
         volatile int eventId = 0;
         TraceSource trace;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/_pcl/Logger.File.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/_pcl/Logger.File.cs
@@ -12,7 +12,7 @@ using System.Text.RegularExpressions;
 
 namespace Amazon.Runtime.Internal.Util
 {
-    internal class InternalFileLogger : InternalLogger
+    internal class InternalFileLogger : BaseLogger
     {
 		enum LogLevel
 		{

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/_pcl/Logger.Mobile.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/_pcl/Logger.Mobile.cs
@@ -30,7 +30,7 @@ namespace Amazon.Runtime.Internal.Util
     /// Logger wrapper for Console.WriteLine()
     /// </summary>
     [Obsolete("Use InternalConsoleLogger instead")]
-    internal class MobileLogger : InternalLogger
+    internal class MobileLogger : BaseLogger
     {
         private const string InfoMsg = "[AWSSDK INFO] {0}";
         private const string DebugMsg = "[AWSSDK DEBUG] {0}";

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/_unity/UnityDebugLogger.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/_unity/UnityDebugLogger.cs
@@ -20,7 +20,7 @@ using System.Text;
 
 namespace Amazon.Runtime.Internal.Util
 {
-    internal class UnityDebugLogger : InternalLogger
+    internal class UnityDebugLogger : BaseLogger
     {
 
         public UnityDebugLogger(Type declaringType)

--- a/sdk/src/Core/Amazon.Util/AWSConfigs.Models.cs
+++ b/sdk/src/Core/Amazon.Util/AWSConfigs.Models.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
+using Amazon.Runtime;
 
 namespace Amazon.Util
 {
@@ -119,6 +120,11 @@ namespace Amazon.Util
         /// A custom formatter added through Configuration
         /// </summary>
         public Amazon.Runtime.IMetricsFormatter LogMetricsCustomFormatter { get; set; }
+
+        /// <summary>
+        /// A custom logger to be used when LogTo includes "Custom"
+        /// </summary>
+        public BaseLogger CustomLogger { get; set; }
 
         internal LoggingConfig()
         {


### PR DESCRIPTION
## Description
I've moved `InternalLogger` up into the `Amazon.Runtime` namespace, renamed it to `BaseLogger` and made it public. Then I added the ability to pass in an instance into the config, and an enum option to enable it.

## Motivation and Context
Currently on .NET Core there is no nice way to get logs. If we targeted `netstandard2.0` we could use the `TraceSource` stuff as a bridge. We could even use the PLC implementation of `FileLogger`, although I would like to be able to provide my own logger implementation still.

I went down the route of using reflection to interact with `Microsoft.Extensions.Logging.Abstractions` so that you could pass in an instance of a `Logger` (as an untyped `object`) and do it the same way as with `log4net`, but I think that it is too much kung-fu for what should be a first class abstraction.

These APIs have been stable for long enough that they can now be made public IMO.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement