### PR TITLE
Removed part of condition which is duplicate

### DIFF
--- a/sdk/src/Core/ThirdParty/Json/JsonReader.cs
+++ b/sdk/src/Core/ThirdParty/Json/JsonReader.cs
@@ -347,8 +347,7 @@ namespace ThirdParty.Json.LitJson
                         this.token == JsonToken.UInt ||
                         this.token == JsonToken.Long ||
                         this.token == JsonToken.ULong ||
-                        this.token == JsonToken.Null ||
-                        this.token == JsonToken.String
+                        this.token == JsonToken.Null
                         ))
                     {
                         // If we found a value but we are not in an array or object then the document is an invalid json document.


### PR DESCRIPTION
Removed part of condition which is duplicate
## Description
this.token == JsonToken.String already exists in this condition.

## Motivation and Context

## Testing

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement