### PR TITLE
Add support for SessionRoleArn and SessionName to GetAWSOptions

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
@@ -133,6 +133,16 @@ namespace Microsoft.Extensions.Configuration
                 options.DefaultConfigurationMode = mode;
             }
 
+            if (!string.IsNullOrEmpty(section["SessionRoleArn"]))
+            {
+                options.SessionRoleArn = section["SessionRoleArn"];
+            }
+
+            if (!string.IsNullOrEmpty(section["SessionName"]))
+            {
+                options.SessionName = section["SessionName"];
+            }
+
             var loggingSection = section.GetSection("Logging");
             if(loggingSection != null)
             {

--- a/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
+++ b/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
@@ -38,6 +38,24 @@ namespace NETCore.SetupTests
         }
 
         [Fact]
+        public void GetRoleNameAndSessionName()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetRoleNameAndSessionNameTest.json");
+
+            IConfiguration config = builder.Build();
+            var options = config.GetAWSOptions();
+
+            Assert.Equal(RegionEndpoint.USWest2, options.Region);
+            Assert.Equal("arn:aws:iam::123456789012:role/fake_role", options.SessionRoleArn);
+            Assert.Equal("TestSessionName", options.SessionName);
+
+            IAmazonS3 client = options.CreateServiceClient<IAmazonS3>();
+            Assert.NotNull(client);
+            Assert.Equal(RegionEndpoint.USWest2, client.Config.RegionEndpoint);
+        }
+
+        [Fact]
         public void LegacyNamesTest()
         {
             var builder = new ConfigurationBuilder();

--- a/extensions/test/NETCore.SetupTests/TestFiles/GetRoleNameAndSessionNameTest.json
+++ b/extensions/test/NETCore.SetupTests/TestFiles/GetRoleNameAndSessionNameTest.json
@@ -1,0 +1,7 @@
+﻿{
+  "AWS": {
+    "SessionRoleArn": "arn:aws:iam::123456789012:role/fake_role",
+    "SessionName": "TestSessionName",
+    "Region": "us-west-2"
+  }
+}


### PR DESCRIPTION
#1743 adds support for `SessionRoleArn` and `SessionName` but no special logic was added to read their values from the configuration file. This PR fixes that.

## Description
Added explicit check if there are values for `SessionRoleArn` and `SessionName`. Also added unit test to make sure the functionality works.

## Motivation and Context
It was missed in #1743 

## Testing
Added unit test to make sure it works properly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement