### PR TITLE
Adds ToJson as an extension method for IEnumerable<Document>.

### DIFF
--- a/sdk/AWSSDK.NetStandard.sln
+++ b/sdk/AWSSDK.NetStandard.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29926.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{9863FCB3-BFA4-4B9C-B8F6-302BA5F660B8}"
 EndProject

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
@@ -692,6 +692,16 @@ namespace Amazon.DynamoDBv2.DocumentModel
             return JsonUtils.FromJson(json);
         }
         
+        /// <summary>
+        /// Parses JSON text to produce an array of <see cref="Document"/>.
+        /// </summary>
+        /// <param name="jsonText"></param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of type <see cref="Document"/>.</returns>
+        public static IEnumerable<Document> FromJsonArray(string jsonText)
+        {
+            return JsonUtils.FromJsonArray(jsonText);
+        }
+
         #endregion
 
         #region IDictionary<string,DynamoDBEntry> Members

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
@@ -7,10 +7,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
 {
     public static class DocumentExtensions
     {
-
         /// <summary>
         /// <para>
-        /// Converts the current <see cref="IEnumerable{Document}"/> into a matching JSON string.
+        /// Converts the current <see cref="IEnumerable{T}"/> of <see cref="Document"/> into a matching JSON string.
         /// </para>
         /// <para>
         /// DynamoDB types are a superset of JSON types, thus the following DynamoDB cannot
@@ -32,7 +31,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         /// <summary>
         /// <para>
-        /// Converts the current <see cref="IEnumerable{Document}"/> into a matching pretty JSON string.
+        /// Converts the current <see cref="IEnumerable{T}"/> of <see cref="Document"/> into a matching pretty JSON string.
         /// </para>
         /// <para>
         /// DynamoDB types are a superset of JSON types, thus the following DynamoDB cannot

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using ThirdParty.Json.LitJson;
+
+namespace Amazon.DynamoDBv2.DocumentModel
+{
+    public static class DocumentExtensions
+    {
+
+        /// <summary>
+        /// <para>
+        /// Converts the current <see cref="IEnumerable{Document}"/> into a matching JSON string.
+        /// </para>
+        /// <para>
+        /// DynamoDB types are a superset of JSON types, thus the following DynamoDB cannot
+        /// be properly represented as JSON data:
+        ///  PrimitiveList (SS, NS, BS types) - these sets will be converted to JSON arrays
+        ///  Binary Primitive (B type) - binary data will be converted to Base64 strings
+        /// </para>
+        /// <para>
+        /// If the resultant JSON is passed to Document.FromJson, the binary values will be
+        /// treated as Base64 strings. Invoke Document.DecodeBase64Attributes to decode these
+        /// strings into binary data.
+        /// </para>
+        /// </summary>
+        /// <returns>JSON string corresponding to the current <see cref="IEnumerable{Document}"/>.</returns>
+        public static string ToJson(this IEnumerable<Document> documents)
+        {
+            return SerializeEnumerable(documents, false);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Converts the current <see cref="IEnumerable{Document}"/> into a matching pretty JSON string.
+        /// </para>
+        /// <para>
+        /// DynamoDB types are a superset of JSON types, thus the following DynamoDB cannot
+        /// be properly represented as JSON data:
+        ///  PrimitiveList (SS, NS, BS types) - these sets will be converted to JSON arrays
+        ///  Binary Primitive (B type) - binary data will be converted to Base64 strings
+        /// </para>
+        /// <para>
+        /// If the resultant JSON is passed to Document.FromJson, the binary values will be
+        /// treated as Base64 strings. Invoke Document.DecodeBase64Attributes to decode these
+        /// strings into binary data.
+        /// </para>
+        /// </summary>
+        /// <returns>JSON string corresponding to the current <see cref="IEnumerable{Document}"/>.</returns>
+        public static string ToJsonPretty(this IEnumerable<Document> documents)
+        {
+            return SerializeEnumerable(documents, true);
+        }
+
+        private static string SerializeEnumerable(IEnumerable<Document> documents, bool prettyPrint)
+        {
+            var sb = new StringBuilder();
+            var writer = new JsonWriter(sb);
+            writer.PrettyPrint = prettyPrint;
+
+            writer.WriteArrayStart();
+            foreach (var document in documents)
+            {
+                JsonUtils.WriteJson(document, writer, DynamoDBEntryConversion.V2);
+            }
+            writer.WriteArrayEnd();
+
+            var jsonText = sb.ToString();
+            return jsonText;
+        }
+    }
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
@@ -59,9 +59,15 @@ namespace Amazon.DynamoDBv2.DocumentModel
             writer.PrettyPrint = prettyPrint;
 
             writer.WriteArrayStart();
-            foreach (var document in documents)
+            if (documents != null)
             {
-                JsonUtils.WriteJson(document, writer, DynamoDBEntryConversion.V2);
+                foreach (var document in documents)
+                {
+                    if (document != null)
+                    {
+                        JsonUtils.WriteJson(document, writer, DynamoDBEntryConversion.V2);
+                    }
+                }
             }
             writer.WriteArrayEnd();
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
@@ -49,6 +49,30 @@ namespace Amazon.DynamoDBv2.DocumentModel
         }
 
         /// <summary>
+        /// Parses JSON text to produce an <see cref="IEnumerable{T}"/> of type <see cref="Document"/>.
+        /// </summary>
+        /// <param name="jsonText"></param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of type <see cref="Document"/></returns>
+        public static IEnumerable<Document> FromJsonArray(string jsonText)
+        {
+            var json = JsonMapper.ToObject(jsonText);
+            if (!json.IsArray)
+                throw new InvalidOperationException("Expected array at JSON root.");
+            
+            var array = new List<Document>();
+            for(int i=0;i<json.Count;i++)
+            {
+                var item = json[i];
+                var entry = ToEntry(item, DynamoDBEntryConversion.V2) as Document;
+                if (entry == null)
+                    throw new InvalidOperationException();
+                array.Add(entry);
+            }
+
+            return array;
+        }
+
+        /// <summary>
         /// Creates JSON text for a given Document
         /// </summary>
         /// <param name="document"></param>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
@@ -256,7 +256,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
         }
 
         // Writes a JSON representation of the given DynamoDBEntry
-        private static void WriteJson(DynamoDBEntry entry, JsonWriter writer, DynamoDBEntryConversion conversion)
+        internal static void WriteJson(DynamoDBEntry entry, JsonWriter writer, DynamoDBEntryConversion conversion)
         {
             entry = entry.ToConvertedEntry(conversion);
 


### PR DESCRIPTION
## Description
The current SDK does not expose a way to serialize a list of Document objects returned from operations such as Query or Scan. This change introduces a new extension method that wraps the existing JSON serialization methods inside an array start/end.

## Motivation and Context
Implementers of Serverless Application Model Lambdas need a way to populate the body of the response as a string. If the intent is to return an array of Document objects, they would either have to resort to string concentation + <Document>.ToJson() or other such workarounds. This will eliminate the need for any such customer to write that code.

## Testing
Implemented in a test .NET Core Lambda, ran against populated/empty tables

This change does change the access modifier of JsonUtils.WriteJson from private to internal in order to re-use that code. The fact that it is an extension method means no modification of the Document.cs code was necessary.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement