### PR TITLE
Add support for mocking DynamoDB AsyncSearch

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/AsyncSearch.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/AsyncSearch.cs
@@ -26,6 +26,14 @@ namespace Amazon.DynamoDBv2.DataModel
     {
         #region Constructor
 
+        /// <summary>
+        /// This constructor is used for mocking. Users that want to mock AsyncSearch can create a subclass of AsyncSearch and make a public parameterless constructor.
+        /// </summary>
+        protected AsyncSearch()
+        {
+
+        }
+
         internal AsyncSearch(DynamoDBContext source, DynamoDBContext.ContextSearch contextSearch)
         {
             SourceContext = source;
@@ -48,7 +56,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// Flag that, if true, indicates that the search is done
         /// </summary>
-        public bool IsDone
+        public virtual bool IsDone
         {
             get
             {

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.Async.cs
@@ -45,7 +45,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// A Task that can be used to poll or wait for results, or both.
         /// Results will include the next set of result items from DynamoDB.
         /// </returns>
-        public async Task<List<T>> GetNextSetAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<List<T>> GetNextSetAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var documents = await DocumentSearch.GetNextSetHelperAsync(cancellationToken).ConfigureAwait(false);
             List<T> items = SourceContext.FromDocumentsHelper<T>(documents, this.Config).ToList();
@@ -60,7 +60,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// A Task that can be used to poll or wait for results, or both.
         /// Results will include the remaining result items from DynamoDB.
         /// </returns>
-        public async Task<List<T>> GetRemainingAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<List<T>> GetRemainingAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var documents = await DocumentSearch.GetRemainingHelperAsync(cancellationToken).ConfigureAwait(false);
             List<T> items = SourceContext.FromDocumentsHelper<T>(documents, this.Config).ToList();

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -11,6 +12,8 @@ using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.Model;
 using ThirdParty.Json.LitJson;
+
+using Moq;
 
 namespace AWSSDK_DotNet35.UnitTests
 {
@@ -173,5 +176,39 @@ namespace AWSSDK_DotNet35.UnitTests
             Assert.IsNull(doc["Name"].AsPrimitive().Value);
         }
 
+#if ASYNC_AWAIT
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public async Task TestMockingAsyncSeach()
+        {
+            var mockDBContext = new Mock<IDynamoDBContext>();
+            mockDBContext
+                .Setup(x => x.ScanAsync<DataItem>(
+                   It.IsAny<IEnumerable<ScanCondition>>(),
+                   It.IsAny<DynamoDBOperationConfig>()))
+                .Returns(
+                   new MockAsyncSearch<DataItem>() // Return mock version of AsyncSearch
+                );
+
+            var search = mockDBContext.Object.ScanAsync<DataItem>(new List<ScanCondition>());
+            Assert.IsInstanceOfType(search, typeof(MockAsyncSearch<DataItem>));
+
+            var items = await search.GetNextSetAsync();
+            Assert.AreEqual(0, items.Count());
+        }
+
+        public class DataItem
+        {
+            public string Id { get; set; }
+        }
+
+        public class MockAsyncSearch<T> : AsyncSearch<T>
+        {
+            public override Task<List<T>> GetNextSetAsync(CancellationToken cancellationToken = default(CancellationToken))
+            {
+                return Task.FromResult(new List<T>());
+            }
+        }
+#endif
     }
 }


### PR DESCRIPTION
## Description
Address issue https://github.com/aws/aws-sdk-net/issues/772 adding support for mocking the `AsyncSearch` from the DynamoDBContext's `ScanAsync` and `QueryAsync` methods.

To mock `AsyncSearch` you must use a subclass. The unit test in the PR shows how to make that work. We can't use interfaces for mocking in this case because we would have to make a breaking change on `DynamoDBContext` by changing the return of the `QueryAsync` and `ScanAsync` operation.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement