### PR TITLE
Fix typos in AutoConstructedTypes.cs summary tags

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/AutoConstructedTypes.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/AutoConstructedTypes.cs
@@ -22,7 +22,7 @@ using System.Runtime.Serialization;
 namespace Amazon.Runtime.Internal
 {
     /// <summary>
-    /// Collection used to indicate if the property was initialized was created by the SDK.
+    /// Collection used to indicate if the property was initialized by the SDK.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public class AutoConstructedList<T> : List<T>
@@ -30,7 +30,7 @@ namespace Amazon.Runtime.Internal
     }
 
     /// <summary>
-    /// Collection used to indicate if the property was initialized was created by the SDK.
+    /// Collection used to indicate if the property was initialized by the SDK.
     /// </summary>
     /// <typeparam name="K"></typeparam>
     /// <typeparam name="V"></typeparam>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Summary tags for several classes in the AutoConstructedTypes.cs file contained the sentence, "Collection used to indicate if the property was initialized was created by the SDK." The phrase "was initialized was created" is likely a typo. I removed the redundant clause "was created," so that the documentation now reads, "Collection used to indicate if the property was initialized by the SDK."

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

Fixes a typo in the documentation.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A. Small documentation typo fix.

## Screenshots (if appropriate)

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project
- [ X] My change requires a change to the documentation
- [ X] I have updated the documentation accordingly
- [ X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement