### PR TITLE
📦 Include symbols (snupkg's) when creating nuget packages.

### DIFF
--- a/sdk/src/Core/AWSSDK.Core.NetStandard.csproj
+++ b/sdk/src/Core/AWSSDK.Core.NetStandard.csproj
@@ -23,7 +23,15 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>        
 
     <NetStandardImplicitPackageVersion Condition="'$(TargetFramework)' == 'netstandard1.3'">1.6.0</NetStandardImplicitPackageVersion>
+      
+    <!-- Sourcelink -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+    
     <!-- Async Enumerable Compatibility -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <LangVersion>8.0</LangVersion>
@@ -81,6 +89,10 @@
     <PackageReference Include="System.Security.Cryptography.Csp" Version="4.0.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/sdk/src/Services/S3/AWSSDK.S3.NetStandard.csproj
+++ b/sdk/src/Services/S3/AWSSDK.S3.NetStandard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
    <RunAnalyzersDuringBuild Condition="'$(RunAnalyzersDuringBuild)'==''">true</RunAnalyzersDuringBuild>
     <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp3.1</TargetFrameworks>
@@ -20,9 +20,17 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
 
-    <NetStandardImplicitPackageVersion  Condition="'$(TargetFramework)' == 'netstandard1.3'">1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition="'$(TargetFramework)' == 'netstandard1.3'">1.6.0</NetStandardImplicitPackageVersion>
+
+    <!-- Sourcelink -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-  <!-- Async Enumerable Compatibility -->
+
+    <!-- Async Enumerable Compatibility -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
@@ -32,11 +40,7 @@
   <PropertyGroup Condition=" '$(RuleSetFileForBuild)' == 'true' ">
     <CodeAnalysisRuleSet>..\..\..\AWSDotNetSDKForBuild.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-
+  
   <Choose>
     <When Condition=" '$(AWSKeyFile)' == '' ">
       <PropertyGroup>
@@ -51,20 +55,27 @@
   </Choose>
 
   <ItemGroup Condition="$(RunAnalyzersDuringBuild)">
-    <Analyzer Include= "..\..\..\..\buildtools\CustomRoslynAnalyzers.dll" />
+    <Analyzer Include="..\..\..\..\buildtools\CustomRoslynAnalyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Remove="**/_bcl35/**"/>
-    <Compile Remove="**/_bcl45/**"/>
-    <Compile Remove="**/_bcl/**"/>
-    <Compile Remove="**/obj/**"/>
+    <Compile Remove="**/_bcl35/**" />
+    <Compile Remove="**/_bcl45/**" />
+    <Compile Remove="**/_bcl/**" />
+    <Compile Remove="**/obj/**" />
     <None Remove="**/obj/**" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Core\AWSSDK.Core.NetStandard.csproj"/>
+    <ProjectReference Include="..\..\Core\AWSSDK.Core.NetStandard.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+    
   <ItemGroup Condition="$(RunAnalyzersDuringBuild)">
         <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3">
             <PrivateAssets>all</PrivateAssets>
@@ -72,8 +83,6 @@
         <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
As discussed in #1777 this PR is one of potentially many to come (not necessarily from me, though).

To help developers debug their applications, if a NuGet package (which is being consumed by the developers project) has [Source link enabled](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink), then a developer could optionally "step into" a method that is provided by the 3rd party NuGet package.

So in the case of this AWS .NET Sdk, a developer could step into some of the public methods provided in the AWS SDK NuGet's!

To enable this, I had up update the `.csproj` file for the relevant project which will be `dotnet pack` into a NuGet package.

As of the time of me creating the code changes today, there was 260+ projects in the .NET Standard solution! Egads! That's a lot. As such:

- I've only started with the S3 project (in this PR).
- the S3 project takes a dependency on the AWS SDK "Core" project, so I've also enabled that.
- I'm not planning on enabling Source link for all of the other projects because that's too time consuming (for me) and I don't use 99% of them.

- ⚠️ This PR is only tackling .NET Standard. I'm not bothering with .NET35 or .NET45 as these are (more or less) obsolete so I'm spending _my_ energy there. Of course, others can!
- 🚀 If this PR is successful, I'll also do 2x more for SNS and SQS (more services I use).

## Motivation and Context
- Helps resolve #1777 
- Helps developers debug their own code when they consume AWS SDK services and might need to step into the AWS code.

## Testing
- Testing requires `dotnet pack`'ing to occur. 
- In the `sdk\services\s3` folder, type: `dotnet pack -c RELEASE -o C:\temp\Nuget /p:ContinuousIntegrationBuild=true /p:version=100.2.3.4   .\AWSSDK.S3.NetStandard.csproj`

- `/p:ContinuousIntegrationBuild=true` == deterministic builds, I believe.
- `/p:version=100.2.3.4` is just me making a version of the NuGet so it is to find in a NuGet package manager or on the hard disk.

Before (the current vesrion on NuGet.org):

![image](https://user-images.githubusercontent.com/899878/105834521-b19bdf80-601e-11eb-9562-1f2e31f153e1.png)

And after running the `dotnet pack` command:

![image](https://user-images.githubusercontent.com/899878/105834597-cd9f8100-601e-11eb-967d-d3b1147b5b5f.png)

NOTE: similar info should also apply to the `AWSSDK.Core` NuGet package.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license

---

### ⚠️ ⚠️ ⚠️  AWS SDK + CI / CD

I couldn't find any documentation about how this solution/repo handles CI/CD.

- What system does it use? GH Actions? Travis? AppVeyor?
- How does CI/CD kick off? Does a PR kick this off?

As such, I couldn't find where to update the code where/how `dotnet pack` is ran. THIS STEP IS IMPORTANT and requires a possible modification (as listed above in this readme). Specifically the `/p:ContinuousIntegrationBuild=true`