### PR TITLE
Use Array.Empty<byte>() instead of byte[0]

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/UnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/UnmarshallerContext.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.Util.Internal;
 using Amazon.Runtime.Internal.Util;
 using System;
 using System.Collections.Generic;
@@ -64,7 +65,7 @@ namespace Amazon.Runtime.Internal.Transform
             }
             else
             {
-                return new byte[0];
+                return ArrayEx.Empty<byte>();
             }
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ChunkedUploadWrapperStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ChunkedUploadWrapperStream.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using Amazon.Util;
+using Amazon.Util.Internal;
 using Amazon.Runtime.Internal.Auth;
 using System.Security.Cryptography;
 using System.Collections.Generic;
@@ -366,7 +367,7 @@ namespace Amazon.Runtime.Internal.Util
             try
             {
                 var header = Encoding.UTF8.GetBytes(chunkHeader.ToString());
-                var trailer = new byte[0];
+                var trailer = ArrayEx.Empty<byte>();
 
                 // Append a trailing CRLF unless this is the final data chunk and there are trailing headers 
                 if (!(isFinalDataChunk && _trailingHeaders?.Count > 0))
@@ -407,7 +408,7 @@ namespace Amazon.Runtime.Internal.Util
             // If the trailing headers included a trailing checksum, set the hash value
             if (_hashAlgorithm != null)
             {
-                _hashAlgorithm.TransformFinalBlock(new byte[0], 0, 0);
+                _hashAlgorithm.TransformFinalBlock(ArrayEx.Empty<byte>(), 0, 0);
                 _trailingHeaders[ChecksumUtils.GetChecksumHeaderKey(_trailingChecksum)] = Convert.ToBase64String(_hashAlgorithm.Hash);
             }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/HashStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/HashStream.cs
@@ -20,6 +20,7 @@
  *
  */
 
+using Amazon.Util.Internal;
 using System;
 using System.IO;
 #if AWS_ASYNC_API
@@ -310,10 +311,10 @@ namespace Amazon.Runtime.Internal.Util
             {
                 if (ExpectedLength < 0 || CurrentPosition == ExpectedLength)
                 {
-                    CalculatedHash = Algorithm.AppendLastBlock(new byte[0]);
+                    CalculatedHash = Algorithm.AppendLastBlock(ArrayEx.Empty<byte>());
                 }
                 else
-                    CalculatedHash = new byte[0];
+                    CalculatedHash = ArrayEx.Empty<byte>();
 
                 if (CalculatedHash.Length > 0 && ExpectedHash != null && ExpectedHash.Length > 0)
                 {

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/TrailingHeadersWrapperStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/TrailingHeadersWrapperStream.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using Amazon.Util;
+using Amazon.Util.Internal;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -170,7 +171,7 @@ namespace Amazon.Runtime.Internal.Util
                 {
                     if (_hashAlgorithm != null)
                     {
-                        _hashAlgorithm.TransformFinalBlock(new byte[0], 0, 0);
+                        _hashAlgorithm.TransformFinalBlock(ArrayEx.Empty<byte>(), 0, 0);
                     }
                     _haveFinishedStream = true;
                     _suffix = GenerateTrailingHeaderChunk();

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
@@ -17,6 +17,7 @@ using Amazon.Runtime.Internal.Auth;
 using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
+using Amazon.Util.Internal;
 using System;
 using System.Globalization;
 using System.Net;
@@ -488,7 +489,7 @@ namespace Amazon.Runtime.Internal
                     }
                     else
                     {
-                        request.Content = new Byte[0];
+                        request.Content = ArrayEx.Empty<byte>();
                     }
                 }
 

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -1196,7 +1196,7 @@ namespace Amazon.Util
 
             var hashed = content != null ?
                 CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(content) :
-                CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(new byte[0]);
+                CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(ArrayEx.Empty<byte>());
 
             if (fBase64Encode)
             {

--- a/sdk/src/Core/Amazon.Util/Internal/_bcl/ArrayEx.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/_bcl/ArrayEx.cs
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.Util.Internal
+{
+    /// <summary>
+    /// Array extensions for cross compilation across different supported framework versions.
+    /// </summary>
+    static class ArrayEx
+    {
+        /// <summary>
+        /// Returns an empty array.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements of the array.</typeparam>
+        /// <returns>An empty array.</returns>
+        public static T[] Empty<T>()
+        {
+            return EmptyArray<T>.Value;
+        }
+        
+        private static class EmptyArray<T>
+        {
+#pragma warning disable CA1825 // this is the implementation of ArrayEx.Empty<T>()
+            internal static readonly T[] Value = new T[0];
+#pragma warning restore CA1825
+        }
+    }
+}

--- a/sdk/src/Core/Amazon.Util/Internal/_netstandard/ArrayEx.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/_netstandard/ArrayEx.cs
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Amazon.Util.Internal
+{
+    /// <summary>
+    /// Array extensions for cross compilation across different supported framework versions.
+    /// </summary>
+    static class ArrayEx
+    {
+        /// <summary>
+        /// Returns an empty array.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements of the array.</typeparam>
+        /// <returns>An empty array.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] Empty<T>()
+        {
+            return Array.Empty<T>();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Use Array.Empty<byte>() instead of byte[0]

## Motivation and Context

It is not necessary to allocate `byte[0]`

## Testing

Passes tests locally

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement