### PR TITLE
Support IAsyncEnumerable for Amazon.DynamoDBv2.DataModel.AsyncSearch

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NETSTANDARD20
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#if NETCOREAPP3_1
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+
+namespace Amazon.DynamoDBv2.DataModel
+{
+    public partial class AsyncSearch<T> : IAsyncEnumerable<IList<T>>
+    {
+        #region IAsyncEnumerable<IList<T>>
+
+        /// <summary>
+        /// Gets asynchronous enumerators of results from DynamoDB.
+        /// </summary>
+        /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
+        /// <returns>
+        /// Asynchronous enumerator of results from DynamoDB.
+        /// </returns>
+        public IAsyncEnumerator<IList<T>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new AsyncSearchEnumerator<T>(this, cancellationToken);
+        }
+
+        #endregion
+    }
+
+    internal struct AsyncSearchEnumerator<T> : IAsyncEnumerator<IList<T>>
+    {
+ 
+        #region Private members
+
+        private readonly AsyncSearch<T> SearchSource;
+        private readonly CancellationToken CancellationToken;
+
+        #endregion
+
+        #region Constructor
+
+        public AsyncSearchEnumerator(AsyncSearch<T> searchSource, CancellationToken cancellationToken = default)
+        {
+            SearchSource = searchSource;
+            CancellationToken = cancellationToken;
+            Current = default;
+        }
+ 
+        #endregion
+
+        #region IAsyncEnumerator<IList<T>>
+
+        public IList<T> Current { get; private set; }
+
+        public ValueTask DisposeAsync() => default;
+
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            if (SearchSource.IsDone)
+            {
+                return false;
+            }
+            Current = await SearchSource.GetNextSetAsync(CancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.IAsyncEnumerable.cs
@@ -42,7 +42,7 @@ namespace Amazon.DynamoDBv2.DataModel
         #endregion
     }
 
-    internal struct AsyncSearchEnumerator<T> : IAsyncEnumerator<IList<T>>
+    internal sealed class AsyncSearchEnumerator<T> : IAsyncEnumerator<IList<T>>
     {
  
         #region Private members


### PR DESCRIPTION
Support IAsyncEnumerable for Amazon.DynamoDBv2.DataModel.AsyncSearch.

## Description
Implement IAsyncEnumerable for AsyncSearch in netcoreapp3.1.

I created pull request #1482. However, this request was rejected due to breaking changes. Now SDK support netcoreapp3.1 target. This request does not add a new target and a new dependency package.

#1468

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement