### PR TITLE
Consolidate getting profile name

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/AWSRegion.cs
+++ b/sdk/src/Core/Amazon.Runtime/AWSRegion.cs
@@ -136,11 +136,7 @@ namespace Amazon.Runtime
         /// <param name="source">The ICredentialProfileSource to read the profile from.</param>
         public ProfileAWSRegion(ICredentialProfileSource source)
         {
-            var profileName = AWSConfigs.AWSProfileName;
-            if (string.IsNullOrEmpty(profileName)) // RootConfig chooses empty string for null values.
-                profileName = Environment.GetEnvironmentVariable(FallbackCredentialsFactory.AWS_PROFILE_ENVIRONMENT_VARIABLE);
-            if (profileName == null)
-                profileName = FallbackCredentialsFactory.DefaultProfileName;
+            var profileName = FallbackCredentialsFactory.GetProfileName();
             Setup(source, profileName);
         }
 

--- a/sdk/src/Core/Amazon.Runtime/CSM/CSMFallbackConfigChain.cs
+++ b/sdk/src/Core/Amazon.Runtime/CSM/CSMFallbackConfigChain.cs
@@ -95,12 +95,7 @@ namespace Amazon.Runtime.Internal
         }
         public ProfileCSMConfigs(ICredentialProfileSource source, CSMFallbackConfigChain cSMFallbackConfigChain)
         {
-            ProfileName = AWSConfigs.AWSProfileName ?? Environment.GetEnvironmentVariable(FallbackCredentialsFactory.AWS_PROFILE_ENVIRONMENT_VARIABLE);
-
-            if (string.IsNullOrEmpty(ProfileName))
-            {
-                ProfileName = FallbackCredentialsFactory.DefaultProfileName;
-            }
+            ProfileName = FallbackCredentialsFactory.GetProfileName();
             CredentialProfile profile;
             if (!source.TryGetProfile(ProfileName, out profile))
             {

--- a/sdk/src/Core/Amazon.Runtime/Credentials/FallbackCredentialsFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/FallbackCredentialsFactory.cs
@@ -59,7 +59,7 @@ namespace Amazon.Runtime
             };
         }
 
-        public static string GetProfileName()
+        internal static string GetProfileName()
         {
             var profileName = AWSConfigs.AWSProfileName ?? 
                               Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);

--- a/sdk/src/Core/Amazon.Runtime/Credentials/FallbackCredentialsFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/FallbackCredentialsFactory.cs
@@ -59,10 +59,22 @@ namespace Amazon.Runtime
             };
         }
 
+        public static string GetProfileName()
+        {
+            var profileName = AWSConfigs.AWSProfileName ?? 
+                              Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
+
+            if (string.IsNullOrEmpty(profileName))
+            {
+                profileName = DefaultProfileName;
+            }
+
+            return profileName;
+        }
+
         private static AWSCredentials GetAWSCredentials(ICredentialProfileSource source)
         {
-            var profileName = Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE) ?? DefaultProfileName;
-
+            var profileName = GetProfileName();
             CredentialProfile profile;
             if (source.TryGetProfile(profileName, out profile))
                 return profile.GetAWSCredentials(source, true);

--- a/sdk/src/Core/Amazon.Runtime/EndpointDiscoveryEnabled.cs
+++ b/sdk/src/Core/Amazon.Runtime/EndpointDiscoveryEnabled.cs
@@ -78,9 +78,7 @@ namespace Amazon.Runtime
         /// <param name="source">The ICredentialProfileSource to read the profile from.</param>
         public ProfileAWSEndpointDiscoveryEnabled(ICredentialProfileSource source)
         {
-            var profileName = Environment.GetEnvironmentVariable(FallbackCredentialsFactory.AWS_PROFILE_ENVIRONMENT_VARIABLE);
-            if (profileName == null)
-                profileName = FallbackCredentialsFactory.DefaultProfileName;
+            var profileName = FallbackCredentialsFactory.GetProfileName();
             Setup(source, profileName);
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
@@ -188,9 +188,7 @@ namespace Amazon.Runtime.Internal
         /// <param name="source">The ICredentialProfileSource to read the profile from.</param>
         public ProfileInternalConfiguration(ICredentialProfileSource source)
         {
-            var profileName = Environment.GetEnvironmentVariable(FallbackCredentialsFactory.AWS_PROFILE_ENVIRONMENT_VARIABLE);
-            if (profileName == null)
-                profileName = FallbackCredentialsFactory.DefaultProfileName;
+            var profileName = FallbackCredentialsFactory.GetProfileName();
             Setup(source, profileName);
         }
 

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/FallbackFactoryTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/FallbackFactoryTest.cs
@@ -77,10 +77,13 @@ namespace AWSSDK.UnitTests
             .AppendLine("use_fips_endpoint=false")
             .ToString();
 
-        [TestMethod]
-        public void TestDefaultProfile()
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("  ")]
+        public void TestDefaultProfile(string awsProfileValue)
         {
-            using (new FallbackFactoryTestFixture(ProfileText, null))
+            using (new FallbackFactoryTestFixture(ProfileText, awsProfileValue))
             {
                 var creds = FallbackCredentialsFactory.GetCredentials();
                 Assert.AreEqual("default_aws_access_key_id", creds.GetCredentials().AccessKey);


### PR DESCRIPTION
Consolidate getting the profile name into one method

## Description
Added a function to resolve the profile name and make this consistent across all the places that require a profile name. 

## Motivation and Context
Some of the places where the profile name is retrieved it does not look at some of the expected configurations (like `AWSConfigs.AWSProfileName`)

## Testing
Added test cases for the scenario where the environment variable can be null or empty and it returns the default profile name.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement