### PR TITLE
Support to reload endpoints

### DIFF
--- a/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
@@ -109,7 +109,7 @@ namespace Amazon.S3
                 }
 
                 var fallbackToSigV2 = useSigV2Fallback && !AWSConfigsS3.UseSigV4SetExplicitly;
-                if (endpoint == RegionEndpoint.USEast1 && fallbackToSigV2)
+                if (endpoint?.SystemName == RegionEndpoint.USEast1.SystemName && fallbackToSigV2)
                 {
                     aws4Signing = false;
                 }

--- a/sdk/src/Services/S3/Custom/AmazonS3Config.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Config.cs
@@ -35,7 +35,7 @@ namespace Amazon.S3
         private bool forcePathStyle = false;
         private bool useAccelerateEndpoint = false;
         private S3UsEast1RegionalEndpointValue? s3UsEast1RegionalEndpointValue;
-        private readonly RegionEndpoint legacyUSEast1GlobalRegion = RegionEndpoint.USEast1;
+        private readonly string legacyUSEast1GlobalRegionSystemName = RegionEndpoint.USEast1.SystemName;
 
         private static CredentialProfileStoreChain credentialProfileChain = new CredentialProfileStoreChain();
          
@@ -95,7 +95,7 @@ namespace Amazon.S3
                     if (!this._useArnRegion.HasValue)
                     {
                         // To maintain consistency with buckets default UseArnRegion to true when client configured for us-east-1.
-                        this._useArnRegion = this.RegionEndpoint == RegionEndpoint.USEast1;
+                        this._useArnRegion = this.RegionEndpoint?.SystemName == RegionEndpoint.USEast1.SystemName;
                     }
                 }
 
@@ -151,7 +151,7 @@ namespace Amazon.S3
             }
 
             var actual = this.RegionEndpoint;
-            if (actual == legacyUSEast1GlobalRegion && !UseAccelerateEndpoint && !UseDualstackEndpoint
+            if (actual?.SystemName == legacyUSEast1GlobalRegionSystemName && !UseAccelerateEndpoint && !UseDualstackEndpoint
                 && USEast1RegionalEndpointValue == S3UsEast1RegionalEndpointValue.Regional)
             {
                 actual = RegionEndpoint.GetBySystemName("us-east-1-regional");

--- a/sdk/src/Services/S3/Custom/Internal/AmazonS3KmsHandler.cs
+++ b/sdk/src/Services/S3/Custom/Internal/AmazonS3KmsHandler.cs
@@ -82,7 +82,7 @@ namespace Amazon.S3.Internal
             // Skip this for S3-compatible storage provider endpoints
             if (request.OriginalRequest is S3.Model.GetObjectRequest && 
                 AmazonS3Uri.TryParseAmazonS3Uri(request.Endpoint, out var amazonS3Uri) && 
-                amazonS3Uri.Region != RegionEndpoint.USEast1)     
+                amazonS3Uri.Region?.SystemName != RegionEndpoint.USEast1.SystemName)     
             {
                 request.UseSigV4 = true;
             }

--- a/sdk/src/Services/S3/Custom/Util/_bcl/AmazonS3Util.Operations.cs
+++ b/sdk/src/Services/S3/Custom/Util/_bcl/AmazonS3Util.Operations.cs
@@ -360,7 +360,7 @@ namespace Amazon.S3.Util
         public static S3PostUploadResponse PostUpload(S3PostUploadRequest request)
         {
             string url;
-            string subdomain = request.Region.Equals(RegionEndpoint.USEast1) ? "s3" : "s3-" + request.Region.SystemName;
+            string subdomain = (request.Region.Equals(RegionEndpoint.USEast1) || request.Region?.SystemName == RegionEndpoint.USEast1.SystemName) ? "s3" : "s3-" + request.Region.SystemName;
 
             if (request.Bucket.IndexOf('.') > -1)
                 url = string.Format(CultureInfo.InvariantCulture, "https://{0}.amazonaws.com/{1}/", subdomain, request.Bucket);

--- a/sdk/src/Services/S3/GlobalSuppressions.cs
+++ b/sdk/src/Services/S3/GlobalSuppressions.cs
@@ -3,7 +3,7 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("AwsSdkRules", "CR1004:Do not use static readonly RegionEndpoint members from within the SDK.", Justification = "<Pending>", Scope = "member", Target = "~F:Amazon.S3.AmazonS3Config.legacyUSEast1GlobalRegion")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("AwsSdkRules", "CR1004:Do not use static readonly RegionEndpoint members from within the SDK.", Justification = "<Pending>", Scope = "member", Target = "~F:Amazon.S3.AmazonS3Config.legacyUSEast1GlobalRegionSystemName")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("AwsSdkRules", "CR1004:Do not use static readonly RegionEndpoint members from within the SDK.", Justification = "<Pending>", Scope = "member", Target = "~P:Amazon.S3.AmazonS3Config.UseArnRegion")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>", Scope = "member", Target = "~M:Amazon.S3.Util.AmazonS3Uri.TryParseAmazonS3Uri(System.String,Amazon.S3.Util.AmazonS3Uri@)~System.Boolean")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("AwsSdkRules", "CR1004:Do not use static readonly RegionEndpoint members from within the SDK.", Justification = "<Pending>", Scope = "member", Target = "~M:Amazon.S3.Internal.AmazonS3RetryPolicy.SharedRetryForExceptionSync(Amazon.Runtime.IExecutionContext,System.Exception,Amazon.Runtime.Internal.Util.ILogger,System.Func{Amazon.Runtime.IExecutionContext,System.Exception,System.Boolean})~System.Nullable{System.Boolean}")]

--- a/sdk/src/Services/S3Control/Custom/AmazonS3ControlConfig.Extension.cs
+++ b/sdk/src/Services/S3Control/Custom/AmazonS3ControlConfig.Extension.cs
@@ -55,7 +55,7 @@ namespace Amazon.S3Control
                     if (!this._useArnRegion.HasValue)
                     {
                         // To maintain consistency with buckets default UseArnRegion to true when client configured for us-east-1.
-                        this._useArnRegion = this.RegionEndpoint == RegionEndpoint.USEast1;
+                        this._useArnRegion = this.RegionEndpoint?.SystemName == RegionEndpoint.USEast1.SystemName;
                     }
                 }
 

--- a/sdk/src/Services/SecurityToken/Custom/AmazonSecurityTokenServiceConfig.Extension.cs
+++ b/sdk/src/Services/SecurityToken/Custom/AmazonSecurityTokenServiceConfig.Extension.cs
@@ -61,7 +61,7 @@ namespace Amazon.SecurityToken
         private static CredentialProfileStoreChain credentialProfileChain = new CredentialProfileStoreChain();
         
 #if BCL35
-        private readonly HashSet<RegionEndpoint> legacyGlobalRegions = new HashSet<RegionEndpoint>
+        private static readonly HashSet<RegionEndpoint> legacyGlobalRegions = new HashSet<RegionEndpoint>
          {
              RegionEndpoint.USEast1,
              RegionEndpoint.USEast2,
@@ -79,8 +79,9 @@ namespace Amazon.SecurityToken
              RegionEndpoint.APSouth1,
              RegionEndpoint.APNortheast1
          };
+        private static readonly HashSet<string> legacyGlobalRegionSystemNames = new HashSet<string>();
 #else
-        private readonly ISet<RegionEndpoint> legacyGlobalRegions = new HashSet<RegionEndpoint>
+        private static readonly ISet<RegionEndpoint> legacyGlobalRegions = new HashSet<RegionEndpoint>
          {
              RegionEndpoint.USEast1,
              RegionEndpoint.USEast2,
@@ -98,7 +99,16 @@ namespace Amazon.SecurityToken
              RegionEndpoint.APSouth1,
              RegionEndpoint.APNortheast1
          };
+        private static readonly ISet<string> legacyGlobalRegionSystemNames = new HashSet<string>();
 #endif
+
+        static AmazonSecurityTokenServiceConfig()
+        {
+            foreach (var legacyGlobalRegion in legacyGlobalRegions)
+            {
+                legacyGlobalRegionSystemNames.Add(legacyGlobalRegion.SystemName);
+            }
+        }
 
         /// <summary>
         /// Override DetermineServiceURL to set the url to the 
@@ -113,7 +123,8 @@ namespace Amazon.SecurityToken
                 return this.ServiceURL;
             }
             // also check if the region is within the list of legacy global regions
-            else if (this.StsRegionalEndpoints == StsRegionalEndpointsValue.Legacy && legacyGlobalRegions.Contains(this.RegionEndpoint))
+            else if (this.StsRegionalEndpoints == StsRegionalEndpointsValue.Legacy &&
+                     (this.RegionEndpoint != null && legacyGlobalRegionSystemNames.Contains(this.RegionEndpoint?.SystemName)))
             {
                 this.AuthenticationRegion = "us-east-1";
                 return StsDefaultHostname;

--- a/sdk/test/UnitTests/Custom/Runtime/RegionEndpointTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RegionEndpointTests.cs
@@ -1,0 +1,113 @@
+﻿using Amazon;
+using Amazon.Internal;
+using Json.LitJson;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace AWSSDK.UnitTests
+{
+    [TestClass]
+    public class RegionEndpointTests
+    {
+        private static class SampleValues
+        {
+            public const string SampleRegionDisplayName = "US west too";
+            public const string SampleHostName = "host-name";
+            public const string SampleAuthRegion = "auth-region";
+            public const string SampleDnsSuffix = "dns-suffix";
+        }
+
+        private const string TestRegionSystemName = "us-west-2";
+        private const string TestService = "lambda";
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // Reset the RegionEndpoint static maps so that other tests don't use
+            // sample data from this test.
+            RegionEndpoint.Reload(null);
+        }
+
+        [TestMethod]
+        public void Reload()
+        {
+            var initialRegionEndpoint = RegionEndpoint.USWest2;
+            var initialTestServiceEndpoint = initialRegionEndpoint.GetEndpointForService(TestService);
+
+            // Get and Mutate the manifest
+            var rootData = GetEndpointsManifest();
+            ApplySampleValuesToManifest(rootData);
+
+            // Reload with this mutated manifest
+            var json = rootData.ToJson();
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            {
+                RegionEndpoint.Reload(ms);
+            }
+
+            // Verify the SDK resolves regions and endpoints against the mutated data
+            var regionEndpoint = RegionEndpoint.GetBySystemName(TestRegionSystemName);
+            Assert.IsNotNull(regionEndpoint);
+            Assert.AreEqual(SampleValues.SampleRegionDisplayName, regionEndpoint.DisplayName);
+            Assert.AreEqual(SampleValues.SampleDnsSuffix, regionEndpoint.PartitionDnsSuffix);
+            var endpoint = regionEndpoint.GetEndpointForService(TestService);
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual(SampleValues.SampleAuthRegion, endpoint.AuthRegion);
+            Assert.AreEqual(SampleValues.SampleHostName, endpoint.Hostname);
+
+            // Verify the initial region-endpoint is unaffected
+            Assert.AreNotEqual(initialRegionEndpoint.DisplayName, regionEndpoint.DisplayName);
+            Assert.AreNotEqual(initialTestServiceEndpoint.AuthRegion, endpoint.AuthRegion);
+            Assert.AreNotEqual(initialTestServiceEndpoint.Hostname, endpoint.Hostname);
+        }
+
+        private JsonData GetEndpointsManifest()
+        {
+            using (var stream = GetStream())
+            using (var reader = new StreamReader(stream))
+            {
+                return JsonMapper.ToObject(reader);
+            }
+        }
+
+        private Stream GetStream()
+        {
+            // Load endpoints.json from AWSSDK.Core
+            var assembly = typeof(RegionEndpointProviderV3).Assembly;
+            // The resource may be called Amazon.endpoints.json or Core.endpoints.json
+            var resourceName = assembly.GetManifestResourceNames().Single(r => r.EndsWith(".endpoints.json"));
+            return assembly.GetManifestResourceStream(resourceName);
+        }
+
+        private JsonData GetAwsPartition(JsonData rootData)
+        {
+            foreach (JsonData jsonData in rootData["partitions"])
+            {
+                if (jsonData["partition"].ToString() == "aws")
+                {
+                    return jsonData;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Takes endpoints.json contents, and modifies them with sample values
+        /// </summary>
+        private void ApplySampleValuesToManifest(JsonData rootData)
+        {
+            // Change things that help us verify that the SDK is reloading the manifest contents.
+            // In this case, we'll change things about the Oregon region, and its lambda service endpoints.
+            var awsPartition = GetAwsPartition(rootData);
+            awsPartition["dnsSuffix"] = SampleValues.SampleDnsSuffix;
+            awsPartition["regions"][TestRegionSystemName]["description"] = SampleValues.SampleRegionDisplayName;
+
+            var service = awsPartition["services"][TestService]["endpoints"][TestRegionSystemName];
+            service["hostname"] = SampleValues.SampleHostName;
+            service["credentialScope"] = new JsonData { ["region"] = SampleValues.SampleAuthRegion };
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds a `Reload` method to RegionEndpoint, allowing callers to provide updated endpoints manifest data. The updated manifest data is used by the SDK when instantiating new service clients.

I had to update some code around the SDK that made assumptions around RegionEndpoint object equality with static fields like RegionEndpoint.USEast1. These checks now test against the region system name, treating this as a region endpoint's primary ID. The suppressions for analyzer CR1004 (Do not use static readonly RegionEndpoint members from within the SDK) were used to identify possible places in the SDK to change.

Notes:
* RegionEndpoint has static readonly fields like RegionEndpoint.USEast1. When Reload is called, these instances are not re-created, and properties on these objects do not get updated.
* Equality tests comparing RegionEndpoint static fields to RegionEndpoint objects retieved with GetEndpoint are not guaranteed to pass after calling Reload

## Motivation and Context
This change allows applications like the AWS Toolkit to obtain updated endpoints.json manifest files and leverage them without requiring (1) application updates (2) SDK package reference updates. This also avoids the need to duplicate the SDK's logic for endpoint resolution into any application (like the Toolkit).

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* provided unit test to verify that Reload updates the region endpoint details
* locally ran a test to instantiate a service client after calling Reload. The service client contained config details relating to the updated region endpoints.,

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement