### PR TITLE
Recognize inherited DynamoDBAttributes on properties

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
@@ -219,9 +219,9 @@ namespace Amazon.DynamoDBv2.DataModel
         {
             if (targetMemberInfo == null) throw new ArgumentNullException("targetMemberInfo");
 #if NETSTANDARD
-            object[] attributes = targetMemberInfo.GetCustomAttributes(typeof(DynamoDBAttribute), true).ToArray();
+            object[] attributes = CustomAttributeExtensions.GetCustomAttributes(targetMemberInfo, typeof(DynamoDBAttribute), true).ToArray<object>();
 #else
-            object[] attributes = targetMemberInfo.GetCustomAttributes(typeof(DynamoDBAttribute), true);
+            object[] attributes = Attribute.GetCustomAttributes(targetMemberInfo, typeof(DynamoDBAttribute), true).ToArray<object>();
 #endif
             return attributes;
         }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Amazon.Auth.AccessControlPolicy;
 using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
+using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.Model;
@@ -17,8 +18,6 @@ using Moq;
 
 namespace AWSSDK_DotNet35.UnitTests
 {
-    using Amazon.DynamoDBv2;
-
     [TestClass]
     public class DynamoDBEntryTests
     {

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -17,6 +17,8 @@ using Moq;
 
 namespace AWSSDK_DotNet35.UnitTests
 {
+    using Amazon.DynamoDBv2;
+
     [TestClass]
     public class DynamoDBEntryTests
     {
@@ -284,6 +286,38 @@ namespace AWSSDK_DotNet35.UnitTests
 
             Assert.IsTrue(doc["Name"] is Primitive);
             Assert.IsNull(doc["Name"].AsPrimitive().Value);
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestPropertyAttributeInheritance()
+        {
+            // Use a mock client to skip credential checks.
+            var mockClient = new Mock<IAmazonDynamoDB>();
+            var context = new DynamoDBContext(mockClient.Object);
+
+            var parent = new Parent();
+            parent.Property1 = "Value";
+
+            var child = new Child();
+            child.Property1 = "Value";
+
+            var parentDocument = context.ToDocument(parent);
+            var childDocument = context.ToDocument(child);
+
+            Assert.AreEqual(parentDocument["actualPropertyName"].AsString(), parent.Property1);
+            Assert.AreEqual(childDocument["actualPropertyName"].AsString(), child.Property1);
+        }
+
+        public class Parent
+        {
+            [DynamoDBProperty("actualPropertyName")]
+            public virtual string Property1 { get; set; }
+        }
+
+        public class Child : Parent
+        {
+            public override string Property1 { get; set; }
         }
 
 #if ASYNC_AWAIT


### PR DESCRIPTION
Fix attribute inheritance issue with DynamoDB in object persistence model

## Description
This pull request addresses the issue where `DynamoDBAttribute`s on properties were not being inherited in the object persistence model. The fix involves updating the `GetAttributeObjects` method to use `CustomAttributeExtensions.GetCustomAttributes` (`Attribute.GetCustomAttributes` for .Net Framework) instead of `MemberInfo.GetCustomAttributes`.

## Motivation and Context
This change is required to ensure correct serialization and deserialization of objects when using inheritance in the AWS SDK .NET with DynamoDB. This PR fixes issue #2590.

## Testing
The changes were tested by creating a parent class with a property decorated with a DynamoDBProperty attribute and a child class that inherits from the parent class and overrides the property. The SDK now recognizes the attribute in the property in the inherited class as expected.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement