### PR TITLE
Integrationtest

### DIFF
--- a/sdk/test/CrossPlatformTests/CommonTests/CommonTests.csproj
+++ b/sdk/test/CrossPlatformTests/CommonTests/CommonTests.csproj
@@ -60,8 +60,9 @@
     <Compile Include="IntegrationTests\CloudWatch.cs" />
     <Compile Include="IntegrationTests\CloudWatchLogs.cs" />
     <Compile Include="IntegrationTests\CodeDeploy.cs" />
-	<Compile Include="IntegrationTests\MobileAnalyticsManager.cs" />
-	<Compile Include="IntegrationTests\S3\WebProxyTest.cs" />
+    <Compile Include="IntegrationTests\CognitoIdentityTests.cs" />
+    <Compile Include="IntegrationTests\MobileAnalyticsManager.cs" />
+    <Compile Include="IntegrationTests\S3\WebProxyTest.cs" />
     <Compile Include="IntegrationTests\SyncManager.cs" />
     <Compile Include="IntegrationTests\CredentialsTests.cs" />
     <Compile Include="IntegrationTests\DataPipeline.cs" />

--- a/sdk/test/CrossPlatformTests/CommonTests/Framework/Settings.cs
+++ b/sdk/test/CrossPlatformTests/CommonTests/Framework/Settings.cs
@@ -16,7 +16,7 @@ namespace CommonTests.Framework
         public static RegionEndpoint RegionEndpoint { get; private set; }
         public static string ResultsBucket { get; private set; }
         public static string ResultsTopic { get; private set; }
-
+        public static StoredSettings storedSettings { get;  private set;}
         private const string DefaultRegion = "us-west-2";
 
         static Settings()
@@ -33,7 +33,7 @@ namespace CommonTests.Framework
         {
             SetDefaults();
 
-            var storedSettings = GetStoredSettings(settingsResourcePartialName);
+            storedSettings = GetStoredSettings(settingsResourcePartialName);
             if (storedSettings == null)
                 return;
 
@@ -97,7 +97,7 @@ namespace CommonTests.Framework
             }
         }
 
-        private class StoredSettings
+        public class StoredSettings
         {
             public string AccessKeyId { get; set; }
             public string SecretAccessKey { get; set; }
@@ -107,6 +107,17 @@ namespace CommonTests.Framework
 
             public string ResultsBucket { get; set; }
             public string ResultsTopic { get; set; }
-        }
+            public string CognitoPoolId { get; set; }
+            public string UnAuthCognitoPoolId { get; set; }
+            public string AuthCognitoPoolId { get; set; }
+            public string UnAuthUnAuthRole { get; set; }
+            public string UnAuthAuthRole { get; set; }
+            public string AuthUnAuthRole { get; set; }
+            public string AuthAuthRole { get; set; }
+            public string AccountId { get; set; }
+            public string AuthProvider { get; set; }
+            public string AuthToken { get; set; }
+
+       }
     }
 }

--- a/sdk/test/CrossPlatformTests/CommonTests/Framework/TestBase.cs
+++ b/sdk/test/CrossPlatformTests/CommonTests/Framework/TestBase.cs
@@ -24,9 +24,9 @@ namespace CommonTests.Framework
         {
             credentials = credentials ?? TestRunner.Credentials;
             endpoint = endpoint ?? TestRunner.RegionEndpoint;
-
+            //use credentials, the parameter passed to the function, instead of the default credential to create the service.
             return (TClient)Activator.CreateInstance(typeof(TClient),
-                    new object[] { TestRunner.Credentials,  endpoint});
+                    new object[] { credentials,  endpoint});
         }
     }
 

--- a/sdk/test/CrossPlatformTests/CommonTests/Framework/TestRunner.cs
+++ b/sdk/test/CrossPlatformTests/CommonTests/Framework/TestRunner.cs
@@ -45,7 +45,8 @@ namespace CommonTests.Framework
         internal static AWSCredentials Credentials { get; set; }
         internal static RegionEndpoint RegionEndpoint { get; set; }
         public static TestRunner Instance { get; private set; }
-
+        //Let the setting data can be accessed directly from outside of the class
+        internal static Settings.StoredSettings StoredSettings { get; private set; } 
         private TextWriter LogWriter { get; set; }
         public virtual ITestListener Listener { get; private set; }
         public virtual ITestFilter Filter
@@ -87,6 +88,7 @@ namespace CommonTests.Framework
         {
             TestRunner.Credentials = Settings.Credentials;
             TestRunner.RegionEndpoint = Settings.RegionEndpoint;
+            TestRunner.StoredSettings = Settings.storedSettings; 
             var logging = AWSConfigs.LoggingConfig;
             logging.LogTo = LoggingOptions.SystemDiagnostics;
             logging.LogResponses = ResponseLoggingOption.Always;
@@ -232,6 +234,14 @@ namespace CommonTests.Framework
         }
 
         #endregion
+        //Let the log file path is accessible from outside of the class
+        public string logfilepath
+        {
+            get
+            {
+                return LogWriter.ToString(); 
+            }
+        }
 
         #region Log pushes
 

--- a/sdk/test/CrossPlatformTests/CommonTests/IntegrationTests/CognitoIdentityTests.cs
+++ b/sdk/test/CrossPlatformTests/CommonTests/IntegrationTests/CognitoIdentityTests.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Amazon.CognitoIdentity;
+using CommonTests.Framework;
+using Amazon.S3;
+using Amazon;
+using Amazon.S3.Model;
+namespace CommonTests.IntegrationTests
+{
+    [TestFixture]
+    public class CognitoIdentityTests
+    {
+        [Test]
+        [Category("CognitoIdentity")]
+        //test Amazon Cognito Enhanced(Simplified) Flow with unauthenticated role
+        public void TestUnAuthorEnhancedFlow()
+        {
+            string poolId = TestRunner.StoredSettings.UnAuthCognitoPoolId;
+            RegionEndpoint regionEndpoint = TestRunner.RegionEndpoint;
+            CognitoAWSCredentials cognitoCredentials = new CognitoAWSCredentials(poolId, regionEndpoint);
+            VerifyCredentailsProperties(cognitoCredentials, poolId);
+            VerifyServiceAccess(cognitoCredentials);
+        }
+
+        [Test]
+        [Category("CognitoIdentity")]
+        //test Amazon Cognito Authentication Basic (Classic) Flow with Unauthenticated role
+        public void TesUnAuthorBasedFlow()
+        {
+            string accountId = TestRunner.StoredSettings.AccountId;
+            string poolId = TestRunner.StoredSettings.UnAuthCognitoPoolId;
+            RegionEndpoint regionEndpoint = TestRunner.RegionEndpoint;
+            string authRole = TestRunner.StoredSettings.UnAuthAuthRole;
+            string unauthRole = TestRunner.StoredSettings.UnAuthUnAuthRole;
+            CognitoAWSCredentials cognitoCredentials = new CognitoAWSCredentials(accountId, poolId, unauthRole, authRole, regionEndpoint);
+            VerifyCredentailsProperties(cognitoCredentials, poolId, accountId,unauthRole,authRole);
+            VerifyServiceAccess(cognitoCredentials);
+        }
+
+        [Test]
+        [Category("CognitoIdentity")]
+        //test Amazon Cognito Enhanced (Simplified) Flow with Authenticated role
+        public void TestAuthorEnhancedFlow()
+        {
+            string poolId = TestRunner.StoredSettings.AuthCognitoPoolId;
+            RegionEndpoint regionEndpoint = TestRunner.RegionEndpoint;
+            string authProvider = TestRunner.StoredSettings.AuthProvider;
+            string authToken = TestRunner.StoredSettings.AuthToken;
+            CognitoAWSCredentials cognitoCredentials = new CognitoAWSCredentials(poolId, regionEndpoint);
+            cognitoCredentials.AddLogin(authProvider, authToken);
+            VerifyCredentailsProperties(cognitoCredentials, poolId);
+            VerifyServiceAccess(cognitoCredentials);
+        }
+
+        [Test]
+        [Category("CognitoIdentity")]
+        //test Amazon Cognito Authentication Basic (Classic) Flow with Authenticated role
+        public void TestAuthorBasedFlow()
+        {
+            string accountId = TestRunner.StoredSettings.AccountId;
+            string poolId = TestRunner.StoredSettings.AuthCognitoPoolId;
+            RegionEndpoint regionEndpoint = TestRunner.RegionEndpoint;
+            string authRole = TestRunner.StoredSettings.AuthAuthRole;
+            string unauthRole = TestRunner.StoredSettings.AuthUnAuthRole;
+            string authProvider = TestRunner.StoredSettings.AuthProvider;
+            string authToken = TestRunner.StoredSettings.AuthToken;
+            CognitoAWSCredentials cognitoCredentials = new CognitoAWSCredentials(accountId, poolId, unauthRole, authRole, regionEndpoint);
+            cognitoCredentials.AddLogin(authProvider, authToken);
+            VerifyCredentailsProperties(cognitoCredentials, poolId, accountId, unauthRole, authRole);
+            VerifyServiceAccess(cognitoCredentials);
+        }
+
+        //This api is to save the log file to S3 service
+        //We use this api to verify CognitoAWSCredentials object is working
+        private void SaveToS3(AmazonS3Client s3, string key, string log)
+        {
+            try
+            { 
+                s3.PutObjectAsync(new PutObjectRequest
+                {
+                    BucketName = Settings.ResultsBucket,
+                    Key = key,
+                    ContentBody = log
+                }).Wait();               
+            }
+            catch (Exception e)
+            {
+                Assert.Fail(e.Message); 
+            }
+        }
+
+        public void VerifyCredentailsProperties(CognitoAWSCredentials credentials, string IdentityPoolId)
+        {
+            Assert.IsTrue(credentials.IdentityPoolId == IdentityPoolId);             
+        }
+
+        public void VerifyCredentailsProperties(CognitoAWSCredentials credentials, string IdentityPoolId, string accountId, string unAuthRoleArn, string AuthRoleArn)
+        {
+            VerifyCredentailsProperties(credentials, IdentityPoolId);
+            Assert.IsTrue(credentials.AccountId == accountId);
+            Assert.IsTrue(credentials.UnAuthRoleArn == unAuthRoleArn);
+            Assert.IsTrue(credentials.AuthRoleArn == AuthRoleArn);
+        }
+
+        //Verify the CognitoAWSCredentials object can be used to access AWS services
+        public void VerifyServiceAccess(CognitoAWSCredentials credentials)
+        {
+            var originalS3Signature = AWSConfigsS3.UseSignatureVersion4;
+            AWSConfigsS3.UseSignatureVersion4 = true;
+            try
+            {
+                using (var s3 = TestBase.CreateClient<Amazon.S3.AmazonS3Client>(credentials))
+                {                   
+                    string timestampFormat = "yyyy-MM-dd-HH-mm-ss";
+                    var timestamp = DateTime.Now.ToString(timestampFormat);
+                    var key = string.Format("{0}_{1}", "verifycongnito", timestamp);
+                    var file = TestRunner.Instance.logfilepath;
+                    SaveToS3(s3, key, file);
+                    var result = s3.ListBucketsAsync().Result; 
+                    if(result != null)
+                    {
+                        var buckets = s3.ListBucketsAsync().Result.Buckets;
+                        Console.WriteLine(buckets.Count);
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                Assert.Fail(e.Message);
+            }
+
+            finally
+            {
+                AWSConfigsS3.UseSignatureVersion4 = originalS3Signature;
+            }
+        }
+    }
+}

--- a/sdk/test/CrossPlatformTests/CommonTests/Resources/README.txt
+++ b/sdk/test/CrossPlatformTests/CommonTests/Resources/README.txt
@@ -8,4 +8,15 @@ To provide credentials to the test applications, place a file named "settings.js
 	"RegionEndpoint"  : "us-west-2",
 	"ResultsBucket"   : "",
 	"ResultsTopic"    : ""
+	"UnAuthCognitoPoolId" : "",
+	"UnAuthUnAuthRole" : "",
+	"UnAuthAuthRole" : "",
+	"AuthCognitoPoolId" : "",
+	"AuthUnAuthRole" : "",
+	"AuthAuthRole" : "",
+	"AccountId" : "",
+
+	"AuthProvider" : "",
+	"AuthToken" : ""
+
 }


### PR DESCRIPTION
 

## Description
Add test code for Cognito Identity
Fix a bug with which the default AWSCredentials is always used to create a AWS service

## Motivation and Context

Let Cognito Identity service can be tested by the test project



## Testing

Run the test project, the four test cases for Cognito identity service should be executed

## Screenshots (if appropriate)

## Types of changes
 
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement