### PR TITLE
Support IAsyncEnumerable

### DIFF
--- a/sdk/src/Services/DynamoDBv2/AWSSDK.DynamoDBv2.NetStandard.csproj
+++ b/sdk/src/Services/DynamoDBv2/AWSSDK.DynamoDBv2.NetStandard.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.3'">$(DefineConstants);NETSTANDARD13;ADD_SUPPORT_ICLONEABLE;ADD_SUPPORT_IORDERED_DICTIONARY</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETSTANDARD20</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);NETSTANDARD21</DefineConstants>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>AWSSDK.DynamoDBv2</AssemblyName>
@@ -56,6 +57,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Core\AWSSDK.Core.NetStandard.csproj"/>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#if NETSTANDARD && !NETSTANDARD13
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Amazon.DynamoDBv2.DataModel
+{
+    partial class AsyncSearch<T> : IAsyncEnumerable<IList<T>>
+    {
+        #region IAsyncEnumerable<IList<T>>
+
+        IAsyncEnumerator<IList<T>> IAsyncEnumerable<IList<T>>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default)
+        {
+            return new AsyncSearchEnumerator<T>(this, cancellationToken);
+        }
+
+        #endregion
+    }
+
+    internal sealed class AsyncSearchEnumerator<T> : IAsyncEnumerator<IList<T>>
+    {
+ 
+        #region Private members
+
+        private readonly AsyncSearch<T> SearchSource;
+        private readonly System.Threading.CancellationToken CancellationToken;
+
+        #endregion
+
+        #region Constructor
+
+        public AsyncSearchEnumerator(AsyncSearch<T> searchSource, System.Threading.CancellationToken cancellationToken = default)
+        {
+            SearchSource = searchSource;
+            CancellationToken = cancellationToken;
+            Current = default;
+        }
+ 
+        #endregion
+
+        #region IAsyncEnumerator<IList<T>>
+
+        public IList<T> Current { get; private set; }
+
+        public ValueTask DisposeAsync() => default;
+
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            if (SearchSource.IsDone)
+            {
+                return false;
+            }
+            Current = await SearchSource.GetNextSetAsync(CancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/_async/Search.IAsyncEnumerable.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/_async/Search.IAsyncEnumerable.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#if NETSTANDARD && !NETSTANDARD13
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Amazon.DynamoDBv2.DocumentModel
+{
+    public partial class Search : IAsyncEnumerable<IList<Document>>
+    {
+        #region IAsyncEnumerable<IList<Document>>
+
+        IAsyncEnumerator<IList<Document>> IAsyncEnumerable<IList<Document>>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default)
+        {
+            return new SearchEnumerator(this, cancellationToken);
+        }
+
+        #endregion
+    }
+
+    internal sealed class SearchEnumerator : IAsyncEnumerator<IList<Document>>
+    {
+ 
+        #region Private members
+
+        private readonly Search SearchSource;
+        private readonly System.Threading.CancellationToken CancellationToken;
+
+        #endregion
+
+        #region Constructor
+
+        public SearchEnumerator(Search searchSource, System.Threading.CancellationToken cancellationToken = default)
+        {
+            SearchSource = searchSource;
+            CancellationToken = cancellationToken;
+            Current = default;
+        }
+ 
+        #endregion
+
+        #region IAsyncEnumerator<IList<Document>>
+
+        public IList<Document> Current { get; private set; }
+
+        public ValueTask DisposeAsync() => default;
+
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            if (SearchSource.IsDone)
+            {
+                return false;
+            }
+            Current = await SearchSource.GetNextSetAsync(CancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/sdk/src/Services/DynamoDBv2/Properties/AssemblyInfo.cs
+++ b/sdk/src/Services/DynamoDBv2/Properties/AssemblyInfo.cs
@@ -19,6 +19,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("The Amazon Web Services SDK for .NET (NetStandard 1.3)- Amazon DynamoDB. Amazon DynamoDB is a fast and flexible NoSQL database service for all applications that need consistent, single-digit millisecond latency at any scale.")]
 #elif NETSTANDARD20
 [assembly: AssemblyDescription("The Amazon Web Services SDK for .NET (NetStandard 2.0)- Amazon DynamoDB. Amazon DynamoDB is a fast and flexible NoSQL database service for all applications that need consistent, single-digit millisecond latency at any scale.")]
+#elif NETSTANDARD21
+[assembly: AssemblyDescription("The Amazon Web Services SDK for .NET (NetStandard 2.1)- Amazon DynamoDB. Amazon DynamoDB is a fast and flexible NoSQL database service for all applications that need consistent, single-digit millisecond latency at any scale.")]
 #else
 #error Unknown platform constant - unable to set correct AssemblyDescription
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add netstandard2.1 to TargetFrameworkds.
Add PachageReference Microsoft.Bcl.AsyncInterfaces to netstandard 2.0.
Implement IAsyncEnumerable for AsyncSearch on netstandard 2.0 and netstandard 2.1.

## Motivation and Context
- For 'await foreach'. #1468
- support interface for mock. #604, #632, #1187, #1391

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement