### PR TITLE
Fix remaining Core AOT JSON warnings

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/ClientContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientContext.cs
@@ -29,6 +29,11 @@ namespace Amazon.Runtime.Internal
     /// This class composes Client Context header for Amazon Web Service client.
     /// It contains information like app title, version code, version name, client id, OS platform etc.
     /// </summary>
+#if NET6_0_OR_GREATER
+    // This class wasn't updated to use source generators because the object to JSON method uses the non generic IDictionary. Usage of this class is probably very low since it is not used directly
+    // by the SDK and it is in an internal namespace.
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ClientContext has not been updated to support producing JSON using source generators. For requests that need client context JSON the JSON must be created manually.")]
+#endif
     public partial class ClientContext
     {
         //client related keys
@@ -87,7 +92,7 @@ namespace Amazon.Runtime.Internal
                 _custom.Add(key,value);
             }
         }
-        
+
         /// <summary>
         /// Gets a Json Representation of the Client Context.
         /// </summary>

--- a/sdk/src/Core/Amazon.Runtime/Credentials/ECSTaskCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/ECSTaskCredentials.cs
@@ -14,6 +14,7 @@
  */
 
 using Amazon.Util;
+using Amazon.Util.Internal;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -90,7 +91,7 @@ namespace Amazon.Runtime
                     // If this variable is set the SDK will set the Authorization header on the HTTP request with the environment variable's value.
                     var headers = CreateAuthorizationHeader();
 
-                    credentials = GetObjectFromResponse<SecurityCredentials>(ecsEndpointUri, Proxy, headers);
+                    credentials = GetObjectFromResponse<SecurityCredentials, SecurityCredentialsJsonSerializerContexts>(ecsEndpointUri, Proxy, headers);
                     if (credentials != null)
                     {
                         break;

--- a/sdk/src/Core/Amazon.Runtime/Credentials/InstanceProfileAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/InstanceProfileAWSCredentials.cs
@@ -14,6 +14,7 @@
  */
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
+using Amazon.Util.Internal;
 using AWSSDK.Runtime.Internal.Util;
 using System;
 using System.Collections.Generic;
@@ -314,13 +315,13 @@ namespace Amazon.Runtime
         private static SecurityInfo GetServiceInfo(IWebProxy proxy, string token)
         {
             CheckIsIMDSEnabled();
-            return GetObjectFromResponse<SecurityInfo>(InfoUri, proxy, CreateMetadataTokenHeaders(token));
+            return GetObjectFromResponse<SecurityInfo, SecurityInfoJsonSerializerContexts>(InfoUri, proxy, CreateMetadataTokenHeaders(token));
         }
 
         private SecurityCredentials GetRoleCredentials(string token)
         {
             CheckIsIMDSEnabled();
-            return GetObjectFromResponse<SecurityCredentials>(CurrentRoleUri, _proxy, CreateMetadataTokenHeaders(token));
+            return GetObjectFromResponse<SecurityCredentials, SecurityCredentialsJsonSerializerContexts>(CurrentRoleUri, _proxy, CreateMetadataTokenHeaders(token));
         }
 
         private static void CheckIsIMDSEnabled()

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SsoTokenUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SsoTokenUtils.cs
@@ -14,11 +14,16 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml;
 using Amazon.Util;
+using Amazon.Util.Internal;
 using ThirdParty.Json.LitJson;
+
+#if NET6_0_OR_GREATER
+using System.Text.Json;
+#endif
 
 namespace Amazon.Runtime.Credentials.Internal
 {
@@ -100,26 +105,19 @@ namespace Amazon.Runtime.Credentials.Internal
         /// <param name="token">Token to serialize</param>
         public static string ToJson(SsoToken token)
         {
-            var json = new StringBuilder();
-            var writer = new JsonWriter(json)
+            var jsonData = new Dictionary<string, string>
             {
-                PrettyPrint = true,
+                [JsonPropertyNames.AccessToken] = token.AccessToken,
+                [JsonPropertyNames.ExpiresAt] = XmlConvert.ToString(token.ExpiresAt, XmlDateTimeSerializationMode.Utc),
+                [JsonPropertyNames.RefreshToken] = token.RefreshToken,
+                [JsonPropertyNames.ClientId] = token.ClientId,
+                [JsonPropertyNames.ClientSecret] = token.ClientSecret,
+                [JsonPropertyNames.RegistrationExpiresAt] = token.RegistrationExpiresAt,
+                [JsonPropertyNames.Region] = token.Region,
+                [JsonPropertyNames.StartUrl] = token.StartUrl
             };
 
-            var jsonData = new JsonData
-            {
-                [JsonPropertyNames.AccessToken] = new JsonData(token.AccessToken),
-                [JsonPropertyNames.ExpiresAt] = new JsonData(XmlConvert.ToString(token.ExpiresAt, XmlDateTimeSerializationMode.Utc)),
-                [JsonPropertyNames.RefreshToken] = new JsonData(token.RefreshToken),
-                [JsonPropertyNames.ClientId] = new JsonData(token.ClientId),
-                [JsonPropertyNames.ClientSecret] = new JsonData(token.ClientSecret),
-                [JsonPropertyNames.RegistrationExpiresAt] = new JsonData(token.RegistrationExpiresAt),
-                [JsonPropertyNames.Region] = new JsonData(token.Region),
-                [JsonPropertyNames.StartUrl] = new JsonData(token.StartUrl)
-            };
-
-            JsonMapper.ToJson(jsonData, writer);
-            return json.ToString();
+            return JsonSerializerHelper.Serialize<Dictionary<string, string>>(jsonData, new DictionaryStringStringJsonSerializerContexts(new JsonSerializerOptions { WriteIndented = true }));
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 #if NETSTANDARD
 using System.Runtime.InteropServices;
+using Amazon.Util.Internal;
 #endif
 
 namespace Amazon.Runtime
@@ -174,7 +175,7 @@ namespace Amazon.Runtime
                         ProcessCredentialVersion1 processCredentialDataV1 = null;            
                         try
                         {
-                            processCredentialDataV1 = JsonMapper.ToObject<ProcessCredentialVersion1>(processInfo.StandardOutput);
+                            processCredentialDataV1 = JsonSerializerHelper.Deserialize<ProcessCredentialVersion1>(processInfo.StandardOutput, ProcessCredentialVersion1JsonSerializerContexts.Default);
                         }
                         catch (Exception e)
                         {

--- a/sdk/src/Core/Amazon.Runtime/Credentials/SAMLImmutableCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/SAMLImmutableCredentials.cs
@@ -14,6 +14,7 @@
  */
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
+using Amazon.Util.Internal;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -137,7 +138,7 @@ namespace Amazon.Runtime
 
             props.Add(SubjectProperty, Subject);
 
-            return JsonMapper.ToJson(props);
+            return JsonSerializerHelper.Serialize<Dictionary<string, string>>(props, DictionaryStringStringJsonSerializerContexts.Default);
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Credentials/URIBasedRefreshingCredentialHelper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/URIBasedRefreshingCredentialHelper.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using Amazon.Util;
+using Amazon.Util.Internal;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -48,21 +49,46 @@ namespace Amazon.Runtime
             }
         }
 
+        [Obsolete("This method is not compatible with Native AOT builds. The GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
+#endif
         protected static T GetObjectFromResponse<T>(Uri uri)
         {
             return GetObjectFromResponse<T>(uri, null, null);
         }
 
+        [Obsolete("This method is not compatible with Native AOT builds. The GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
+#endif
         protected static T GetObjectFromResponse<T>(Uri uri, IWebProxy proxy)
         {
             return GetObjectFromResponse<T>(uri, proxy, null);
         }
 
+        [Obsolete("This method is not compatible with Native AOT builds. The GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
+#endif
         protected static T GetObjectFromResponse<T>(Uri uri, IWebProxy proxy, Dictionary<string, string> headers)
         {
             string json = GetContents(uri, proxy, headers);
             return JsonMapper.ToObject<T>(json);
-        }                
+        }
+
+        protected static T GetObjectFromResponse<T, TC>(Uri uri, IWebProxy proxy, Dictionary<string, string> headers)
+            where TC :
+#if NET6_0_OR_GREATER
+                System.Text.Json.Serialization.JsonSerializerContext,
+#else
+                Amazon.Util.Internal.JsonSerializerContext,
+#endif
+                new()
+        {
+            string json = GetContents(uri, proxy, headers);
+            return JsonSerializerHelper.Deserialize<T>(json, new TC());
+        }
 
         protected static void ValidateResponse(SecurityBase response)
         {
@@ -75,20 +101,21 @@ namespace Amazon.Runtime
         }
 
         #region Private serialization classes
-        protected class SecurityBase
+#pragma warning disable CA1034
+        public class SecurityBase
         {
             public string Code { get; set; }
             public string Message { get; set; }
             public DateTime LastUpdated { get; set; }
         }
 
-        protected class SecurityInfo : SecurityBase
+        public class SecurityInfo : SecurityBase
         {
             public string InstanceProfileArn { get; set; }
             public string InstanceProfileId { get; set; }
         }
 
-        protected class SecurityCredentials : SecurityBase
+        public class SecurityCredentials : SecurityBase
         {
             public string Type { get; set; }
             public string AccessKeyId { get; set; }
@@ -97,6 +124,8 @@ namespace Amazon.Runtime
             public DateTime Expiration { get; set; }
             public string RoleArn { get; set; }
         }
+#pragma warning restore CA1034
+
         #endregion
 
     }

--- a/sdk/src/Core/Amazon.Runtime/Documents/Document.cs
+++ b/sdk/src/Core/Amazon.Runtime/Documents/Document.cs
@@ -410,6 +410,9 @@ namespace Amazon.Runtime.Documents
         /// for performance critical work.  Additionally, if <paramref name="o"/> is a known primitive (ie <see cref="int"/>),
         /// using a <see cref="Document"/> constructor directly will be more performant.
         /// </summary> 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("FromObject is not currently supported for Native AOT compilation due unbounded reflection required.")]
+#endif        
         public static Document FromObject(object o)
         {
             IJsonWrapper jsonData = JsonMapper.ToObject(JsonMapper.ToJson(o));
@@ -417,6 +420,9 @@ namespace Amazon.Runtime.Documents
             return FromObject(jsonData);
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("FromObject is not currently supported for Native AOT compilation due unbounded reflection required.")]
+#endif  
         private static Document FromObject(IJsonWrapper jsonData)
         {
             switch (jsonData.GetJsonType())
@@ -444,6 +450,9 @@ namespace Amazon.Runtime.Documents
             throw new NotSupportedException($"Couldn't convert {jsonData.GetJsonType()}");
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("FromObject is not currently supported for Native AOT compilation due unbounded reflection required.")]
+#endif  
         private static void Copy(IDictionary source, Dictionary<string, Document> target)
         {
             foreach (var key in source.Keys)

--- a/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Partition.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Partition.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using Amazon.Runtime.Endpoints;
+using Amazon.Util.Internal;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -105,7 +106,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
             try
             {
                 var json = File.ReadAllText(partitionsFile);
-                var partitions = JsonMapper.ToObject<PartitionFunctionShape>(json);
+                var partitions = JsonSerializerHelper.Deserialize<PartitionFunctionShape>(json, PartitionFunctionShapeJsonSerializerContexts.Default);
                 _partitionsByRegionName.Clear();
                 _partitionsByRegex.Clear();
                 _defaultPartition = null;

--- a/sdk/src/Core/Amazon.Runtime/Internal/ParametersDictionaryFacade.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/ParametersDictionaryFacade.cs
@@ -24,6 +24,7 @@ using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Util;
 using System.Collections;
+using Amazon.Util.Internal;
 
 namespace Amazon.Runtime.Internal
 {
@@ -60,7 +61,7 @@ namespace Amazon.Runtime.Internal
                 return spv.Value;
             else if (slpv != null)
             {
-                var json = ThirdParty.Json.LitJson.JsonMapper.ToJson(slpv.Value);
+                var json = JsonSerializerHelper.Serialize<List<string>>(slpv.Value, ListStringJsonSerializerContexts.Default);
                 return json;
             }
             else
@@ -81,7 +82,7 @@ namespace Amazon.Runtime.Internal
             }
             else if (slpv != null)
             {
-                var stringList = ThirdParty.Json.LitJson.JsonMapper.ToObject<List<string>>(newValue);
+                var stringList = JsonSerializerHelper.Deserialize<List<string>>(newValue, ListStringJsonSerializerContexts.Default);
                 slpv.Value = stringList;
             }
             else

--- a/sdk/src/Core/Amazon.Runtime/Internal/Settings/SettingsCollection.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Settings/SettingsCollection.cs
@@ -26,14 +26,14 @@ namespace Amazon.Runtime.Internal.Settings
 {
     public class SettingsCollection : IEnumerable<SettingsCollection.ObjectSettings>
     {
-        Dictionary<string, Dictionary<string, object>> _values;
+        Dictionary<string, Dictionary<string, string>> _values;
         public SettingsCollection()
         {
-            this._values = new Dictionary<string, Dictionary<string, object>>();
+            this._values = new Dictionary<string, Dictionary<string, string>>();
             this.InitializedEmpty = true;
         }
 
-        public SettingsCollection(Dictionary<string, Dictionary<string, object>> values)
+        public SettingsCollection(Dictionary<string, Dictionary<string, string>> values)
         {
             this._values = values;
             this.InitializedEmpty = false;
@@ -82,7 +82,7 @@ namespace Amazon.Runtime.Internal.Settings
         {
             get 
             {
-                Dictionary<string, object> values;
+                Dictionary<string, string> values;
                 if (!this._values.TryGetValue(key, out values))
                 {
                     return NewObjectSettings(key);
@@ -100,7 +100,7 @@ namespace Amazon.Runtime.Internal.Settings
 
         public ObjectSettings NewObjectSettings(string uniqueKey)
         {
-            Dictionary<string, object> backStore = new Dictionary<string, object>();
+            Dictionary<string, string> backStore = new Dictionary<string, string>();
             ObjectSettings settings = new ObjectSettings(uniqueKey, backStore);
             this._values[uniqueKey] = backStore;
             return settings;
@@ -119,9 +119,9 @@ namespace Amazon.Runtime.Internal.Settings
         public class ObjectSettings
         {
             string _uniqueKey;
-            Dictionary<string, object> _values;
+            Dictionary<string, string> _values;
 
-            internal ObjectSettings(string uniqueKey, Dictionary<string, object> values)
+            internal ObjectSettings(string uniqueKey, Dictionary<string, string> values)
             {
                 this._uniqueKey = uniqueKey;
                 this._values = values;
@@ -136,9 +136,9 @@ namespace Amazon.Runtime.Internal.Settings
             {
                 get 
                 {
-                    object o;
-                    this._values.TryGetValue(key, out o);
-                    return o as string; 
+                    string s;
+                    this._values.TryGetValue(key, out s);
+                    return s; 
                 }
                 set { this._values[key] = value; }
             }
@@ -171,7 +171,7 @@ namespace Amazon.Runtime.Internal.Settings
             {
                 get
                 {
-                    Dictionary<string, object>.KeyCollection keys = this._values.Keys;
+                    Dictionary<string, string>.KeyCollection keys = this._values.Keys;
                     string[] k = new string[keys.Count];
                     this._values.Keys.CopyTo(k,0);
                     return k;

--- a/sdk/src/Core/Amazon.Util/Internal/JsonSerializerHelper.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/JsonSerializerHelper.cs
@@ -33,7 +33,7 @@ namespace Amazon.Util.Internal
             var json = new StringBuilder();
             var writer = new ThirdParty.Json.LitJson.JsonWriter(json)
             {
-                PrettyPrint = (typeInfo.Options?.WriteIndented).GetValueOrDefault()
+                PrettyPrint = (typeInfo?.Options?.WriteIndented).GetValueOrDefault()
             };
 
             ThirdParty.Json.LitJson.JsonMapper.ToJson(obj, writer);
@@ -53,6 +53,17 @@ namespace Amazon.Util.Internal
     {
 #if !NET6_0_OR_GREATER
         public DictionaryStringStringJsonSerializerContexts(JsonSerializerOptions defaultOptions)
+            : base(defaultOptions)
+        {
+        }
+#endif
+    }
+
+    [JsonSerializable(typeof(Dictionary<string, Dictionary<string, string>>))]
+    public partial class DictionaryStringDictionaryStringJsonSerializerContexts : JsonSerializerContext
+    {
+#if !NET6_0_OR_GREATER
+        public DictionaryStringDictionaryStringJsonSerializerContexts(JsonSerializerOptions defaultOptions)
             : base(defaultOptions)
         {
         }

--- a/sdk/src/Services/S3/Custom/Encryption/EncryptionUtils.cs
+++ b/sdk/src/Services/S3/Custom/Encryption/EncryptionUtils.cs
@@ -439,7 +439,7 @@ namespace Amazon.S3.Encryption
                 }
 
                 metadata.Add(XAmzIV, base64EncodedIV);
-                metadata.Add(XAmzMatDesc, JsonMapper.ToJson(instructions.MaterialsDescription));
+                metadata.Add(XAmzMatDesc, Amazon.Util.Internal.JsonSerializerHelper.Serialize<Dictionary<string, string>>(instructions.MaterialsDescription, Amazon.Util.Internal.DictionaryStringStringJsonSerializerContexts.Default));
             }
         }
 

--- a/sdk/test/NetStandard/UnitTests/JsonSerializationTests.cs
+++ b/sdk/test/NetStandard/UnitTests/JsonSerializationTests.cs
@@ -1,6 +1,13 @@
 ﻿using Amazon.Util.Internal;
 using Amazon.Util;
 using Xunit;
+using Amazon.Runtime.Internal.Settings;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+
+#if NET6_0_OR_GREATER
+using System.Text.Json;
+#endif
 
 namespace UnitTests.NetStandard
 {
@@ -11,6 +18,54 @@ namespace UnitTests.NetStandard
         {
             var obj = JsonSerializerHelper.Deserialize<IAMInstanceProfileMetadata>("{\"Code\": \"foo\"}", EC2InstanceMetadataJsonSerializerContexts.Default);
             Assert.Equal("foo", obj.Code);
+        }
+
+        [Fact]
+        public void RoundTripDictionary()
+        {
+            var original = new Dictionary<string, string>();
+            original["foo"] = "bar";
+            original["North"] = "South";
+
+            var json = JsonSerializerHelper.Serialize<Dictionary<string, string>>(original, DictionaryStringStringJsonSerializerContexts.Default);
+            var newDictionary = JsonSerializerHelper.Deserialize<Dictionary<string, string>>(json, DictionaryStringStringJsonSerializerContexts.Default);
+
+            Assert.Equal(original, newDictionary);
+        }
+
+        [Fact]
+        public void PrettyPrintJson()
+        {
+            var original = new Dictionary<string, string>();
+            original["foo"] = "bar";
+            original["North"] = "South";
+
+            var json = JsonSerializerHelper.Serialize<Dictionary<string, string>>(original, DictionaryStringStringJsonSerializerContexts.Default);
+            Assert.DoesNotContain("\n", json);
+
+            json = JsonSerializerHelper.Serialize<Dictionary<string, string>>(original, new DictionaryStringStringJsonSerializerContexts(new JsonSerializerOptions {WriteIndented = true }));
+            Assert.Contains("\n", json);
+        }
+
+        [Fact]
+        public void PersistenceManagerConfirmSwitchToDictionaryStringString()
+        {
+            // The PersistenceManager is only valid for Windows storing information in the AppData folder
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
+            var settings = new SettingsCollection();
+            var oc1 = settings.NewObjectSettings("oc1");
+            oc1["foo"] = "bar";
+
+            var oc2 = settings.NewObjectSettings("Oc2");
+            oc2["North"] = "South";
+
+            PersistenceManager.Instance.SaveSettings("sdk-unit-test", settings);
+
+            var loadSettings = PersistenceManager.Instance.GetSettings("sdk-unit-test");
+            Assert.Equal("bar", loadSettings["oc1"]["foo"]);
+            Assert.Equal("South", loadSettings["Oc2"]["North"]);
         }
     }
 }


### PR DESCRIPTION
## Description
Fix remaining JSON AOT warnings in Core. This involved moving direct usage of LitJson to the new JsonSerializerHelper abstraction that switches between LitJson and System.Text.Json.

### Decisions made
* Mark `ClientContext` as incompatible for AOT due to its JSON usage over `object`. Could possibly rework the class but I don't think the class is even really used anymore. It is in an internal namespace and not referenced anywhere. There are some features in MobileAnalytics that allow you to set a client context JSON. In theory a user could still be using the class even though it is in an internal namespace to generate the JSON. The usage has to be really low so marking incompatible and wait to see if we get request to make it work.
* Mark `Document` as incompatible for AOT. This is a special service data type used for services that work with unstructured data. It is not used very much and the class's design is based on reflection over `object`. I'm willing for the first version of the SDK with AOT support to not have `Document` support and it later when there is demand.
* The `SettingsCollection` class used a `Dictionary<string, Dictionary<string, object>>` as its backing store. The use of `object` makes it impossible to work for AOT when it comes to JSON serialization. The class actually never used anything other than strings so I change the backing store to use `Dictionary<string, Dictionary<string, string>>`. The class is really old predating shared credentials file and I think we just used object for future extensibility but since we really don't even want to be using this settings system anymore, we don't need the extensibility.




## Motivation and Context
Effort to make the SDK compatible with Native AOT

## Testing
Added new JSON unit tests

## Screenshots (if appropriate)


## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement