### PR TITLE
Support to use `Func<IServiceProvider, AWSOptions>` to create AWSOptions object.

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
@@ -31,6 +31,21 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServiceCollectionExtensions
     {
+        
+        /// <summary>
+        /// Adds the AWSOptions object to the dependency injection framework providing information
+        /// that will be used to construct Amazon service clients.
+        /// </summary>
+        /// <param name="collection"></param>
+        /// <param name="implementationFactory">The factory that creates the service AWSOptions</param>
+        /// <param name="lifetime">The lifetime of the AWSOptions. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection AddDefaultAWSOptions(this IServiceCollection collection, Func<IServiceProvider, AWSOptions> implementationFactory, ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        {
+            collection.Add(new ServiceDescriptor(typeof(AWSOptions), implementationFactory, lifetime));
+            return collection;
+        }
+        
         /// <summary>
         /// Adds the AWSOptions object to the dependency injection framework providing information
         /// that will be used to construct Amazon service clients.

--- a/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
+++ b/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
@@ -74,6 +74,66 @@ namespace DependencyInjectionTests
             Assert.True(s3.GetType() == mockS3.GetType());
         }
 
+        [Fact]
+        public void CreateAWSOptionsByDIObjects()
+        {
+            RegionEndpoint expectRegion = RegionEndpoint.APSouth1;
+            string expectProfile = "MockProfile";
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new AWSSetting() {
+                Region = expectRegion,
+                Profile = expectProfile
+            });
+
+            services.AddDefaultAWSOptions(sp=> {
+                var setting = sp.GetRequiredService<AWSSetting>();
+                return new AWSOptions()
+                {
+                    Region = setting.Region,
+                    Profile = setting.Profile
+                };
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var awsOptions = serviceProvider.GetRequiredService<AWSOptions>();
+
+            Assert.NotNull(awsOptions);
+            Assert.Equal(expectRegion, awsOptions.Region);
+            Assert.Equal(expectProfile, awsOptions.Profile);
+        }
+
+        [Fact]
+        public void InjectS3ClientByDIConfigs()
+        {
+            RegionEndpoint expectRegion = RegionEndpoint.APSouth1;
+            string expectProfile = "MockProfile";
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new AWSSetting()
+            {
+                Region = expectRegion,
+                Profile = expectProfile
+            });
+
+            services.AddDefaultAWSOptions(sp => {
+                var setting = sp.GetRequiredService<AWSSetting>();
+                return new AWSOptions()
+                {
+                    Region = setting.Region,
+                    Profile = setting.Profile
+                };
+            });
+
+            services.AddAWSService<IAmazonS3>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(expectRegion, controller.S3Client.Config.RegionEndpoint);
+        }
+
         public class TestController
         {
             public IAmazonS3 S3Client { get; private set; }
@@ -81,6 +141,12 @@ namespace DependencyInjectionTests
             {
                 S3Client = s3Client;
             }
+        }
+
+        internal class AWSSetting {
+            public RegionEndpoint Region { get; set; }
+
+            public string Profile { get; set; }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Support to use `Func<IServiceProvider, AWSOptions>` to create AWSOptions object.

## Description
<!--- Describe your changes in detail -->

Add an extension method that supports users can use DI Container objects setting to create `AWSOptions` object.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

This PR was an enhancement for #1957, 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I wrote some unit tests for this modify

## Screenshots (if appropriate)

`AWSSDK.Extensions` test result.

![image](https://user-images.githubusercontent.com/9159452/147897515-84a59b77-ee38-40d3-ada6-6484505bd588.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement