### PR TITLE
save the clientid to the local setting before assign it to class memb…

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/_pcl/ClientContext.pcl.cs
+++ b/sdk/src/Core/Amazon.Runtime/_pcl/ClientContext.pcl.cs
@@ -38,9 +38,10 @@ namespace Amazon.Runtime.Internal
             {
                 _clientID = _appSetting.GetValue(APP_ID_KEY, ApplicationSettingsMode.Local);
                 if (string.IsNullOrEmpty(_clientID))
-                {
-                    _clientID = Guid.NewGuid().ToString();
-                    _appSetting.SetValue(APP_ID_KEY, _clientID, ApplicationSettingsMode.Local);
+                { 
+                    string newClientID = Guid.NewGuid().ToString();
+                    _appSetting.SetValue(APP_ID_KEY, newClientID, ApplicationSettingsMode.Local);
+                    _clientID = newClientID;
                 }
             }
         }


### PR DESCRIPTION
…er variable so that if the saving operation throw an exception, the class member will not be assigned

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix an issue in ClientContext constructor
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

save the clientid to the local setting before assign it to class member variable so that if saving operation throw an exception, the class member will not be assigned

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement