### PR TITLE
[NativeAOT Progress] Deprecate TypeFactory and remove its uses in the SDK

### DIFF
--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -522,7 +522,7 @@ namespace Amazon
 
         private static T GetConfigEnum<T>(string name)
         {
-            var type = TypeFactory.GetTypeInfo(typeof(T));
+            var type = typeof(T);
             if (!type.IsEnum) throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Type {0} must be enum", type.FullName));
 
             string value = GetConfig(name);

--- a/sdk/src/Core/Amazon.Runtime/ConstantClass.cs
+++ b/sdk/src/Core/Amazon.Runtime/ConstantClass.cs
@@ -99,29 +99,28 @@ namespace Amazon.Runtime
             ConstantClass foundValue;
             if (!fields.TryGetValue(value, out foundValue))
             {
-                var typeInfo = TypeFactory.GetTypeInfo(typeof(T));
-                var constructor = typeInfo.GetConstructor(new ITypeInfo[] { TypeFactory.GetTypeInfo(typeof(string)) });
+                var type = typeof(T);
+                var constructor = type.GetConstructor(new Type[] { typeof(string) });
                 return constructor.Invoke(new object[] { value }) as T;
             }
 
             return foundValue as T;
         }
 
-        private static void LoadFields(Type t)
+        private static void LoadFields(Type type)
         {
-            if (staticFields.ContainsKey(t))
+            if (staticFields.ContainsKey(type))
                 return;
 
             lock (staticFieldsLock)
             {
-                if (staticFields.ContainsKey(t)) return;
+                if (staticFields.ContainsKey(type)) return;
 
                 var map = new Dictionary<string, ConstantClass>(StringComparer.OrdinalIgnoreCase);
 
-                var typeInfo = TypeFactory.GetTypeInfo(t);
-                foreach (var fieldInfo in typeInfo.GetFields())
+                foreach (var fieldInfo in type.GetFields())
                 {
-                    if (fieldInfo.IsStatic && fieldInfo.FieldType == t)
+                    if (fieldInfo.IsStatic && fieldInfo.FieldType == type)
                     {
                         var cc = fieldInfo.GetValue(null) as ConstantClass;
                         map[cc.Value] = cc;
@@ -130,7 +129,7 @@ namespace Amazon.Runtime
 
                 // create copy of dictionary with new value
                 var newDictionary = new Dictionary<Type, Dictionary<string, ConstantClass>>(staticFields);
-                newDictionary[t] = map;
+                newDictionary[type] = map;
 
                 // swap in the new dictionary
                 staticFields = newDictionary;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
@@ -15,6 +15,7 @@
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.SharedInterfaces;
 using Amazon.Util.Internal;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -54,10 +55,10 @@ namespace Amazon.Runtime.Internal.Auth
                     {
                         try
                         {
-                            var crtWrapperTypeInfo = ServiceClientHelpers.LoadTypeFromAssembly(CRT_WRAPPER_ASSEMBLY_NAME, CRT_WRAPPER_CLASS_NAME);
-                            var constructor = crtWrapperTypeInfo.GetConstructor(new ITypeInfo[]
+                            var crtWrapperType = ServiceClientHelpers.LoadTypeFromAssembly(CRT_WRAPPER_ASSEMBLY_NAME, CRT_WRAPPER_CLASS_NAME);
+                            var constructor = crtWrapperType.GetConstructor(new Type[]
                             {
-                                TypeFactory.GetTypeInfo(typeof(bool))
+                                typeof(bool)
                             });
 
                             _awsSigV4AProvider = constructor.Invoke(new object[] { signPayload }) as IAWSSigV4aProvider;

--- a/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
@@ -35,12 +35,12 @@ namespace Amazon.Runtime.Internal
             var credentials = originalServiceClient.Credentials;
             var newConfig = originalServiceClient.CloneConfig<TConfig>();
 
-            var newServiceClientTypeInfo = TypeFactory.GetTypeInfo(typeof(TClient));
+            var newServiceClientTypeInfo = typeof(TClient);
 
-            var constructor = newServiceClientTypeInfo.GetConstructor(new ITypeInfo[]
+            var constructor = newServiceClientTypeInfo.GetConstructor(new Type[]
                 {
-                    TypeFactory.GetTypeInfo(typeof(AWSCredentials)),
-                    TypeFactory.GetTypeInfo(newConfig.GetType())
+                    typeof(AWSCredentials),
+                    newConfig.GetType()
                 });
 
             var newServiceClient = constructor.Invoke(new object[] { credentials, newConfig }) as TClient;
@@ -54,9 +54,9 @@ namespace Amazon.Runtime.Internal
         {
             var serviceClientTypeInfo = LoadServiceClientType(assemblyName, serviceClientClassName);
 
-            var constructor = serviceClientTypeInfo.GetConstructor(new ITypeInfo[]
+            var constructor = serviceClientTypeInfo.GetConstructor(new Type[]
                 {
-                    TypeFactory.GetTypeInfo(typeof(RegionEndpoint))
+                    typeof(RegionEndpoint)
                 });
 
             var newServiceClient = constructor.Invoke(new object[] { region }) as TClient;
@@ -70,10 +70,10 @@ namespace Amazon.Runtime.Internal
         {
             var serviceClientTypeInfo = LoadServiceClientType(assemblyName, serviceClientClassName);
 
-            var constructor = serviceClientTypeInfo.GetConstructor(new ITypeInfo[]
+            var constructor = serviceClientTypeInfo.GetConstructor(new Type[]
                 {
-                    TypeFactory.GetTypeInfo(typeof(AWSCredentials)),
-                    TypeFactory.GetTypeInfo(typeof(RegionEndpoint))
+                    typeof(AWSCredentials),
+                    typeof(RegionEndpoint)
                 });
 
             var newServiceClient = constructor.Invoke(new object[] { credentials, region }) as TClient;
@@ -87,10 +87,10 @@ namespace Amazon.Runtime.Internal
         {
             var serviceClientTypeInfo = LoadServiceClientType(assemblyName, serviceClientClassName);
         
-            var constructor = serviceClientTypeInfo.GetConstructor(new ITypeInfo[]
+            var constructor = serviceClientTypeInfo.GetConstructor(new Type[]
                 {
-                    TypeFactory.GetTypeInfo(typeof(AWSCredentials)),
-                    TypeFactory.GetTypeInfo(config.GetType())
+                    typeof(AWSCredentials),
+                    config.GetType()
                 });
 
             var newServiceClient = constructor.Invoke(new object[] { credentials, config }) as TClient;
@@ -106,10 +106,10 @@ namespace Amazon.Runtime.Internal
             var config = CreateServiceConfig(assemblyName, serviceClientClassName.Replace("Client", "Config"));
             originalServiceClient.CloneConfig(config);
 
-            var constructor = serviceClientTypeInfo.GetConstructor(new ITypeInfo[]
+            var constructor = serviceClientTypeInfo.GetConstructor(new Type[]
                 {
-                    TypeFactory.GetTypeInfo(typeof(AWSCredentials)),
-                    TypeFactory.GetTypeInfo(config.GetType())
+                    typeof(AWSCredentials),
+                    config.GetType()
                 });
 
             var newServiceClient = constructor.Invoke(new object[] { originalServiceClient.Credentials, config }) as TClient;
@@ -121,28 +121,28 @@ namespace Amazon.Runtime.Internal
         {
             var typeInfo = LoadServiceConfigType(assemblyName, serviceConfigClassName);
 
-            var ci = typeInfo.GetConstructor(new ITypeInfo[0]);
+            var ci = typeInfo.GetConstructor(new Type[0]);
             var config = ci.Invoke(new object[0]);
 
             return config as ClientConfig;
         }
 
-        private static ITypeInfo LoadServiceClientType(string assemblyName, string serviceClientClassName)
+        private static Type LoadServiceClientType(string assemblyName, string serviceClientClassName)
         {
             return LoadTypeFromAssembly(assemblyName, serviceClientClassName);
         }
 
-        private static ITypeInfo LoadServiceConfigType(string assemblyName, string serviceConfigClassName)
+        private static Type LoadServiceConfigType(string assemblyName, string serviceConfigClassName)
         {
             return LoadTypeFromAssembly(assemblyName, serviceConfigClassName);
         }
 
-        internal static ITypeInfo LoadTypeFromAssembly(string assemblyName, string className)
+        internal static Type LoadTypeFromAssembly(string assemblyName, string className)
         {
             var assembly = GetSDKAssembly(assemblyName);
             var type = assembly.GetType(className);
 
-            return TypeFactory.GetTypeInfo(type);
+            return type;
         }
 
         private static Assembly GetSDKAssembly(string assemblyName)

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumCRTWrapper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumCRTWrapper.cs
@@ -16,6 +16,7 @@ using Amazon.Runtime;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.SharedInterfaces.Internal;
 using Amazon.Util.Internal;
+using System;
 using System.Globalization;
 using System.IO;
 
@@ -46,8 +47,8 @@ namespace AWSSDK.Runtime.Internal.Util
                     {
                         try
                         {
-                            var crtWrapperTypeInfo = ServiceClientHelpers.LoadTypeFromAssembly(CRT_WRAPPER_ASSEMBLY_NAME, CRT_WRAPPER_CLASS_NAME);
-                            var constructor = crtWrapperTypeInfo.GetConstructor(new ITypeInfo[] { });
+                            var crtWrapperType = ServiceClientHelpers.LoadTypeFromAssembly(CRT_WRAPPER_ASSEMBLY_NAME, CRT_WRAPPER_CLASS_NAME);
+                            var constructor = crtWrapperType.GetConstructor(new Type[] { });
 
                             _instance = constructor.Invoke(null) as IChecksumProvider;
                         }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
@@ -37,15 +37,12 @@ namespace Amazon.Runtime.Internal.Util
         static readonly object LOCK = new object();
 
         static Type logMangerType;
-        static ITypeInfo logMangerTypeInfo;
         static MethodInfo getLoggerWithTypeMethod;
 
         static Type logType;
-        static ITypeInfo logTypeInfo;
         static MethodInfo logMethod;
 
         static Type levelType;
-        static ITypeInfo levelTypeInfo;
         static object debugLevelPropertyValue;
         static object infoLevelPropertyValue;
         static object errorLevelPropertyValue;
@@ -80,30 +77,27 @@ namespace Amazon.Runtime.Internal.Util
 
                     // The LogManager and its methods
                     logMangerType = Type.GetType("log4net.Core.LoggerManager, log4net");
-                    logMangerTypeInfo = TypeFactory.GetTypeInfo(logMangerType);
                     if (logMangerType == null)
                     {
                         loadState = LoadState.Failed;
                         return;
                     }
 
-                    getLoggerWithTypeMethod = logMangerTypeInfo.GetMethod("GetLogger", new ITypeInfo[] { TypeFactory.GetTypeInfo(typeof(Assembly)), TypeFactory.GetTypeInfo(typeof(Type)) });
+                    getLoggerWithTypeMethod = logMangerType.GetMethod("GetLogger", new Type[] { typeof(Assembly), typeof(Type) });
 
                     // The ILog and its methdods
                     logType = Type.GetType("log4net.Core.ILogger, log4net");
-                    logTypeInfo = TypeFactory.GetTypeInfo(logType);
 
                     levelType = Type.GetType("log4net.Core.Level, log4net");
-                    levelTypeInfo = TypeFactory.GetTypeInfo(levelType);
 
-                    debugLevelPropertyValue = levelTypeInfo.GetField("Debug").GetValue(null);
-                    infoLevelPropertyValue = levelTypeInfo.GetField("Info").GetValue(null);
-                    errorLevelPropertyValue = levelTypeInfo.GetField("Error").GetValue(null);
+                    debugLevelPropertyValue = levelType.GetField("Debug").GetValue(null);
+                    infoLevelPropertyValue = levelType.GetField("Info").GetValue(null);
+                    errorLevelPropertyValue = levelType.GetField("Error").GetValue(null);
 
                     systemStringFormatType = Type.GetType("log4net.Util.SystemStringFormat, log4net");
 
-                    logMethod = logTypeInfo.GetMethod("Log", new ITypeInfo[] { TypeFactory.GetTypeInfo(typeof(Type)), levelTypeInfo, TypeFactory.GetTypeInfo(typeof(object)), TypeFactory.GetTypeInfo(typeof(Exception)) });
-                    isEnabledForMethod = logTypeInfo.GetMethod("IsEnabledFor", new ITypeInfo[] { levelTypeInfo });
+                    logMethod = logType.GetMethod("Log", new Type[] { typeof(Type), levelType, typeof(object), typeof(Exception) });
+                    isEnabledForMethod = logType.GetMethod("IsEnabledFor", new Type[] { levelType });
 
                     if (getLoggerWithTypeMethod == null ||
                         isEnabledForMethod == null ||
@@ -122,10 +116,10 @@ namespace Amazon.Runtime.Internal.Util
                     if (log4netSectionPresent &&
                         (AWSConfigs.LoggingConfig.LogTo & LoggingOptions.Log4Net) == LoggingOptions.Log4Net)
                     {
-                        ITypeInfo xmlConfiguratorType = TypeFactory.GetTypeInfo(Type.GetType("log4net.Config.XmlConfigurator, log4net"));
+                        Type xmlConfiguratorType = Type.GetType("log4net.Config.XmlConfigurator, log4net");
                         if (xmlConfiguratorType != null)
                         {
-                            MethodInfo configureMethod = xmlConfiguratorType.GetMethod("Configure", new ITypeInfo[0]);
+                            MethodInfo configureMethod = xmlConfiguratorType.GetMethod("Configure", new Type[0]);
                             if (configureMethod != null)
                             {
                                 configureMethod.Invoke(null, null);
@@ -154,7 +148,7 @@ namespace Amazon.Runtime.Internal.Util
             if (logMangerType == null)
                 return;
 
-            this.internalLogger = getLoggerWithTypeMethod.Invoke(null, new object[] { TypeFactory.GetTypeInfo(declaringType).Assembly, declaringType }); //Assembly.GetCallingAssembly()
+            this.internalLogger = getLoggerWithTypeMethod.Invoke(null, new object[] { declaringType.Assembly, declaringType }); //Assembly.GetCallingAssembly()
         }
 
         #region Overrides

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/ErrorHandler/ErrorHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/ErrorHandler/ErrorHandler.cs
@@ -194,7 +194,6 @@ namespace Amazon.Runtime.Internal
             // Start by checking if there is a matching handler for the specific exception type,
             // if not check for handlers for it's base type till we find a match.
             var exceptionType = exception.GetType();
-            var exceptionTypeInfo = TypeFactory.GetTypeInfo(exception.GetType());
             do
             {
                 IExceptionHandler exceptionHandler = null;
@@ -203,8 +202,7 @@ namespace Amazon.Runtime.Internal
                 {
                     return exceptionHandler.Handle(executionContext, exception);
                 }
-                exceptionType = exceptionTypeInfo.BaseType;
-                exceptionTypeInfo = TypeFactory.GetTypeInfo(exceptionTypeInfo.BaseType);
+                exceptionType = exceptionType.BaseType;
 
             } while (exceptionType != typeof(Exception));
 
@@ -236,7 +234,6 @@ namespace Amazon.Runtime.Internal
             // Start by checking if there is a matching handler for the specific exception type,
             // if not check for handlers for it's base type till we find a match.
             var exceptionType = exception.GetType();
-            var exceptionTypeInfo = TypeFactory.GetTypeInfo(exception.GetType());
             do
             {
                 IExceptionHandler exceptionHandler = null;
@@ -245,8 +242,7 @@ namespace Amazon.Runtime.Internal
                 {
                     return await exceptionHandler.HandleAsync(executionContext, exception).ConfigureAwait(false);
                 }
-                exceptionType = exceptionTypeInfo.BaseType;
-                exceptionTypeInfo = TypeFactory.GetTypeInfo(exceptionTypeInfo.BaseType);
+                exceptionType = exceptionType.BaseType;
 
             } while (exceptionType != typeof(Exception));
 

--- a/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
@@ -114,20 +114,20 @@ namespace Amazon.Util.Internal
             if (propertyValues == null || propertyValues.Count == 0)
                 return;
 
-            var targetTypeInfo = TypeFactory.GetTypeInfo(target.GetType());
+            var targetType = target.GetType();
             
             foreach(var kvp in propertyValues)
             {
-                var property = targetTypeInfo.GetProperty(kvp.Key);
+                var property = targetType.GetProperty(kvp.Key);
                 if (property == null)
-                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unable to find property {0} on type {1}.", kvp.Key, targetTypeInfo.FullName));
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unable to find property {0} on type {1}.", kvp.Key, targetType.FullName));
 
                 try
                 {
-                    var propertyTypeInfo = TypeFactory.GetTypeInfo(property.PropertyType);
+                    var propertyTypeInfo = property.PropertyType;
                     if (propertyTypeInfo.IsEnum)
                     {
-                        var enumValue = Enum.Parse(property.PropertyType, kvp.Value.ToString(), true);
+                        var enumValue = Enum.Parse(propertyTypeInfo, kvp.Value.ToString(), true);
                         property.SetValue(target, enumValue, null);
                     }
                     else
@@ -137,7 +137,7 @@ namespace Amazon.Util.Internal
                 }
                 catch(Exception e)
                 {
-                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unable to set property {0} on type {1}: {2}", kvp.Key, targetTypeInfo.FullName, e.Message));
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unable to set property {0} on type {1}: {2}", kvp.Key, targetType.FullName, e.Message));
                 }
             }
         }

--- a/sdk/src/Core/Amazon.Util/Internal/TypeWrapper.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/TypeWrapper.cs
@@ -20,12 +20,14 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 
 namespace Amazon.Util.Internal
 {
+    [Obsolete("The TypeFactory abstraction should not be used. This was needed when the SDK targeted .NET Standard 1.3 which was removed as part of version 3.7. Type information should be accessed directly from the System.Type class.")]
     public interface ITypeInfo
     {
         Type BaseType { get; }
@@ -68,11 +70,7 @@ namespace Amazon.Util.Internal
 
         object EnumToObject(object value);
 
-        ITypeInfo EnumGetUnderlyingType();
-
         object CreateInstance();
-
-        ITypeInfo GetElementType();
 
         bool IsType(Type type);
 
@@ -90,22 +88,38 @@ namespace Amazon.Util.Internal
 
     }
 
+    [Obsolete("The TypeFactory abstraction should not be used. This was needed when the SDK targeted .NET Standard 1.3 which was removed as part of version 3.7. Type information should be accessed directly from the System.Type class.")]
     public static partial class TypeFactory
     {
         public static readonly ITypeInfo[] EmptyTypes = new ITypeInfo[] { };
+
+#if NET6_0_OR_GREATER
+        
+        public static ITypeInfo GetTypeInfo([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]  Type type)
+#else
         public static ITypeInfo GetTypeInfo(Type type)
+#endif
+
         {
             if (type == null)
                 return null;
+
 
             return new TypeInfoWrapper(type);
         }
 
         abstract class AbstractTypeInfo : ITypeInfo
         {
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
             protected Type _type;
 
+#if NET6_0_OR_GREATER
+            internal AbstractTypeInfo([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
+#else
             internal AbstractTypeInfo(Type type)
+#endif
             {
                 this._type = type;
             }
@@ -174,11 +188,6 @@ namespace Amazon.Util.Internal
                 return Enum.ToObject(this._type, value);
             }
 
-            public ITypeInfo EnumGetUnderlyingType()
-            {
-                return TypeFactory.GetTypeInfo(Enum.GetUnderlyingType(this._type));
-            }
-
             public object CreateInstance()
             {
                 return Activator.CreateInstance(this._type);
@@ -187,11 +196,6 @@ namespace Amazon.Util.Internal
             public Array ArrayCreateInstance(int length)
             {
                 return Array.CreateInstance(this._type, length);
-            }
-
-            public ITypeInfo GetElementType()
-            {
-                return TypeFactory.GetTypeInfo(this._type.GetElementType());
             }
 
             public string FullName 

--- a/sdk/src/Core/Amazon.Util/Internal/_netstandard/TypeWrapper.netstandard.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/_netstandard/TypeWrapper.netstandard.cs
@@ -20,6 +20,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -30,9 +31,16 @@ namespace Amazon.Util.Internal
     {
         class TypeInfoWrapper : AbstractTypeInfo
         {
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
             TypeInfo _typeInfo;
 
+#if NET6_0_OR_GREATER
+            internal TypeInfoWrapper([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
+#else
             internal TypeInfoWrapper(Type type)
+#endif
                 : base(type)
             {
                 this._typeInfo = type.GetTypeInfo();
@@ -79,7 +87,13 @@ namespace Amazon.Util.Internal
                 var isBackingField = mi.Name.IndexOf("k__BackingField", StringComparison.Ordinal) >= 0;
                 return isBackingField;
             }
+
+#if NET6_0_OR_GREATER
+            private static IEnumerable<MemberInfo> GetMembers_Helper([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TypeInfo ti)
+#else
             private static IEnumerable<MemberInfo> GetMembers_Helper(TypeInfo ti)
+#endif
+
             {
                 // Keep track of properties already returned. This makes sure properties that are overridden in sub classes are not returned back multiple times.
                 var processedProperties = new HashSet<string>();

--- a/sdk/src/Core/Amazon.Util/PaginatedResourceFactory.cs
+++ b/sdk/src/Core/Amazon.Util/PaginatedResourceFactory.cs
@@ -41,8 +41,8 @@ namespace Amazon.Util
         private static PaginatedResource<ItemType> Create<ItemType, TRequestType, TResponseType>
             (object client, string methodName, object request, string tokenRequestPropertyPath, string tokenResponsePropertyPath, string itemListPropertyPath)
         {
-            ITypeInfo clientType = TypeFactory.GetTypeInfo(client.GetType());
-            MethodInfo fetcherMethod = clientType.GetMethod(methodName, new ITypeInfo[] { TypeFactory.GetTypeInfo(typeof(TRequestType)) });
+            Type clientType = client.GetType();
+            MethodInfo fetcherMethod = clientType.GetMethod(methodName, new Type[] { typeof(TRequestType) });
 
             Type funcType = GetFuncType<TRequestType, TResponseType>();
             Func<TRequestType, TResponseType> call = (req) =>
@@ -84,11 +84,11 @@ namespace Amazon.Util
             for (; i < propPath.Length - 1; i++)
             {
                 string property = propPath[i];
-                currentProperty = TypeFactory.GetTypeInfo(currentType).GetProperty(property);
+                currentProperty = currentType.GetProperty(property);
                 currentValue = currentProperty.GetValue(currentValue, null);
                 currentType = currentProperty.PropertyType;
             }
-            currentProperty = TypeFactory.GetTypeInfo(currentType).GetProperty(propPath[i]);
+            currentProperty = currentType.GetProperty(propPath[i]);
             currentProperty.SetValue(currentValue, value, null);
         }
         private static T GetPropertyValueFromPath<T>(object instance, string path)
@@ -100,7 +100,7 @@ namespace Amazon.Util
 
             foreach (string property in propPath)
             {
-                currentProperty = TypeFactory.GetTypeInfo(currentType).GetProperty(property);
+                currentProperty = currentType.GetProperty(property);
                 currentValue = currentProperty.GetValue(currentValue, null);
                 currentType = currentProperty.PropertyType;
             }
@@ -113,7 +113,7 @@ namespace Amazon.Util
             PropertyInfo currentProperty = null;
             foreach (string property in propPath)
             {
-                currentProperty = TypeFactory.GetTypeInfo(currentType).GetProperty(property);
+                currentProperty = currentType.GetProperty(property);
                 currentType = currentProperty.PropertyType;
             }
             return currentType;
@@ -172,7 +172,7 @@ namespace Amazon.Util
                     ret = "{0}";
                     if (Client != null && !String.IsNullOrEmpty(MethodName))
                     {
-                        MethodInfo mi = TypeFactory.GetTypeInfo(Client.GetType()).GetMethod(MethodName);
+                        MethodInfo mi = Client.GetType().GetMethod(MethodName);
                         if (mi != null)
                         {
                             Type responseType = mi.ReturnType;
@@ -181,7 +181,7 @@ namespace Amazon.Util
                             {
                                 baseName = baseName.Substring(0, baseName.Length - 8);
                             }
-                            if (TypeFactory.GetTypeInfo(responseType).GetProperty(string.Format(CultureInfo.InvariantCulture, "{0}Result", baseName)) != null)
+                            if (responseType.GetProperty(string.Format(CultureInfo.InvariantCulture, "{0}Result", baseName)) != null)
                             {
                                 ret = string.Format(CultureInfo.InvariantCulture, ret, string.Format(CultureInfo.InvariantCulture, "{0}Result.{1}", baseName, "{0}"));
                             }
@@ -245,7 +245,7 @@ namespace Amazon.Util
 
             //MethodName exists on Client and takes one argument of the declared request type
             Type clientType = Client.GetType();
-            MethodInfo mi = TypeFactory.GetTypeInfo(clientType).GetMethod(MethodName, new ITypeInfo[] { TypeFactory.GetTypeInfo(Request.GetType()) });
+            MethodInfo mi = clientType.GetMethod(MethodName, new Type[] { Request.GetType() });
             if (mi == null)
             {
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "{0} has no method called {1}", clientType.Name, MethodName));

--- a/sdk/src/Core/RegionEndpoint/RegionEndpointProviderV2.cs
+++ b/sdk/src/Core/RegionEndpoint/RegionEndpointProviderV2.cs
@@ -322,11 +322,11 @@ namespace Amazon.Internal
 
             static void LoadEndpointDefinitionsFromEmbeddedResource()
             {
-                using (var stream = Amazon.Util.Internal.TypeFactory.GetTypeInfo(typeof(RegionEndpoint)).Assembly.GetManifestResourceStream(REGIONS_FILE))
+                using (var stream = typeof(RegionEndpoint).Assembly.GetManifestResourceStream(REGIONS_FILE))
                 {
                     ReadEndpointFile(stream);
                 }
-                using (var stream = Amazon.Util.Internal.TypeFactory.GetTypeInfo(typeof(RegionEndpoint)).Assembly.GetManifestResourceStream(REGIONS_CUSTOMIZATIONS_FILE))
+                using (var stream = typeof(RegionEndpoint).Assembly.GetManifestResourceStream(REGIONS_CUSTOMIZATIONS_FILE))
                 {
                     ReadEndpointFile(stream);
                 }

--- a/sdk/src/Core/RegionEndpoint/RegionEndpointProviderV3.cs
+++ b/sdk/src/Core/RegionEndpoint/RegionEndpointProviderV3.cs
@@ -455,7 +455,7 @@ namespace Amazon.Internal
             //
             // Default to endpoints.json file provided in the resource manifest:
             //
-            return Amazon.Util.Internal.TypeFactory.GetTypeInfo(typeof(RegionEndpointProviderV3)).Assembly.GetManifestResourceStream(ENDPOINT_JSON_RESOURCE);
+            return typeof(RegionEndpointProviderV3).Assembly.GetManifestResourceStream(ENDPOINT_JSON_RESOURCE);
         }
 
         private IEnumerable<IRegionEndpoint> _allRegionEndpoints;

--- a/sdk/src/Services/CognitoIdentity/Custom/CognitoAWSCredentials.cs
+++ b/sdk/src/Services/CognitoIdentity/Custom/CognitoAWSCredentials.cs
@@ -32,6 +32,7 @@ namespace Amazon.CognitoIdentity
     {
         #region Private members
         private static object refreshIdLock = new object();
+        private readonly object identityChangeEventLock = new object();
         private string identityId;
         private static int DefaultDurationSeconds = (int)TimeSpan.FromHours(1).TotalSeconds;
         private IAmazonCognitoIdentity cib;
@@ -443,14 +444,14 @@ namespace Amazon.CognitoIdentity
         {
             add
             {
-                lock (this)
+                lock (identityChangeEventLock)
                 {
                     mIdentityChangedEvent += value;
                 }
             }
             remove
             {
-                lock (this)
+                lock (identityChangeEventLock)
                 {
                     mIdentityChangedEvent -= value;
                 }

--- a/sdk/src/Services/CognitoSync/Custom/Internal/CognitoCredentialsRetriever.cs
+++ b/sdk/src/Services/CognitoSync/Custom/Internal/CognitoCredentialsRetriever.cs
@@ -103,14 +103,14 @@ namespace Amazon.CognitoSync.Internal
             /// </summary>
             private class CSRequest
             {
-                private ITypeInfo requestType;
+                private Type requestType;
                 private PropertyInfo identityPoolIdProperty;
                 private PropertyInfo identityIdProperty;
-                public static ITypeInfo SyncRequestType = TypeFactory.GetTypeInfo(typeof(AmazonCognitoSyncRequest));
+                public static Type SyncRequestType = typeof(AmazonCognitoSyncRequest);
 
                 public CSRequest(Type requestType)
                 {
-                    this.requestType = TypeFactory.GetTypeInfo(requestType);
+                    this.requestType = requestType;
 
                     if (!SyncRequestType.IsAssignableFrom(this.requestType))
                         throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Unable to assign {0} from {1}",
@@ -143,7 +143,7 @@ namespace Amazon.CognitoSync.Internal
                 // Look up all CognitoSync request objects for caching.
                 foreach (var type in allTypes)
                 {
-                    var typeInfo = TypeFactory.GetTypeInfo(type);
+                    var typeInfo = type;
                     if (CSRequest.SyncRequestType.IsAssignableFrom(typeInfo) && !typeInfo.Equals(CSRequest.SyncRequestType))
                     {
                         var csRequest = new CSRequest(type);

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -378,16 +378,10 @@ namespace Amazon.DynamoDBv2
 
         private void AddConverters(string suffix)
         {
-            var typedConverterTypeInfo = TypeFactory.GetTypeInfo(typeof(Converter));
-            var assembly = TypeFactory.GetTypeInfo(typeof(DynamoDBEntryConversion)).Assembly;
-#if NETSTANDARD
-            var allTypeInfos = assembly.DefinedTypes;
-            var allTypes = new List<Type>();
-            foreach (var typeInfo in allTypeInfos)
-                allTypes.Add(typeInfo.AsType());
-#else
+            var typedConverterType = typeof(Converter);
+            var assembly = typeof(DynamoDBEntryConversion).Assembly;
+
             var allTypes = assembly.GetTypes();
-#endif
 
             foreach (var type in allTypes)
             {
@@ -396,14 +390,13 @@ namespace Amazon.DynamoDBv2
                 //if (type.Namespace != typedConverterType.Namespace)
                 //    continue;
 
-                var typeInfo = TypeFactory.GetTypeInfo(type);
-                if (typeInfo.IsAbstract)
+                if (type.IsAbstract)
                     continue;
 
                 if (!type.Name.EndsWith(suffix, StringComparison.Ordinal))
                     continue;
 
-                if (!typedConverterTypeInfo.IsAssignableFrom(typeInfo))
+                if (!typedConverterType.IsAssignableFrom(type))
                     continue;
 
                 AddConverter(type);
@@ -645,8 +638,7 @@ namespace Amazon.DynamoDBv2
             var type = typeof(T);
             yield return type;
 
-            var typeInfo = TypeFactory.GetTypeInfo(type);
-            if (typeInfo.IsValueType)
+            if (type.IsValueType)
             {
                 //yield return typeof(Nullable<T>);
                 var nullableType = typeof(Nullable<>).MakeGenericType(type);
@@ -806,9 +798,8 @@ namespace Amazon.DynamoDBv2
                 throw new ArgumentNullException("type");
 
             // all enums use the same converter, one for Enum
-            var ti = TypeFactory.GetTypeInfo(type);
-            if (ti.IsEnum)
-                type = EnumType;
+            if (type.IsEnum)
+                return Cache.TryGetValue(EnumType, out converter);
 
             return Cache.TryGetValue(type, out converter);
         }

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
@@ -112,7 +112,7 @@ namespace Amazon.DynamoDBv2
     /// </summary>
     internal class CollectionConverterV2 : PrimitiveCollectionConverterV1
     {
-        private static ITypeInfo setTypeInfo = TypeFactory.GetTypeInfo(typeof(HashSet<>));
+        private static Type setTypeInfo = typeof(HashSet<>);
         private static Type enumerableType = typeof(IEnumerable<>);
 
         /// <summary>
@@ -124,12 +124,11 @@ namespace Amazon.DynamoDBv2
         public override bool TryTo(object value, out PrimitiveList pl)
         {
             var inputType = value.GetType();
-            var inputTypeInfo = TypeFactory.GetTypeInfo(inputType);
 
-            if (inputTypeInfo.IsGenericType)
+            if (inputType.IsGenericType)
             {
-                var genericTypeInfo = TypeFactory.GetTypeInfo(inputTypeInfo.GetGenericTypeDefinition());
-                if (setTypeInfo.IsAssignableFrom(genericTypeInfo))
+                var genericType = inputType.GetGenericTypeDefinition();
+                if (setTypeInfo.IsAssignableFrom(genericType))
                 {
                     pl = Conversion.ItemsToPrimitiveList(value as IEnumerable);
                     return true;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -59,15 +59,14 @@ namespace Amazon.DynamoDBv2.DataModel
         }
         private static void IncrementVersion(Type memberType, ref Primitive version)
         {
-            var memberTypeWrapper = TypeFactory.GetTypeInfo(memberType);
-            if (memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(Byte)))) version = version.AsByte() + 1;
-            else if (memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(SByte)))) version = version.AsSByte() + 1;
-            else if (memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(int)))) version = version.AsInt() + 1;
-            else if (memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(uint)))) version = version.AsUInt() + 1;
-            else if (memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(long)))) version = version.AsLong() + 1;
-            else if (memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(ulong)))) version = version.AsULong() + 1;
-            else if (memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(short)))) version = version.AsShort() + 1;
-            else if (memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(ushort)))) version = version.AsUShort() + 1;
+            if (memberType.IsAssignableFrom(typeof(Byte))) version = version.AsByte() + 1;
+            else if (memberType.IsAssignableFrom(typeof(SByte))) version = version.AsSByte() + 1;
+            else if (memberType.IsAssignableFrom(typeof(int))) version = version.AsInt() + 1;
+            else if (memberType.IsAssignableFrom(typeof(uint))) version = version.AsUInt() + 1;
+            else if (memberType.IsAssignableFrom(typeof(long))) version = version.AsLong() + 1;
+            else if (memberType.IsAssignableFrom(typeof(ulong))) version = version.AsULong() + 1;
+            else if (memberType.IsAssignableFrom(typeof(short))) version = version.AsShort() + 1;
+            else if (memberType.IsAssignableFrom(typeof(ushort))) version = version.AsUShort() + 1;
         }
         private static Document CreateExpectedDocumentForVersion(ItemStorage storage)
         {
@@ -220,14 +219,14 @@ namespace Amazon.DynamoDBv2.DataModel
             if (attributes.Count != properties.Count)
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, 
                     "Number of {0} keys on table {1} does not match number of hash keys on type {2}",
-                    keyType, table.TableName, config.TargetTypeInfo.FullName));
+                    keyType, table.TableName, config.TargetType.FullName));
             foreach (string hashProperty in properties)
             {
                 PropertyStorage property = config.GetPropertyStorage(hashProperty);
                 if (!attributes.Contains(property.AttributeName))
                     throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, 
                         "Key property {0} on type {1} does not correspond to a {2} key on table {3}",
-                        hashProperty, config.TargetTypeInfo.FullName, keyType, table.TableName));
+                        hashProperty, config.TargetType.FullName, keyType, table.TableName));
             }
         }
 
@@ -437,15 +436,13 @@ namespace Amazon.DynamoDBv2.DataModel
         }
         private bool TryFromList(Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
         {
-            var targetTypeWrapper = TypeFactory.GetTypeInfo(targetType);
-            return targetTypeWrapper.IsArray ?
+            return targetType.IsArray ?
                  TryFromListToArray(targetType, list, flatConfig, out output) : //targetType is Array
                  TryFromListToIList(targetType, list, flatConfig, out output) ; //targetType is IList or has Add method.
         }
 
         private bool TryFromListToIList(Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
         {
-            var targetTypeWrapper = TypeFactory.GetTypeInfo(targetType);
             if ((!Utils.ImplementsInterface(targetType, typeof(ICollection<>)) &&
                 !Utils.ImplementsInterface(targetType, typeof(IList))) ||
                 !Utils.CanInstantiate(targetType))
@@ -454,7 +451,7 @@ namespace Amazon.DynamoDBv2.DataModel
                 return false;
             }
 
-            var elementType = targetTypeWrapper.GetGenericArguments()[0];
+            var elementType = targetType.GetGenericArguments()[0];
             var collection = Utils.Instantiate(targetType);
             IList ilist = collection as IList;
             bool useIListInterface = ilist != null;
@@ -463,7 +460,7 @@ namespace Amazon.DynamoDBv2.DataModel
             MethodInfo collectionAdd = null;
             if (!useIListInterface)
             {
-                collectionAdd = targetTypeWrapper.GetMethod("Add");
+                collectionAdd = targetType.GetMethod("Add");
             }
 
             foreach (DynamoDBEntry entry in list.Entries)
@@ -579,9 +576,8 @@ namespace Amazon.DynamoDBv2.DataModel
         {
             output = null;
 
-            ITypeInfo typeWrapper;
             Type keyType, valueType;
-            if (!IsSupportedDictionaryType(type, out typeWrapper, out keyType, out valueType))
+            if (!IsSupportedDictionaryType(type, out keyType, out valueType))
                 return false;
 
             var idictionary = value as IDictionary;
@@ -642,7 +638,6 @@ namespace Amazon.DynamoDBv2.DataModel
         }
         private bool TryToScalar(object value, Type type, DynamoDBFlatConfig flatConfig, ref DynamoDBEntry entry)
         {
-            var typeWrapper = TypeFactory.GetTypeInfo(type);
             var elementType = Utils.GetElementType(type);
             if (elementType != null)
             {
@@ -652,7 +647,7 @@ namespace Amazon.DynamoDBv2.DataModel
                 if (enumerable == null || value is string)
                 {
                     // Only convert if value matches collection element type
-                    if (TypeFactory.GetTypeInfo(value.GetType()).IsAssignableFrom(TypeFactory.GetTypeInfo(elementType)))
+                    if (value.GetType().IsAssignableFrom(elementType))
                     {
                         DynamoDBEntryConversion conversion = flatConfig.Conversion;
                         if (conversion.HasConverter(elementType))
@@ -678,22 +673,19 @@ namespace Amazon.DynamoDBv2.DataModel
 
         private static bool IsSupportedDictionaryType(Type type, out Type valueType)
         {
-            ITypeInfo typeWrapper;
             Type keyType;
-            return IsSupportedDictionaryType(type, out typeWrapper, out keyType, out valueType);
+            return IsSupportedDictionaryType(type, out keyType, out valueType);
         }
-        private static bool IsSupportedDictionaryType(Type type, out ITypeInfo typeWrapper, out Type keyType, out Type valueType)
+        private static bool IsSupportedDictionaryType(Type type, out Type keyType, out Type valueType)
         {
             keyType = valueType = null;
-            typeWrapper = null;
 
             // Type must implement both IDictionary<TKey,TValue> and IDictionary
             if (!(Utils.ImplementsInterface(type, typeof(IDictionary<,>)) &&
                  Utils.ImplementsInterface(type, typeof(IDictionary))))
                 return false;
 
-            typeWrapper = TypeFactory.GetTypeInfo(type);
-            var genericArguments = typeWrapper.GetGenericArguments();
+            var genericArguments = type.GetGenericArguments();
             if (genericArguments.Length != 2)
                 return false;
             keyType = genericArguments[0];

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -230,7 +230,7 @@ namespace Amazon.DynamoDBv2.DataModel
         public List<PropertyStorage> Properties { get; private set; }
 
         // target type
-        public ITypeInfo TargetTypeInfo { get; private set; }
+        public Type TargetType { get; private set; }
 
         // target type members
         public Dictionary<string, MemberInfo> TargetTypeMembers { get; private set; }
@@ -306,11 +306,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return true;
         }
 
-        private static Dictionary<string, MemberInfo> GetMembersDictionary(ITypeInfo typeInfo)
+        private static Dictionary<string, MemberInfo> GetMembersDictionary(Type type)
         {
             Dictionary<string, MemberInfo> dictionary = new Dictionary<string, MemberInfo>(StringComparer.Ordinal);
 
-            var members = typeInfo
+            var members = type
                 .GetMembers()
                 .Where(IsValidMemberInfo)
                 .ToList();
@@ -324,21 +324,20 @@ namespace Amazon.DynamoDBv2.DataModel
 
         
         // constructor
-        public StorageConfig(ITypeInfo targetTypeInfo)
+        public StorageConfig(Type targetType)
         {
-            var type = targetTypeInfo.Type;
-            if (!Utils.CanInstantiate(type))
+            if (!Utils.CanInstantiate(targetType))
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
-                    "Type {0} is unsupported, it cannot be instantiated", targetTypeInfo.FullName));
+                    "Type {0} is unsupported, it cannot be instantiated", targetType.FullName));
 
-            TargetTypeInfo = targetTypeInfo;
+            TargetType = targetType;
             Properties = new List<PropertyStorage>();
             PropertyToPropertyStorageMapping = new Dictionary<string, PropertyStorage>(StringComparer.Ordinal);
-            TargetTypeMembers = GetMembersDictionary(targetTypeInfo);
+            TargetTypeMembers = GetMembersDictionary(targetType);
 
             if (TargetTypeMembers.Count == 0)
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
-                    "Type {0} is unsupported, it has no supported members", targetTypeInfo.FullName));
+                    "Type {0} is unsupported, it has no supported members", targetType.FullName));
         }
     }
     
@@ -479,7 +478,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
             if (this.Properties.Count == 0)
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
-                    "Type {0} is unsupported, it has no supported members", TargetTypeInfo.FullName));
+                    "Type {0} is unsupported, it has no supported members", TargetType.FullName));
         }
 
         private void AddPropertyStorage(PropertyStorage value)
@@ -554,8 +553,8 @@ namespace Amazon.DynamoDBv2.DataModel
 
 
         // constructor
-        public ItemStorageConfig(ITypeInfo targetTypeInfo)
-            : base(targetTypeInfo)
+        public ItemStorageConfig(Type targetType)
+            : base(targetType)
         {
             AttributeToIndexesNameMapping = new Dictionary<string, List<string>>(StringComparer.Ordinal);
             IndexNameToLSIRangePropertiesMapping = new Dictionary<string, List<string>>(StringComparer.Ordinal);
@@ -691,11 +690,12 @@ namespace Amazon.DynamoDBv2.DataModel
         }
         private ItemStorageConfig CreateStorageConfig(Type baseType, string actualTableName)
         {
-            if (baseType == null) throw new ArgumentNullException("baseType");
-            ITypeInfo typeInfo = TypeFactory.GetTypeInfo(baseType);
-            ItemStorageConfig config = new ItemStorageConfig(typeInfo);
+            if (baseType == null) 
+                throw new ArgumentNullException("baseType");
 
-            PopulateConfigFromType(config, typeInfo);
+            ItemStorageConfig config = new ItemStorageConfig(baseType);
+
+            PopulateConfigFromType(config, baseType);
             PopulateConfigFromMappings(config, AWSConfigsDynamoDB.Context.TypeMappings);
 
             // try to populate config from table definition only if actual table name is known
@@ -721,12 +721,12 @@ namespace Amazon.DynamoDBv2.DataModel
             return config;
         }
 
-        private static void PopulateConfigFromType(ItemStorageConfig config, ITypeInfo typeInfo)
+        private static void PopulateConfigFromType(ItemStorageConfig config, Type type)
         {
-            DynamoDBTableAttribute tableAttribute = Utils.GetTableAttribute(typeInfo);
+            DynamoDBTableAttribute tableAttribute = Utils.GetTableAttribute(type);
             if (tableAttribute == null)
             {
-                config.TableName = typeInfo.Name;
+                config.TableName = type.Name;
             }
             else
             {
@@ -739,7 +739,7 @@ namespace Amazon.DynamoDBv2.DataModel
             if (AWSConfigsDynamoDB.Context.TableAliases.TryGetValue(config.TableName, out tableAlias))
                 config.TableName = tableAlias;
 
-            foreach (var member in typeInfo.GetMembers())
+            foreach (var member in type.GetMembers())
             {
                 if (!StorageConfig.IsValidMemberInfo(member))
                     continue;
@@ -875,7 +875,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
         private static void PopulateConfigFromMappings(ItemStorageConfig config, Dictionary<Type, TypeMapping> typeMappings)
         {
-            var baseType = config.TargetTypeInfo.Type;
+            var baseType = config.TargetType;
             TypeMapping typeMapping;
             if (typeMappings.TryGetValue(baseType, out typeMapping))
             {

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
@@ -29,6 +29,8 @@ namespace Amazon.DynamoDBv2.DataModel
 {
     internal static class Utils
     {
+        private static readonly Type[] EmptyTypes = new Type[0];
+
         #region Type methods
 
         private static readonly Type[] primitiveTypesArray = new Type[]
@@ -55,13 +57,10 @@ namespace Amazon.DynamoDBv2.DataModel
         };
 
         public static readonly IEnumerable<Type> PrimitiveTypes = new HashSet<Type>(primitiveTypesArray);
-        private static readonly HashSet<ITypeInfo> PrimitiveTypeInfos = new HashSet<ITypeInfo>(primitiveTypesArray
-            .Select(p => TypeFactory.GetTypeInfo(p)));
 
         public static bool IsPrimitive(Type type)
         {
-            var typeWrapper = TypeFactory.GetTypeInfo(type);
-            return PrimitiveTypeInfos.Any(ti => typeWrapper.IsAssignableFrom(ti));
+            return PrimitiveTypes.Any(ti => type.IsAssignableFrom(ti));
         }
         public static bool IsPrimitive<T>()
         {
@@ -80,16 +79,15 @@ namespace Amazon.DynamoDBv2.DataModel
 
         public static void ValidateVersionType(Type memberType)
         {
-            var memberTypeWrapper = TypeFactory.GetTypeInfo(memberType);
-            if (memberTypeWrapper.IsGenericType && memberTypeWrapper.GetGenericTypeDefinition() == typeof(Nullable<>) &&
-                (memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(Byte))) ||
-                memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(SByte))) ||
-                memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(int))) ||
-                memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(uint))) ||
-                memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(long))) ||
-                memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(ulong))) ||
-                memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(short))) ||
-                memberTypeWrapper.IsAssignableFrom(TypeFactory.GetTypeInfo(typeof(ushort)))))
+            if (memberType.IsGenericType && memberType.GetGenericTypeDefinition() == typeof(Nullable<>) &&
+                (memberType.IsAssignableFrom(typeof(Byte)) ||
+                memberType.IsAssignableFrom(typeof(SByte)) ||
+                memberType.IsAssignableFrom(typeof(int)) ||
+                memberType.IsAssignableFrom(typeof(uint)) ||
+                memberType.IsAssignableFrom(typeof(long)) ||
+                memberType.IsAssignableFrom(typeof(ulong)) ||
+                memberType.IsAssignableFrom(typeof(short)) ||
+                memberType.IsAssignableFrom(typeof(ushort))))
             {
                 return;
             }
@@ -114,8 +112,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
             if (elementType == null)
             {
-                var collectionTypeInfo = TypeFactory.GetTypeInfo(collectionType);
-                var genericArguments = collectionTypeInfo.GetGenericArguments();
+                var genericArguments = collectionType.GetGenericArguments();
                 if (genericArguments != null && genericArguments.Length == 1)
                     elementType = genericArguments[0];
             }
@@ -143,8 +140,7 @@ namespace Amazon.DynamoDBv2.DataModel
                 return true;
             }
 
-            var targetTypeInfo = TypeFactory.GetTypeInfo(targetType);
-            var addMethod = targetTypeInfo.GetMethod("Add");
+            var addMethod = targetType.GetMethod("Add");
             if (addMethod != null)
             {
                 foreach (var item in items)
@@ -174,18 +170,18 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #region Attribute methods
 
-        public static DynamoDBTableAttribute GetTableAttribute(ITypeInfo targetTypeInfo)
+        public static DynamoDBTableAttribute GetTableAttribute(Type targetType)
         {
-            DynamoDBTableAttribute tableAttribute = GetAttribute(targetTypeInfo) as DynamoDBTableAttribute;
+            DynamoDBTableAttribute tableAttribute = GetAttribute(targetType) as DynamoDBTableAttribute;
             if (tableAttribute == null)
                 return null;
             return tableAttribute;
         }
 
-        public static DynamoDBAttribute GetAttribute(ITypeInfo targetTypeInfo)
+        public static DynamoDBAttribute GetAttribute(Type targetType)
         {
-            if (targetTypeInfo == null) throw new ArgumentNullException("targetTypeInfo");
-            object[] attributes = targetTypeInfo.GetCustomAttributes(TypeFactory.GetTypeInfo(typeof(DynamoDBAttribute)), true);
+            if (targetType == null) throw new ArgumentNullException("targetType");
+            object[] attributes = targetType.GetCustomAttributes(typeof(DynamoDBAttribute), true);
             return GetSingleDDBAttribute(attributes);
         }
         public static DynamoDBAttribute GetAttribute(MemberInfo targetMemberInfo)
@@ -238,19 +234,19 @@ namespace Amazon.DynamoDBv2.DataModel
             return sb.ToString();
         }
 
-        private static ITypeInfo[][] validConstructorInputs = new ITypeInfo[][]
+        private static Type[][] validConstructorInputs = new Type[][]
         {
-            TypeFactory.EmptyTypes,
+            EmptyTypes,
         };
-        private static ITypeInfo[][] validArrayConstructorInputs = new ITypeInfo[][]
+        private static Type[][] validArrayConstructorInputs = new Type[][]
         {
             //supports one dimension Array only
-            new ITypeInfo[] { TypeFactory.GetTypeInfo(typeof(int)) } 
+            new Type[] { typeof(int) } 
         };
-        private static ITypeInfo[][] validConverterConstructorInputs = new ITypeInfo[][]
+        private static Type[][] validConverterConstructorInputs = new Type[][]
         {
-            TypeFactory.EmptyTypes,
-            new ITypeInfo[] { TypeFactory.GetTypeInfo(typeof(DynamoDBContext)) }
+            EmptyTypes,
+            new Type[] { typeof(DynamoDBContext) }
         };
 
         public static object InstantiateConverter(Type objectType, IDynamoDBContext context)
@@ -265,15 +261,14 @@ namespace Amazon.DynamoDBv2.DataModel
         {
             return InstantiateHelper(objectType, validConstructorInputs, null);
         }
-        private static object InstantiateHelper(Type objectType, ITypeInfo[][] validConstructorInputs, object[] optionalInput = null)
+        private static object InstantiateHelper(Type objectType, Type[][] validConstructorInputs, object[] optionalInput = null)
         {
             if (objectType == null)
                 throw new ArgumentNullException("objectType");
             if (!CanInstantiateHelper(objectType, validConstructorInputs))
                 throw new InvalidOperationException("Cannot instantiate type " + objectType.FullName);
 
-            var objectTypeWrapper = TypeFactory.GetTypeInfo(objectType);
-            var constructors = GetConstructors(objectTypeWrapper, validConstructorInputs).ToList();
+            var constructors = GetConstructors(objectType, validConstructorInputs).ToList();
 
             if (constructors != null && constructors.Count > 0)
             {
@@ -289,7 +284,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
             throw new InvalidOperationException("Unable to find valid constructor for type " + objectType.FullName);
         }
-        private static IEnumerable<ConstructorInfo> GetConstructors(ITypeInfo typeInfo, ITypeInfo[][] validConstructorInputs)
+        private static IEnumerable<ConstructorInfo> GetConstructors(Type typeInfo, Type[][] validConstructorInputs)
         {
             foreach(var inputTypes in validConstructorInputs)
             {
@@ -311,9 +306,9 @@ namespace Amazon.DynamoDBv2.DataModel
         {
             return CanInstantiateHelper(objectType, validConverterConstructorInputs);
         }
-        private static bool CanInstantiateHelper(Type objectType, ITypeInfo[][] validConstructorInputs)
+        private static bool CanInstantiateHelper(Type objectType, Type[][] validConstructorInputs)
         {
-            var objectTypeWrapper = TypeFactory.GetTypeInfo(objectType);
+            var objectTypeWrapper = objectType;
 
             bool candidate =
                 //objectType.IsPublic &&
@@ -362,19 +357,16 @@ namespace Amazon.DynamoDBv2.DataModel
         }
         public static bool ImplementsInterface(Type targetType, Type interfaceType)
         {
-            var targetTypeWrapper = TypeFactory.GetTypeInfo(targetType);
-            var interfaceTypeWrapper = TypeFactory.GetTypeInfo(interfaceType);
-            if (!interfaceTypeWrapper.IsInterface)
+            if (!interfaceType.IsInterface)
                 throw new ArgumentOutOfRangeException("interfaceType", "Type is not an interface");
 
-            foreach (var inter in targetTypeWrapper.GetInterfaces())
+            foreach (var inter in targetType.GetInterfaces())
             {
-                var interWrapper = TypeFactory.GetTypeInfo(inter);
-                if (object.Equals(interWrapper, interfaceTypeWrapper))
+                if (object.Equals(inter, interfaceType))
                     return true;
-                if (interfaceTypeWrapper.IsGenericTypeDefinition && interWrapper.IsGenericType)
+                if (inter.IsGenericTypeDefinition && inter.IsGenericType)
                 {
-                    var generic = interWrapper.GetGenericTypeDefinition();
+                    var generic = inter.GetGenericTypeDefinition();
                     if (generic == interfaceType)
                         return true;
                 }

--- a/sdk/src/Services/EC2/Custom/AmazonEC2Client.Extensions.cs
+++ b/sdk/src/Services/EC2/Custom/AmazonEC2Client.Extensions.cs
@@ -110,8 +110,7 @@ namespace Amazon.EC2
                     _methodCache = new Dictionary<Type, DryRunInfo>();
 
                     var ec2RequestType = typeof(AmazonEC2Request);
-                    var ec2RequestTypeInfo = TypeFactory.GetTypeInfo(ec2RequestType);
-                    var allMembers = TypeFactory.GetTypeInfo(typeof(AmazonEC2Client)).GetMembers();
+                    var allMembers = typeof(AmazonEC2Client).GetMembers();
                     foreach (var member in allMembers)
                     {
                         MethodInfo method = member as MethodInfo;
@@ -130,8 +129,7 @@ namespace Amazon.EC2
 
                         // The input parameter must extend EC2Request, but must not be EC2Request
                         var inputType = parameters[0].ParameterType;
-                        var inputTypeInfo = TypeFactory.GetTypeInfo(inputType);
-                        if (inputType == ec2RequestType || !ec2RequestTypeInfo.IsAssignableFrom(inputTypeInfo))
+                        if (inputType == ec2RequestType || !ec2RequestType.IsAssignableFrom(inputType))
                             continue;
 
                         // Method name must match: [Name]Request = [InputTypeName]


### PR DESCRIPTION
## Description
This PR is to the staging `feature/net6` branch where also trying to address Native AOT trimming warnings.

The SDK abstracted away type information through `Amazon.Util.Internal.TypeFactory` and `Amazon.Util.Internal.ITypeInfo`. This was necessary when the SDK supported .NET Standard 1.3 and the `System.Type` type in .NET Standard 1.3 did not have all of the same properties and methods as .NET Framework version did. With .NET Standard 2.0 `System.Type` is now the same, at least for our purposes, between .NET Standard 2.0+ and .NET Framework.

The abstraction was making it difficult to apply the AOT trimming attributes because they can only be set on `System.Type` not our abstraction. Since it is not needed in our SDK because we dropped .NET Standard 1.3 support in 3.7 the usage has been completely removed from the SDK. The `TypeFactory` was left in the SDK for backwards compatibility if a user ends up with a new core but an old service package that relied on `TypeFactory`. To confirm I removed the usage of `TypeFactory` I first deleted `TypeFactory` and then fixed all compile errors in the SDK. Then added back `TypeFactory` with the `Obsolete` attribute.


## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement