### PR TITLE
Fix messaging for diagnostic title

### DIFF
--- a/sdk/code-analysis/SharedAnalysisCode/AbstractPropertyValueAssignmentAnalyzer.cs
+++ b/sdk/code-analysis/SharedAnalysisCode/AbstractPropertyValueAssignmentAnalyzer.cs
@@ -115,12 +115,12 @@ namespace Amazon.CodeAnalysis.Shared
                 {
                     this._patternRule = new DiagnosticDescriptor(
                         string.Format("{0}1002", GetServiceName()),
-                        "Property value does match required pattern",
+                        "Property value does not match required pattern",
                         "Value \"{0}\" does not match required pattern \"{1}\" for property {2}",
                         Category,
                         DiagnosticSeverity.Warning,
                         isEnabledByDefault: true,
-                        description: "Property value does match required pattern");
+                        description: "Property value does not match required pattern");
                 }
                 return this._patternRule;
             }


### PR DESCRIPTION
## Description
When there is an invalid value passed into a service client, for example an S3 bucket name could be given a single name character for an `Amazon.S3.Model.PutObjectRequest.BucketName` property.

This will (correctly) trigger a code analysis diagnostic to be reported in the form of `{ServiceName}1002`, continuing the S3 example, `S31002`.

However, both the title and the description of the error message are slightly incorrect, and do not match the message of the description. I have updated both the title and the description to match the intention of the diagnostic.

## Motivation and Context
By chance I happened to encounter the affected diagnostic and noticed that it could be improved.

## Testing
I tested this by taking the resulting assembly, referencing it locally, and reproducing the result. I could have made larger changes to also verify via unit tests, but this was avoided because the scope of this change is so small.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license