### PR TITLE
S3DirectoryInfo MoveTo throws "key is a directory name" exception

### DIFF
--- a/sdk/src/Services/S3/Custom/_bcl/IO/S3DirectoryInfo.cs
+++ b/sdk/src/Services/S3/Custom/_bcl/IO/S3DirectoryInfo.cs
@@ -660,7 +660,11 @@ namespace Amazon.S3.IO
                             .WithItemListPropertyPath("S3Objects")
                             .WithTokenRequestPropertyPath("Marker")
                             .WithTokenResponsePropertyPath("NextMarker"))))
-                        .Where(s3Object => !String.Equals(S3Helper.DecodeKey(s3Object.Key), key, StringComparison.Ordinal) && !s3Object.Key.EndsWith("\\", StringComparison.Ordinal)),
+                        .Where(s3Object =>
+                        {
+                            string decodeKey = S3Helper.DecodeKey(s3Object.Key);
+                            return !String.Equals(decodeKey, key, StringComparison.Ordinal) && !decodeKey.EndsWith("\\", StringComparison.Ordinal);
+                        }),
                         s3Object => new S3FileInfo(s3Client, bucket, S3Helper.DecodeKey(s3Object.Key)));
             }
 


### PR DESCRIPTION
## Description

 IEnumerable<S3FileInfo> EnumerateFiles  use decodeKey only for first condition and not for directory check. S3FileInfo throws "key is a directory name" exception in this case.
I have change for reuse DecodeKey value in second condition too.

## Motivation and Context
it fixes an open issue #957.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement