### PR TITLE
NETCore.Setup: Add null-check on options in CreateServiceClient.

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
@@ -81,7 +81,7 @@ namespace Amazon.Extensions.NETCore.Setup
             PerformGlobalConfig(logger, options);
             var credentials = CreateCredentials(logger, options);
 
-            if (!string.IsNullOrEmpty(options.SessionRoleArn))
+            if (!string.IsNullOrEmpty(options?.SessionRoleArn))
             {
                 credentials = new AssumeRoleAWSCredentials(credentials, options.SessionRoleArn, options.SessionName);
             }

--- a/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
+++ b/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
@@ -43,6 +43,7 @@ namespace DependencyInjectionTests
 
             var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
             Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.USEast1, controller.S3Client.Config.RegionEndpoint);
         }
 
         [Fact]

--- a/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
+++ b/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
@@ -32,6 +32,18 @@ namespace DependencyInjectionTests
         }
 
         [Fact]
+        public void InjectS3ClientWithoutDefaultConfig()
+        {
+            ServiceCollection services = new ServiceCollection();
+            services.AddAWSService<IAmazonS3>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+        }
+
+        [Fact]
         public void InjectS3ClientWithOverridingConfig()
         {
             var builder = new ConfigurationBuilder();

--- a/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
+++ b/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
@@ -7,6 +7,7 @@ using Amazon;
 using Amazon.S3;
 using Amazon.Extensions.NETCore.Setup;
 using Moq;
+using System;
 
 namespace DependencyInjectionTests
 {
@@ -34,6 +35,7 @@ namespace DependencyInjectionTests
         [Fact]
         public void InjectS3ClientWithoutDefaultConfig()
         {
+            Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
             ServiceCollection services = new ServiceCollection();
             services.AddAWSService<IAmazonS3>();
 

--- a/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
+++ b/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
@@ -35,15 +35,24 @@ namespace DependencyInjectionTests
         [Fact]
         public void InjectS3ClientWithoutDefaultConfig()
         {
-            Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
-            ServiceCollection services = new ServiceCollection();
-            services.AddAWSService<IAmazonS3>();
+            var savedRegion = Environment.GetEnvironmentVariable("AWS_REGION");
+            
+            try
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
+                ServiceCollection services = new ServiceCollection();
+                services.AddAWSService<IAmazonS3>();
 
-            var serviceProvider = services.BuildServiceProvider();
+                var serviceProvider = services.BuildServiceProvider();
 
-            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
-            Assert.NotNull(controller.S3Client);
-            Assert.Equal(RegionEndpoint.USEast1, controller.S3Client.Config.RegionEndpoint);
+                var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+                Assert.NotNull(controller.S3Client);
+                Assert.Equal(RegionEndpoint.USEast1, controller.S3Client.Config.RegionEndpoint);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", savedRegion);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Add a null-check to options in CreateServiceClient

## Description

The check for `SessionRoleArn` in `ClientFactory.CreateServiceClient` assumes that an `AWSOptions` instance has been initialized during dependency injection setup. If this is not the case, then a `NullReferenceException` is thrown upwards.

Added a monadic null-check to make the method safe for nulls. This brings `CreateServiceClient` in line with the methods that it invokes, which all check for a null `options` value in one way or another.

## Motivation and Context

Resolves a breaking change introduced between `3.7.2` and `3.7.3`

## Testing

* Added a unit test that shall fail if the change to `ClientFactory.CreateServiceClient` is not present.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement