### PR TITLE
Fix null ref when field is null

### DIFF
--- a/sdk/src/Services/SimpleNotificationService/Custom/Util/Message.cs
+++ b/sdk/src/Services/SimpleNotificationService/Custom/Util/Message.cs
@@ -64,7 +64,7 @@ namespace Amazon.SimpleNotificationService.Util
 
                     // Check to see if the field can be found with a different case.
                     var anyCaseKey = jsonData.PropertyNames.FirstOrDefault(x => string.Equals(x, fieldName, StringComparison.OrdinalIgnoreCase));
-                    if (!string.IsNullOrEmpty(anyCaseKey) && jsonData[anyCaseKey].IsString)
+                    if (!string.IsNullOrEmpty(anyCaseKey) && jsonData[anyCaseKey] != null && jsonData[anyCaseKey].IsString)
                         return (string)jsonData[anyCaseKey];
 
                     return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I have fixed a null reference error when the json passed into the Message.ParseMessage has a property with a value of null.

## Motivation and Context
I am using the localstack project which doesn't provide a value for `Token` or `SubscribeURL` when a message goes from SNS -> SQS

I don't know whether the Message class can have nullable values for those properties, but i'm pretty sure that the desired behaviour isn't a null ref exception

## Testing
I have create a new sln file and used the following test, \i did not include these chnges in the PR

```
var m = "{'Type': 'Notification', 'MessageId': \"ecc27311-a504-414a-9a1f-5ebfc5020902\", 'Token': null, 'TopicArn': \"arn:aws:sns:us-east-1:000000000000:sometopic\", 'Message': \"blah\", 'SubscribeURL': null, 'Timestamp': \"2020-11-30T15:04:28.130Z\", 'SignatureVersion': \"1\", 'Signature': \"EXAMPLEpH+..\", 'SigningCertURL': \"https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem\"}";
var me = Amazon.SimpleNotificationService.Util.Message.ParseMessage(m);
            
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement