### PR TITLE
Make S3 metadata collection keys case-insensitive

### DIFF
--- a/sdk/src/Services/S3/Custom/Model/MetadataCollection.cs
+++ b/sdk/src/Services/S3/Custom/Model/MetadataCollection.cs
@@ -26,7 +26,7 @@ namespace Amazon.S3.Model
     {
         internal const string MetaDataHeaderPrefix = "x-amz-meta-";
             
-        IDictionary<string, string> values = new Dictionary<string, string>();
+        IDictionary<string, string> values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets and sets meta data for the object. Meta data names must start with "x-amz-meta-". If the name passeed in as the indexer 


### PR DESCRIPTION
## Description
As the title states this PR makes S3 metadata collection keys case-insensitive to be consistent with the headers collection and also with the other comparisons within the class itself.

## Motivation and Context
This makes the SDK compatible with Minio since Minio itself won't be compatible with AWS (minio/minio#5594, minio/minio#6471).

## Testing
Tested with Minio and https://github.com/hotchkj/AspNetCore.DataProtection.Aws project.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
