### PR TITLE
Performance improvement in S3 endpoint validation logic

### DIFF
--- a/sdk/src/Services/S3/Custom/Internal/AmazonS3KmsHandler.cs
+++ b/sdk/src/Services/S3/Custom/Internal/AmazonS3KmsHandler.cs
@@ -80,11 +80,11 @@ namespace Amazon.S3.Internal
         internal static void EvaluateIfSigV4Required(IRequest request)
         {
             // Skip this for S3-compatible storage provider endpoints
-            if ((request.OriginalRequest is S3.Model.GetObjectRequest) && (AmazonS3Uri.IsAmazonS3Endpoint(request.Endpoint)))
+            if (request.OriginalRequest is S3.Model.GetObjectRequest && 
+                AmazonS3Uri.TryParseAmazonS3Uri(request.Endpoint, out var amazonS3Uri) && 
+                amazonS3Uri.Region != RegionEndpoint.USEast1)     
             {
-                var region = new AmazonS3Uri(request.Endpoint.OriginalString).Region;
-                if(region != RegionEndpoint.USEast1)
-                    request.UseSigV4 = true;
+                request.UseSigV4 = true;
             }
         }
     }

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
@@ -34,6 +34,10 @@ namespace Amazon.S3.Util
     {
         private const string EndpointPattern = @"^(.+\.)?s3[.-]([a-z0-9-]+)\.";
 
+        private static Regex endpointRegexMatch;
+
+        private static Regex EndpointRegexMatch => endpointRegexMatch ?? (endpointRegexMatch = new Regex(EndpointPattern, RegexOptions.Compiled));
+
         /// <summary>
         /// True if the URI contains the bucket in the path, false if it contains the bucket in the authority.
         /// </summary>
@@ -221,16 +225,14 @@ namespace Amazon.S3.Util
             if (uri == null)
                 throw new ArgumentNullException("uri");
 
-            var match = new Regex(EndpointPattern).Match(uri.Host);
             if (uri.Host.EndsWith("amazonaws.com", StringComparison.OrdinalIgnoreCase) || uri.Host.EndsWith("amazonaws.com.cn", StringComparison.OrdinalIgnoreCase))
             {
-                return match.Success;
+                return EndpointRegexMatch.Match(uri.Host).Success;
             }
             else
             {
                 return false;
             }
-
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
@@ -32,7 +32,7 @@ namespace Amazon.S3.Util
     /// </summary>
     public class AmazonS3Uri
     {
-        private static Regex EndpointRegexMatch = new Regex(@"^(.+\.)?s3[.-]([a-z0-9-]+)\.", RegexOptions.Compiled);
+        private static readonly Regex EndpointRegexMatch = new Regex(@"^(.+\.)?s3[.-]([a-z0-9-]+)\.", RegexOptions.Compiled);
 
         /// <summary>
         /// True if the URI contains the bucket in the path, false if it contains the bucket in the authority.

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
@@ -195,7 +195,9 @@ namespace Amazon.S3.Util
                 }
             }
             // intentionally suppress all exceptions, because this is a try method
+#pragma warning disable CA1031 // Do not catch general exception types
             catch { }
+#pragma warning restore CA1031 // Do not catch general exception types
 
             amazonS3Uri = null;
             return false;

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
@@ -32,11 +32,9 @@ namespace Amazon.S3.Util
     /// </summary>
     public class AmazonS3Uri
     {
-        private const string EndpointPattern = @"^(.+\.)?s3[.-]([a-z0-9-]+)\.";
-
         private static Regex endpointRegexMatch;
 
-        private static Regex EndpointRegexMatch => endpointRegexMatch ?? (endpointRegexMatch = new Regex(EndpointPattern, RegexOptions.Compiled));
+        private static Regex EndpointRegexMatch => endpointRegexMatch ?? (endpointRegexMatch = new Regex(@"^(.+\.)?s3[.-]([a-z0-9-]+)\.", RegexOptions.Compiled));
 
         /// <summary>
         /// True if the URI contains the bucket in the path, false if it contains the bucket in the authority.
@@ -81,7 +79,7 @@ namespace Amazon.S3.Util
             if (string.IsNullOrEmpty(uri.Host))
                 throw new ArgumentException("Invalid URI - no hostname present");
 
-            var match = new Regex(EndpointPattern).Match(uri.Host);
+            var match = EndpointRegexMatch.Match(uri.Host);
             if (!match.Success)
                 throw new ArgumentException("Invalid S3 URI - hostname does not appear to be a valid S3 endpoint");
 

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
@@ -32,9 +32,7 @@ namespace Amazon.S3.Util
     /// </summary>
     public class AmazonS3Uri
     {
-        private static Regex endpointRegexMatch;
-
-        private static Regex EndpointRegexMatch => endpointRegexMatch ?? (endpointRegexMatch = new Regex(@"^(.+\.)?s3[.-]([a-z0-9-]+)\.", RegexOptions.Compiled));
+        private static Regex EndpointRegexMatch = new Regex(@"^(.+\.)?s3[.-]([a-z0-9-]+)\.", RegexOptions.Compiled);
 
         /// <summary>
         /// True if the URI contains the bucket in the path, false if it contains the bucket in the authority.


### PR DESCRIPTION
## Description
The logic for an AmazonS3Uri.IsAmazonS3Endpoint method overload was updated to improve performance.  

## Motivation and Context
The current logic does not take advantage of static and compile options available with Regex usage. Code was updated by creating a static property for the Regex match logic, using the compile option. Additionally, the order of options was changed so that that the Regex logic would not be called unless a valid URI was provided. This improves performance by short circuiting the evaluation.

The performance impact was was reported in Issue #1700. 

## Testing
I created a local test client that tested calls ranging from 5 to 100,000 within an execution, and observed over a 90% performance improvement when using a mix of 70% Amazon vs 30% non-Amazon URI calls. 

I executed the related Unit Tests provided in the solution(AWSSDK.IntegrationTests.S3.Net35, AWSSDK.IntegrationTests.S3.Net45,
AWSSDK.UnitTestUtilities.Net35, AWSSDK.UnitTestUtilities.Net45, AWSSDK.UnitTests.S3.Net35, AWSSDK.UnitTests.S3.Net45). All passed, except for:
- S3CapacityManagerIntegrationTest - Exception "Amazon.Runtime.AmazonUnmarshallingException: Error unmarshalling response back from AWS. Response Body: System.InvalidOperationException: Sequence contains no elements" (this exception was also thrown with the original code)
- EncryptionInteropTest : 9 tests skipped
- Replicationtests : 2 tests skipped
- RequesterPaysTests : 8 tests skipped

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement