### PR TITLE
Fix for #3009 - Error response is not parsed if Content-Type header also contains character set

### DIFF
--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/S3ErrorResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/S3ErrorResponseUnmarshaller.cs
@@ -83,7 +83,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 }
             }
 
-            if (context.Stream.CanRead && contentLength != 0 && contentTypeHeader.EndsWith("/xml", StringComparison.OrdinalIgnoreCase))
+            if (context.Stream.CanRead && contentLength != 0 && (contentTypeHeader.EndsWith("/xml", StringComparison.OrdinalIgnoreCase) || contentTypeHeader.ToLower().Contains("/xml;")))
             {
                 try
                 {


### PR DESCRIPTION
Allow parsing of error response if Content-Type header contains an additional token after "/xml", e.g. charset=utf-8

## Description
If an S3 store returns the following header in error responses:
`Content-Type: application/xml;charset=utf-8`
the S3ErrorResponseUnmarshaller did not parse the XML body so that the produced exception did not contain full error information. Instead, the exception is filled only with data from the HTTP status.

The change ensures that the response will also be parsed, if there is a token after "/xml".

## Motivation and Context
- Fixes open issue [#3009](https://github.com/aws/aws-sdk-net/issues/3009)
- Improves compatibilty with other S3 server implementations.

## Testing
Tested behaviour with different S3 server vendors.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement