### PR TITLE
Update AmazonSecurityTokenServiceConfig.cs

### DIFF
--- a/sdk/src/Services/SecurityToken/Generated/AmazonSecurityTokenServiceConfig.cs
+++ b/sdk/src/Services/SecurityToken/Generated/AmazonSecurityTokenServiceConfig.cs
@@ -42,7 +42,15 @@ namespace Amazon.SecurityToken
         public AmazonSecurityTokenServiceConfig()
         {
             this.AuthenticationServiceName = "sts";
-            var region = FallbackRegionFactory.GetRegionEndpoint(false);
+            RegionEndpoint region;
+            try
+            {
+                region = FallbackRegionFactory.GetRegionEndpoint(false);
+            }
+            catch
+            {
+                region = RegionEndpoint.USEast1;
+            }
             this.RegionEndpoint = region ?? RegionEndpoint.USEast1;
         }
 


### PR DESCRIPTION
the call to FallbackRegionFactory.GetRegionEndpoint(false) throws exceptions when the configuration is not set. This causes problems when the application has no configuration, does not intend to ever have one, and AmazonSecurityTokenServiceClient is instantiated by passing the RegionEndpoint in the constructor. It really should never call FallbackRegionFactory.GetRegionEndpoint(false) if the RegionEndpoint is passed to the constructor. This caused me an entire day of frustration, and required me to set AWSConfig.Region in my application startup.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement