### PR TITLE
Issue 1953 - AWS4SigningResult.ForQueryParameters does not escape semicolons

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4SigningResult.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4SigningResult.cs
@@ -91,18 +91,18 @@ namespace Amazon.Runtime.Internal.Auth
         /// Returns the signature in a form usable as a set of query string parameters.
         /// </summary>
         public string ForQueryParameters 
-        { 
-            get 
-            { 
+        {
+            get
+            {
                 var authParams = new StringBuilder()
                     .AppendFormat("{0}={1}", HeaderKeys.XAmzAlgorithm, AWS4Signer.AWS4AlgorithmTag)
                     .AppendFormat("&{0}={1}", HeaderKeys.XAmzCredential, string.Format(CultureInfo.InvariantCulture, "{0}/{1}", AccessKeyId, Scope))
                     .AppendFormat("&{0}={1}", HeaderKeys.XAmzDateHeader, ISO8601DateTime)
                     .AppendFormat("&{0}={1}", HeaderKeys.XAmzSignedHeadersHeader, System.Uri.EscapeDataString(SignedHeaders))
                     .AppendFormat("&{0}={1}", HeaderKeys.XAmzSignature, Signature);
-        
-                return authParams.ToString(); 
-            } 
-        } 
+
+                return authParams.ToString();
+            }
+        }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4SigningResult.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4SigningResult.cs
@@ -90,19 +90,19 @@ namespace Amazon.Runtime.Internal.Auth
         /// <summary>
         /// Returns the signature in a form usable as a set of query string parameters.
         /// </summary>
-        public string ForQueryParameters
-        {
-            get
-            {
+        public string ForQueryParameters 
+        { 
+            get 
+            { 
                 var authParams = new StringBuilder()
                     .AppendFormat("{0}={1}", HeaderKeys.XAmzAlgorithm, AWS4Signer.AWS4AlgorithmTag)
                     .AppendFormat("&{0}={1}", HeaderKeys.XAmzCredential, string.Format(CultureInfo.InvariantCulture, "{0}/{1}", AccessKeyId, Scope))
                     .AppendFormat("&{0}={1}", HeaderKeys.XAmzDateHeader, ISO8601DateTime)
-                    .AppendFormat("&{0}={1}", HeaderKeys.XAmzSignedHeadersHeader, SignedHeaders)
+                    .AppendFormat("&{0}={1}", HeaderKeys.XAmzSignedHeadersHeader, System.Uri.EscapeDataString(SignedHeaders))
                     .AppendFormat("&{0}={1}", HeaderKeys.XAmzSignature, Signature);
-
-                return authParams.ToString();
-            }
-        }
+        
+                return authParams.ToString(); 
+            } 
+        } 
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4SigningResult.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4SigningResult.cs
@@ -90,7 +90,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// <summary>
         /// Returns the signature in a form usable as a set of query string parameters.
         /// </summary>
-        public string ForQueryParameters 
+        public string ForQueryParameters
         {
             get
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I changed the formatting of the ForQueryParameters.XAmzSignedHeadersHeader to use url encoding for the values to have it change ; to %3B (and other encoding)


## Motivation and Context
The ForQueryParameters method does not escape special characters. In particular, if there are multiple signed headers, then it includes them delimited by a literal semicolon instead of %3B. This is a violation of the RFC spec, and also causes issues with parsers in other languages. For example, Go treats the semicolon either as a delimiter between query parameters or as an invalid character, depending on the language version.

## Testing

The level of unit tests did not seem to cover this level of functionality, so I did not add one.  But I would be happy to add one if you wanted me to.

I used a sample program to generate a pre-signed url with a specific signed header using a current version of the packages and then the updated version.   I compared the results and tested both of them with CURL commands.   See below:

## Test 1: Using "current" packages

using AWSSDK.Core 3.7.2.6 and AWSDK.SecurityToken 3.7.1.44
Notice X-Amz-SignedHeaders=host;x-company-stage

$ curl "https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15&X-Amz-Expires=900&X-Amz-Security-Token=REDACTED&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=REDACTED/us-east-1/sts/aws4_request&X-Amz-Date=20211222T192129Z&X-Amz-SignedHeaders=host;x-company-stage&X-Amz-Signature=de64cf8c93bd973c934f2a5f701fdd69d88472044947657a084d6c76da3aed23" -H "X-company-Stage: dev"

## Result 1: 
<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
  <GetCallerIdentityResult>
    <Arn>REDACTED</Arn>
    <UserId>REDACTED</UserId>
    <Account>REDACTED</Account>
  </GetCallerIdentityResult>
  <ResponseMetadata>
    <RequestId>REDACTED</RequestId>
  </ResponseMetadata>
</GetCallerIdentityResponse>


## Test 2 - New Changes
--After Change when using local updated package
Notice X-Amz-SignedHeaders=host%3Bx-company-stage

$ curl "https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15&X-Amz-Expires=900&X-Amz-Security-Token=REDACTED&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=REDACTED/us-east-1/sts/aws4_request&X-Amz-Date=20211222T193009Z&X-Amz-SignedHeaders=host%3Bx-company-stage&X-Amz-Signature=REDACTED" -H "X-company-Stage: dev"

## Result #2
<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
  <GetCallerIdentityResult>
    <Arn>REDACTED</Arn>
    <UserId>REDACTED</UserId>
    <Account>REDACTED</Account>
  </GetCallerIdentityResult>
  <ResponseMetadata>
    <RequestId>REDACTED</RequestId>
  </ResponseMetadata>
</GetCallerIdentityResponse>

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement