### PR TITLE
Add possibility to instantiate services with credentials from STS

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
@@ -46,6 +46,10 @@ namespace Amazon.Extensions.NETCore.Setup
         /// </summary>
         public RegionEndpoint Region { get; set; }
 
+        public string SessionRoleArn { get; set; }
+
+        public string SessionName { get; set; } = "DefaultSessionName";
+
         /// <summary>
         /// AWS Credentials used for creating service clients. If this is set it overrides the Profile property.
         /// </summary>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
@@ -45,9 +45,15 @@ namespace Amazon.Extensions.NETCore.Setup
         /// The AWS region the service client should use when making service operations.
         /// </summary>
         public RegionEndpoint Region { get; set; }
-
+     
+        /// <summary>
+        /// If set this role will be assumed using the resolved AWS credentials.
+        /// </summary>
         public string SessionRoleArn { get; set; }
 
+        /// <summary>
+        /// The session name for the assumed session using the SessionRoleArn.
+        /// </summary>
         public string SessionName { get; set; } = "DefaultSessionName";
 
         /// <summary>


### PR DESCRIPTION
This is a tentative solution at issue #1741 

## Description
If the user has specified a `SessionRoleArn` in the `AWSOptions`, an instance of `AssumeRoleAWSCredentials` is used to fetch the credentials for the service.

## Motivation and Context
Fixes #1741 

## Testing
This is a tentative solution, I'd welcome feedback from the maintainers before proceeding further with this PR. I created a test console application that link to the project directly.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement