### PR TITLE
Fix NullReferenceException if security credentials null

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/DefaultInstanceProfileAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/DefaultInstanceProfileAWSCredentials.cs
@@ -140,6 +140,8 @@ namespace Amazon.Runtime
         private static ImmutableCredentials FetchCredentials()
         {
             var securityCredentials = EC2InstanceMetadata.IAMSecurityCredentials;
+            if (securityCredentials == null)
+                throw new AmazonServiceException("Unable to get IAM security credentials from EC2 Instance Metadata Service.");
 
             string firstRole = null;
             foreach (var role in securityCredentials.Keys)


### PR DESCRIPTION
## Description

Fix `NullReferenceException` when enumerating roles for the default instance profile if the EC2 Instance Metadata Service returns `null`.

## Motivation and Context

We observed this issue on an EC2 instance with the SQS and SNS SDKs:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Amazon.Runtime.DefaultInstanceProfileAWSCredentials.FetchCredentials() in E:\JenkinsWorkspaces\v3-trebuchet-release\AWSDotNetPublic\sdk\src\Core\Amazon.Runtime\Credentials\_bcl+coreclr\DefaultInstanceProfileAWSCredentials.cs:line 146
   at Amazon.Runtime.DefaultInstanceProfileAWSCredentials.GetCredentials() in E:\JenkinsWorkspaces\v3-trebuchet-release\AWSDotNetPublic\sdk\src\Core\Amazon.Runtime\Credentials\_bcl+coreclr\DefaultInstanceProfileAWSCredentials.cs:line 89
   at Amazon.Runtime.DefaultInstanceProfileAWSCredentials.GetCredentialsAsync() in E:\JenkinsWorkspaces\v3-trebuchet-release\AWSDotNetPublic\sdk\src\Core\Amazon.Runtime\Credentials\_bcl+coreclr\DefaultInstanceProfileAWSCredentials.cs:line 107
   at Amazon.Runtime.Internal.CredentialsRetriever.<InvokeAsync>d__7`1.MoveNext() in E:\JenkinsWorkspaces\v3-trebuchet-release\AWSDotNetPublic\sdk\src\Core\Amazon.Runtime\Pipeline\Handlers\CredentialsRetriever.cs:line 92
```

## Testing

None, simple code change.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement