### PR TITLE
fix the issue that System.InvalidOperationException when constructing…

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/AWSRegion.cs
+++ b/sdk/src/Core/Amazon.Runtime/AWSRegion.cs
@@ -206,7 +206,9 @@ namespace Amazon.Runtime
             cachedRegion = null;
             AllGenerators = new List<RegionGenerator>
             {
+#if !PCL
                 () => new AppConfigAWSRegion(),
+#endif
 #if BCL || CORECLR
                 () => new EnvironmentVariableAWSRegion(),
                 () => new ProfileAWSRegion(credentialProfileChain),
@@ -216,7 +218,9 @@ namespace Amazon.Runtime
 
             NonMetadataGenerators = new List<RegionGenerator>
             {
+#if !PCL
                 () => new AppConfigAWSRegion(),
+#endif
 #if BCL || CORECLR
                 () => new EnvironmentVariableAWSRegion(),
                 () => new ProfileAWSRegion(credentialProfileChain),


### PR DESCRIPTION
When constructing a CognitoAWSCredentials with Xamarin sdk, an exception System.InvalidOperationException is thrown. 

## Description
When constructing a CognitoAWSCredentials with Xamarin sdk, it will also create a AppConfigAWSRegion, which will try to read region information from configure file. Xamarin sdk does not use configure file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
avoid throwing exception  System.InvalidOperationException  When constructing a CognitoAWSCredentials with Xamarin sdk. 

The change is to fix the issue in https://github.com/jbachelor/DevAuthIdentitiesWithAwsCognitoInXamForms/issues/1


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement