### PR TITLE
Make compatible with Unity 2017.2

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Pipeline/_unity/UnityWebRequestWrapper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/_unity/UnityWebRequestWrapper.cs
@@ -68,6 +68,7 @@ namespace Amazon.Runtime.Internal
 
             setRequestHeaderMethod = unityWebRequestType.GetMethod("SetRequestHeader");
             sendMethod = unityWebRequestType.GetMethod("Send");
+            sendMethod = sendMethod ?? unityWebRequestType.GetMethod("SendWebRequest"); // from Unity 2017.2
             getResponseHeadersMethod = unityWebRequestType.GetMethod("GetResponseHeaders");
 
             isDoneGetMethod = isDoneProperty.GetGetMethod();

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/_unity/UnityWebRequestWrapper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/_unity/UnityWebRequestWrapper.cs
@@ -67,8 +67,8 @@ namespace Amazon.Runtime.Internal
             PropertyInfo errorProperty = unityWebRequestType.GetProperty("error");
 
             setRequestHeaderMethod = unityWebRequestType.GetMethod("SetRequestHeader");
-            sendMethod = unityWebRequestType.GetMethod("Send");
-            sendMethod = sendMethod ?? unityWebRequestType.GetMethod("SendWebRequest"); // from Unity 2017.2
+            sendMethod = unityWebRequestType.GetMethod("SendWebRequest"); // from Unity 2017.2
+            sendMethod = sendMethod ?? unityWebRequestType.GetMethod("Send");
             getResponseHeadersMethod = unityWebRequestType.GetMethod("GetResponseHeaders");
 
             isDoneGetMethod = isDoneProperty.GetGetMethod();


### PR DESCRIPTION
Support API update of UnityWebRequest at Unity 2017.2.

## Description
From Unity 2017.2, `UnityWebRequest.Send` became obsolete and `UnityWebRequest.SendWebRequest` is added.
Ref of `Send` : https://docs.unity3d.com/2017.2/Documentation/ScriptReference/Networking.UnityWebRequest.Send.html
Ref of `SendWebRequest`: https://docs.unity3d.com/2017.2/Documentation/ScriptReference/Networking.UnityWebRequest.SendWebRequest.html
You should use new API as it will lead to NullPointerException at here: https://github.com/aws/aws-sdk-net/blob/a6dfc29fe6802bd2982a2c981980a73d1f386918/sdk/src/Core/Amazon.Runtime/Pipeline/_unity/UnityWebRequestWrapper.cs#L190

## Motivation and Context
Our project with Unity 2018.2 using Kinesis Firehose, but of this problem it couldn't send.
I think there is no issue related to this.

## Testing
I tested this change by building dll and deployed AWSSDK.Core.dll to Unity 2018.1, and it worked successfully.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement