### PR TITLE
[FIX] Unity Readme: Incorrect XML and NullReferenceException

### DIFF
--- a/Unity.README.md
+++ b/Unity.README.md
@@ -32,14 +32,14 @@ There are only a few fundamentals that are helpful to know when developing again
 * To enable logging you need to create a config file called awsconfig.xml in a `Resources` directory add add the following
 
 		<?xml version="1.0" encoding="utf-8"?>
-		<aws 
+		<aws region="ap-northeast-1" correctForClockSkew="true"> 
 			<logging
 	    		logTo="UnityLogger"
 	    		logResponses="Always"
 	    		logMetrics="true"
 	    		logMetricsFormat="JSON" />
 			/>
-		/>
+		</aws>
 	
 You can also do this configuration in a script
 
@@ -77,7 +77,11 @@ You can also do this configuration in a script
 		<assembly fullname="AWSSDK.Core" preserve="all">
 			<namespace fullname="Amazon.Util.Internal.PlatformServices" preserve="all"/>
 		</assembly>
-   		<assembly fullname="AWSSDK.CognitoIdentity" preserve="all"/>
-   		<assembly fullname="AWSSDK.SecurityToken" preserve="all"/>
+		<assembly fullname="AWSSDK.CognitoIdentity" preserve="all">
+			<namespace fullname="Amazon.Util.Internal.PlatformServices" preserve="all"/>
+		</assembly>
+		<assembly fullname="AWSSDK.SecurityToken" preserve="all">
+			<namespace fullname="Amazon.Util.Internal.PlatformServices" preserve="all"/>
+		</assembly>
 		add more services that you need here... 
 		</linker>


### PR DESCRIPTION
Update for proper workable format for Unity by fixing example XML.

I have come across the same issus as [#1635](https://github.com/aws/aws-sdk-net/issues/1635), and the error is fixed after modifying the format of the two XML files, which are shown wrongly in the example.

## Description
Changed README for the proper usage of `link.xml` and `awsconfig.xml` file for use in Unity.

## Motivation and Context
Fixed #1635 issue by providing an updated context.

## Testing
My build is using unity v2019.4.2f1, with the latest build of aws .net sdk

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement