### PR TITLE
DynamoDB: Document should allow assigning of null property values

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBEntry.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBEntry.cs
@@ -588,8 +588,10 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <returns>DynamoDBEntry representing the data</returns>
         public static implicit operator DynamoDBEntry(String data)
         {
+            if(data == null) return new Primitive();
             return new UnconvertedDynamoDBEntry(data);
         }
+
         /// <summary>
         /// Explicitly convert DynamoDBEntry to String
         /// </summary>

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -103,5 +103,49 @@ namespace AWSSDK_DotNet35.UnitTests
                 Assert.AreEqual(jsonOriginal[property].ToString(), jsonNew[property].ToString());
             }
         }
+
+        private class EmptyStringTestObject
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestEmptyPropertyFromObjectOnDocument()
+        {
+            var obj = new EmptyStringTestObject
+            {
+                Id = 1,
+                Name = null
+            };
+
+            var doc = new Document
+            {
+                ["Id"] = obj.Id,
+                ["Name"] = obj.Name
+            };
+
+            Assert.AreEqual(2, doc.Keys.Count);
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestExplicitNullPropertyOnDocument()
+        {
+            var obj = new EmptyStringTestObject
+            {
+                Id = 1
+            };
+
+            var doc = new Document
+            {
+                ["Id"] = obj.Id,
+                ["Name"] = null
+            };
+
+            Assert.AreEqual(2, doc.Keys.Count);
+        }
+
     }
 }


### PR DESCRIPTION
DynamoDB DocumentModel

Assigning a Document property with null works, but assigning it from an object with a string property set to null doesn't work. It should generate the same result (a new primitive that will not be included when saving in DynamoDB since empty string values are not allowed).

The added logic applies to strings in DynamoDBEntry, see "this" property in Document for an example of the same logic.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
See included unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement