### PR TITLE
TryParse should handle all exceptions that could arise from parsing

### DIFF
--- a/sdk/src/Core/Arn.cs
+++ b/sdk/src/Core/Arn.cs
@@ -98,7 +98,9 @@ namespace Amazon
                     return true;
                 }
             }
+#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception) { }
+#pragma warning restore CA1031 // Do not catch general exception types
             arn = null;
             return false;
         }

--- a/sdk/src/Core/Arn.cs
+++ b/sdk/src/Core/Arn.cs
@@ -98,7 +98,7 @@ namespace Amazon
                     return true;
                 }
             }
-            catch (ArgumentException) { }
+            catch (Exception) { }
             arn = null;
             return false;
         }


### PR DESCRIPTION
Fixes #1837

The current code doesn't catch `AmazonClientException` which can occur if the account id is not well formed: https://github.com/aws/aws-sdk-net/blob/92cdca1f9e331826a46502b1706999af0b8e6880/sdk/src/Core/Arn.cs#L61