### PR TITLE
Fix performance issue: Check file existence before reading it.

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/_bcl+netstandard/OptimisticLockedTextFile.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/_bcl+netstandard/OptimisticLockedTextFile.cs
@@ -132,6 +132,9 @@ namespace Amazon.Runtime.Internal.Util
         {
             // Store a copy of the file for checking concurrency
             OriginalContents = "";
+
+            if (!File.Exists(FilePath)) return;
+
             try
             {
                 OriginalContents = File.ReadAllText(FilePath);

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/_bcl+netstandard/OptimisticLockedTextFile.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/_bcl+netstandard/OptimisticLockedTextFile.cs
@@ -133,19 +133,20 @@ namespace Amazon.Runtime.Internal.Util
             // Store a copy of the file for checking concurrency
             OriginalContents = "";
 
-            if (!File.Exists(FilePath)) return;
-
-            try
+            if (File.Exists(FilePath))
             {
-                OriginalContents = File.ReadAllText(FilePath);
-            }
-            catch (FileNotFoundException)
-            {
-                // This is OK.  The Persist() method will create it if necessary.
-            }
-            catch (DirectoryNotFoundException)
-            {
-                // This is OK.  The Persist() method will create it if necessary.
+                try
+                {
+                    OriginalContents = File.ReadAllText(FilePath);
+                }
+                catch (FileNotFoundException)
+                {
+                    // This is OK.  The Persist() method will create it if necessary.
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    // This is OK.  The Persist() method will create it if necessary.
+                }
             }
 
             // Parse the lines ourselves since we need to preserve the line endings.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix performance issue: Check file existence before reading it. Throwing exceptions is expensive. 

The current approach uses exceptions to control the flow with empty try catches and no logs, which in some cases results in performance downgrade. Added file validation before the file read. It might still happen due to concurrency that file got removed after the validation but it should cover 99% of the normal scenarios.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
We found a degradation in performance when a profile file didn't exist. 
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual, unit tests don't need to be updated
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement