### PR TITLE
Arn.IsArn does a culture-aware StartsWith() when only Ordinal is required

### DIFF
--- a/sdk/src/Core/Arn.cs
+++ b/sdk/src/Core/Arn.cs
@@ -79,7 +79,7 @@ namespace Amazon
         /// <returns></returns>
         public static bool IsArn(string arn)
         {
-            return arn != null && arn.StartsWith("arn:");
+            return arn != null && arn.StartsWith("arn:", StringComparison.Ordinal);
         }
 
         /// <summary>


### PR DESCRIPTION
Arn.IsArn does a culture-aware StartsWith() when only Ordinal is required

## Description
Arn.IsArn does a StartsWith on a string literal with all characters falling within the ASCII range. By default, string.StartsWith will perform a [culture-aware comparison](https://learn.microsoft.com/en-us/dotnet/api/system.string.startswith?view=net-7.0#system-string-startswith(system-string)) which incurs additional overhead. Doing StartsWith on an ordinal is not only faster, but will better lend itself to runtime vectorization on a broader variety of platforms.

## Motivation and Context
This is a minor performance improvement

## Testing
All existing unit tests passed both before and after making the change

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Performance Improvement

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement