### PR TITLE
AWS Credentials from User Environment Variables

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+coreclr/EnvironmentVariablesAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+coreclr/EnvironmentVariablesAWSCredentials.cs
@@ -65,11 +65,11 @@ namespace Amazon.Runtime
         /// <returns></returns>
         public ImmutableCredentials FetchCredentials()
         {
-            string accessKeyId = Environment.GetEnvironmentVariable(ENVIRONMENT_VARIABLE_ACCESSKEY);
-            string secretKey = Environment.GetEnvironmentVariable(ENVIRONMENT_VARIABLE_SECRETKEY);
+            string accessKeyId = GetEnvironmentVariable(ENVIRONMENT_VARIABLE_ACCESSKEY);
+            string secretKey = GetEnvironmentVariable(ENVIRONMENT_VARIABLE_SECRETKEY);
             if (string.IsNullOrEmpty(secretKey))
             {
-                secretKey = Environment.GetEnvironmentVariable(LEGACY_ENVIRONMENT_VARIABLE_SECRETKEY);
+                secretKey = GetEnvironmentVariable(LEGACY_ENVIRONMENT_VARIABLE_SECRETKEY);
                 if (!string.IsNullOrEmpty(secretKey))
                     logger.InfoFormat("AWS secret key found using legacy and non-standard environment variable '{0}', consider updating to the cross-SDK standard variable '{1}'.",
                                       LEGACY_ENVIRONMENT_VARIABLE_SECRETKEY, ENVIRONMENT_VARIABLE_SECRETKEY);
@@ -82,7 +82,7 @@ namespace Amazon.Runtime
                     ENVIRONMENT_VARIABLE_ACCESSKEY, ENVIRONMENT_VARIABLE_SECRETKEY, ENVIRONMENT_VARIABLE_SESSION_TOKEN));
             }
 
-            string sessionToken = Environment.GetEnvironmentVariable(ENVIRONMENT_VARIABLE_SESSION_TOKEN);
+            string sessionToken = GetEnvironmentVariable(ENVIRONMENT_VARIABLE_SESSION_TOKEN);
 
             logger.InfoFormat("Credentials found using environment variables.");
 
@@ -96,6 +96,16 @@ namespace Amazon.Runtime
         public override ImmutableCredentials GetCredentials()
         {
             return FetchCredentials();
+        }
+
+        /// <summary>
+        /// Retrieve an environment variable at the process level by default, but fallback to user variables if unavailable.
+        /// </summary>
+        /// <returns>string containing environment variable value, otherwise null.</returns>
+        private string GetEnvironmentVariable(string name)
+        {
+            return Environment.GetEnvironmentVariable(name, EnvironmentVariableTarget.Process)
+                   ?? Environment.GetEnvironmentVariable(name, EnvironmentVariableTarget.User);
         }
     }
 }


### PR DESCRIPTION
One of the credential options used automatically as a part of the FallbackCredentialsFactory is to pull the key ID and secret directly out of Environment Variables with the following class: EnvironmentVariablesAWSCredentials. Currently, this class pulls only from "Process" level environment variables. This change adds a check to "User" level variables to see if the key ID and secret are available.

## Motivation and Context
The key motivation for this is mainly for local development purposes using .NET 4.5+. Our team specifies key ID, secret and session token via User level environment variables that is generated and added to the system via many different command line tools available. This is necessary since the role to assume for the applications requires MFA entry on assume (and therefore cannot be assumed directly by the application itself). A temporary session token and values are stored in user level environment variables. When developing in .NET 4.5 against IIS Express all the user level variables are automatically brought into the process and this works fine. However, working against local IIS (with app pool configured as my own user account with the variables) the environment user variables are not loaded into the process (even with the "load user profile" IIS option).

This change would be highly convenient, and also would seem to make sense to pull in User level variables for this. Since IIS Express and .NET Core already automatically bring in the User level variables on start, this should provide more consistency as well.

## Testing
Existing supported tests are passing: EnvironmentalVariablesAWSCredentialsTest
I would like to add additional testing here, but would require further changes to the EnvironmentVariablesAWSCredentials class to mock out the usage of Environment variables (abstract it). I'm open to making these changes if interested.

## Types of changes
The change would be entirely backwards compatible.