### PR TITLE
Support Reflected Type Conversion for DynamoDBEntryConversion

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -14,7 +14,6 @@
  */
 
 using System;
-using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -198,6 +197,23 @@ namespace Amazon.DynamoDBv2
         }
 
         /// <summary>
+        /// Convert value to DynamoDBEntry
+        /// </summary>
+        /// <typeparam name="TInput"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public DynamoDBEntry ConvertToEntry(Type inputType, object value)
+        {
+            if (inputType == null) throw new ArgumentNullException("inputType");
+            if (value == null) throw new ArgumentNullException("value");
+
+            var converter = ConverterCache.GetConverter(inputType);
+            DynamoDBEntry output = converter.ToEntry(value);
+
+            return output;
+        }
+
+        /// <summary>
         /// Try to convert value to DynamoDBEntry. If it fails the method returns false.
         /// </summary>
         /// <typeparam name="TInput"></typeparam>
@@ -208,6 +224,23 @@ namespace Amazon.DynamoDBv2
         {
             var inputType = typeof(TInput);
             return TryConvertToEntry(inputType, value, out entry);
+        }
+
+        /// <summary>
+        /// Try to convert value to DynamoDBEntry. If it fails the method returns false.
+        /// </summary>
+        /// <param name="inputType"></param>
+        /// <param name="value"></param>
+        /// <param name="entry"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public bool TryConvertToEntry(Type inputType, object value, out DynamoDBEntry entry)
+        {
+            if (inputType == null) throw new ArgumentNullException("inputType");
+            if (value == null) throw new ArgumentNullException("value");
+
+            var converter = ConverterCache.GetConverter(inputType);
+            return converter.TryToEntry(value, out entry);
         }
 
         /// <summary>
@@ -224,6 +257,24 @@ namespace Amazon.DynamoDBv2
 
             throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
                 "Unable to convert [{0}] of type {1} to {2}", entry, entry.GetType().FullName, typeof(TOutput).FullName));
+        }
+
+        /// <summary>
+        /// Convert the DynamoDBEntry to the specified type.
+        /// </summary>
+        /// <param name="outputType"></param>
+        /// <param name="entry"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public object ConvertFromEntry(Type outputType, DynamoDBEntry entry)
+        {
+            if (outputType == null) throw new ArgumentNullException("outputType");
+            if (entry == null) throw new ArgumentNullException("entry");
+
+            var converter = ConverterCache.GetConverter(outputType);
+            object output = converter.FromEntry(entry, outputType);
+
+            return output;
         }
 
         /// <summary>
@@ -251,6 +302,23 @@ namespace Amazon.DynamoDBv2
             return false;
         }
 
+        /// <summary>
+        /// Try to convert the DynamoDBEntry to the specified type. If it fails the method returns false.
+        /// </summary>
+        /// <param name="outputType"></param>
+        /// <param name="entry"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public bool TryConvertFromEntry(Type outputType, DynamoDBEntry entry, out object value)
+        {
+            if (outputType == null) throw new ArgumentNullException("outputType");
+            if (entry == null) throw new ArgumentNullException("entry");
+
+            var converter = ConverterCache.GetConverter(outputType);
+            return converter.TryFromEntry(entry, outputType, out value);
+        }
+
         #endregion
 
         #region Internal members
@@ -266,44 +334,6 @@ namespace Amazon.DynamoDBv2
             return ConverterCache.HasConverter(type);
         }
 
-        internal bool TryConvertToEntry(Type inputType, object value, out DynamoDBEntry entry)
-        {
-            if (inputType == null) throw new ArgumentNullException("inputType");
-            if (value == null) throw new ArgumentNullException("value");
-
-            var converter = ConverterCache.GetConverter(inputType);
-            return converter.TryToEntry(value, out entry);
-        }
-        internal bool TryConvertFromEntry(Type outputType, DynamoDBEntry entry, out object value)
-        {
-            if (outputType == null) throw new ArgumentNullException("outputType");
-            if (entry == null) throw new ArgumentNullException("entry");
-
-            var converter = ConverterCache.GetConverter(outputType);
-            return converter.TryFromEntry(entry, outputType, out value);
-        }
-
-        internal DynamoDBEntry ConvertToEntry(Type inputType, object value)
-        {
-            if (inputType == null) throw new ArgumentNullException("inputType");
-            if (value == null) throw new ArgumentNullException("value");
-
-            var converter = ConverterCache.GetConverter(inputType);
-            DynamoDBEntry output = converter.ToEntry(value);
-
-            return output;
-        }
-        internal object ConvertFromEntry(Type outputType, DynamoDBEntry entry)
-        {
-            if (outputType == null) throw new ArgumentNullException("outputType");
-            if (entry == null) throw new ArgumentNullException("entry");
-
-            var converter = ConverterCache.GetConverter(outputType);
-            object output = converter.FromEntry(entry, outputType);
-
-            return output;
-        }
-
         internal IEnumerable<DynamoDBEntry> ConvertToEntries(Type elementType, IEnumerable values)
         {
             if (values == null) throw new ArgumentNullException("values");
@@ -314,7 +344,7 @@ namespace Amazon.DynamoDBv2
         internal IEnumerable<DynamoDBEntry> ConvertToEntries<T>(IEnumerable<T> values)
         {
             if (values == null) throw new ArgumentNullException("values");
-            
+
             var elementType = typeof(T);
             foreach (var value in values)
                 yield return ConvertToEntry(elementType, value);
@@ -424,7 +454,7 @@ namespace Amazon.DynamoDBv2
             }
         }
 
-#endregion
+        #endregion
     }
 
     internal abstract class Converter


### PR DESCRIPTION
## Description

This PR promotes ConvertFromEntry, TryConvertFromEntry, ConvertToEntry, and TryConvertToEntry from `internal` to `public`.  

## Motivation and Context

The current public API for DynamoDBEntryConversion exposes Generic accessors to type conversions making it difficult for runtime reflection to occur if needed.  These public methods call existing `internal` versions that accept Type parameters to function allowing information obtained from `PropertyInfo` and other reflection primitives that obtain `Type` objects to be supplied to `DynamoDBEntryConversion` and operate within the native SDK without additional complexity.

Current work around involved a complex Reflection off `MethodInfo`, maintaining a fork of the SDK, or large duplication of what already exists in the SDK (such as layering on a converter map or a large conditional list of types to convert).

## Testing

No logic was altered in this PR.  No tests were created or modified to support.  All tests continued to pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement