### PR TITLE
Native AOT Part1: Fix up ServiceFactory and InternalConfiguration trim warnings

### DIFF
--- a/sdk/src/Core/AWSSDK.Core.NetStandard.csproj
+++ b/sdk/src/Core/AWSSDK.Core.NetStandard.csproj
@@ -26,6 +26,9 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(RuleSetFileForBuild)' == 'false' Or '$(RuleSetFileForBuild)' == '' ">
     <CodeAnalysisRuleSet>..\..\AWSDotNetSDK.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
@@ -13,15 +13,12 @@
  * permissions and limitations under the License.
  */
 using System;
-using System.Globalization;
 
 using Amazon.Runtime.Internal.Util;
 using System.Collections.Generic;
-using Amazon.Util;
 #if BCL || NETSTANDARD
 using Amazon.Runtime.CredentialManagement;
 #endif
-using System.ComponentModel;
 
 namespace Amazon.Runtime.Internal
 {
@@ -130,17 +127,31 @@ namespace Amazon.Runtime.Internal
                 return null;
             }
 
-            var converter = TypeDescriptor.GetConverter(typeof(T?));
-            if (converter == null)
-            {
-                throw new InvalidOperationException($"Unable to obtain type converter for type {typeof(T?)} " +
-                    $"to convert environment variable {name}.");
-            }
-
-
             try
             {
-                return (T?)converter.ConvertFromString(value);
+                object convertedValue;
+                if(typeof(T) == typeof(bool))
+                {
+                    convertedValue = bool.Parse(value);
+                }
+                else if (typeof(T) == typeof(int))
+                {
+                    convertedValue = int.Parse(value);
+                }
+                else if (typeof(T).IsEnum)
+                {
+                    convertedValue = Enum.Parse(typeof(T), value);
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Unable to convert type {typeof(T?)} for environment variable {name}.");
+                }
+
+                return (T?)convertedValue;
+            }
+            catch(InvalidOperationException)
+            {
+                throw;
             }
             catch (Exception e)
             {

--- a/sdk/src/Core/Amazon.Util/Internal/PlatformServices/ServiceFactory.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/PlatformServices/ServiceFactory.cs
@@ -49,7 +49,7 @@ namespace Amazon.Util.Internal.PlatformServices
                 var serviceType = service.Key;
                 if (service.Value == InstantiationModel.Singleton)
                 {
-                    var serviceInstance = Activator.CreateInstance(_mappings[serviceType]);
+                    var serviceInstance = CreateInstance(_mappings[serviceType]);
                     _singletonServices.Add(serviceType, serviceInstance);
                 }
             }
@@ -82,7 +82,7 @@ namespace Amazon.Util.Internal.PlatformServices
             }
 
             var concreteType = GetServiceType<T>();
-            return (T)Activator.CreateInstance(concreteType);
+            return (T)CreateInstance(typeof(T));
         }
 
         private static Type GetServiceType<T>()
@@ -91,6 +91,33 @@ namespace Amazon.Util.Internal.PlatformServices
             {
                 return _mappings[typeof(T)];
             }
+        }
+
+        private static object CreateInstance(Type serviceType)
+        {
+            object service;
+            if (serviceType == typeof(IApplicationSettings))
+            {
+                service = new ApplicationSettings();
+            }
+            else if (serviceType == typeof(INetworkReachability))
+            {
+                service = new NetworkReachability();
+            }
+            else if (serviceType == typeof(IApplicationInfo))
+            {
+                service = new ApplicationInfo();
+            }
+            else if (serviceType == typeof(IEnvironmentInfo))
+            {
+                service = new EnvironmentInfo();
+            }
+            else
+            {
+                throw new ArgumentException($"Unknown service {serviceType.FullName}");
+            }
+
+            return service;
         }
     }
 }


### PR DESCRIPTION
## Description
This PR gets Core's trim warnings down from 19 to 15 warnings.

It removes use of the Activator and TypeConverter which were used to create only a small subset of data types. Instead of relying on reflection in Activator and TypeConverter replace them with explicit conditionals.

## Motivation and Context
Attempting to make progress getting the SDK trim compatible.

## Testing
This is just for a feature branch not into `main` so have relied on local testing.


## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement