### PR TITLE
- Add support for honoring 302 and 303 redirects

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/RedirectHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/RedirectHandler.cs
@@ -106,7 +106,10 @@ namespace Amazon.Runtime.Internal
             if (response.StatusCode >= HttpStatusCode.Ambiguous &&
                 response.StatusCode < HttpStatusCode.BadRequest)
             {
-                if (response.StatusCode == HttpStatusCode.TemporaryRedirect &&
+                // HTTP 302, 303,and 307 are all valid Redirect Mechanisms
+                if ((response.StatusCode == HttpStatusCode.Redirect ||
+                     response.StatusCode == HttpStatusCode.RedirectMethod ||
+                     response.StatusCode == HttpStatusCode.TemporaryRedirect ) &&
                     response.IsHeaderPresent(HeaderKeys.LocationHeader))
                 {
                     var requestContext = executionContext.RequestContext;

--- a/sdk/test/UnitTests/Custom/Runtime/RedirectHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RedirectHandlerTests.cs
@@ -33,7 +33,7 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         [TestCategory("UnitTest")]
         [TestCategory("Runtime")]
-        public void TestRedirect()
+        public void TestRedirectWith307()
         {
             var context = CreateTestContext();
             var httpResponse = context.ResponseContext.HttpResponse;
@@ -62,6 +62,72 @@ namespace AWSSDK.UnitTests
             RuntimePipeline.InvokeSync(context);
             Assert.AreEqual(2, Tester.CallCount);
         }
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestRedirectWith303()
+        {
+            var context = CreateTestContext();
+            var httpResponse = context.ResponseContext.HttpResponse;
+            Tester.Reset();
+            Tester.Action2 = (callCount, executionContext) =>
+            {
+                if (callCount == 1)
+                {
+                    executionContext.ResponseContext.HttpResponse = new HttpWebRequestResponseData(
+                        HttpWebResponseHelper.Create(HttpStatusCode.RedirectMethod,
+                            new WebHeaderCollection { { "location", RedirectLocation } }));
+                }
+                else
+                {
+                    executionContext.ResponseContext.HttpResponse = httpResponse;
+                }
+            };
+            Tester.Validate = (int callCount) =>
+            {
+                if (callCount == 2)
+                {
+                    Assert.AreEqual(RedirectLocation, context.RequestContext.Request.Endpoint.AbsoluteUri);
+                }
+            };
+
+            RuntimePipeline.InvokeSync(context);
+            Assert.AreEqual(2, Tester.CallCount);
+        }        
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestRedirectWith302()
+        {
+            var context = CreateTestContext();
+            var httpResponse = context.ResponseContext.HttpResponse;
+            Tester.Reset();
+            Tester.Action2 = (callCount, executionContext) =>
+            {
+                if (callCount == 1)
+                {
+                    executionContext.ResponseContext.HttpResponse = new HttpWebRequestResponseData(
+                        HttpWebResponseHelper.Create(HttpStatusCode.Redirect,
+                            new WebHeaderCollection { { "location", RedirectLocation } }));
+                }
+                else
+                {
+                    executionContext.ResponseContext.HttpResponse = httpResponse;
+                }
+            };
+            Tester.Validate = (int callCount) =>
+            {
+                if (callCount == 2)
+                {
+                    Assert.AreEqual(RedirectLocation, context.RequestContext.Request.Endpoint.AbsoluteUri);
+                }
+            };
+
+            RuntimePipeline.InvokeSync(context);
+            Assert.AreEqual(2, Tester.CallCount);
+        }
+
 
 
 #if BCL45
@@ -70,7 +136,7 @@ namespace AWSSDK.UnitTests
         [TestCategory("UnitTest")]
         [TestCategory("Runtime")]
         [TestCategory(@"Runtime\Async45")]
-        public async Task TestRedirectAsync()
+        public async Task TestRedirectAsync307()
         {
             var context = CreateTestContext();
             var httpResponse = context.ResponseContext.HttpResponse;
@@ -100,12 +166,79 @@ namespace AWSSDK.UnitTests
             Assert.AreEqual(2, Tester.CallCount);
         }
 
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        [TestCategory(@"Runtime\Async45")]
+        public async Task TestRedirectAsync303()
+        {
+            var context = CreateTestContext();
+            var httpResponse = context.ResponseContext.HttpResponse;
+            Tester.Reset();
+            Tester.Action2 = (callCount, executionContext) =>
+            {
+                if (callCount == 1)
+                {
+                    executionContext.ResponseContext.HttpResponse = new HttpWebRequestResponseData(
+                        HttpWebResponseHelper.Create(HttpStatusCode.RedirectMethod,
+                                new WebHeaderCollection { { "location", RedirectLocation } }));
+                }
+                else
+                {
+                    executionContext.ResponseContext.HttpResponse = httpResponse;
+                }
+            };
+            Tester.Validate = (int callCount) =>
+            {
+                if (callCount == 2)
+                {
+                    Assert.AreEqual(RedirectLocation, context.RequestContext.Request.Endpoint.AbsoluteUri);
+                }
+            };
+
+            await RuntimePipeline.InvokeAsync<AmazonWebServiceResponse>(context);
+            Assert.AreEqual(2, Tester.CallCount);
+        }
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        [TestCategory(@"Runtime\Async45")]
+        public async Task TestRedirectAsync302()
+        {
+            var context = CreateTestContext();
+            var httpResponse = context.ResponseContext.HttpResponse;
+            Tester.Reset();
+            Tester.Action2 = (callCount, executionContext) =>
+            {
+                if (callCount == 1)
+                {
+                    executionContext.ResponseContext.HttpResponse = new HttpWebRequestResponseData(
+                        HttpWebResponseHelper.Create(HttpStatusCode.Redirect,
+                                new WebHeaderCollection { { "location", RedirectLocation } }));
+                }
+                else
+                {
+                    executionContext.ResponseContext.HttpResponse = httpResponse;
+                }
+            };
+            Tester.Validate = (int callCount) =>
+            {
+                if (callCount == 2)
+                {
+                    Assert.AreEqual(RedirectLocation, context.RequestContext.Request.Endpoint.AbsoluteUri);
+                }
+            };
+
+            await RuntimePipeline.InvokeAsync<AmazonWebServiceResponse>(context);
+            Assert.AreEqual(2, Tester.CallCount);
+        }        
+
 #elif !BCL45 && BCL
 
         [TestMethod][TestCategory("UnitTest")]
         [TestCategory("Runtime")]
         [TestCategory(@"Runtime\Async35")]
-        public void TestRedirectAsync()
+        public void TestRedirectAsync307()
         {
             var context = CreateAsyncTestContext();        
             var httpResponse = context.ResponseContext.HttpResponse;
@@ -135,7 +268,75 @@ namespace AWSSDK.UnitTests
             asyncResult.AsyncWaitHandle.WaitOne();
             Assert.AreEqual(2, Tester.CallCount);
         }
+        
+        [TestMethod][TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        [TestCategory(@"Runtime\Async35")]
+        public void TestRedirectAsync303()
+        {
+            var context = CreateAsyncTestContext();        
+            var httpResponse = context.ResponseContext.HttpResponse;
+            Tester.Reset();
+            Tester.Action2 = (callCount, executionContext) =>
+            {
+                if (callCount == 1)
+                {
+                    executionContext.ResponseContext.HttpResponse = new HttpWebRequestResponseData(
+                        HttpWebResponseHelper.Create(HttpStatusCode.RedirectMethod,
+                            new WebHeaderCollection { { "location", RedirectLocation } }));
+                }
+                else
+                {
+                    executionContext.ResponseContext.HttpResponse = httpResponse;
+                }
+            };
+            Tester.Validate = (int callCount) =>
+            {
+                if (callCount == 2)
+                {
+                    Assert.AreEqual(RedirectLocation, context.RequestContext.Request.Endpoint.AbsoluteUri);
+                }
+            };
 
+            var asyncResult = RuntimePipeline.InvokeAsync(context);
+            asyncResult.AsyncWaitHandle.WaitOne();
+            Assert.AreEqual(2, Tester.CallCount);
+        }
+        
+        [TestMethod][TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        [TestCategory(@"Runtime\Async35")]
+        public void TestRedirectAsync302()
+        {
+            var context = CreateAsyncTestContext();        
+            var httpResponse = context.ResponseContext.HttpResponse;
+            Tester.Reset();
+            Tester.Action2 = (callCount, executionContext) =>
+            {
+                if (callCount == 1)
+                {
+                    executionContext.ResponseContext.HttpResponse = new HttpWebRequestResponseData(
+                        HttpWebResponseHelper.Create(HttpStatusCode.Redirect,
+                            new WebHeaderCollection { { "location", RedirectLocation } }));
+                }
+                else
+                {
+                    executionContext.ResponseContext.HttpResponse = httpResponse;
+                }
+            };
+            Tester.Validate = (int callCount) =>
+            {
+                if (callCount == 2)
+                {
+                    Assert.AreEqual(RedirectLocation, context.RequestContext.Request.Endpoint.AbsoluteUri);
+                }
+            };
+
+            var asyncResult = RuntimePipeline.InvokeAsync(context);
+            asyncResult.AsyncWaitHandle.WaitOne();
+            Assert.AreEqual(2, Tester.CallCount);
+        }
+        
 #endif
 
     }


### PR DESCRIPTION
- Add Support for honoring 302 and 303 as long as Location Header is present (Same behavior as 307).

- This current client implementation expects to be only talking to S3 Directly which only returns 307, but this can change if the Network topology adds a Caching Proxy in the middle, which can at times return 302 or 303.
- The Unit tests are added in the same pattern as existing tests, which is that they are independent and self contained (thus look repetitive).

Add Support for honoring 302 and 303 as long as Location Header is present (Same behavior as 307).

## Description
- This current client implementation expects to be only talking to S3 Directly which only returns 307, but this can change if the Network topology adds a Caching Proxy in the middle, which can at times return 302 or 303.
- The Unit tests are added in the same pattern as existing tests, which is that they are independent and self contained (thus look repetitive).

## Motivation and Context
- Allow S3 Client to work in Network Topology that can have a Proxy in the middle

## Testing
- Unit Tests

## Screenshots (if appropriate)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues/1547
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement