### PR TITLE
DynamoDBv2 Allow lists and maps to be mapped even if null is set to false

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
@@ -578,10 +578,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
             if (TryToDynamoDBBool(attributeValue, out ddbBool))
                 return ddbBool;
 
-            DynamoDBNull ddbNull;
-            if (TryToDynamoDBNull(attributeValue, out ddbNull))
-                return ddbNull;
-
             DynamoDBList ddbList;
             if (TryToDynamoDBList(attributeValue, out ddbList))
                 return ddbList;
@@ -589,6 +585,10 @@ namespace Amazon.DynamoDBv2.DocumentModel
             Document document;
             if (TryToDocument(attributeValue, out document))
                 return document;
+
+            DynamoDBNull ddbNull;
+            if (TryToDynamoDBNull(attributeValue, out ddbNull))
+                return ddbNull;
 
             return null;
         }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -9,7 +9,7 @@ using Amazon.Auth.AccessControlPolicy;
 using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.DynamoDBv2.DataModel;
-
+using Amazon.DynamoDBv2.Model;
 using ThirdParty.Json.LitJson;
 
 namespace AWSSDK_DotNet35.UnitTests
@@ -44,6 +44,49 @@ namespace AWSSDK_DotNet35.UnitTests
             };
 
             Assert.AreEqual("Test", config.TableNamePrefix);
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestConvertingListIfNullSet()
+        {
+            var initialAttributeMap = new Dictionary<string, AttributeValue>
+            {
+                {
+                    "testlist", new AttributeValue
+                    {
+                        L = new List<AttributeValue>
+                        {
+                            new AttributeValue("test")
+                        },
+                        NULL = false
+                    }
+                }
+            };
+
+            var dynamoDocument = Document.FromAttributeMap(initialAttributeMap);
+
+            Assert.AreEqual("test", dynamoDocument["testlist"].AsDynamoDBList().Entries[0].AsString());
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestConvertingMapIfNullSet()
+        {
+            var initialAttributeMap = new Dictionary<string, AttributeValue>
+            {
+                {
+                    "testmap", new AttributeValue
+                    {
+                        M = new Dictionary<string, AttributeValue>(){{"test", new AttributeValue("testvalue")}},
+                        NULL = false
+                    }
+                }
+            };
+
+            var dynamoDocument = Document.FromAttributeMap(initialAttributeMap);
+
+            Assert.AreEqual("testvalue", dynamoDocument["testmap"].AsDocument()["test"].AsString());
         }
 
         private static List<Type> GetSubTypes(Type baseType)


### PR DESCRIPTION
This change is required to be able to deserialize maps and lists from json when NULL exists in the json. To fix #1980 

## Description
We are moving the order in which attributes types decided so that if NULL is set to false then map and lists are not skipped over.

## Motivation and Context
We want to use the sdk to deserialize messages from the dynamo stream in a lambda.

## Testing

Added 2 tests. One for lists and one for maps.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement