### PR TITLE
Fixed hang in CognitoAWSCredentials.GenerateNewCredentials()

### DIFF
--- a/sdk/src/Services/SecurityToken/Custom/AssumeRoleAWSCredentials.cs
+++ b/sdk/src/Services/SecurityToken/Custom/AssumeRoleAWSCredentials.cs
@@ -13,7 +13,7 @@ namespace Amazon.SecurityToken
     /// AssumeRole or AssumeRoleWithSAML action.
     /// </summary>
     [Obsolete("This class has been replaced by Amazon.Runtime.AssumeRoleAWSCredentials and Amazon.Runtime.StoredProfileFederatedCredentials, and will be removed in a future version.", false)]
-    public partial class STSAssumeRoleAWSCredentials : RefreshingAWSCredentials, IDisposable
+    public partial class STSAssumeRoleAWSCredentials : RefreshingAWSCredentials
     {
 #if !UNITY
         private IAmazonSecurityTokenService _stsClient;
@@ -81,7 +81,7 @@ namespace Amazon.SecurityToken
         /// </summary>
         /// <param name="disposing">Whether this object is being disposed via a call to Dispose
         /// or garbage collected.</param>
-        protected virtual void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (!this._isDisposed)
             {
@@ -91,16 +91,9 @@ namespace Amazon.SecurityToken
                     _stsClient = null;
                 }
                 this._isDisposed = true;
-            }
-        }
 
-        /// <summary>
-        /// Disposes of all managed and unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
+                base.Dispose(disposing);
+            }
         }
 
         #endregion

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/CognitoIdentity.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/CognitoIdentity.cs
@@ -1,0 +1,114 @@
+﻿using Amazon.CognitoIdentity;
+using Amazon.CognitoIdentity.Model;
+using Amazon.IdentityManagement;
+using Amazon.IdentityManagement.Model;
+using Amazon.Runtime;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.DNXCore.IntegrationTests
+{
+    public class CognitoIdentity : TestBase<AmazonCognitoIdentityClient>
+    {
+        private readonly ITestOutputHelper output;
+        private const string IdentityPoolName = "AWSSDKIntegrationTest";
+        private const string UnauthRoleName = "AWSSDKIntegrationTest_Cognito_UnauthRole";
+
+        public CognitoIdentity(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public async Task TestCognitoIdentity()
+        {
+            var iamClient = UtilityMethods.CreateClient<AmazonIdentityManagementServiceClient>();
+            var identityPoolId = await CreateIdentityPoolAsync(iamClient);
+
+            try
+            {
+                using (var cognitoCreds = new CognitoAWSCredentials(identityPoolId, ActualEndpoint))
+                {
+                    ImmutableCredentials creds;
+                    int attempts = 5;
+
+                    while (true)
+                    {
+                        --attempts;
+
+                        Task<ImmutableCredentials> task = cognitoCreds.GetCredentialsAsync();
+
+                        var firstCompletedTask = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(10)));
+                        Assert.True(firstCompletedTask == task, "GetCredentialsAsync timed out");
+
+                        try
+                        {
+                            creds = await task;
+                            break;
+                        }
+                        catch (InvalidIdentityPoolConfigurationException)
+                        {
+                            Assert.True(attempts > 0, "InvalidIdentityPoolConfigurationException, out of attempts");
+                            output.WriteLine("InvalidIdentityPoolConfigurationException, retrying...");
+                            await Task.Delay(TimeSpan.FromSeconds(5));
+                        }
+                    }
+
+                    Assert.False(string.IsNullOrEmpty(creds.AccessKey));
+                    output.WriteLine($"AccessKey:{creds.AccessKey}");
+                }
+            }
+            finally
+            {
+                await Client.DeleteIdentityPoolAsync(identityPoolId);
+                await iamClient.DeleteRoleAsync(new DeleteRoleRequest { RoleName = UnauthRoleName });
+            }
+        }
+
+        private async Task<string> CreateIdentityPoolAsync(AmazonIdentityManagementServiceClient iamClient)
+        {
+            var createIdentityPoolRequest = new CreateIdentityPoolRequest()
+            {
+                AllowUnauthenticatedIdentities = true,
+                IdentityPoolName = IdentityPoolName,
+            };
+            var createIdentityPoolResponse = await Client.CreateIdentityPoolAsync(createIdentityPoolRequest);
+            string identityPoolId = createIdentityPoolResponse.IdentityPoolId;
+            Assert.False(string.IsNullOrEmpty(identityPoolId));
+            output.WriteLine($"identityPoolId:{identityPoolId}");
+
+            string roleArn = await CreateUnauthRoleAsync(iamClient, identityPoolId);
+            output.WriteLine($"roleArn:{roleArn}");
+
+            SetIdentityPoolRolesRequest setIdentityPoolRolesRequest = new SetIdentityPoolRolesRequest
+            {
+                IdentityPoolId = identityPoolId,
+                Roles = new System.Collections.Generic.Dictionary<string, string>
+                {
+                    { "unauthenticated", roleArn },
+                }
+            };
+            var setIdentityPoolRolesResponse = await Client.SetIdentityPoolRolesAsync(setIdentityPoolRolesRequest);
+            Assert.True(setIdentityPoolRolesResponse.HttpStatusCode == System.Net.HttpStatusCode.OK);
+
+            return identityPoolId;
+        }
+
+        private async Task<string> CreateUnauthRoleAsync(AmazonIdentityManagementServiceClient iamClient, string identityPoolId)
+        {
+            string assumeRolePolicyDocument = $"{{\"Version\":\"2012-10-17\",\"Statement\":[{{\"Effect\":\"Allow\",\"Principal\":{{\"Federated\":\"cognito-identity.amazonaws.com\"}},\"Action\":\"sts:AssumeRoleWithWebIdentity\",\"Condition\":{{\"StringEquals\":{{\"cognito-identity.amazonaws.com:aud\":\"{identityPoolId}\"}},\"ForAnyValue:StringLike\":{{\"cognito-identity.amazonaws.com:amr\":\"unauthenticated\"}}}}}}]}}";
+
+            CreateRoleRequest createRoleRequest = new CreateRoleRequest
+            {
+                RoleName = UnauthRoleName,
+                AssumeRolePolicyDocument = assumeRolePolicyDocument,
+            };
+            var createRoleResponse = await iamClient.CreateRoleAsync(createRoleRequest);
+            string roleArn = createRoleResponse.Role.Arn;
+            Assert.False(string.IsNullOrEmpty(roleArn));
+            return roleArn;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
RefreshingAWSCredentials.ClearCredentials() made lock-free, added _credentialsCleared flag. I don't think that access to this flag needs to be protected by a lock or be volatile.
Fixed Dispose pattern implementation in STSAssumeRoleAWSCredentials (derived from IDisposable RefreshingAWSCredentials).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes issues #1321, #1328.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added integration test: sdk/test/NetStandard/IntegrationTests/IntegrationTests/CognitoIdentity.cs
This test fails before this fix and passes after this fix.
It creates an identity pool, creates and assigns unauthenticated role, attempts to get credentials from this pool.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement