### PR TITLE
Allow setting aws logger through appsettings.json in .net core and respond to runtime configuration changes

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
@@ -47,6 +47,12 @@ namespace Amazon.Extensions.NETCore.Setup
         public RegionEndpoint Region { get; set; }
 
         /// <summary>
+        /// The Logging destination.
+        /// Changes to this setting will propagate within 500 ms.
+        /// </summary>
+        public LoggingOptions LogTo { get; set; }
+
+        /// <summary>
         /// AWS Credentials used for creating service clients. If this is set it overrides the Profile property.
         /// </summary>
         public AWSCredentials Credentials { get; set; }

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptionsMonitor.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptionsMonitor.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace Amazon.Extensions.NETCore.Setup
+{
+    /// <summary>
+    /// This class reacts to reloads triggered by IConfiguration.
+    /// </summary>
+    public class AWSOptionsMonitor : IDisposable
+    {
+        private readonly IConfiguration configuration;
+        private readonly AWSOptions options;
+        private readonly IDisposable changeRegistration;
+        private readonly object changeProcessingLock = new object();
+
+        public AWSOptionsMonitor(IConfiguration configuration, AWSOptions options)
+        {
+            this.configuration = configuration;
+            this.options = options;
+
+            changeRegistration = ChangeToken.OnChange(
+                configuration.GetReloadToken,
+                InvokeChanged
+            );
+        }
+
+        private void InvokeChanged()
+        {
+            lock (changeProcessingLock)
+            {
+                var updatedAwsOptions = configuration.GetAWSOptions();
+                if (options.LogTo != updatedAwsOptions.LogTo)
+                {
+                    options.LogTo = updatedAwsOptions.LogTo;
+                    AWSConfigs.LoggingConfig.LogTo = updatedAwsOptions.LogTo;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            changeRegistration?.Dispose();
+        }
+    }
+}

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.Configuration
         public static AWSOptions GetAWSOptions(this IConfiguration config, string configSection)
         {
             var options = new AWSOptions();
-
+            
             IConfiguration section;
             if (string.IsNullOrEmpty(configSection))
                 section = config;
@@ -126,6 +126,12 @@ namespace Microsoft.Extensions.Configuration
             else if (!string.IsNullOrEmpty(section["AWSRegion"]))
             {
                 options.Region = RegionEndpoint.GetBySystemName(section["AWSRegion"]);
+            }
+
+            if (!string.IsNullOrEmpty(section["LogTo"]) 
+            && Enum.TryParse(section["LogTo"], out LoggingOptions logToFlag))
+            {
+                options.LogTo = logToFlag;
             }
 
             return options;

--- a/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
+++ b/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -8,6 +9,8 @@ using Microsoft.Extensions.Configuration;
 using Xunit;
 
 using Amazon;
+using Amazon.Extensions.NETCore.Setup;
+using Amazon.NETCore.SetupTests;
 using Amazon.S3;
 
 namespace NETCore.SetupTests
@@ -113,6 +116,55 @@ namespace NETCore.SetupTests
             {
                 Environment.SetEnvironmentVariable("AWS_REGION", existingValue);
             }
-        } 
+        }
+
+        [Fact]
+        public void GetLogToConfigTest()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/LogToConfigTest.json");
+
+            IConfiguration config = builder.Build();
+            var options = config.GetAWSOptions();
+
+            Assert.Equal(LoggingOptions.Console, options.LogTo);
+
+            // The services extension propagates the initial logging option to AWSConfigs, so it is expected to be None here
+            Assert.Equal(LoggingOptions.None, AWSConfigs.LoggingConfig.LogTo);
+        }
+
+        [Fact]
+        public async Task LogToUpdatesOnFileChangeTest()
+        {
+            var testFileContents = File.ReadAllText("./TestFiles/LogToConfigTest.json");
+
+            using (var tempFileHelper = new TempFileHelper(testFileContents))
+            {
+                var builder = new ConfigurationBuilder();
+                builder.AddJsonFile(tempFileHelper.Path, true, true);
+
+                IConfiguration config = builder.Build();
+
+                var options = config.GetAWSOptions();
+
+                using (var monitor = new AWSOptionsMonitor(config, options))
+                {
+                    Assert.Equal(LoggingOptions.Console, options.LogTo);
+                    // The services extension propagates the initial logging option to AWSConfigs, so it is expected to be None here
+                    Assert.Equal(LoggingOptions.None, AWSConfigs.LoggingConfig.LogTo);
+
+                    var updatedFileContents =
+                        testFileContents.Replace(@"""LogTo"": ""Console""", @"""LogTo"": ""Console,Log4Net""");
+
+                    tempFileHelper.Write(updatedFileContents);
+
+                    await Task.Delay(500).ConfigureAwait(false);
+
+                    Assert.Equal(LoggingOptions.Console | LoggingOptions.Log4Net, options.LogTo);
+                    // The monitor propagates updates to AWSConfigs, so it is expected to be set now
+                    Assert.Equal(LoggingOptions.Console | LoggingOptions.Log4Net, AWSConfigs.LoggingConfig.LogTo);
+                }
+            }
+        }
     }
 }

--- a/extensions/test/NETCore.SetupTests/Framework/TempFileHelper.cs
+++ b/extensions/test/NETCore.SetupTests/Framework/TempFileHelper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+
+namespace Amazon.NETCore.SetupTests
+{
+    public class TempFileHelper : IDisposable
+    {
+        public readonly string Path;
+
+        public TempFileHelper()
+        {
+            Path = System.IO.Path.GetTempFileName();
+        }
+        public TempFileHelper(string contents) : this()
+        {
+            Write(contents);
+        }
+
+        public TempFileHelper Write(string contents)
+        {
+            File.WriteAllText(Path, contents);
+            return this;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                File.Delete(Path);
+            } catch{}
+        }
+    }
+}

--- a/extensions/test/NETCore.SetupTests/TestFiles/LogToConfigTest.json
+++ b/extensions/test/NETCore.SetupTests/TestFiles/LogToConfigTest.json
@@ -1,0 +1,5 @@
+﻿{
+  "AWS": {
+    "LogTo": "Console"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the ability to set a logger through appsettings.json ( or any IConfiguration source ) under the `LogTo` property. `LogTo` was chosen as a name to mirror `AWSConfigs.cs`. I am aware that the field is obsolete in `AWSConfigs.cs`, however the related `LogResponse` and `LogMetrics` can already be set on the configuration file, and I thought it would be cleaner to keep them together.

Added an options monitor that listens for configuration changes and will forward any changes made to the `LogTo` property to `AWSConfigs.cs`. The  `InvokeChanged` method can be extended in the future to react and propagate other updated configurations in the future. A lock is used to prevent rapid file updates from colliding.

As the unit test needs to write changes to a JSON file, I've added a helper that creates a temporary file and stores the path to it.

The monitor absolutely the IConfiguration, so the change monitoring only works if either of the new `AddDefaultAWSOptions` overloads is used. 

One open thought or concern is that users could inject their AWSOptions class somewhere and change LogTo, and it would not do anything ( as only the change monitor propagates the updates value to AWSConfigs.cs ). I think the best approach there is to make AWSOptions implement property change notification and making the monitor respond to them. This ensures we only have a single AWSOptions-of-truth ( the singleton in the DI context ) and only respond to changes made to that particular instance.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
We would have been able to debug an ongoing issue if we have had the ability to turn on logging during runtime. With this change you can go onto your box/container, update appsettings to specify LogTo and get the data you need.

This is especially important as dotnet tooling for linux is still lacking, and any form of debugging or dumping requires extra software that can't always be installed on production boxes, meaning logging can sometimes be the only way to debug ongoing production issues.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added 3 Tests that ensure correct propagation of the LogTo property and the monitor's ability to respond to file changes.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

I held off on documentation changes for now, as I am not 100% sure how you want to document this new functionality.

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement