### PR TITLE
Fixed a typo in UseToken XML comment

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/ImmutableCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/ImmutableCredentials.cs
@@ -43,7 +43,7 @@ namespace Amazon.Runtime
 
         /// <summary>
         /// Gets the UseToken property for the current credentials.
-        /// Specifies if Token property is non-emtpy.
+        /// Specifies if Token property is non-empty.
         /// </summary>
         public bool UseToken { get { return !string.IsNullOrEmpty(Token); } }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed non-emtpy -> non-empty in `ImmutableCredentials`

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement