### PR TITLE
RedirectHandler adds port number to redirected endpoint

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/RedirectHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/RedirectHandler.cs
@@ -149,7 +149,15 @@ namespace Amazon.Runtime.Internal
             var uri = new Uri(redirectedLocation);
 
             var requestContext = executionContext.RequestContext;
-            requestContext.Request.Endpoint = new UriBuilder(uri.Scheme, uri.Host).Uri;
+            
+            if (uri.IsDefaultPort)
+            {
+                requestContext.Request.Endpoint = new UriBuilder(uri.Scheme, uri.Host).Uri;
+            }
+            else
+            {
+                requestContext.Request.Endpoint = new UriBuilder(uri.Scheme, uri.Host, uri.Port).Uri;
+            }
 
             RetryHandler.PrepareForRetry(executionContext.RequestContext);
         }


### PR DESCRIPTION
This patch adds the port number to the redirected endpoint if it is not the default port number.

## Description
If redirected port number is the default port then it works as before. Otherwise it adds the port number to the generated endpoint address.

## Motivation and Context
If it fixes an open [[issue][issues]#1689]

## Testing

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement