### PR TITLE
Makes MetadataCollection lookups case-insensitive.

### DIFF
--- a/sdk/src/Services/S3/Custom/Model/MetadataCollection.cs
+++ b/sdk/src/Services/S3/Custom/Model/MetadataCollection.cs
@@ -26,7 +26,7 @@ namespace Amazon.S3.Model
     {
         internal const string MetaDataHeaderPrefix = "x-amz-meta-";
             
-        IDictionary<string, string> values = new Dictionary<string, string>();
+        IDictionary<string, string> values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets and sets meta data for the object. Meta data names must start with "x-amz-meta-". If the name passeed in as the indexer 

--- a/sdk/test/Services/S3/UnitTests/Custom/MetadataCollectionTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/MetadataCollectionTests.cs
@@ -1,0 +1,21 @@
+﻿using Amazon.S3.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSSDK.UnitTests
+{
+    [TestClass]
+    public class MetadataCollectionTests
+    {
+        [TestMethod]
+        [TestCategory("S3")]
+        public void MetadataCollectionIndexerIsCaseInsensitive()
+        {
+            var sut = new MetadataCollection
+            {
+                ["KeYnAmE"] = "foo"
+            };
+            
+            Assert.AreEqual(sut["kEyNaMe"], "foo");
+        }
+    }
+}


### PR DESCRIPTION
## Description
This patch makes the MetadataCollection lookups case-insentive. So accessing metadata["FOO"] returns the same as metadata["foo"].

## Motivation and Context
I added a custom metadata entry to an object with key "MD5" but when fetching the object later on and trying to retrieve the value for the key "MD5" returned null. S3 persists metadata keys in lowercase and the implementation of MetadataCollection doesn't take this into account.

## Testing
Added an extra unit test since it's a very isolated change with no expected side-effects.

## Screenshots (if appropriate)

## Types of changes
I believe this to be a non-breaking change as any existing code would not be functioning if it depended on S3 to respect the casing.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

I can't really run the entire test suite in my current environment. Hopefully, your CI can.
## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement