### PR TITLE
Fix reflection issues introduced by Unity 2019.1.0f2 (Issue #1286)

### DIFF
--- a/sdk/src/Core/Amazon.Util/Internal/_unity/AndroidInterop.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/_unity/AndroidInterop.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -68,9 +68,11 @@ namespace Amazon.Util.Internal
             if (androidJavaClassType != null)
             {
                 var javaClass = Activator.CreateInstance(androidJavaClassType, className);
-                var callStaticMethod = androidJavaClassType.GetMethods()
-                    .Where(x => x.Name == "CallStatic")
-                    .First(x => x.ContainsGenericParameters);
+
+                var callStaticMethod = androidJavaClassType.GetMethods().Where(x => x.Name == "CallStatic").First(x =>
+                    x.ContainsGenericParameters &&
+                    x.GetParameters().Select(y => y.ParameterType).SequenceEqual(new Type[] { typeof(string), typeof(object[]) })
+                );
 
                 var genericStaticMethod = callStaticMethod.MakeGenericMethod(androidJavaObjectType);
 
@@ -89,7 +91,11 @@ namespace Amazon.Util.Internal
         /// <returns></returns>
         public static T CallMethod<T>(object androidJavaObject, string methodName, params object[] parameters)
         {
-            var method = androidJavaObject.GetType().GetMethods().Where(x => x.Name == "Call").First(x => x.ContainsGenericParameters);
+            var method = androidJavaObject.GetType().GetMethods().Where(x => x.Name == "Call").First(x =>
+                x.ContainsGenericParameters &&
+                x.GetParameters().Select(y => y.ParameterType).SequenceEqual(new Type[] { typeof(string), typeof(object[]) })
+            );
+
             var genericMethod = method.MakeGenericMethod(typeof(T));
             return (T)genericMethod.Invoke(androidJavaObject, new object[] { methodName, parameters });
         }
@@ -104,9 +110,12 @@ namespace Amazon.Util.Internal
         public static object CallMethod(object androidJavaObject, string methodName, params object[] parameters)
         {
             Type androidJavaObjectType = InternalSDKUtils.GetTypeFromUnityEngine("AndroidJavaObject");
-            var method = androidJavaObject.GetType().GetMethods()
-                .Where(x => x.Name == "Call")
-                .First(x => x.ContainsGenericParameters);
+
+            var method = androidJavaObject.GetType().GetMethods().Where(x => x.Name == "Call").First(x =>
+                x.ContainsGenericParameters &&
+                x.GetParameters().Select(y => y.ParameterType).SequenceEqual(new Type[] { typeof(string), typeof(object[]) })
+            );
+
             var genericMethod = method.MakeGenericMethod(androidJavaObjectType);
             return genericMethod.Invoke(androidJavaObject, new object[] { methodName, parameters });
         }
@@ -169,7 +178,11 @@ namespace Amazon.Util.Internal
         /// <returns></returns>
         public static T GetJavaField<T>(object androidJavaObject, string methodName)
         {
-            var method = androidJavaObject.GetType().GetMethods().Where(x => x.Name == "Get").First(x => x.ContainsGenericParameters);
+            var method = androidJavaObject.GetType().GetMethods().Where(x => x.Name == "Get").First(x =>
+                x.ContainsGenericParameters &&
+                x.GetParameters().Select(y => y.ParameterType).SequenceEqual(new Type[] { typeof(string) })
+            );
+
             var genericMethod = method.MakeGenericMethod(typeof(T));
             return (T)genericMethod.Invoke(androidJavaObject, new object[] { methodName });
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed the LINQ queries which stopped working after changes made to `AndroidJavaObject` in Unity 2019.1.0f2. See #1286 for more details.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
See #1286 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement