### PR TITLE
Add async version of RDSAuthTokenGenerator GenerateAuthToken

### DIFF
--- a/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
+++ b/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
@@ -122,6 +122,35 @@ namespace Amazon.RDS.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
+            var immutableCredentials = credentials.GetCredentials();
+            return GenerateAuthToken(immutableCredentials, region, hostname, port, dbUser);
+        }
+
+#if AWS_ASYNC_API
+        /// <summary>
+        /// Generate a token for IAM authentication to an RDS database.
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="region">The region of the RDS database.</param>
+        /// <param name="hostname">Hostname of the RDS database.</param>
+        /// <param name="port">Port of the RDS database.</param>
+        /// <param name="dbUser">Database user for the token.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateAuthTokenAsync(AWSCredentials credentials, RegionEndpoint region, string hostname, int port, string dbUser)
+        {
+            if (credentials == null)
+                throw new ArgumentNullException("credentials");
+
+            var immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            return GenerateAuthToken(immutableCredentials, region, hostname, port, dbUser);
+        }
+#endif
+
+        private static string GenerateAuthToken(ImmutableCredentials immutableCredentials, RegionEndpoint region, string hostname, int port, string dbUser)
+        {
+            if (immutableCredentials == null)
+                throw new ArgumentNullException("immutableCredentials");
+
             if (region == null)
                 throw new ArgumentNullException("region");
 
@@ -146,7 +175,6 @@ namespace Amazon.RDS.Util
             request.Parameters.Add(ActionKey, ActionValue);
             request.Endpoint = new UriBuilder(HTTPS, hostname, port).Uri;
 
-            var immutableCredentials = credentials.GetCredentials();
             if (immutableCredentials.UseToken)
             {
                 request.Parameters[XAmzSecurityToken] = immutableCredentials.Token;

--- a/sdk/test/Services/RDS/UnitTests/Custom/RDSAuthTokenGeneratorTest.cs
+++ b/sdk/test/Services/RDS/UnitTests/Custom/RDSAuthTokenGeneratorTest.cs
@@ -62,6 +62,24 @@ namespace AWSSDK.UnitTests.RDS
             FallbackCredentialsFactory.CredentialsGenerators = originalFallbackList;
         }
 
+#if ASYNC_AWAIT
+        [TestMethod]
+        [TestCategory("RDS")]
+        public async System.Threading.Tasks.Task GenerateAuthTokenBasicAsync()
+        {
+            AssertAuthToken(await RDSAuthTokenGenerator.GenerateAuthTokenAsync(BasicCredentials,
+                AWSRegion, DBHost, DBPort, DBUser), AccessKey, AWSRegion);
+        }
+
+        [TestMethod]
+        [TestCategory("RDS")]
+        public async System.Threading.Tasks.Task GenerateAuthTokenSessionAsync()
+        {
+            AssertAuthToken(await RDSAuthTokenGenerator.GenerateAuthTokenAsync(SessionCredentials,
+                AWSRegion, DBHost, DBPort, DBUser), AccessKey, AWSRegion, true);
+        }
+#endif
+
         [TestMethod]
         [TestCategory("RDS")]
         public void GenerateAuthTokenBasic()


### PR DESCRIPTION
https://github.com/aws/aws-sdk-net/issues/2628

## Description
Per feature request https://github.com/aws/aws-sdk-net/issues/2628 added an async version of the RDSAuthTokenGenerator method GenerateAuthToken. The `GetCredential` call is where there could be a async over sync call which is was refactored out of the method to put all of the shared logic into new private method that works with the resolved credentials.

