### PR TITLE
DynamoDBContext SaveAsync should persist empty lists

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -225,7 +225,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
             var primitiveList = entry as PrimitiveList;
             if (primitiveList != null)
-                return (primitiveList.Entries != null && primitiveList.Entries.Count > 0);
+                return (primitiveList.Entries != null);
 
             var dynamoDBBool = entry as DynamoDBBool;
             if (dynamoDBBool != null)


### PR DESCRIPTION
## Description
Updates `DynamoDBContext` so that calls to `SaveAsync` will persist properties which are an empty list.

## Motivation and Context
Fixes #1995

## Testing
No automated coverage exists for this functionality, but can test a pre-release nuget?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement