### PR TITLE
Delay SSO options validation until they are used

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl45+netstandard/SSOAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl45+netstandard/SSOAWSCredentials.cs
@@ -156,16 +156,6 @@ namespace Amazon.Runtime
 
         private void ValidateCredentialsInputs()
         {
-            if (string.IsNullOrEmpty(Options.ClientName))
-            {
-                throw new ArgumentNullException($"Options property cannot be empty: {nameof(Options.ClientName)}");
-            }
-
-            if (Options.SsoVerificationCallback == null)
-            {
-                throw new ArgumentNullException($"Options property cannot be empty: {nameof(Options.SsoVerificationCallback)}");
-            }
-
             // Get the name of any empty properties
             var emptyPropertyNames = new Dictionary<string, string>
                 {
@@ -236,6 +226,16 @@ namespace Amazon.Runtime
             // Get and cache a SSO token if necessary
             if (string.IsNullOrWhiteSpace(token))
             {
+                if (string.IsNullOrEmpty(Options.ClientName))
+                {
+                    throw new ArgumentNullException($"Options property cannot be empty: {nameof(Options.ClientName)}");
+                }
+
+                if (Options.SsoVerificationCallback == null)
+                {
+                    throw new ArgumentNullException($"Options property cannot be empty: {nameof(Options.SsoVerificationCallback)}");
+                }
+
                 var response = oidc.GetSsoToken(new GetSsoTokenRequest()
                 {
                     ClientName = GetSsoClientName(),
@@ -275,6 +275,16 @@ namespace Amazon.Runtime
             // Get and cache a SSO token if necessary
             if (string.IsNullOrWhiteSpace(token))
             {
+                if (string.IsNullOrEmpty(Options.ClientName))
+                {
+                    throw new ArgumentNullException($"Options property cannot be empty: {nameof(Options.ClientName)}");
+                }
+
+                if (Options.SsoVerificationCallback == null)
+                {
+                    throw new ArgumentNullException($"Options property cannot be empty: {nameof(Options.SsoVerificationCallback)}");
+                }
+
                 var response = await oidc.GetSsoTokenAsync(new GetSsoTokenRequest()
                 {
                     ClientName = GetSsoClientName(),


### PR DESCRIPTION
## Description
Currently if you are using a SSO profile and you do not configure a `ClientName` or `SsoVerificationCallback` in your application it will always fail to execute, even if these values aren't currently necessary because of a cached SSO token.

This change allows the use of SSO Profiles without needing to add SSO specific code into the project. You can use applications like the AWS CLI v2 to authenticate and cache an SSO auth token that can then be used by any application pointing to that profile, until that token expires. This does not remove any current validations, but simply delays the validation until the values are actually needed. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
This is related to the issue: #1821 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I executed the Unit Tests in the solution and they all passed

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement