### PR TITLE
[WIP] DynamoDBContext TableDescription caching spike

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -74,7 +74,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// If property is not set, version checks are performed.
         /// </summary>
         public bool? SkipVersionCheck { get; set; }
-
+        
         /// <summary>
         /// Property that directs DynamoDBContext to prefix all table names
         /// with a specific string.
@@ -82,6 +82,14 @@ namespace Amazon.DynamoDBv2.DataModel
         /// table names are used.
         /// </summary>
         public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to prefix table description
+        /// cache keys with a specific string.
+        /// If property is null or empty, the combination of credentials,
+        /// region and service url will be used.
+        /// </summary>
+        public string TableDescriptionCachePrefix { get; set; }
 
         /// <summary>
         /// Property that directs DynamoDBContext to ignore null values
@@ -278,6 +286,7 @@ namespace Amazon.DynamoDBv2.DataModel
             OverrideTableName = null,
             SkipVersionCheck = null,
             TableNamePrefix = null,
+            TableDescriptionCachePrefix = null,
             IgnoreNullValues = null,
             BackwardQuery = null,
             IndexName = null,
@@ -290,6 +299,7 @@ namespace Amazon.DynamoDBv2.DataModel
             ConsistentRead = null,
             SkipVersionCheck = null,
             TableNamePrefix = null,
+            TableDescriptionCachePrefix = null,
             IgnoreNullValues = null,
             Conversion = null,
             IsEmptyStringValueEnabled = null
@@ -311,6 +321,9 @@ namespace Amazon.DynamoDBv2.DataModel
             string tableNamePrefix =
                 !string.IsNullOrEmpty(operationConfig.TableNamePrefix) ? operationConfig.TableNamePrefix :
                 !string.IsNullOrEmpty(contextConfig.TableNamePrefix) ? contextConfig.TableNamePrefix : string.Empty;
+            string tableDescriptionCachePrefix =
+                !string.IsNullOrEmpty(operationConfig.TableDescriptionCachePrefix) ? operationConfig.TableDescriptionCachePrefix :
+                !string.IsNullOrEmpty(contextConfig.TableDescriptionCachePrefix) ? contextConfig.TableDescriptionCachePrefix : string.Empty;
             bool backwardQuery = operationConfig.BackwardQuery ?? false;
             string indexName =
                 !string.IsNullOrEmpty(operationConfig.IndexName) ? operationConfig.IndexName : DefaultIndexName;
@@ -324,6 +337,7 @@ namespace Amazon.DynamoDBv2.DataModel
             IsEmptyStringValueEnabled = isEmptyStringValueEnabled;
             OverrideTableName = overrideTableName;
             TableNamePrefix = tableNamePrefix;
+            TableDescriptionCachePrefix = tableDescriptionCachePrefix;
             BackwardQuery = backwardQuery;
             IndexName = indexName;
             QueryFilter = queryFilter;
@@ -353,6 +367,14 @@ namespace Amazon.DynamoDBv2.DataModel
         /// table names are used.
         /// </summary>
         public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to prefix table description
+        /// cache keys with a specific string.
+        /// If property is null or empty, the combination of credentials,
+        /// region and service url will be used.
+        /// </summary>
+        public string TableDescriptionCachePrefix { get; set; }
 
         /// <summary>
         /// Property that directs DynamoDBContext to ignore null values

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -84,12 +84,12 @@ namespace Amazon.DynamoDBv2.DataModel
         public string TableNamePrefix { get; set; }
 
         /// <summary>
-        /// Property that directs DynamoDBContext to prefix table description
-        /// cache keys with a specific string.
-        /// If property is null or empty, the combination of credentials,
-        /// region and service url will be used.
+        /// Property that directs DynamoDBContext to use only the table name
+        /// when constructing a cache key.
+        /// If property is false (or not set), the combination of credentials,
+        /// region and service url will be used in addition to table name.
         /// </summary>
-        public string TableDescriptionCachePrefix { get; set; }
+        public bool? SingleAccountMode { get; set; }
 
         /// <summary>
         /// Property that directs DynamoDBContext to ignore null values
@@ -286,7 +286,7 @@ namespace Amazon.DynamoDBv2.DataModel
             OverrideTableName = null,
             SkipVersionCheck = null,
             TableNamePrefix = null,
-            TableDescriptionCachePrefix = null,
+            SingleAccountMode = null,
             IgnoreNullValues = null,
             BackwardQuery = null,
             IndexName = null,
@@ -299,7 +299,7 @@ namespace Amazon.DynamoDBv2.DataModel
             ConsistentRead = null,
             SkipVersionCheck = null,
             TableNamePrefix = null,
-            TableDescriptionCachePrefix = null,
+            SingleAccountMode = null,
             IgnoreNullValues = null,
             Conversion = null,
             IsEmptyStringValueEnabled = null
@@ -321,9 +321,7 @@ namespace Amazon.DynamoDBv2.DataModel
             string tableNamePrefix =
                 !string.IsNullOrEmpty(operationConfig.TableNamePrefix) ? operationConfig.TableNamePrefix :
                 !string.IsNullOrEmpty(contextConfig.TableNamePrefix) ? contextConfig.TableNamePrefix : string.Empty;
-            string tableDescriptionCachePrefix =
-                !string.IsNullOrEmpty(operationConfig.TableDescriptionCachePrefix) ? operationConfig.TableDescriptionCachePrefix :
-                !string.IsNullOrEmpty(contextConfig.TableDescriptionCachePrefix) ? contextConfig.TableDescriptionCachePrefix : string.Empty;
+            bool singleAccountMode = operationConfig.SingleAccountMode ?? contextConfig.SingleAccountMode ?? false;
             bool backwardQuery = operationConfig.BackwardQuery ?? false;
             string indexName =
                 !string.IsNullOrEmpty(operationConfig.IndexName) ? operationConfig.IndexName : DefaultIndexName;
@@ -337,7 +335,7 @@ namespace Amazon.DynamoDBv2.DataModel
             IsEmptyStringValueEnabled = isEmptyStringValueEnabled;
             OverrideTableName = overrideTableName;
             TableNamePrefix = tableNamePrefix;
-            TableDescriptionCachePrefix = tableDescriptionCachePrefix;
+            SingleAccountMode = singleAccountMode;
             BackwardQuery = backwardQuery;
             IndexName = indexName;
             QueryFilter = queryFilter;
@@ -369,12 +367,12 @@ namespace Amazon.DynamoDBv2.DataModel
         public string TableNamePrefix { get; set; }
 
         /// <summary>
-        /// Property that directs DynamoDBContext to prefix table description
-        /// cache keys with a specific string.
-        /// If property is null or empty, the combination of credentials,
-        /// region and service url will be used.
+        /// Property that directs DynamoDBContext to use only the table name
+        /// when constructing a cache key.
+        /// If property is false, the combination of credentials,
+        /// region and service url will be used in addition to table name.
         /// </summary>
-        public string TableDescriptionCachePrefix { get; set; }
+        public bool SingleAccountMode { get; set; }
 
         /// <summary>
         /// Property that directs DynamoDBContext to ignore null values

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -141,7 +141,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
             var tableConfig = new TableConfig(tableName, flatConfig.Conversion, consumer,
                 storageConfig.AttributesToStoreAsEpoch, flatConfig.IsEmptyStringValueEnabled,
-                flatConfig.TableDescriptionCachePrefix);
+                flatConfig.SingleAccountMode);
             var table = unconfiguredTable.Copy(tableConfig);
             return table;
         }
@@ -181,7 +181,7 @@ namespace Amazon.DynamoDBv2.DataModel
                 }
 
                 var emptyConfig = new TableConfig(tableName, conversion: null, consumer: Table.DynamoDBConsumer.DataModel,
-                    storeAsEpoch: null, isEmptyStringValueEnabled: false, tableDescriptionCachePrefix: this.Config.TableDescriptionCachePrefix);
+                    storeAsEpoch: null, isEmptyStringValueEnabled: false, singleAccountMode: this.Config.SingleAccountMode ?? false);
                 table = Table.LoadTable(Client, emptyConfig);
                 tablesMap[tableName] = table;
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -140,7 +140,8 @@ namespace Amazon.DynamoDBv2.DataModel
             ValidateConfigAgainstTable(storageConfig, unconfiguredTable);
 
             var tableConfig = new TableConfig(tableName, flatConfig.Conversion, consumer,
-                storageConfig.AttributesToStoreAsEpoch, flatConfig.IsEmptyStringValueEnabled);
+                storageConfig.AttributesToStoreAsEpoch, flatConfig.IsEmptyStringValueEnabled,
+                flatConfig.TableDescriptionCachePrefix);
             var table = unconfiguredTable.Copy(tableConfig);
             return table;
         }
@@ -180,7 +181,7 @@ namespace Amazon.DynamoDBv2.DataModel
                 }
 
                 var emptyConfig = new TableConfig(tableName, conversion: null, consumer: Table.DynamoDBConsumer.DataModel,
-                    storeAsEpoch: null, isEmptyStringValueEnabled: false);
+                    storeAsEpoch: null, isEmptyStringValueEnabled: false, tableDescriptionCachePrefix: this.Config.TableDescriptionCachePrefix);
                 table = Table.LoadTable(Client, emptyConfig);
                 tablesMap[tableName] = table;
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
@@ -31,12 +31,12 @@ namespace Amazon.DynamoDBv2.DocumentModel
         public string TableName { get; set; }
 
         /// <summary>
-        /// Property that directs DynamoDBContext to prefix table description
-        /// cache keys with a specific string.
-        /// If property is null or empty, the combination of credentials,
-        /// region and service url will be used.
+        /// Property that directs DynamoDBContext to use only the table name
+        /// when constructing a cache key.
+        /// If property is false, the combination of credentials,
+        /// region and service url will be used in addition to table name.
         /// </summary>
-        public string TableDescriptionCachePrefix { get; set; }
+        public bool SingleAccountMode { get; set; }
 
         /// <summary>
         /// Conversion to use for converting .NET values to DynamoDB values.
@@ -62,17 +62,17 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <param name="tableName">Name of the table.</param>
         public TableConfig(string tableName)
             : this(tableName, DynamoDBEntryConversion.CurrentConversion, Table.DynamoDBConsumer.DocumentModel, null,
-                false, tableDescriptionCachePrefix: null)
+                false, singleAccountMode: false)
         {
         }
 
         internal TableConfig(string tableName, DynamoDBEntryConversion conversion, Table.DynamoDBConsumer consumer,
-            IEnumerable<string> storeAsEpoch, bool isEmptyStringValueEnabled, string tableDescriptionCachePrefix)
+            IEnumerable<string> storeAsEpoch, bool isEmptyStringValueEnabled, bool singleAccountMode)
         {
             if (string.IsNullOrEmpty(tableName)) throw new ArgumentNullException("tableName");
 
             TableName = tableName;
-            TableDescriptionCachePrefix = tableDescriptionCachePrefix;
+            SingleAccountMode = singleAccountMode;
             Conversion = conversion;
             Consumer = consumer;
             IsEmptyStringValueEnabled = isEmptyStringValueEnabled;

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
@@ -31,6 +31,14 @@ namespace Amazon.DynamoDBv2.DocumentModel
         public string TableName { get; set; }
 
         /// <summary>
+        /// Property that directs DynamoDBContext to prefix table description
+        /// cache keys with a specific string.
+        /// If property is null or empty, the combination of credentials,
+        /// region and service url will be used.
+        /// </summary>
+        public string TableDescriptionCachePrefix { get; set; }
+
+        /// <summary>
         /// Conversion to use for converting .NET values to DynamoDB values.
         /// Default is AWSConfigs.DynamoDBConfig.ConversionSchema.
         /// </summary>
@@ -54,16 +62,17 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <param name="tableName">Name of the table.</param>
         public TableConfig(string tableName)
             : this(tableName, DynamoDBEntryConversion.CurrentConversion, Table.DynamoDBConsumer.DocumentModel, null,
-                false)
+                false, tableDescriptionCachePrefix: null)
         {
         }
 
         internal TableConfig(string tableName, DynamoDBEntryConversion conversion, Table.DynamoDBConsumer consumer,
-            IEnumerable<string> storeAsEpoch, bool isEmptyStringValueEnabled)
+            IEnumerable<string> storeAsEpoch, bool isEmptyStringValueEnabled, string tableDescriptionCachePrefix)
         {
             if (string.IsNullOrEmpty(tableName)) throw new ArgumentNullException("tableName");
 
             TableName = tableName;
+            TableDescriptionCachePrefix = tableDescriptionCachePrefix;
             Conversion = conversion;
             Consumer = consumer;
             IsEmptyStringValueEnabled = isEmptyStringValueEnabled;

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -18,6 +18,58 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
     {
         [TestMethod]
         [TestCategory("DynamoDBv2")]
+        public void DescribeTable_is_called_twice_for_different_credentials_when_TableDescriptionCachePrefix_is_null()
+        {
+            var config = new DynamoDBContextConfig
+            {
+                TableDescriptionCachePrefix = null,
+            };
+            Context = new DynamoDBContext(Client, config);
+
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DescribeTable_is_called_once_for_same_credentials_when_TableDescriptionCachePrefix_is_null()
+        {
+            var config = new DynamoDBContextConfig
+            {
+                TableDescriptionCachePrefix = null,
+            };
+            Context = new DynamoDBContext(Client, config);
+
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DescribeTable_is_called_once_for_different_credentials_when_TableDescriptionCachePrefix_is_set()
+        {
+            var config = new DynamoDBContextConfig
+            {
+                TableDescriptionCachePrefix = "ArbitraryValue",
+            };
+            Context = new DynamoDBContext(Client, config);
+
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DescribeTable_is_called_once_for_same_credentials_when_TableDescriptionCachePrefix_is_set()
+        {
+            var config = new DynamoDBContextConfig
+            {
+                TableDescriptionCachePrefix = "ArbitraryValue",
+            };
+            Context = new DynamoDBContext(Client, config);
+
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
         public void TestContextWithEmptyStringEnabled()
         {
             // It is a known bug that this test currently fails due to an AOT-compilation

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -18,52 +18,62 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
     {
         [TestMethod]
         [TestCategory("DynamoDBv2")]
-        public void DescribeTable_is_called_twice_for_different_credentials_when_TableDescriptionCachePrefix_is_null()
+        public void DescribeTable_is_called_twice_for_different_credentials_when_SingleAccountMode_is_null_or_false()
         {
             var config = new DynamoDBContextConfig
             {
-                TableDescriptionCachePrefix = null,
+                SingleAccountMode = null,
             };
             Context = new DynamoDBContext(Client, config);
+
+            // TODO: Would need to create two Clients with different credentials here
+            // TODO: Would need to perform an action on two different contexts
+            
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DescribeTable_is_called_once_for_same_credentials_when_SingleAccountMode_is_null_or_false()
+        {
+            var config = new DynamoDBContextConfig
+            {
+                SingleAccountMode = null,
+            };
+            Context = new DynamoDBContext(Client, config);
+
+            // TODO: Would need to perform an action on two different contexts
 
             Assert.Fail();
         }
 
         [TestMethod]
         [TestCategory("DynamoDBv2")]
-        public void DescribeTable_is_called_once_for_same_credentials_when_TableDescriptionCachePrefix_is_null()
+        public void DescribeTable_is_called_once_for_different_credentials_when_SingleAccountMode_is_true()
         {
             var config = new DynamoDBContextConfig
             {
-                TableDescriptionCachePrefix = null,
+                SingleAccountMode = true,
             };
             Context = new DynamoDBContext(Client, config);
+
+            // TODO: Would need to create two Clients with different credentials here
+            // TODO: Would need to perform an action on two different contexts
 
             Assert.Fail();
         }
 
         [TestMethod]
         [TestCategory("DynamoDBv2")]
-        public void DescribeTable_is_called_once_for_different_credentials_when_TableDescriptionCachePrefix_is_set()
+        public void DescribeTable_is_called_once_for_same_credentials_when_SingleAccountMode_is_true()
         {
             var config = new DynamoDBContextConfig
             {
-                TableDescriptionCachePrefix = "ArbitraryValue",
+                SingleAccountMode = true,
             };
             Context = new DynamoDBContext(Client, config);
 
-            Assert.Fail();
-        }
-
-        [TestMethod]
-        [TestCategory("DynamoDBv2")]
-        public void DescribeTable_is_called_once_for_same_credentials_when_TableDescriptionCachePrefix_is_set()
-        {
-            var config = new DynamoDBContextConfig
-            {
-                TableDescriptionCachePrefix = "ArbitraryValue",
-            };
-            Context = new DynamoDBContext(Client, config);
+            // TODO: Would need to perform an action on two different contexts
 
             Assert.Fail();
         }


### PR DESCRIPTION
Further to call with @normj and @ashovlin earlier I've sketched out a possible solution that I believe would work for our use-case where we are seeing excessive DescribeTable calls.

The aim is to reduce calls to the DescribeTable when client credentials differ per request.

## Description
Added `TableDescriptionCachePrefix` to `DynamoDBContextConfig` to allow a consumer provided prefix to be used when constructing a cache key for the `TableDescription` cache.

There are some unrelated static Table methods that would need to be given the prefix before this could be considered complete.

## Motivation and Context
The existing behaviour uses the credentials in the Dynamo client to form part of the cache key. In a multi-tenancy environment where new credentials are used per request it results in the cache key having high cardinality leading to excessive DescribeTable invocations. By allowing the consumer to provide a value for the prefix we can lower this and reduce the calls to DescribeTable for the same physical table.

While this PR won't fix https://github.com/aws/aws-sdk-net/issues/1476 I believe it will reduce the symptoms to just the first series of calls after container startup.

## Testing
I've included some as yet incomplete  tests 

## Screenshots (if appropriate)
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement