### PR TITLE
Make Metadata Collection case insensitive

### DIFF
--- a/sdk/src/Services/S3/Custom/Model/MetadataCollection.cs
+++ b/sdk/src/Services/S3/Custom/Model/MetadataCollection.cs
@@ -26,7 +26,7 @@ namespace Amazon.S3.Model
     {
         internal const string MetaDataHeaderPrefix = "x-amz-meta-";
             
-        IDictionary<string, string> values = new Dictionary<string, string>();
+        IDictionary<string, string> values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets and sets meta data for the object. Meta data names must start with "x-amz-meta-". If the name passeed in as the indexer 


### PR DESCRIPTION
## Description

The metadata collection has been changed to use a case insensitive Dictionary.

## Motivation and Context

I was unable to use the Amazon S3 Encryption Client class with a MinIO S3 server.

Due to the Go Language implementation of HTTP response headers keys are always appended in camelcase. This prevents usage of the Encryption Client, as the expected headers were not detected correctly, even though they were set by the MinIO server.

The GetObject request caused a misleading exception, as the Encryption Client's fallback causes it to look for an instruction file instead.

Additionally this change ensures compatibility with RFC 2616:

Each header field consists of a name followed by a colon (":") and the
field value. Field names are case-insensitive.

https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

This fixes #927 .

## Testing

Manual tests with MinIO S3 server.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement