### PR TITLE
Fix to throw expected argumentexception when null host or username is passed

### DIFF
--- a/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
+++ b/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
@@ -128,11 +128,11 @@ namespace Amazon.RDS.Util
             if (port < 0 || port > 65535)
                 throw new ArgumentException(String.Format(CultureInfo.InvariantCulture, "{0} is an invalid port. Port must be 0 to 65535.", port));
 
-            hostname = hostname.Trim();
+            hostname = hostname?.Trim();
             if (string.IsNullOrEmpty(hostname))
                 throw new ArgumentException("Hostname must not be null or empty.");
 
-            dbUser = dbUser.Trim();
+            dbUser = dbUser?.Trim();
             if (string.IsNullOrEmpty(dbUser))
                 throw new ArgumentException("DBUser must not be null or empty.");
 

--- a/sdk/test/Services/RDS/UnitTests/Custom/RDSAuthTokenGeneratorTest.cs
+++ b/sdk/test/Services/RDS/UnitTests/Custom/RDSAuthTokenGeneratorTest.cs
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
- using Amazon;
+using Amazon;
 using Amazon.RDS;
 using Amazon.RDS.Util;
 using Amazon.Runtime;
@@ -63,6 +63,7 @@ namespace AWSSDK.UnitTests.RDS
         }
 
         [TestMethod]
+        [TestCategory("RDS")]
         public void GenerateAuthTokenBasic()
         {
             AssertAuthToken(RDSAuthTokenGenerator.GenerateAuthToken(BasicCredentials,
@@ -120,11 +121,31 @@ namespace AWSSDK.UnitTests.RDS
 
         [TestMethod]
         [TestCategory("RDS")]
+        public void GenerateAuthTokenNullHostname()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                RDSAuthTokenGenerator.GenerateAuthToken(AWSRegion, null, DBPort, DBUser);
+            }, typeof(ArgumentException));
+        }
+
+        [TestMethod]
+        [TestCategory("RDS")]
         public void GenerateAuthTokenEmptyHostname()
         {
             AssertExtensions.ExpectException(() =>
             {
                 RDSAuthTokenGenerator.GenerateAuthToken(AWSRegion, " ", DBPort, DBUser);
+            }, typeof(ArgumentException));
+        }
+
+        [TestMethod]
+        [TestCategory("RDS")]
+        public void GenerateAuthTokenEmptyDBUser()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                RDSAuthTokenGenerator.GenerateAuthToken(AWSRegion, DBHost, DBPort, null);
             }, typeof(ArgumentException));
         }
 


### PR DESCRIPTION
Throws an argument exception instead of a null reference if the host or username parameters were null

## Description
Only trim the parameters if they are not null.

## Motivation and Context
Improves ease of troubleshooting when connection information is missing.
Fixes https://github.com/aws/aws-sdk-net/issues/1755

## Testing
Updated unit tests to include tests checking for null arguments in addition to the empty arguments.

## Screenshots (if appropriate)
[n/a]

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [X] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement