### PR TITLE
Mark JsonMapper with RequiresUnreferencedCode

### DIFF
--- a/sdk/src/Core/ThirdParty/Json/JsonMapper.cs
+++ b/sdk/src/Core/ThirdParty/Json/JsonMapper.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -170,6 +171,10 @@ namespace ThirdParty.Json.LitJson
 
 
         #region Private Methods
+
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         private static void AddArrayMetadata (Type type)
         {
             if (array_metadata.ContainsKey (type))
@@ -205,6 +210,9 @@ namespace ThirdParty.Json.LitJson
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         private static void AddObjectMetadata (Type type)
         {
             if (object_metadata.ContainsKey (type))
@@ -260,6 +268,9 @@ namespace ThirdParty.Json.LitJson
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         private static void AddTypeProperties (Type type)
         {
             if (type_properties.ContainsKey (type))
@@ -296,6 +307,9 @@ namespace ThirdParty.Json.LitJson
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         private static MethodInfo GetConvOp (Type t1, Type t2)
         {
             lock (conv_ops_lock) {
@@ -320,6 +334,9 @@ namespace ThirdParty.Json.LitJson
             return op;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         private static object ReadValue (Type inst_type, JsonReader reader)
         {
             reader.Read ();
@@ -488,6 +505,9 @@ namespace ThirdParty.Json.LitJson
             return instance;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         private static void ValidateRequiredFields(object instance, Type inst_type)
         {
             foreach (var prop in inst_type.GetProperties())
@@ -743,6 +763,9 @@ namespace ThirdParty.Json.LitJson
             table[json_type][value_type] = importer;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         private static void WriteValue (object obj, JsonWriter writer,
                                         bool writer_is_private,
                                         int depth)
@@ -894,7 +917,9 @@ namespace ThirdParty.Json.LitJson
         }
         #endregion
 
-
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         public static string ToJson (object obj)
         {
             lock (static_writer_lock) {
@@ -906,6 +931,9 @@ namespace ThirdParty.Json.LitJson
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         public static void ToJson (object obj, JsonWriter writer)
         {
             WriteValue (obj, writer, false, 0);
@@ -931,11 +959,17 @@ namespace ThirdParty.Json.LitJson
                 delegate { return new JsonData (); }, json);
         }
 
-        public static T ToObject<T> (JsonReader reader)
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
+        public static T ToObject<T>(JsonReader reader)
         {
             return (T) ReadValue (typeof (T), reader);
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         public static T ToObject<T> (TextReader reader)
         {
             JsonReader json_reader = new JsonReader (reader);
@@ -943,6 +977,9 @@ namespace ThirdParty.Json.LitJson
             return (T) ReadValue (typeof (T), json_reader);
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
+#endif
         public static T ToObject<T> (string json)
         {
             JsonReader reader = new JsonReader (json);


### PR DESCRIPTION
The JsonMapper is used to convert between JSON to .NET types. This requires reflection over unknown types which isn't compatible with Native AOT.

This PR marks JsonMapper with the `RequiresUnreferencedCode` attribute which triggers new warnings where ever it is called. Future PRs will come that for .NET 6 replace the usage of JsonMapper with System.Text.Json with its source generator context to make it compatible with Native AOT.