### PR TITLE
Use AnonymousAWSCredentials for STS client

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/AssumeRoleWithWebIdentityCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/AssumeRoleWithWebIdentityCredentials.cs
@@ -228,7 +228,7 @@ namespace Amazon.Runtime
                 }
 
                 return ServiceClientHelpers.CreateServiceFromAssembly<ICoreAmazonSTS_WebIdentity>(
-                            ServiceClientHelpers.STS_ASSEMBLY_NAME, ServiceClientHelpers.STS_SERVICE_CLASS_NAME, region);
+                            ServiceClientHelpers.STS_ASSEMBLY_NAME, ServiceClientHelpers.STS_SERVICE_CLASS_NAME, new AnonymousAWSCredentials(), region);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Description
Calls to AssumeRoleWithWebIdentity do not require AWS security credentials so use anonymous credentials to prevent a dead lock when trying to resolve new credentials again

## Motivation and Context
Fixes #1493 

## Testing
Ran test code from issue with updated version of AWSSDK.Core and verified that dead lock is resolved and that the client is able to make API calls given it has a valid web identity yoken. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
 
Note: don't have access to a .NET Framework build environment to run the tests at the moment

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement