### PR TITLE
Update RequestPayer docs to universal summary

### DIFF
--- a/sdk/src/Services/S3/Custom/Model/AbortMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/AbortMultipartUploadRequest.cs
@@ -104,7 +104,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
@@ -177,7 +177,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
@@ -685,7 +685,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectRequest.cs
@@ -158,7 +158,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectsRequest.cs
@@ -153,7 +153,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
@@ -332,7 +332,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/GetObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectRequest.cs
@@ -415,7 +415,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/GetObjectTorrentRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectTorrentRequest.cs
@@ -71,7 +71,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
@@ -336,7 +336,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/ListPartsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListPartsRequest.cs
@@ -154,7 +154,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
@@ -516,7 +516,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/RestoreObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/RestoreObjectRequest.cs
@@ -121,7 +121,7 @@ namespace Amazon.S3.Model
         }
 
 		/// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer

--- a/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
@@ -355,7 +355,7 @@ namespace Amazon.S3.Model
         }
 
         /// <summary>
-        /// Confirms that the requester knows that she or he will be charged for the list objects request.
+        /// Confirms that the requester knows that she or he will be charged for the request.
         /// Bucket owners need not specify this parameter in their requests.
         /// </summary>
         public RequestPayer RequestPayer


### PR DESCRIPTION
## Description
It looks like the ListObjects's RequestPayer documentation was copy and pasted for all RequestPayer usages. This PR fixes those summary comments with more universal wording.

## Motivation and Context
Documentation around RequestPayer is incorrect for most requests because it was intended for the ListObjects requests.

## Testing
Unit tests still pass.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license