### PR TITLE
Support the [default] profile in config file

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/_bcl+netstandard/SharedCredentialsFile.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/_bcl+netstandard/SharedCredentialsFile.cs
@@ -402,6 +402,7 @@ namespace Amazon.Runtime.CredentialManagement
             var hasConfigProperties = false;
             if (_configFile != null)
             {
+                _configFile.ProfileMarkerRequired = sectionName != DefaultProfileName;
                 hasConfigProperties = _configFile.TryGetSection(sectionName, out configProperties);
             }
 

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/SharedCredentialsFileTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/SharedCredentialsFileTest.cs
@@ -35,6 +35,12 @@ namespace AWSSDK.UnitTests
     {
         private static readonly Guid UniqueKey = Guid.NewGuid();
 
+        private static readonly string DefaultProfileText = new StringBuilder()
+            .AppendLine("[default]")
+            .AppendLine("aws_access_key_id=aws_access_key_id")
+            .AppendLine("aws_secret_access_key=aws_secret_access_key")
+            .ToString();
+
         private static readonly string SessionProfileText = new StringBuilder()
             .AppendLine("[session_profile]")
             .AppendLine("aws_access_key_id=session_aws_access_key_id")
@@ -210,7 +216,7 @@ namespace AWSSDK.UnitTests
             .Append("property2=value2")
             .ToString();
 
-        private static readonly Dictionary<string,string> UpdatedProfileWithPropertiesBefore = new Dictionary<string, string>()
+        private static readonly Dictionary<string, string> UpdatedProfileWithPropertiesBefore = new Dictionary<string, string>()
         {
             { "property1", "value1" },
             { "property2", "value2" },
@@ -257,6 +263,15 @@ namespace AWSSDK.UnitTests
             .AppendLine("; other comment")
             .AppendLine("property=value")
             .ToString();
+
+        [TestMethod]
+        public void ReadDefaultConfigProfile()
+        {
+            using (var tester = new SharedCredentialsFileTestFixture(null, DefaultProfileText))
+            {
+                tester.TestTryGetProfile("default", true, true);
+            }
+        }
 
         [TestMethod]
         public void ReadBasicProfile()
@@ -319,7 +334,7 @@ namespace AWSSDK.UnitTests
                 AssertExtensions.ExpectException(() =>
                 {
                     tester.AssertWriteProfile("basic_profile", BasicProfileOptions, properties, BasicProfileCredentialsText);
-                }, typeof(ArgumentException), "The profile properties dictionary cannot contain a key named "+ propertyName +
+                }, typeof(ArgumentException), "The profile properties dictionary cannot contain a key named " + propertyName +
                 " because it is in the name mapping dictionary.");
             }
         }
@@ -391,8 +406,8 @@ namespace AWSSDK.UnitTests
         public void WriteEndpointDiscoveryEnabledOnlyProfile()
         {
             using (var tester = new SharedCredentialsFileTestFixture())
-            {                
-                tester.AssertWriteProfile("endpoint_discovery_enabled_only_profile", EndpointDiscoveryEnabledOnlyProfileOptions, true, EndpointDiscoveryEnabledOnlyProfileText);             
+            {
+                tester.AssertWriteProfile("endpoint_discovery_enabled_only_profile", EndpointDiscoveryEnabledOnlyProfileOptions, true, EndpointDiscoveryEnabledOnlyProfileText);
             }
         }
 
@@ -871,9 +886,9 @@ namespace AWSSDK.UnitTests
             if (addUniqueKey)
                 profileText += "toolkit_artifact_guid=" + UniqueKey + Environment.NewLine;
 
-            var anotherSection = addAnotherSection ? "[another_section]" + Environment.NewLine + "propertyx=valuex" + Environment.NewLine: "";
+            var anotherSection = addAnotherSection ? "[another_section]" + Environment.NewLine + "propertyx=valuex" + Environment.NewLine : "";
 
-                using (var tester = new SharedCredentialsFileTestFixture(profileText + anotherSection))
+            using (var tester = new SharedCredentialsFileTestFixture(profileText + anotherSection))
             {
                 // read the profile
                 CredentialProfile profile1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the `ProfileMarkerRequired` requirement when requested profile is `DefaultProfileName` (default).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I want to be able to call `new AmazonS3Client()` without any credentials so my code will run in production using a role and locally using my default profile. This will allow the default profile in the config file work so an `role_arn` and `source_profile` can be used.
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Relates to: https://github.com/aws/aws-sdk-net/issues/1041

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've added a unit test that failed before and now passes. Shouldn't affect anything else.

## Screenshots (if appropriate)
Here are sample files of what this helps with:

`~/.aws/credentials`
```
[dev]
aws_access_key_id = AAAABBBBCCCCDDDD
aws_secret_access_key = a123b123c123d123e123
```
`~/.aws/config`
```
[default]
role_arn = arn:aws:iam::1234567890:role/role_for_dev
source_profile = dev
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement