### PR TITLE
AOT: Add utility json deserialization method 

### DIFF
--- a/sdk/src/Core/Amazon.Util/EC2InstanceMetadata.cs
+++ b/sdk/src/Core/Amazon.Util/EC2InstanceMetadata.cs
@@ -26,6 +26,7 @@ using System.Globalization;
 using Amazon.Runtime.Internal.Util;
 using AWSSDK.Runtime.Internal.Util;
 using Amazon.Runtime.Internal;
+using Amazon.Util.Internal;
 
 namespace Amazon.Util
 {
@@ -348,7 +349,7 @@ namespace Amazon.Util
                 IAMInstanceProfileMetadata info;
                 try
                 {
-                    info = JsonMapper.ToObject<IAMInstanceProfileMetadata>(json);
+                    info = JsonSerializerHelper.Deserialize<IAMInstanceProfileMetadata>(json, EC2InstanceMetadataJsonSerializerContexts.Default);
                 }
                 catch
                 {
@@ -380,7 +381,7 @@ namespace Amazon.Util
                     var json = GetData("/iam/security-credentials/" + item);
                     try
                     {
-                        var cred = JsonMapper.ToObject<IAMSecurityCredentialMetadata>(json);
+                        var cred = JsonSerializerHelper.Deserialize<IAMSecurityCredentialMetadata>(json, EC2InstanceMetadataJsonSerializerContexts.Default);
                         creds[item] = cred;
                     }
                     catch

--- a/sdk/src/Core/Amazon.Util/Internal/JsonSerializerHelper.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/JsonSerializerHelper.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+#if NET6_0_OR_GREATER
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+#endif
+
+namespace Amazon.Util.Internal
+{
+    public static class JsonSerializerHelper
+    {
+#if NET6_0_OR_GREATER
+        public static T Deserialize<T>(string json, JsonSerializerContext context)
+        {
+            return JsonSerializer.Deserialize<T>(json, context.GetTypeInfo(typeof(T)) as JsonTypeInfo<T>);
+        }
+#else
+        public static T Deserialize<T>(string json, object typeInfo)
+        {
+            return ThirdParty.Json.LitJson.JsonMapper.ToObject<T>(json);
+        }
+#endif
+    }
+
+    [JsonSerializable(typeof(IAMInstanceProfileMetadata))]
+    [JsonSerializable(typeof(IAMSecurityCredentialMetadata))]
+    public partial class EC2InstanceMetadataJsonSerializerContexts : JsonSerializerContext
+    {
+    }
+
+
+    // For targets below .NET 6 create stub versions of the System.Text.Json types so that the context objects can still compile.
+    // None of these type are actually used because the JSON parsing ends up using JsonMapper from LitJson for targets below .NET 6.
+    // Doing this allows the SDK to have a single JsonSerializerHelper.Deserialize method to use throughout the SDK to handle JSON marshalling.
+#if !NET6_0_OR_GREATER
+    public class JsonSerializerContext
+    {
+        public JsonSerializerContext() { }
+
+        public JsonSerializerContext(JsonSerializerOptions DefaultOptions) { }
+
+        public static JsonSerializerContext Default { get; set; }
+    }
+
+    public class JsonSerializerOptions
+    {
+        public bool PropertyNameCaseInsensitive { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    internal sealed class JsonSerializableAttribute : Attribute { internal JsonSerializableAttribute(Type type) { } }
+#endif
+}

--- a/sdk/test/NetStandard/UnitTests/AWSSDK.UnitTests.Custom.NetStandard.csproj
+++ b/sdk/test/NetStandard/UnitTests/AWSSDK.UnitTests.Custom.NetStandard.csproj
@@ -6,7 +6,7 @@ This project file should not be used as part of a release pipeline.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
         <DefineConstants>$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
         <DebugType>portable</DebugType>
         <PackageId>UnitTests</PackageId>
@@ -44,10 +44,13 @@ This project file should not be used as part of a release pipeline.
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-        <PackageReference Include="xunit" Version="2.2.0" />
-        <PackageReference Include="Moq" Version="4.8.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="Moq" Version="4.18.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/sdk/test/NetStandard/UnitTests/JsonSerializationTests.cs
+++ b/sdk/test/NetStandard/UnitTests/JsonSerializationTests.cs
@@ -1,0 +1,16 @@
+﻿using Amazon.Util.Internal;
+using Amazon.Util;
+using Xunit;
+
+namespace UnitTests.NetStandard
+{
+    public class JsonSerializationTests
+    {
+        [Fact]
+        public void DeserializeCaseInsensitive()
+        {
+            var obj = JsonSerializerHelper.Deserialize<IAMInstanceProfileMetadata>("{\"Code\": \"foo\"}", EC2InstanceMetadataJsonSerializerContexts.Default);
+            Assert.Equal("foo", obj.Code);
+        }
+    }
+}


### PR DESCRIPTION
To support AOT we need to remove the usage inside the SDK of LitJson's JsonMapper which is not AOT safe. This PR adds a new `Amazon.Util.Internal.JsonSerializerHelper.Deserialize` common utility for handling deserialization. There are 2 different implementations of the method. .NET 6+ it uses System.Text.Json along with a `JsonSerializerContext` that uses a source generator to generate all of the deserialization code at compile removing reflection. For older .NET targets continue to use `JsonMapper`.

The goal is through the SDK you can replace the calls for `JsonMapper` with `JsonSerializerHelper.Deserialize` after defining your own `JsonSerializerContext`. So the code compiles with the same line of code regardless of targets stub classes were added for targets less then .NET 6 for the missing `System.Text.Json` types. Those types are not used for anything other then making a compatible method signature.

Initially I was trying to do some work to make sure the System.Text.Json usage was handling things case insensitively. That was proving to be challenging to get work in an abstract way that also didn't break for .NET Framework. Then I discovered that `JsonMapper` was already doing things case sensitive so I simplified the code and got rid of handling case insensitive names.