### PR TITLE
Add missing EUSouth1 and AFSouth1 region endpoints

### DIFF
--- a/sdk/src/Core/RegionEndpoint/RegionEndpoint.cs
+++ b/sdk/src/Core/RegionEndpoint/RegionEndpoint.cs
@@ -91,6 +91,11 @@ namespace Amazon
         public static readonly RegionEndpoint EUCentral1 = GetEndpoint("eu-central-1", "EU Central (Frankfurt)");
 
         /// <summary>
+        /// The Europe (Milan) endpoint.
+        /// </summary>
+        public static readonly RegionEndpoint EUSouth1 = GetEndpoint("eu-south-1", "Europe (Milan)");
+
+        /// <summary>
         /// The Asia Pacific (Hong Kong) endpoint.
         /// </summary>
         public static readonly RegionEndpoint APEast1 = GetEndpoint("ap-east-1", "Asia Pacific (Hong Kong)");
@@ -159,6 +164,11 @@ namespace Amazon
         /// The Middle East (Bahrain) endpoint.
         /// </summary>
         public static readonly RegionEndpoint MESouth1 = GetEndpoint("me-south-1", "Middle East (Bahrain)");
+
+        /// <summary>
+        /// The Africa (Cape Town) endpoint.
+        /// </summary>
+        public static readonly RegionEndpoint AFSouth1 = GetEndpoint("af-south-1", "Africa (Cape Town)");
 
         /// <summary>
         /// Represents the endpoint overridding rules in the endpoints.json


### PR DESCRIPTION
## Description
Add missing region constants


## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement