### PR TITLE
Add AsyncSearch interface for easier mocking

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/AsyncSearch.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/AsyncSearch.cs
@@ -18,11 +18,19 @@ using Amazon.DynamoDBv2.DocumentModel;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
+    public partial interface IAsyncSearch<T>
+    {
+        /// <summary>
+        /// Flag that, if true, indicates that the search is done
+        /// </summary>
+        bool IsDone { get; }
+    }
+
     /// <summary>
     /// A strongly-typed object for retrieving search results (Query or Scan)
     /// from DynamoDB.
     /// </summary>
-    public partial class AsyncSearch<T>
+    public partial class AsyncSearch<T> : IAsyncSearch<T>
     {
         #region Constructor
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.Async.cs
@@ -24,6 +24,31 @@ using Amazon.DynamoDBv2.DataModel;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
+    public partial interface IAsyncSearch<T>
+    {
+        /// <summary>
+        /// Initiates the asynchronous execution to get the next set of results from DynamoDB.
+        /// 
+        /// If there are more items in the Scan/Query, PaginationToken will be
+        /// set and can be consumed in a new Scan/Query operation to resume
+        /// retrieving items from this point.
+        /// </summary>
+        /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
+        /// <returns>
+        /// A Task that can be used to poll or wait for results, or both.
+        /// Results will include the next set of result items from DynamoDB.
+        /// </returns>
+        Task<List<T>> GetNextSetAsync(CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Initiates the asynchronous execution to get all the remaining results from DynamoDB.
+        /// </summary>
+        /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
+        /// <returns>
+        /// A Task that can be used to poll or wait for results, or both.
+        /// Results will include the remaining result items from DynamoDB.
+        /// </returns>
+        Task<List<T>> GetRemainingAsync(CancellationToken cancellationToken = default(CancellationToken));
+    }
     /// <summary>
     /// A strongly-typed object for retrieving search results (Query or Scan)
     /// from DynamoDB.

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/Context.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/Context.Async.cs
@@ -301,7 +301,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </param>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        public AsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null)
+        public IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null)
         {
             var scan = ConvertScan<T>(conditions, operationConfig);
             return FromSearchAsync<T>(scan);
@@ -315,7 +315,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="scanConfig">Scan request object.</param>
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        public AsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null)
+        public IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null)
         {
             if (scanConfig == null) throw new ArgumentNullException("scanConfig");
 
@@ -335,7 +335,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="hashKeyValue">Hash key of the items to query.</param>
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        public AsyncSearch<T> QueryAsync<T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null)
+        public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null)
         {
             var query = ConvertQueryByValue<T>(hashKeyValue, null, operationConfig);
             return FromSearchAsync<T>(query);
@@ -355,7 +355,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </param>
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        public AsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null)
+        public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null)
         {
             if (values == null)
                 throw new ArgumentNullException("values");
@@ -372,7 +372,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="queryConfig">Query request object.</param>
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        public AsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null)
+        public IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null)
         {
             if (queryConfig == null) throw new ArgumentNullException("queryConfig");
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
@@ -234,7 +234,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </param>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        AsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null);
+        IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         ///  Configures an async Scan operation against DynamoDB, finding items
@@ -244,7 +244,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="scanConfig">Scan request object.</param>
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        AsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null);
+        IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null);
 
         #endregion
 
@@ -258,7 +258,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="hashKeyValue">Hash key of the items to query.</param>
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        AsyncSearch<T> QueryAsync<T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null);
+        IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -274,7 +274,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </param>
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        AsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null);
+        IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -284,7 +284,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="queryConfig">Query request object.</param>
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-        AsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null);
+        IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null);
 
         #endregion
     }

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
@@ -33,7 +33,7 @@ using Amazon.Runtime.Internal.Util;
 namespace Amazon.DynamoDBv2.DocumentModel
 {
     /// <summary>
-    /// The Table class is the starting object when using the Document API. It is used to Get documents from the DynamnoDB table
+    /// The Table class is the starting object when using the Document API. It is used to Get documents from the DynamoDB table
     /// and write documents back to the DynamoDB table.
     /// </summary>
     public partial class Table


### PR DESCRIPTION
This is related to issue #632 
Adding an interface so it's possible to mock this code in unit testing scenarios.
Also had to change the return type of method on IDynamoDBContext to return the interface instead.
If this pull request goes through, I intend to add more interfaces (e.g. `Table`).