### PR TITLE
Make sure the full framework path that uses HttpWebRequest honors the request timeout out of the box

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -382,16 +382,6 @@ namespace Amazon.Runtime
         /// Overrides the default request timeout value.
         /// On Unity platform this value is not used as Unity HTTP client does not support timeouts.
         /// </summary>
-#elif BCL35
-        /// <summary>
-        /// Overrides the default request timeout value.
-        /// This field does not impact Begin*/End* calls. A manual timeout must be implemented.
-        /// </summary>
-#elif BCL45
-        /// <summary>
-        /// Overrides the default request timeout value.
-        /// This field does not impact *Async calls. A manual timeout (for instance, using CancellationToken) must be implemented.
-        /// </summary>
 #endif
         /// <remarks>
         /// <para>


### PR DESCRIPTION
See https://github.com/aws/aws-sdk-net/issues/1275

## Description
See https://github.com/aws/aws-sdk-net/issues/1275

## Motivation and Context

See https://github.com/aws/aws-sdk-net/issues/1275

## Testing

It was non-trivial to test it. It looked like the HttpWebRequestFactoryTests are the best position to do it because everything else fakes the request away. 

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement