### PR TITLE
Increase Credentials Lock Timeout for Default Instance Profile Credentials

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultInstanceProfileAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultInstanceProfileAWSCredentials.cs
@@ -39,7 +39,7 @@ namespace Amazon.Runtime
         private static readonly TimeSpan _neverTimespan = TimeSpan.FromMilliseconds(-1);
         private static readonly TimeSpan _refreshRate = TimeSpan.FromMinutes(2); // EC2 refreshes credentials 5 min before expiration
         private const string FailedToGetCredentialsMessage = "Failed to retrieve credentials from EC2 Instance Metadata Service.";
-        private static readonly TimeSpan _credentialsLockTimeout = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan _credentialsLockTimeout = TimeSpan.FromMinutes(1);
 
         /// <summary>
         /// Control flag: in the event IMDS returns an expired credential, a refresh must be immediately


### PR DESCRIPTION
## Motivation and Context
This PR aims to solve https://github.com/aws/aws-sdk-net/issues/1945 by increasing the lock timeout from 5 seconds to a minute. Fetching of credentials can take more than 5 seconds, which will cause the read & write lock wait to expire for other threads, returning the exception `Failed to retrieve credentials from EC2 Instance Metadata Service.`.

I believe the issue was introduced in https://github.com/aws/aws-sdk-net/commit/f75a60855736be1c947a1cb1200e882fca24ffc0.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement