### PR TITLE
AOT trimming warning fixes

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/ConstantClass.cs
+++ b/sdk/src/Core/Amazon.Runtime/ConstantClass.cs
@@ -21,6 +21,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -87,7 +88,11 @@ namespace Amazon.Runtime
             return map.TryGetValue(this.Value, out foundValue) ? foundValue : this;
         }
 
+#if NET6_0_OR_GREATER
+        protected static T FindValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string value) where T : ConstantClass
+#else
         protected static T FindValue<T>(string value) where T : ConstantClass
+#endif
         {
             if (value == null)
                 return null;
@@ -107,7 +112,11 @@ namespace Amazon.Runtime
             return foundValue as T;
         }
 
+#if NET6_0_OR_GREATER
+        private static void LoadFields([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
+#else
         private static void LoadFields(Type type)
+#endif
         {
             if (staticFields.ContainsKey(type))
                 return;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
@@ -27,6 +27,9 @@ namespace Amazon.Runtime.Internal.Util
     /// <summary>
     /// Logger wrapper for reflected log4net logging methods.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("SDK logging to Log4net is not supported when trimming is enabled.")]
+#endif
     internal class InternalLog4netLogger : InternalLogger
     {
         enum LoadState { Uninitialized, Failed, Loading, Success };
@@ -85,7 +88,7 @@ namespace Amazon.Runtime.Internal.Util
 
                     getLoggerWithTypeMethod = logMangerType.GetMethod("GetLogger", new Type[] { typeof(Assembly), typeof(Type) });
 
-                    // The ILog and its methdods
+                    // The ILog and its methods
                     logType = Type.GetType("log4net.Core.ILogger, log4net");
 
                     levelType = Type.GetType("log4net.Core.Level, log4net");

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
@@ -21,6 +21,7 @@ using System.Reflection;
 using System.Text;
 using System.ComponentModel;
 using Amazon.Runtime;
+using Amazon.Util.Internal;
 
 namespace Amazon.Runtime.Internal.Util
 {
@@ -42,8 +43,14 @@ namespace Amazon.Runtime.Internal.Util
         {
             loggers = new List<InternalLogger>();
 
-            InternalLog4netLogger log4netLogger = new InternalLog4netLogger(type);
-            loggers.Add(log4netLogger);
+            if(!InternalSDKUtils.IsRunningNativeAot())
+            {
+#pragma warning disable
+                InternalLog4netLogger log4netLogger = new InternalLog4netLogger(type);
+                loggers.Add(log4netLogger);
+#pragma warning restore
+            }
+
             loggers.Add(new InternalConsoleLogger(type));
             InternalSystemDiagnosticsLogger sdLogger = new InternalSystemDiagnosticsLogger(type);
             loggers.Add(sdLogger);

--- a/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util.Internal.PlatformServices;
 
@@ -240,6 +241,20 @@ namespace Amazon.Util.Internal
 
             //Test if the target file is a child of directoryPath
             return fileInfo.FullName.StartsWith(dirInfo.FullName);
+        }
+
+        /// <summary>
+        /// Returns true if the SDK is being run in an NativeAOT environment.
+        /// </summary>
+        /// <returns></returns>
+        public static bool IsRunningNativeAot()
+        {
+#if NET6_0_OR_GREATER
+            // If dynamic code is not supported we are most likely running in an AOT environment. 
+            return !RuntimeFeature.IsDynamicCodeSupported;
+#else
+        return false;
+#endif
         }
 
         #region IsSet methods


### PR DESCRIPTION
## Description
This PR disable's the Log4net SDK logger since that relies completely on reflection code loading from assemblies by string name. Long term we need to rethink how SDK logging is done that gets rid of this dynamic behavior.

It also adds the `DynamicallyAccessedMembers` attributes to the `ConstantClass` base class to make them trimming compatible.

