### PR TITLE
[Fix #1072] Allow "Assume Role" profiles to reference other "Assume Role" profiles for their source

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/_bcl+coreclr/AWSCredentialsFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/_bcl+coreclr/AWSCredentialsFactory.cs
@@ -22,7 +22,7 @@ using System.IO;
 using Amazon.Runtime.Internal.Settings;
 
 namespace Amazon.Runtime.CredentialManagement
-{        
+{
     /// <summary>
     /// Factory to construct different types of AWSCredentials based on a profile.
     /// </summary>
@@ -38,7 +38,7 @@ namespace Amazon.Runtime.CredentialManagement
             };
 
         private const string RoleSessionNamePrefix = "aws-dotnet-sdk-session-";
-        
+
         /// <summary>
         /// Gets the AWSCredentials for this profile if CanCreateAWSCredentials is true
         /// and AWSCredentials can be created.  Throws an exception otherwise.
@@ -209,12 +209,12 @@ namespace Amazon.Runtime.CredentialManagement
                             ExternalId = options.ExternalID,
                             MfaSerialNumber = options.MfaSerial
                         };
-                        return new AssumeRoleAWSCredentials(sourceCredentials, options.RoleArn, roleSessionName, assumeRoleOptions);                    
-                    case CredentialProfileType.AssumeRoleCredentialSource:                                                                        
+                        return new AssumeRoleAWSCredentials(sourceCredentials, options.RoleArn, roleSessionName, assumeRoleOptions);
+                    case CredentialProfileType.AssumeRoleCredentialSource:
                         // get credentials specified by credentialSource
                         try
                         {
-                            sourceCredentials = GetCredentialSourceAWSCredentials(options.CredentialSource, throwIfInvalid);                            
+                            sourceCredentials = GetCredentialSourceAWSCredentials(options.CredentialSource, throwIfInvalid);
                         }
                         catch (InvalidDataException e)
                         {
@@ -265,10 +265,10 @@ namespace Amazon.Runtime.CredentialManagement
                 return ThrowInvalidOrReturnNull(profileName, throwIfInvalid);
             }
         }
-                
+
         private static AWSCredentials GetCredentialSourceAWSCredentials(string credentialSourceType, bool throwIfInvalid)
         {
-            
+
             AWSCredentials credentials;
             CredentialSourceType type;
             try
@@ -306,7 +306,7 @@ namespace Amazon.Runtime.CredentialManagement
 
             return credentials;
         }
-        
+
         private static AWSCredentials GetSourceAWSCredentials(string sourceProfileName,
             ICredentialProfileSource profileSource, bool throwIfInvalid)
         {

--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/_bcl+coreclr/AWSCredentialsFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/_bcl+coreclr/AWSCredentialsFactory.cs
@@ -315,13 +315,12 @@ namespace Amazon.Runtime.CredentialManagement
             {
                 if (sourceProfile.CanCreateAWSCredentials)
                 {
-                    if (sourceProfile.ProfileType == CredentialProfileType.Basic)
-                        return new BasicAWSCredentials(sourceProfile.Options.AccessKey, sourceProfile.Options.SecretKey);
-                    else if (sourceProfile.ProfileType == CredentialProfileType.Session)
-                        return new SessionAWSCredentials(sourceProfile.Options.AccessKey, sourceProfile.Options.SecretKey, sourceProfile.Options.Token);
-                    else
+                    if (TryGetAWSCredentials(sourceProfile, profileSource, out var sourceCredentials)) {
+                        return sourceCredentials;
+                    } else {
                         return ThrowOrReturnNull(string.Format(CultureInfo.InvariantCulture,
-                            "Source profile [{0}] is not a basic or a session profile.", sourceProfileName), null, throwIfInvalid);
+                            "Could not get credentials from source profile [{0}].", sourceProfileName), null, throwIfInvalid);
+                    }
                 }
                 else
                 {

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/AWSCredentialsFactoryTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/AWSCredentialsFactoryTest.cs
@@ -34,7 +34,7 @@ namespace AWSSDK.UnitTests
         private const string SourceNotBasicOrSessionFormat = "Source profile [{0}] is not a basic or a session profile.";
         private const string SourceNotFoundFormat = "Source profile [{0}] was not found.";
 
-        private const string InvalidErrorFormat = "Credential profile [{0}] is not valid.  Please ensure the profile contains a valid combination of properties.";        
+        private const string InvalidErrorFormat = "Credential profile [{0}] is not valid.  Please ensure the profile contains a valid combination of properties.";
         private const string SourceErrorFormat = "Error reading source profile [{0}] for profile [{1}].";
         private const string MfaCallbackErrorFormat = "The profile [{0}] is an assume role profile that requires an MFA.  This type of profile is not allowed here.  " +
             "Please use an assume role profile that doesn't require an MFA, or a different type of profile.";
@@ -243,7 +243,7 @@ namespace AWSSDK.UnitTests
             {
                 UserIdentity = "user_identity"
             });
-                
+
         [TestMethod]
         public void TryGetInvalidCredentials()
         {
@@ -541,10 +541,10 @@ namespace AWSSDK.UnitTests
             using (new AWSCredentialsFactoryTestCredentialSourceFixture(AssumeRoleCredentialSourceEnvironment.Options, SessionCredentials))
             {
                 AWSCredentials credentials;
-                Assert.IsTrue(AWSCredentialsFactory.TryGetAWSCredentials(AssumeRoleCredentialSourceEnvironment.Options, ProfileStore, out credentials));                
+                Assert.IsTrue(AWSCredentialsFactory.TryGetAWSCredentials(AssumeRoleCredentialSourceEnvironment.Options, ProfileStore, out credentials));
                 Assert.IsNotNull(credentials);
                 Assert.AreEqual(typeof(EnvironmentVariablesAWSCredentials), ReflectionHelpers.Invoke(credentials, "SourceCredentials").GetType());
-            }                
+            }
         }
 
         [TestMethod]
@@ -554,7 +554,7 @@ namespace AWSSDK.UnitTests
             {
                 AWSCredentials credentials;
                 Assert.IsTrue(AWSCredentialsFactory.TryGetAWSCredentials(AssumeRoleCredentialSourceEc2InstanceMetadata.Options, ProfileStore, out credentials));
-                Assert.IsNotNull(credentials);                
+                Assert.IsNotNull(credentials);
                 Assert.AreEqual("Amazon.Runtime.DefaultInstanceProfileAWSCredentials", ReflectionHelpers.Invoke(credentials, "SourceCredentials").GetType().ToString());
             }
         }
@@ -565,7 +565,7 @@ namespace AWSSDK.UnitTests
             using (new AWSCredentialsFactoryTestCredentialSourceFixture(AssumeRoleCredentialSourceEcsContainer.Options, null))
             {
                 AWSCredentials credentials;
-                Assert.IsTrue(AWSCredentialsFactory.TryGetAWSCredentials(AssumeRoleCredentialSourceEcsContainer.Options, ProfileStore, out credentials));                                
+                Assert.IsTrue(AWSCredentialsFactory.TryGetAWSCredentials(AssumeRoleCredentialSourceEcsContainer.Options, ProfileStore, out credentials));
                 Assert.IsNotNull(credentials);
                 Assert.AreEqual(typeof(ECSTaskCredentials), ReflectionHelpers.Invoke(credentials, "SourceCredentials").GetType());
             }
@@ -583,21 +583,21 @@ namespace AWSSDK.UnitTests
                 }, typeof(InvalidDataException), string.Format(CredentialSourceErrorFormat, AssumeRoleCredentialSourceInvalid.Options.CredentialSource,
                 AssumeRoleCredentialSourceInvalid.Name)).InnerException;
             }
-            , typeof(InvalidDataException), string.Format(InvalidCredentialSourceErrorFormat, AssumeRoleCredentialSourceInvalid.Options.CredentialSource));            
+            , typeof(InvalidDataException), string.Format(InvalidCredentialSourceErrorFormat, AssumeRoleCredentialSourceInvalid.Options.CredentialSource));
         }
 
         [TestMethod]
         public void GetAssumeRoleCredentialSourceIDMSNotEnabled()
-        {            
+        {
             AssertExtensions.ExpectException(() =>
             {
                 using (new AWSCredentialsFactoryTestCredentialSourceFixture(AssumeRoleCredentialSourceEc2InstanceMetadata.Options, null, true))
                 {
                     AWSCredentialsFactory.GetAWSCredentials(AssumeRoleCredentialSourceEc2InstanceMetadata, ProfileStore);
-                }                            
+                }
             }, typeof(AmazonServiceException), IMDSNotEnabledError);
         }
-                
+
         [TestMethod]
         public void GetAssumeRoleCredentialSourceEcContainerNotSet()
         {
@@ -690,7 +690,7 @@ namespace AWSSDK.UnitTests
                     case CredentialSourceType.EcsContainer:
                         originalContainerURIEnvVariableValue = SetEnvironmentVariable(ECSTaskCredentials.ContainerCredentialsURIEnvVariable, disable ? null : MOCK_ECSContainer_URIEnvVariableValue);
                         break;
-                }                                
+                }
             }
 
             public void Dispose()
@@ -717,7 +717,7 @@ namespace AWSSDK.UnitTests
                 Environment.SetEnvironmentVariable(name, value);
                 return originalValue;
             }
-            
+
         }
     }
 }

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/AWSCredentialsFactoryTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/AWSCredentialsFactoryTest.cs
@@ -171,6 +171,13 @@ namespace AWSSDK.UnitTests
                 CredentialSource = "InvalidSource"
             });
 
+        private static readonly CredentialProfile AssumeRoleChainedAssumeRoleSource =
+            new CredentialProfile("assume_role_chained_assume_role_source", new CredentialProfileOptions
+            {
+                RoleArn = "second_role_arn",
+                CredentialSource = "assume_role_profile_basic_source"
+            });
+
         static AWSCredentialsFactoryTest()
         {
             ProfileStore.Profiles.Add(InvalidProfile.Name, InvalidProfile);
@@ -189,6 +196,7 @@ namespace AWSSDK.UnitTests
             ProfileStore.Profiles.Add(AssumeRoleCredentialSourceEc2InstanceMetadata.Name, AssumeRoleCredentialSourceEc2InstanceMetadata);
             ProfileStore.Profiles.Add(AssumeRoleCredentialSourceEcsContainer.Name, AssumeRoleCredentialSourceEcsContainer);
             ProfileStore.Profiles.Add(AssumeRoleCredentialSourceInvalid.Name, AssumeRoleCredentialSourceInvalid);
+            ProfileStore.Profiles.Add(AssumeRoleChainedAssumeRoleSource.Name, AssumeRoleChainedAssumeRoleSource);
         }
 
         private static readonly BasicAWSCredentials BasicCredentials =
@@ -221,6 +229,9 @@ namespace AWSSDK.UnitTests
                 ExternalId = "external_id",
                 MfaSerialNumber = "mfa_serial"
             });
+
+        private static readonly AssumeRoleAWSCredentials AssumeRoleChainedAssumeRoleCredentials =
+            new AssumeRoleAWSCredentials(AssumeRoleCredentialsBasicSource, "second_role_arn", "role_session_name");
 
         private static readonly SAMLEndpoint SomeSAMLEndpoint = new SAMLEndpoint("endpoint_name", new Uri("https://samlendpoint.com"));
 
@@ -308,6 +319,12 @@ namespace AWSSDK.UnitTests
         public void GetAssumeRoleExternalMfaCredentials()
         {
             AssertAssumeRoleCredentialsAreEqual(AssumeRoleExternalMfaCredentials, AWSCredentialsFactory.GetAWSCredentials(AssumeRoleExternalMfaProfile, ProfileStore));
+        }
+
+        [TestMethod]
+        public void GetAssumeRoleChainedAssumeRoleCredentials()
+        {
+            AssertAssumeRoleCredentialsAreEqual(AssumeRoleChainedAssumeRoleCredentials, AWSCredentialsFactory.GetAWSCredentials(AssumeRoleChainedAssumeRoleSource, ProfileStore));
         }
 
         [TestMethod]
@@ -447,6 +464,12 @@ namespace AWSSDK.UnitTests
         public void GetAssumeRoleExternalMfaCredentialsAnonymous()
         {
             AssertAssumeRoleCredentialsAreEqual(AssumeRoleExternalMfaCredentials, AWSCredentialsFactory.GetAWSCredentials(AssumeRoleExternalMfaProfile.Options, ProfileStore));
+        }
+
+        [TestMethod]
+        public void GetAssumeRoleChainedAssumeRoleCredentialsAnonymous()
+        {
+            AssertAssumeRoleCredentialsAreEqual(AssumeRoleChainedAssumeRoleCredentials, AWSCredentialsFactory.GetAWSCredentials(AssumeRoleChainedAssumeRoleSource.Options, ProfileStore));
         }
 
         [TestMethod]

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/AWSCredentialsFactoryTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/AWSCredentialsFactoryTest.cs
@@ -175,7 +175,7 @@ namespace AWSSDK.UnitTests
             new CredentialProfile("assume_role_chained_assume_role_source", new CredentialProfileOptions
             {
                 RoleArn = "second_role_arn",
-                CredentialSource = "assume_role_profile_basic_source"
+                SourceProfile = "assume_role_profile_basic_source"
             });
 
         static AWSCredentialsFactoryTest()
@@ -623,7 +623,10 @@ namespace AWSSDK.UnitTests
             Assert.IsTrue(actual.RoleSessionName.StartsWith("aws-dotnet-sdk-session-"));
             Assert.AreEqual(expected.RoleArn, actual.RoleArn);
             Assert.AreEqual(expected.PreemptExpiryTime, actual.PreemptExpiryTime);
-            Assert.AreEqual(expected.SourceCredentials, actual.SourceCredentials);
+            if (expected.SourceCredentials is AssumeRoleAWSCredentials && actual.SourceCredentials is AssumeRoleAWSCredentials)
+                AssertAssumeRoleCredentialsAreEqual(expected.SourceCredentials as AssumeRoleAWSCredentials, actual.SourceCredentials);
+            else
+                Assert.AreEqual(expected.SourceCredentials, actual.SourceCredentials);
             Assert.AreEqual(expected.Options.DurationSeconds, actual.Options.DurationSeconds);
             Assert.AreEqual(expected.Options.ExternalId, actual.Options.ExternalId);
             Assert.AreEqual(expected.Options.MfaSerialNumber, actual.Options.MfaSerialNumber);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #1072 .

## Description
<!--- Describe your changes in detail -->
This small change allows profiles to assume a `role_arn` from a `source_profile`  where the source is in turn another assumed role profile.
This behaviour is supported in the Python and JS sdks, so it should be possible in .NET as well.

In addition, because it seemed simpler and I couldn't think of a reason why not to, I removed the restrictions on source profile types altogether - the only other type is a SAML profile, and I (as a project outsider) do not know why assuming a role from this profile would be forbidden (please yell up if there is a valid reason for this!)

## Motivation and Context
This change should bring the .NET SDK in line with the other language SDKs.

## Testing
Tested in .NET framework by unit testing. Can't run unit tests on .NET Core in my Linux dev environment because either a) I'm stupid and can't work it out or b) it's impossbile, see #1181 .

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [?] My change requires a change to the documentation
- [?] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

Unsure if docs require updating. The generic AWS SDK docs already say this behaviour is supported (hence the bugfix checkbox above) and the .NET docs make no mention of the subject.

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license