### PR TITLE
DynamoDB Expose ability to map types

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -157,6 +157,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         // Checks if the IndexName is set on the config
         internal bool IsIndexOperation { get { return !string.IsNullOrEmpty(IndexName); } }
+
+        /// <summary>
+        /// Instructs the context to not attempt to do any describe table or validation of the data model being mapped.
+        /// </summary>
+        internal bool? ConvertOnly { get; set; }
     }
 
     /// <summary>
@@ -283,7 +288,8 @@ namespace Amazon.DynamoDBv2.DataModel
             IndexName = null,
             ConditionalOperator = ConditionalOperatorValues.And,
             Conversion = null,
-            IsEmptyStringValueEnabled = null
+            IsEmptyStringValueEnabled = null,
+            ConvertOnly = null
         };
         private static DynamoDBContextConfig _emptyContextConfig = new DynamoDBContextConfig
         {
@@ -314,6 +320,7 @@ namespace Amazon.DynamoDBv2.DataModel
             bool backwardQuery = operationConfig.BackwardQuery ?? false;
             string indexName =
                 !string.IsNullOrEmpty(operationConfig.IndexName) ? operationConfig.IndexName : DefaultIndexName;
+            bool convertOnly = operationConfig.ConvertOnly ?? false;
             List<ScanCondition> queryFilter = operationConfig.QueryFilter ?? new List<ScanCondition>();
             ConditionalOperatorValues conditionalOperator = operationConfig.ConditionalOperator;
             DynamoDBEntryConversion conversion = operationConfig.Conversion ?? contextConfig.Conversion ?? DynamoDBEntryConversion.CurrentConversion;
@@ -329,6 +336,7 @@ namespace Amazon.DynamoDBv2.DataModel
             QueryFilter = queryFilter;
             ConditionalOperator = conditionalOperator;
             Conversion = conversion;
+            ConvertOnly = convertOnly;
 
             State = new OperationState();
         }
@@ -410,6 +418,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// .NET and DynamoDB types happens.
         /// </summary>
         public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <summary>
+        /// Instructs the context to not attempt to do any describe table or validation of the data model being mapped.
+        /// </summary>
+        public bool? ConvertOnly { get; set; }
 
         // Checks if the IndexName is set on the config
         internal bool IsIndexOperation { get { return !string.IsNullOrEmpty(IndexName); } }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -237,7 +237,6 @@ namespace Amazon.DynamoDBv2.DataModel
             return new MultiTableBatchWrite(batches);
         }
 
-
         #endregion
 
         #region Save/serialize

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -322,6 +322,11 @@ namespace Amazon.DynamoDBv2.DataModel
             if (value == null) return null;
 
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
+            if (flatConfig.ConvertOnly.GetValueOrDefault(false))
+            {
+                return SerializeToDocument(value, typeof(T), flatConfig);
+            }
+
             ItemStorage storage = ObjectToItemStorage<T>(value, false, flatConfig);
             if (storage == null) return null;
 
@@ -427,6 +432,10 @@ namespace Amazon.DynamoDBv2.DataModel
         public T FromDocument<T>(Document document, DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
+            if (flatConfig.ConvertOnly.GetValueOrDefault(false))
+            {
+                return (T)DeserializeFromDocument(document, typeof(T), flatConfig);
+            }
             return FromDocumentHelper<T>(document, flatConfig);
         }
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/DynamoDbContextExtensions.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/DynamoDbContextExtensions.cs
@@ -1,0 +1,66 @@
+using Amazon.DynamoDBv2.DocumentModel;
+
+namespace Amazon.DynamoDBv2.DataModel
+{
+    /// <summary>
+    /// Extension methods extending <seealso cref="IDynamoDBContext"/> with additional functionality.
+    /// </summary>
+    public static class DynamoDbContextExtensions
+    {
+        /// <summary>
+        /// Serializes an object to a Document.
+        /// </summary>
+        /// <typeparam name="T">Type to serialize as.</typeparam>
+        /// <param name="value">Object to serialize.</param>
+        /// <remarks>In contrast to <see cref="IDynamoDBContext.ToDocument{T}(T)"/> this method bypassed any table loading, caching or validation against the table.</remarks>
+        /// <returns>Document with attributes populated from object.</returns>
+        public static Document ConvertToDocument<T>(this IDynamoDBContext dynamoDbContext, T value)
+        {
+            return dynamoDbContext.ConvertToDocument(value, new DynamoDBOperationConfig());
+        }
+
+        /// <summary>
+        /// Serializes an object to a Document.
+        /// </summary>
+        /// <typeparam name="T">Type to serialize as.</typeparam>
+        /// <param name="value">Object to serialize.</param>
+        /// <param name="operationConfig">Config object which can be used to override conversion settings.</param>
+        /// <remarks>In contrast to <see cref="IDynamoDBContext.ToDocument{T}(T)"/> this method bypassed any table loading, caching or validation against the table.</remarks>
+        /// <returns>Document with attributes populated from object.</returns>
+        public static Document ConvertToDocument<T>(this IDynamoDBContext dynamoDbContext, T value, DynamoDBOperationConfig operationConfig)
+        {
+            operationConfig.ConvertOnly = true;
+            return dynamoDbContext.ToDocument(value, operationConfig);
+        }
+
+        /// <summary>
+        /// Deserializes a document to an instance of type T.
+        /// </summary>
+        /// <typeparam name="T">Type to populate.</typeparam>
+        /// <param name="document">Document with properties to use.</param>
+        /// <remarks>In contrast to <see cref="IDynamoDBContext.ToDocument{T}(T)"/> this method bypassed any table loading, caching or validation against the table.</remarks>
+        /// <returns>
+        /// Object of type T, populated with properties from the document.
+        /// </returns>
+        public static T ConvertFromDocument<T>(this IDynamoDBContext dynamoDbContext, Document document)
+        {
+            return dynamoDbContext.ConvertFromDocument<T>(document, new DynamoDBOperationConfig());
+        }
+
+        /// <summary>
+        /// Deserializes a document to an instance of type T.
+        /// </summary>
+        /// <typeparam name="T">Type to populate.</typeparam>
+        /// <param name="document">Document with properties to use.</param>
+        /// <param name="operationConfig">Config object which can be used to override conversion settings.</param>
+        /// <remarks>In contrast to <see cref="IDynamoDBContext.ToDocument{T}(T)"/> this method bypassed any table loading, caching or validation against the table.</remarks>
+        /// <returns>
+        /// Object of type T, populated with properties from the document.
+        /// </returns>
+        public static T ConvertFromDocument<T>(this IDynamoDBContext dynamoDbContext, Document document, DynamoDBOperationConfig operationConfig)
+        {
+            operationConfig.ConvertOnly = true;
+            return dynamoDbContext.FromDocument<T>(document, operationConfig);
+        }
+    }
+}


### PR DESCRIPTION
## Description

As discussed with @normj yesterday, currently, there is no way to use `ToDocument` or `FromDocument` without it doing table description and validation. This means the conversion logic is inaccessible for anyone not following the assumptions of the dynamodb context.

This PR introduces convert methods that allow mapping arbitrary types without triggering table description or validation.

## Motivation and Context

Without this behavior, we would have to go through JSON -> Document -> Attribute maps or completely reimplement the mapping logic which is already part of the SDK ourselves.

Alternatives considered:

- Adding methods to the interface directly (would be a larger breaking change)
- Publicly exposing the `ConvertOnly` flag on `DynamoDBOperationConfig` (feels off because that type can also be used to configure other methods like BatchWrite)
- Extracting the mapping into some static helper class outside the context (felt like a huge effort and potentially introducing regression because of the state access on the context)

## Testing

I have tried to write a test to verify no describe calls are being done but failed due to various constraints. I would need to use strict mocks but unfortunately the GetCache method safely casts to AmazonServiceClient and when that is null bypasses client access

![image](https://user-images.githubusercontent.com/174258/223476719-b914e431-2234-4b3c-bcc1-c7fdf149fd25.png)

furthermore setting up mocks to actually pass through that code would require something like

```csharp
            var dynamodbClientMock = new Mock<AmazonServiceClient>(MockBehavior.Strict);
            var client = dynamodbClientMock.As<IAmazonDynamoDB>();
```

which doesn't work because the config property of AmazonServiceClient is not virtual plus there is not protected empty constructor on AmazonServiceClient. 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement