### PR TITLE
IBatchWrite interface in order to allow mocking

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWrite.cs
@@ -74,7 +74,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a strongly-typed object for writing/deleting a batch of items
     /// in a single DynamoDB table
     /// </summary>
-    public class BatchWrite<T> : BatchWrite
+    public class BatchWrite<T> : BatchWrite, IBatchWrite<T>
     {
         #region Public combine methods
 
@@ -226,6 +226,46 @@ namespace Amazon.DynamoDBv2.DataModel
 #endif
 
         #endregion
+    }
+
+    /// <summary>
+    /// Interface for writing/deleting a batch of items in a single DynamoDB table
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public partial interface IBatchWrite<in T> : IBatchWrite
+    {
+        /// <summary>
+        /// Add a number of items to be put in the current batch operation
+        /// </summary>
+        /// <param name="values">Items to put</param>
+        void AddPutItems(IEnumerable<T> values);
+
+        /// <summary>
+        /// Add a single item to be put in the current batch operation
+        /// </summary>
+        /// <param name="item"></param>
+        void AddPutItem(T item);
+
+        /// <summary>
+        /// Add a number of items to be deleted in the current batch operation
+        /// </summary>
+        /// <param name="values">Items to be deleted</param>
+        void AddDeleteItems(IEnumerable<T> values);
+
+        /// <summary>
+        /// Add a single item to be deleted in the current batch operation.
+        /// Item is identified by its hash primary key.
+        /// </summary>
+        /// <param name="hashKey">Hash key of the item to delete</param>
+        void AddDeleteKey(object hashKey);
+
+        /// <summary>
+        /// Add a single item to be deleted in the current batch operation.
+        /// Item is identified by its hash-and-range primary key.
+        /// </summary>
+        /// <param name="hashKey">Hash key of the item to delete</param>
+        /// <param name="rangeKey">Range key of the item to delete</param>
+        void AddDeleteKey(object hashKey, object rangeKey);
     }
 
     /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -208,7 +208,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-        public BatchWrite<T> CreateBatchWrite<T>()
+        public IBatchWrite<T> CreateBatchWrite<T>()
         {
             return CreateBatchWrite<T>(null);
         }
@@ -220,7 +220,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-        public BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig)
+        public IBatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig = null)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<T>(this, config);

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
@@ -143,7 +143,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-        BatchWrite<T> CreateBatchWrite<T>();
+        IBatchWrite<T> CreateBatchWrite<T>();
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -152,7 +152,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-        BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig);
+        IBatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig);
 #else
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -161,7 +161,8 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-        BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig = null);
+        IBatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig = null);
+
 #endif
 
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/BatchWrite.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/BatchWrite.Async.cs
@@ -30,7 +30,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a non-generic object for writing/deleting a batch of items
     /// in a single DynamoDB table
     /// </summary>
-    public abstract partial class BatchWrite
+    public abstract partial class BatchWrite : IBatchWrite
     {
         #region Public methods
 
@@ -47,6 +47,21 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// Interface for writing/deleting a batch of items in a single DynamoDB table
+    /// </summary>
+    public partial interface IBatchWrite
+    {
+        /// <summary>
+        /// Initiates the asynchronous execution of the Execute operation.
+        /// <seealso cref="Amazon.DynamoDBv2.DataModel.BatchWrite.Execute"/>
+        /// </summary>
+        /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
+        /// 
+        /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+        public Task ExecuteAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 
     /// <summary>


### PR DESCRIPTION
This change is required in order to to mock the QueryAsync method

## Description
We are changing the return type for the QueryAsync from BatchWrite to IBatchWrite.
Code may need to updated in order to use the new interface.

## Motivation and Context
We want to use Moq in order to Unit test our code.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement