### PR TITLE
Add DynamoDBContextConfig.DisableFetchingTableMetadata to skip the internal DescribeTable call if the index structure is provided statically

### DIFF
--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -45,7 +45,7 @@ namespace Amazon
     ///   &lt;proxy host="localhost" port="8888" username="1" password="1" /&gt;
     ///   
     ///   &lt;dynamoDB&gt;
-    ///     &lt;dynamoDBContext tableNamePrefix="Prod-" metadataCachingMode="Default"&gt;
+    ///     &lt;dynamoDBContext tableNamePrefix="Prod-" metadataCachingMode="Default" disableFetchingTableMetadata="false"&gt;
     /// 
     ///       &lt;tableAliases&gt;
     ///         &lt;alias fromTable="FakeTable" toTable="People" /&gt;

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -334,6 +334,11 @@ namespace Amazon.DynamoDBv2
             return ConverterCache.HasConverter(type);
         }
 
+        internal bool TryGetConverter(Type type, out Converter converter)
+        {
+            return ConverterCache.TryGetConverter(type, out converter);
+        }
+
         internal IEnumerable<DynamoDBEntry> ConvertToEntries(Type elementType, IEnumerable values)
         {
             if (values == null) throw new ArgumentNullException("values");

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -61,6 +61,7 @@ namespace Amazon.DynamoDBv2.DataModel
             TableNamePrefix = AWSConfigsDynamoDB.Context.TableNamePrefix;
             Conversion = DynamoDBEntryConversion.CurrentConversion;
             MetadataCachingMode = AWSConfigsDynamoDB.Context.MetadataCachingMode;
+            DisableFetchingTableMetadata = AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata;
         }
 
         /// <summary>
@@ -117,6 +118,17 @@ namespace Amazon.DynamoDBv2.DataModel
         /// .NET and DynamoDB types happens.
         /// </summary>
         public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <summary>
+        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
+        /// defined by<see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true can avoid latency and potential deadlocks due to the internal  <see cref="DescribeTableRequest"/> call that is used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be fully described via the above methods, otherwise exceptions may be thrown and/or 
+        /// the results of certain DynamoDB operations may change. It is recommended to test your application prior to setting it to true in production code.
+        /// </remarks>
+        public bool? DisableFetchingTableMetadata { get; set; }
     }
 
     /// <summary>
@@ -320,6 +332,8 @@ namespace Amazon.DynamoDBv2.DataModel
             bool consistentRead = operationConfig.ConsistentRead ?? contextConfig.ConsistentRead ?? false;
             bool skipVersionCheck = operationConfig.SkipVersionCheck ?? contextConfig.SkipVersionCheck ?? false;
             bool ignoreNullValues = operationConfig.IgnoreNullValues ?? contextConfig.IgnoreNullValues ?? false;
+            bool disableFetchingTableMetadata = contextConfig.DisableFetchingTableMetadata ?? false;
+
             bool isEmptyStringValueEnabled = operationConfig.IsEmptyStringValueEnabled ?? contextConfig.IsEmptyStringValueEnabled ?? false;
             string overrideTableName =
                 !string.IsNullOrEmpty(operationConfig.OverrideTableName) ? operationConfig.OverrideTableName : string.Empty;
@@ -346,6 +360,7 @@ namespace Amazon.DynamoDBv2.DataModel
             ConditionalOperator = conditionalOperator;
             Conversion = conversion;
             MetadataCachingMode = metadataCachingMode;
+            DisableFetchingTableMetadata = disableFetchingTableMetadata;
 
             State = new OperationState();
         }
@@ -434,6 +449,9 @@ namespace Amazon.DynamoDBv2.DataModel
         /// .NET and DynamoDB types happens.
         /// </summary>
         public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <inheritdoc cref="DynamoDBContextConfig.DisableFetchingTableMetadata"/>
+        public bool DisableFetchingTableMetadata { get; set; }
 
         // Checks if the IndexName is set on the config
         internal bool IsIndexOperation { get { return !string.IsNullOrEmpty(IndexName); } }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -650,7 +650,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
                     if (tableCache == null)
                     {
-                        var baseStorageConfig = CreateStorageConfig(type, actualTableName: null);
+                        var baseStorageConfig = CreateStorageConfig(type, actualTableName: null, flatConfig);
                         tableCache = new ConfigTableCache(baseStorageConfig);
                         Cache[type] = tableCache;
                     }
@@ -671,7 +671,7 @@ namespace Amazon.DynamoDBv2.DataModel
                     return config;
                 }
 
-                config = CreateStorageConfig(type, actualTableName);
+                config = CreateStorageConfig(type, actualTableName, flatConfig);
                 tableCache.Cache[actualTableName] = config;
 
                 return config;
@@ -689,7 +689,8 @@ namespace Amazon.DynamoDBv2.DataModel
         {
             return (config.LowerCamelCaseProperties ? Utils.ToLowerCamelCase(value) : value);
         }
-        private ItemStorageConfig CreateStorageConfig(Type baseType, string actualTableName)
+
+        private ItemStorageConfig CreateStorageConfig(Type baseType, string actualTableName, DynamoDBFlatConfig flatConfig)
         {
             if (baseType == null) throw new ArgumentNullException("baseType");
             ITypeInfo typeInfo = TypeFactory.GetTypeInfo(baseType);
@@ -704,7 +705,7 @@ namespace Amazon.DynamoDBv2.DataModel
                 Table table;
                 try
                 {
-                    table = Context.GetUnconfiguredTable(actualTableName);
+                    table = Context.GetUnconfiguredTable(actualTableName, flatConfig.DisableFetchingTableMetadata);
                 }
                 catch
                 {
@@ -718,6 +719,21 @@ namespace Amazon.DynamoDBv2.DataModel
             }
 
             config.Denormalize(Context);
+
+            if (flatConfig.DisableFetchingTableMetadata)
+            {
+                if (string.IsNullOrEmpty(actualTableName))
+                {
+                    actualTableName = DynamoDBContext.GetTableName(config.TableName, flatConfig);
+                }
+                var emptyConfig = new TableConfig(actualTableName, conversion: null, consumer: Table.DynamoDBConsumer.DataModel,
+                    storeAsEpoch: null, isEmptyStringValueEnabled: false, metadataCachingMode: flatConfig.MetadataCachingMode);
+                var table = Table.CreateTableFromItemStorageConfig(Context.Client, emptyConfig, config, flatConfig);
+
+                // The table info must be cached under the actual table name exactly how it exists in the DynamoDB service.
+                // This is done to mimic the caching behavior when DisableFetchingTableMetadata is set to false.
+                Context.StoreUnconfiguredTable(actualTableName, table);
+            }
             return config;
         }
 

--- a/sdk/src/Services/DynamoDBv2/GlobalSuppressions.cs
+++ b/sdk/src/Services/DynamoDBv2/GlobalSuppressions.cs
@@ -4,9 +4,10 @@
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DataModel.ItemStorageConfigCache.CreateStorageConfig(System.Type,System.String)~Amazon.DynamoDBv2.DataModel.ItemStorageConfig")]
+using System.Diagnostics.CodeAnalysis;
+
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DocumentModel.Document.DateTimeToEpochSeconds(Amazon.DynamoDBv2.DocumentModel.DynamoDBEntry,System.String)~Amazon.DynamoDBv2.DocumentModel.DynamoDBEntry")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DocumentModel.Document.EpochSecondsToDateTime(Amazon.DynamoDBv2.DocumentModel.DynamoDBEntry,System.String)~Amazon.DynamoDBv2.DocumentModel.DynamoDBEntry")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DocumentModel.Table.TryLoadTable(Amazon.DynamoDBv2.IAmazonDynamoDB,Amazon.DynamoDBv2.DocumentModel.TableConfig,Amazon.DynamoDBv2.DocumentModel.Table@)~System.Boolean")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1720:Identifier contains type name", Scope = "type", Target = "~T:Amazon.DynamoDBv2.DocumentModel.DynamoDBEntryType")]
-
+[assembly: SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DataModel.ItemStorageConfigCache.CreateStorageConfig(System.Type,System.String,Amazon.DynamoDBv2.DataModel.DynamoDBFlatConfig)~Amazon.DynamoDBv2.DataModel.ItemStorageConfig")]

--- a/sdk/test/IntegrationTests/Config/35/App.config
+++ b/sdk/test/IntegrationTests/Config/35/App.config
@@ -35,6 +35,12 @@
             <property name="InternalId" ignore="true" />
             <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.Net35" />
           </map>
+          <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+PartiallyAnnotatedEmployee, AWSSDK.IntegrationTests.Net35" targetTable="HashRangeTable">
+            <property name="ManagerName" attribute="Manager" />
+            <property name="CompanyName" attribute="Company" />
+            <property name="InternalId" ignore="true" />
+            <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.Net35" />
+          </map>
           <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+VersionedEmployee, AWSSDK.IntegrationTests.Net35" targetTable="FakeTable">
             <property name="Version" version="true" />
           </map>

--- a/sdk/test/IntegrationTests/Config/45/App.config
+++ b/sdk/test/IntegrationTests/Config/45/App.config
@@ -35,6 +35,12 @@
                         <property name="InternalId" ignore="true" />
                         <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.Net45" />
                     </map>
+                    <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+PartiallyAnnotatedEmployee, AWSSDK.IntegrationTests.Net45" targetTable="HashRangeTable">
+                        <property name="ManagerName" attribute="Manager" />
+                        <property name="CompanyName" attribute="Company" />
+                        <property name="InternalId" ignore="true" />
+                        <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.Net45" />
+                    </map>
                     <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+VersionedEmployee, AWSSDK.IntegrationTests.Net45" targetTable="FakeTable">
                         <property name="Version" version="true" />
                     </map>

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/Config/35/App.config
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/Config/35/App.config
@@ -36,6 +36,12 @@
             <property name="InternalId" ignore="true" />
             <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.DynamoDBv2.Net35" />
           </map>
+          <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+PartiallyAnnotatedEmployee, AWSSDK.IntegrationTests.DynamoDBv2.Net35" targetTable="HashRangeTable">
+            <property name="ManagerName" attribute="Manager" />
+            <property name="CompanyName" attribute="Company" />
+            <property name="InternalId" ignore="true" />
+            <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.DynamoDBv2.Net35" />
+          </map>
           <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+VersionedEmployee, AWSSDK.IntegrationTests.DynamoDBv2.Net35" targetTable="FakeTable">
             <property name="Version" version="true" />
           </map>

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/Config/45/App.config
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/Config/45/App.config
@@ -36,6 +36,12 @@
             <property name="InternalId" ignore="true" />
             <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.DynamoDBv2.Net45" />
           </map>
+          <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+PartiallyAnnotatedEmployee, AWSSDK.IntegrationTests.DynamoDBv2.Net45" targetTable="HashRangeTable">
+            <property name="ManagerName" attribute="Manager" />
+            <property name="CompanyName" attribute="Company" />
+            <property name="InternalId" ignore="true" />
+            <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.DynamoDBv2.Net45" />
+          </map>
           <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+VersionedEmployee, AWSSDK.IntegrationTests.DynamoDBv2.Net45" targetTable="FakeTable">
             <property name="Version" version="true" />
           </map>

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -44,7 +44,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 TestEnums(conversion);
 
                 TestHashObjects();
-                TestHashRangeObjects();
+                TestHashRangeObjects<Employee>();
                 TestOtherContextOperations();
                 TestBatchOperations();
                 TestTransactionOperations();
@@ -72,6 +72,92 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
             TestEmptyStringsWithFeatureDisabled();
         }
+
+        /// <summary>
+        /// Tests that the DynamoDB operations can be invoked successfully based on the table info 
+        /// supplied only via class attributes.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestContext_DisableFetchingTableMetadata_WithFullAttributes()
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            CreateContext(DynamoDBEntryConversion.V2, true, true);
+
+            TestHashRangeObjects<AnnotatedEmployee>();
+        }
+
+        /// <summary>
+        /// Tests that the DynamoDB operations can be invoked successfully based on the table info 
+        /// supplied via a combination of class attributes and the app config.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestContext_DisableFetchingTableMetadata_WithPartialAttributes()
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            CreateContext(DynamoDBEntryConversion.V2, true, true);
+
+            TestHashRangeObjects<PartiallyAnnotatedEmployee>();
+        }
+
+        /// <summary>
+        /// Tests that the DynamoDB operations can be invoked successfully based on the table info 
+        /// supplied via attributes on the parent class.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestContext_DisableFetchingTableMetadata_WithNonAnnotatedChildClass()
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            CreateContext(DynamoDBEntryConversion.V2, true, true);
+
+            TestHashRangeObjects<EmployeeChild>();
+        }
+
+        /// <summary>
+        /// Tests that the DynamoDB operations can be invoked successfully based on a Datetime attribute as the hash key that is stored as epoch.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestContext_DisableFetchingTableMetadata_DateTimeAsHashKey()
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            CreateContext(DynamoDBEntryConversion.V2, true, true);
+
+            var employee = new AnnotatedNumericEpochEmployee
+            {
+                Name = "Bob",
+                Age = 45,
+                CreationTime = EpochDate,
+                EpochDate2 = EpochDate,
+                NonEpochDate1 = EpochDate,
+                NonEpochDate2 = EpochDate
+            };
+
+            Context.Save(employee);
+            var storedEmployee = Context.Load<AnnotatedNumericEpochEmployee>(employee.CreationTime, employee.Name);
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(EpochDate, storedEmployee.CreationTime);
+            ApproximatelyEqual(EpochDate, storedEmployee.EpochDate2);
+            ApproximatelyEqual(EpochDate, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(EpochDate, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+        }
+
 
         private static void TestEmptyStringsWithFeatureEnabled()
         {
@@ -655,10 +741,10 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             }
         }
 
-        private void TestHashRangeObjects()
+        private void TestHashRangeObjects<T>() where T : Employee, new()
         {
             // Create and save item
-            Employee employee = new Employee
+            T employee = new T
             {
                 Name = "Alan",
                 Age = 31,
@@ -673,7 +759,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Context.Save(employee);
 
             // Load item
-            Employee retrieved = Context.Load(employee);
+            T retrieved = Context.Load(employee);
             Assert.AreEqual(employee.Name, retrieved.Name);
             Assert.AreEqual(employee.Age, retrieved.Age);
             Assert.AreEqual(employee.CompanyName, retrieved.CompanyName);
@@ -697,7 +783,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.AreEqual(employee.Data.Length, retrieved.Data.Length);
 
             // Create more items
-            Employee employee2 = new Employee
+            T employee2 = new T
             {
                 Name = "Diane",
                 Age = 40,
@@ -713,7 +799,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             employee2.Score = 101;
             Context.Save(employee2);
 
-            retrieved = Context.Load<Employee>("Alan", 31);
+            retrieved = Context.Load<T>("Alan", 31);
             Assert.AreEqual(retrieved.Name, "Alan");
             retrieved = Context.Load(employee);
             Assert.AreEqual(retrieved.Name, "Chuck");
@@ -722,35 +808,35 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.AreEqual(retrieved.Age, 24);
 
             // Scan for all items
-            var employees = Context.Scan<Employee>().ToList();
+            var employees = Context.Scan<T>().ToList();
             Assert.AreEqual(4, employees.Count);
 
             // Query for items with Hash-Key = "Diane"
-            employees = Context.Query<Employee>("Diane").ToList();
+            employees = Context.Query<T>("Diane").ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Query for items with Hash-Key = "Diane" and Range-Key > 30
-            employees = Context.Query<Employee>("Diane", QueryOperator.GreaterThan, 30).ToList();
+            employees = Context.Query<T>("Diane", QueryOperator.GreaterThan, 30).ToList();
             Assert.AreEqual(1, employees.Count);
 
             
             // Index Query
 
             // Query local index for items with Hash-Key = "Diane"
-            employees = Context.Query<Employee>("Diane", new DynamoDBOperationConfig { IndexName = "LocalIndex" }).ToList();
+            employees = Context.Query<T>("Diane", new DynamoDBOperationConfig { IndexName = "LocalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Query local index for items with Hash-Key = "Diane" and Range-Key = "Eva"
-            employees = Context.Query<Employee>("Diane", QueryOperator.Equal, new object[] { "Eva" },
+            employees = Context.Query<T>("Diane", QueryOperator.Equal, new object[] { "Eva" },
                 new DynamoDBOperationConfig { IndexName = "LocalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Query global index for item with Hash-Key (Company) = "Big River"
-            employees = Context.Query<Employee>("Big River", new DynamoDBOperationConfig { IndexName = "GlobalIndex" }).ToList();
+            employees = Context.Query<T>("Big River", new DynamoDBOperationConfig { IndexName = "GlobalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Query global index for item with Hash-Key (Company) = "Big River", with QueryFilter for CurrentStatus = Status.Active
-            employees = Context.Query<Employee>("Big River",
+            employees = Context.Query<T>("Big River",
                 new DynamoDBOperationConfig
                 {
                     IndexName = "GlobalIndex",
@@ -765,13 +851,13 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             // Index Scan
 
             // Scan local index for items with Hash-Key = "Diane"
-            employees = Context.Scan<Employee>(
+            employees = Context.Scan<T>(
                 new List<ScanCondition> { new ScanCondition("Name", ScanOperator.Equal, "Diane") },
                 new DynamoDBOperationConfig { IndexName = "LocalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Scan local index for items with Hash-Key = "Diane" and Range-Key = "Eva"
-            employees = Context.Scan<Employee>(
+            employees = Context.Scan<T>(
                 new List<ScanCondition>
                 {
                     new ScanCondition("Name", ScanOperator.Equal, "Diane"),
@@ -781,13 +867,13 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.AreEqual(2, employees.Count);
 
             // Scan global index for item with Hash-Key (Company) = "Big River"
-            employees = Context.Scan<Employee>(
+            employees = Context.Scan<T>(
                 new List<ScanCondition> { new ScanCondition("CompanyName", ScanOperator.Equal, "Big River") },
                 new DynamoDBOperationConfig { IndexName = "GlobalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Scan global index for item with Hash-Key (Company) = "Big River", with QueryFilter for CurrentStatus = Status.Active
-            employees = Context.Scan<Employee>(
+            employees = Context.Scan<T>(
                 new List<ScanCondition>
                 {
                     new ScanCondition("CompanyName", ScanOperator.Equal, "Big River"),
@@ -1414,19 +1500,73 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
         public class Employee
         {
             // Hash key
-            public string Name { get; set; }
+            public virtual string Name { get; set; }
             public string MiddleName { get; set; }
             // Range key
-            public int Age { get; set; }
+            public virtual int Age { get; set; }
 
-            public string CompanyName { get; set; }
-            public int Score { get; set; }
-            public string ManagerName { get; set; }
+            public virtual string CompanyName { get; set; }
+            public virtual int Score { get; set; }
+            public virtual string ManagerName { get; set; }
             public byte[] Data { get; set; }
             public Status CurrentStatus { get; set; }
             public List<string> Aliases { get; set; }
 
             public string InternalId { get; set; }
+        }
+
+        /// <summary>
+        /// Same structure as <see cref="Employee"/>, but the indices are fully annotated
+        /// </summary>
+        [DynamoDBTable("HashRangeTable")]
+        public class AnnotatedEmployee : Employee
+        {
+            // Hash key
+            [DynamoDBHashKey]
+            public override string Name { get; set; }
+
+            // Range key
+            [DynamoDBRangeKey]
+            public override int Age { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexHashKey("GlobalIndex", AttributeName = "Company")]
+            public override string CompanyName { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexRangeKey("GlobalIndex")]
+            public override int Score { get; set; }
+
+            [DynamoDBLocalSecondaryIndexRangeKey("LocalIndex", AttributeName = "Manager")]
+            public override string ManagerName { get; set; }
+        }
+
+        /// <summary>
+        /// Same structure as <see cref="AnnotatedEmployee"/>, but it does not have the <see cref="DynamoDBTableAttribute"/> and attribute names overrides.
+        /// </summary>
+        public class PartiallyAnnotatedEmployee : Employee
+        {
+            // Hash key
+            [DynamoDBHashKey]
+            public override string Name { get; set; }
+
+            // Range key
+            [DynamoDBRangeKey]
+            public override int Age { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexHashKey("GlobalIndex")]
+            public override string CompanyName { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexRangeKey("GlobalIndex")]
+            public override int Score { get; set; }
+
+            [DynamoDBLocalSecondaryIndexRangeKey("LocalIndex")]
+            public override string ManagerName { get; set; }
+        }
+
+        /// <summary>
+        /// Child class of <see cref="AnnotatedEmployee"/> without any attributes.
+        /// </summary>
+        public class EmployeeChild : AnnotatedEmployee
+        {
         }
 
         /// <summary>
@@ -1467,7 +1607,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
         public class EpochEmployee : Employee
         {
             [DynamoDBProperty(StoreAsEpoch = true)]
-            public DateTime CreationTime { get; set; }
+            public virtual DateTime CreationTime { get; set; }
 
             public DateTime EpochDate2 { get; set; }
 
@@ -1484,6 +1624,19 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
         public class NumericEpochEmployee : EpochEmployee
         {
 
+        }
+
+        /// <summary>
+        /// Same structure as <see cref="NumericEpochEmployee"/>, but the Hash key is annotated
+        /// </summary>
+        [DynamoDBTable("NumericHashRangeTable")]
+        public class AnnotatedNumericEpochEmployee : EpochEmployee
+        {
+            [DynamoDBHashKey(StoreAsEpoch = true)]
+            public override DateTime CreationTime { get; set; }
+
+            [DynamoDBRangeKey]
+            public override string Name { get; set; }
         }
 
         #endregion

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DynamoDBTestsBase.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DynamoDBTestsBase.cs
@@ -90,13 +90,14 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ClearTable(numericHashRangeTableName);
         }
 
-        public static void CreateContext(DynamoDBEntryConversion conversion, bool isEmptyStringValueEnabled)
+        public static void CreateContext(DynamoDBEntryConversion conversion, bool isEmptyStringValueEnabled, bool disableFetchingTableMetadata = false)
         {
             var config = new DynamoDBContextConfig
             {
                 //IgnoreNullValues = true
                 IsEmptyStringValueEnabled = isEmptyStringValueEnabled,
-                Conversion = conversion
+                Conversion = conversion,
+                DisableFetchingTableMetadata = disableFetchingTableMetadata
             };
             Context = new DynamoDBContext(Client, config);
         }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -15,6 +15,7 @@ using Amazon.DynamoDBv2.Model;
 using ThirdParty.Json.LitJson;
 
 using Moq;
+using Amazon;
 
 namespace AWSSDK_DotNet35.UnitTests
 {
@@ -328,6 +329,60 @@ namespace AWSSDK_DotNet35.UnitTests
             Assert.AreEqual(document["V"].AsInt(), 1);
         }
 
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestGetTargetTable_DisableFetchingTableMetadata()
+        {
+            var dynamoDBContextConfig = new DynamoDBContextConfig
+            {
+                DisableFetchingTableMetadata = true,
+                TableNamePrefix = "DotnetTest-"
+            };
+            var dynamoDBClient = new Mock<IAmazonDynamoDB>();
+            var dynamoDBContext = new DynamoDBContext(dynamoDBClient.Object, dynamoDBContextConfig);
+
+            var table = dynamoDBContext.GetTargetTable<Employee>();
+            Assert.IsNotNull(table);
+            Assert.AreEqual("DotnetTest-EmployeeDetails", table.TableName);
+            Assert.AreEqual(2, table.Keys.Count);
+            Assert.IsTrue(table.Keys.ContainsKey("Name"));
+            Assert.IsTrue(table.Keys.ContainsKey("Age"));
+
+            Assert.AreEqual(1, table.HashKeys.Count);
+            Assert.AreEqual("Name", table.HashKeys[0]);
+
+            Assert.AreEqual(1, table.RangeKeys.Count);
+            Assert.AreEqual("Age", table.RangeKeys[0]);
+
+            Assert.AreEqual(1, table.GlobalSecondaryIndexes.Count);
+            var gsi = table.GlobalSecondaryIndexes["GlobalIndex"];
+            Assert.AreEqual("GlobalIndex", gsi.IndexName);
+            Assert.AreEqual(2, gsi.KeySchema.Count);
+            Assert.AreEqual("Company", gsi.KeySchema[0].AttributeName);
+            Assert.AreEqual(KeyType.HASH, gsi.KeySchema[0].KeyType);
+            Assert.AreEqual("Score", gsi.KeySchema[1].AttributeName);
+            Assert.AreEqual(KeyType.RANGE, gsi.KeySchema[1].KeyType);
+
+            Assert.AreEqual(1, table.LocalSecondaryIndexes.Count);
+            var lsi = table.LocalSecondaryIndexes["LocalIndex"];
+            Assert.AreEqual("LocalIndex", lsi.IndexName);
+            Assert.AreEqual(2, lsi.KeySchema.Count);
+            Assert.AreEqual("Name", lsi.KeySchema[0].AttributeName);
+            Assert.AreEqual(KeyType.HASH, lsi.KeySchema[0].KeyType);
+            Assert.AreEqual("Manager", lsi.KeySchema[1].AttributeName);
+            Assert.AreEqual(KeyType.RANGE, lsi.KeySchema[1].KeyType);
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestDisableFetchingTableMetadata_UsingGlobalContext()
+        {
+            AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata = true;
+            var config = new DynamoDBContextConfig();
+            Assert.AreEqual(true, config.DisableFetchingTableMetadata);
+            AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata = false;
+        }
+
         public class Parent
         {
             [DynamoDBProperty("actualPropertyName")]
@@ -340,6 +395,27 @@ namespace AWSSDK_DotNet35.UnitTests
         public class Child : Parent
         {
             public override string Property1 { get; set; }
+        }
+
+        [DynamoDBTable("EmployeeDetails")]
+        public class Employee
+        {
+            // Hash key
+            [DynamoDBHashKey]
+            public string Name { get; set; }
+
+            // Range key
+            [DynamoDBRangeKey]
+            public int Age { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexHashKey("GlobalIndex", AttributeName = "Company")]
+            public string CompanyName { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexRangeKey("GlobalIndex")]
+            public int Score { get; set; }
+
+            [DynamoDBLocalSecondaryIndexRangeKey("LocalIndex", AttributeName = "Manager")]
+            public string ManagerName { get; set; }
         }
 
 #if ASYNC_AWAIT


### PR DESCRIPTION
## Description
This is a proposal to _partially_ address https://github.com/aws/aws-sdk-net/issues/1476 if using the object persistence model with a fully annotated class.

Currently both of our higher-level DynamoDB programming models rely on knowledge of the table's index structure which is cached inside the SDK via a `DescribeTable` call.
* For the object mapper, this is done lazily when the first DynamoDB operation is invoked on `DynamoDBContext`
* For the document model, this is more explicit via `Table.LoadTable`

In versions of .NET that only have an async HTTP client, this `DescribeTable` is made via the sync-over-async antipattern becayse we've always carried forward the public sync APIs for the high-level programming models. This is leading to threadpool exhaustion and deadlocks in some scenarios.

As @normj discussed in https://github.com/aws/aws-sdk-net/issues/1476#issuecomment-567221982, one path is to go async-only, but we'd have to do that in a new major version since we currently expose public sync APIs.

Another idea is to remove the need for the `DescribeTable` call if the table structure is provided statically in advance. This PR explores this idea for the object-persistence model.

1. Adds a new option `AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata` which defaults to false.
2. Adds a new option `DynamoDBContextConfig.DisableFetchingTableMetadata`, which defaults to false.
3. If this is set to `true`, when populating the internal SDK cache of table metadata for a given table we only rely on the information from:
    1. The [`DynamoDBAttribute` attributes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DeclarativeTagsList.html) applied to the .NET class that is mapped to to the table
    2. The global [`AWSConfigsDynamoDB`](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Amazon/TAWSConfigsDynamoDB.html) object.

The SDK fills the cache using that static data, then proceeds as if it has made the `DescribeTable` call. 

## Testing
* Existing DynamoDB test cases pass
* Added new automated tests that verify the following scenarios:
  *  DynamoDB operations can be invoked successfully based on the table info supplied only via class attributes.
  *  DynamoDB operations can be invoked successfully based on the table info supplied via a combination of class attributes and the app config.
  *  DynamoDB operations can be invoked successfully based on the table info supplied via attributes on the parent class.
  *  DynamoDB operations can be invoked successfully based on a Datetime attribute as the hash key that is stored as epoch.
  *  The table info is cached using the actual table name and the key/index info is generated correctly based on DynamoDB attributes.
  * Setting the global `AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata` to true propogates to the local `DynamoDBContextConfig`.

There is a separate backog item (DOTNET-7140) to investigate failure modes when the table info provided via class attributes does not match the actual table.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement