### PR TITLE
Added new function for using HTTPS when checking to see if a bucket e…

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/SharedInterfaces/_async/ICoreAmazonS3.cs
+++ b/sdk/src/Core/Amazon.Runtime/SharedInterfaces/_async/ICoreAmazonS3.cs
@@ -108,6 +108,13 @@ namespace Amazon.Runtime.SharedInterfaces
         /// <param name="bucketName"></param>
         /// <returns></returns>
         Task<bool> DoesS3BucketExistAsync(string bucketName);
+        
+        /// <summary>
+        /// Check to see if the bucket exists over HTTPS.
+        /// </summary>
+        /// <param name="bucketName"></param>
+        /// <returns></returns>
+        Task<bool> DoesS3BucketExistV2Async(string bucketName);
 #endif
     }
 }

--- a/sdk/src/Services/S3/Custom/GlobalSuppressions.cs
+++ b/sdk/src/Services/S3/Custom/GlobalSuppressions.cs
@@ -138,6 +138,7 @@ using System.Diagnostics.CodeAnalysis;
 [module: SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Scope = "member", Target = "Amazon.S3.AmazonS3Client.#Amazon.Runtime.SharedInterfaces.ICoreAmazonS3.EnsureBucketExistsAsync(System.String)")]
 [module: SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Scope = "member", Target = "Amazon.S3.AmazonS3Client.#Amazon.Runtime.SharedInterfaces.ICoreAmazonS3.DoesS3BucketExistAsync(System.String)")]
 [module: SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Scope = "member", Target = "Amazon.S3.AmazonS3Client.#Amazon.Runtime.SharedInterfaces.ICoreAmazonS3.DoesS3BucketExistV2Async(System.String)")]
+[module: SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Scope = "member", Target = "Amazon.S3.AmazonS3Client.#Amazon.Runtime.SharedInterfaces.ICoreAmazonS3.DoesS3BucketExistInternalAsync(System.String)")]
 
 // Calling overridable methods in constructors
 [module: SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Scope = "member", Target = "Amazon.V4ClientSection.#.ctor(System.Xml.Linq.XElement)")]

--- a/sdk/src/Services/S3/Custom/GlobalSuppressions.cs
+++ b/sdk/src/Services/S3/Custom/GlobalSuppressions.cs
@@ -137,6 +137,7 @@ using System.Diagnostics.CodeAnalysis;
 [module: SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Scope = "member", Target = "Amazon.S3.AmazonS3Client.#Amazon.Runtime.SharedInterfaces.ICoreAmazonS3.DeletesAsync(System.String,System.Collections.Generic.IEnumerable`1<System.String>,System.Collections.Generic.IDictionary`2<System.String,System.Object>,System.Threading.CancellationToken)")]
 [module: SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Scope = "member", Target = "Amazon.S3.AmazonS3Client.#Amazon.Runtime.SharedInterfaces.ICoreAmazonS3.EnsureBucketExistsAsync(System.String)")]
 [module: SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Scope = "member", Target = "Amazon.S3.AmazonS3Client.#Amazon.Runtime.SharedInterfaces.ICoreAmazonS3.DoesS3BucketExistAsync(System.String)")]
+[module: SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Scope = "member", Target = "Amazon.S3.AmazonS3Client.#Amazon.Runtime.SharedInterfaces.ICoreAmazonS3.DoesS3BucketExistV2Async(System.String)")]
 
 // Calling overridable methods in constructors
 [module: SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Scope = "member", Target = "Amazon.V4ClientSection.#.ctor(System.Xml.Linq.XElement)")]

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
@@ -540,7 +540,6 @@ namespace Amazon.S3.Util
             return key.EndsWith(S3Constants.EncryptionInstructionfileSuffix, StringComparison.Ordinal);
         }
 
-
 #if AWS_ASYNC_API
         /// <summary>
         /// Determines whether an S3 bucket exists or not.
@@ -571,6 +570,82 @@ namespace Amazon.S3.Util
                 Expires = s3Client.Config.CorrectedUtcNow.ToLocalTime().AddDays(1),
                 Verb = HttpVerb.HEAD,
                 Protocol = Protocol.HTTP
+            };
+
+            var url = s3Client.GetPreSignedURL(request);
+            var uri = new Uri(url);
+
+            var httpRequest = WebRequest.Create(uri) as HttpWebRequest;
+            httpRequest.Method = "HEAD";
+            var concreteClient = s3Client as AmazonS3Client;
+            if (concreteClient != null)
+            {
+
+                concreteClient.ConfigureProxy(httpRequest);
+            }
+
+            try
+            {
+#if PCL
+                var result = httpRequest.BeginGetResponse(null, null);
+                using (var httpResponse = httpRequest.EndGetResponse(result) as HttpWebResponse)
+#else 
+                using (var httpResponse = await httpRequest.GetResponseAsync().ConfigureAwait(false) as HttpWebResponse)
+#endif          
+                {
+                    // If all went well, the bucket was found!
+                    return true;
+                }
+            }
+            catch (WebException we)
+            {
+                using (var errorResponse = we.Response as HttpWebResponse)
+                {
+                    if (errorResponse != null)
+                    {
+                        var code = errorResponse.StatusCode;
+                        return code != HttpStatusCode.NotFound &&
+                            code != HttpStatusCode.BadRequest;
+                    }
+
+                    // The Error Response is null which is indicative of either
+                    // a bad request or some other problem
+                    return false;
+                }
+            }
+        }
+#endif
+
+#if AWS_ASYNC_API
+        /// <summary>
+        /// Determines whether an S3 bucket exists or not over HTTPS.
+        /// This is done by:
+        /// 1. Creating a PreSigned Url for the bucket. To work with Signature V4 only regions, as
+        /// well as Signature V4-optional regions, we keep the expiry to within the maximum for V4 
+        /// (which is one week).
+        /// 2. Making a HEAD request to the Url
+        /// </summary>
+        /// <param name="bucketName">The name of the bucket to check.</param>
+        /// <param name="s3Client">The Amazon S3 Client to use for S3 specific operations.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<bool> DoesS3BucketExistV2Async(IAmazonS3 s3Client, string bucketName)
+        {
+            if (s3Client == null)
+            {
+                throw new ArgumentNullException("s3Client", "The s3Client cannot be null!");
+            }
+
+            if (String.IsNullOrEmpty(bucketName))
+            {
+                throw new ArgumentNullException("bucketName", "The bucketName cannot be null or the empty string!");
+            }
+
+            var request = new GetPreSignedUrlRequest
+            {
+                BucketName = bucketName,
+                Expires = s3Client.Config.CorrectedUtcNow.ToLocalTime().AddDays(1),
+                Verb = HttpVerb.HEAD,
+                Protocol = Protocol.HTTPS
             };
 
             var url = s3Client.GetPreSignedURL(request);

--- a/sdk/src/Services/S3/Custom/_bcl+coreclr+pcl/_async/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/_bcl+coreclr+pcl/_async/AmazonS3Client.Extensions.cs
@@ -152,6 +152,11 @@ namespace Amazon.S3
         {
             return Amazon.S3.Util.AmazonS3Util.DoesS3BucketExistAsync(this, bucketName);
         }
+        
+        Task<bool> ICoreAmazonS3.DoesS3BucketExistV2Async(string bucketName)
+        {
+            return Amazon.S3.Util.AmazonS3Util.DoesS3BucketExistV2Async(this, bucketName);
+        }
         #endregion
     }
 }


### PR DESCRIPTION
Added a new function to see if a bucket exists, uses HTTPS rather than HTTP.

## Motivation and Context
Security group won't allow HTTP protocol to validate S3 bucket.

## Testing
Sadly I didn't see any unit tests for the original function (DoesS3BucketExistAsync) so I did not add any that are specific to this.

## Screenshots (if appropriate)
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement