### PR TITLE
Added support for Enum values in IConfiguration interface mapping to …

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
@@ -84,6 +84,15 @@ namespace Microsoft.Extensions.Configuration
                         var timespan = TimeSpan.FromMilliseconds(milliSeconds);
                         property.SetMethod.Invoke(options.DefaultClientConfig, new object[] { timespan });
                     }
+                    else if (property.PropertyType.IsEnum)
+                    {
+
+                        var value = Enum.Parse(property.PropertyType, element.Value);
+                        if ( value != null )
+                        {
+                            property.SetMethod.Invoke(options.DefaultClientConfig, new object[] { value });
+                        }
+                    }
                 }
                 catch(Exception e)
                 {

--- a/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
+++ b/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
@@ -104,6 +104,7 @@ namespace NETCore.SetupTests
             Assert.Equal(TimeSpan.FromMilliseconds(1000), options.DefaultClientConfig.Timeout);
             Assert.Equal("us-east-1", options.DefaultClientConfig.AuthenticationRegion);
             Assert.Equal(DefaultConfigurationMode.Standard, options.DefaultConfigurationMode);
+            Assert.Equal(RequestRetryMode.Standard, options.DefaultClientConfig.RetryMode);
 
             IAmazonS3 client = options.CreateServiceClient<IAmazonS3>();
             Assert.NotNull(client);

--- a/extensions/test/NETCore.SetupTests/TestFiles/GetClientConfigSettingsTest.json
+++ b/extensions/test/NETCore.SetupTests/TestFiles/GetClientConfigSettingsTest.json
@@ -5,6 +5,7 @@
     "Timeout": 1000,
     "AuthenticationRegion": "us-east-1",
     "Region": "us-west-2",
-    "DefaultsMode": "Standard"
+    "DefaultsMode": "Standard",
+    "RetryMode": "Standard"
   }
 }


### PR DESCRIPTION
Support for Enum values in IConfiguration interface mapping to AWSOptions in AWSSDK.Extensions.NETCore.Setup
#2587 
<!--- Provide a general summary of your changes in the Title above -->
Currently Enum values such has , RetryMode mode is not supported during the mapping from IConfiguration to AWSOptions
Documentation does not list the enum configuration [items](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-netcore.html#Allowed%20values%20in%20appsettings%20file)
```json
appSettings.json
{
  "AWS": {
    "Profile": "local-test-profile",
    "Region": "us-west-2",
    "RetryMode": "Standard"
  }
}
```
```csharp
var options = Configuration.GetAWSOptions();
// options  will not have RetryMode eventhough it configured in 
IAmazonS3 client = options.CreateServiceClient<IAmazonS3>();
```
## Description
<!--- Describe your changes in detail -->
Updated GetAWSOptions function to handle Enum tyoes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#2587 

Use Case

Developer shall be able to configure **RetryMode** via configuration file so that all service clients will use the same retry strategy and  developer shall be to configure different retry strategy  by changing the **configuration file** instead of **code**
## Testing
Update unit test to test the scenarion
Test Environment : Windows 10, .NET 6, .NET Framework


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project
- [x ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x ] I have read the **README** document
- [ x] I have added tests to cover my changes
- [x ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement