### PR TITLE
Add thread safety to FallbackCredentialsFactory

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/FallbackCredentialsFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/FallbackCredentialsFactory.cs
@@ -20,12 +20,16 @@ using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Security;
+using System.Threading;
 
 namespace Amazon.Runtime
 {
     // Credentials fallback mechanism
     public static class FallbackCredentialsFactory
     {
+        // Lock to control caching credentials across multiple threads.
+        private static ReaderWriterLockSlim cachedCredentialsLock = new ReaderWriterLockSlim();
+    
         internal const string AWS_PROFILE_ENVIRONMENT_VARIABLE = "AWS_PROFILE";
         internal const string DefaultProfileName = "default";
 
@@ -45,18 +49,26 @@ namespace Amazon.Runtime
 
         public static void Reset(IWebProxy proxy)
         {
-            cachedCredentials = null;
-            CredentialsGenerators = new List<CredentialsGenerator>
+            try
             {
+                cachedCredentialsLock.EnterWriteLock();
+                cachedCredentials = null;
+                CredentialsGenerators = new List<CredentialsGenerator>
+                {
 #if BCL
                 () => new AppConfigAWSCredentials(),            // Test explicit keys/profile name first.
 #endif
-                () => AssumeRoleWithWebIdentityCredentials.FromEnvironmentVariables(),
-                // Attempt to load the default profile.  It could be Basic, Session, AssumeRole, or SAML.
-                () => GetAWSCredentials(credentialProfileChain),
-                () => new EnvironmentVariablesAWSCredentials(), // Look for credentials set in environment vars.
-                () => ECSEC2CredentialsWrapper(proxy),      // either get ECS credentials or instance profile credentials
-            };
+                    () => AssumeRoleWithWebIdentityCredentials.FromEnvironmentVariables(),
+                    // Attempt to load the default profile.  It could be Basic, Session, AssumeRole, or SAML.
+                    () => GetAWSCredentials(credentialProfileChain),
+                    () => new EnvironmentVariablesAWSCredentials(), // Look for credentials set in environment vars.
+                    () => ECSEC2CredentialsWrapper(proxy), // either get ECS credentials or instance profile credentials
+                };
+            }
+            finally
+            {
+                cachedCredentialsLock.ExitWriteLock();
+            }
         }
 
         internal static string GetProfileName()
@@ -124,61 +136,84 @@ namespace Amazon.Runtime
 
         public static AWSCredentials GetCredentials(bool fallbackToAnonymous)
         {
-            if (cachedCredentials != null)
-                return cachedCredentials;
-
-            List<Exception> errors = new List<Exception>();
-
-            foreach (CredentialsGenerator generator in CredentialsGenerators)
+            try
             {
-                try
-                {
-                    cachedCredentials = generator();
-                }
-                // Breaking the FallbackCredentialFactory chain in case a ProcessAWSCredentialException exception 
-                // is encountered. ProcessAWSCredentialException is thrown by the ProcessAWSCredential provider
-                // when an exception is encountered when running a user provided process to obtain Basic/Session 
-                // credentials. The motivation behind this is that, if the user has provided a process to be run
-                // he expects to use the credentials obtained by running the process. Therefore the exception is
-                // surfaced to the user.
-                catch (ProcessAWSCredentialException)
-                {
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    cachedCredentials = null;
-                    errors.Add(e);
-                }
-
+                cachedCredentialsLock.EnterReadLock();
                 if (cachedCredentials != null)
-                    break;
-            }
-
-            if (cachedCredentials == null)
-            {
-                if (fallbackToAnonymous)
                 {
-                    return new AnonymousAWSCredentials();
+                    return cachedCredentials;
                 }
-
-                using (StringWriter writer = new StringWriter(CultureInfo.InvariantCulture))
+            }
+            finally
+            {
+                cachedCredentialsLock.ExitReadLock();
+            }
+            
+            try
+            {
+                cachedCredentialsLock.EnterWriteLock();
+                if (cachedCredentials != null)
                 {
-                    writer.WriteLine("Unable to find credentials");
-                    writer.WriteLine();
-                    for (int i = 0; i < errors.Count; i++)
+                    return cachedCredentials;
+                }
+                
+                List<Exception> errors = new List<Exception>();
+                foreach (CredentialsGenerator generator in CredentialsGenerators)
+                {
+                    try
                     {
-                        Exception e = errors[i];
-                        writer.WriteLine("Exception {0} of {1}:", i + 1, errors.Count);
-                        writer.WriteLine(e.ToString());
-                        writer.WriteLine();
+                        cachedCredentials = generator();
+                    }
+                    // Breaking the FallbackCredentialFactory chain in case a ProcessAWSCredentialException exception 
+                    // is encountered. ProcessAWSCredentialException is thrown by the ProcessAWSCredential provider
+                    // when an exception is encountered when running a user provided process to obtain Basic/Session 
+                    // credentials. The motivation behind this is that, if the user has provided a process to be run
+                    // he expects to use the credentials obtained by running the process. Therefore the exception is
+                    // surfaced to the user.
+                    catch (ProcessAWSCredentialException)
+                    {
+                        throw;
+                    }
+                    catch (Exception e)
+                    {
+                        cachedCredentials = null;
+
+                        errors.Add(e);
                     }
 
-                    throw new AmazonServiceException(writer.ToString());
+                    if (cachedCredentials != null)
+                        break;
                 }
-            }
 
-            return cachedCredentials;
+                if (cachedCredentials == null)
+                {
+                    if (fallbackToAnonymous)
+                    {
+                        return new AnonymousAWSCredentials();
+                    }
+
+                    using (StringWriter writer = new StringWriter(CultureInfo.InvariantCulture))
+                    {
+                        writer.WriteLine("Unable to find credentials");
+                        writer.WriteLine();
+                        for (int i = 0; i < errors.Count; i++)
+                        {
+                            Exception e = errors[i];
+                            writer.WriteLine("Exception {0} of {1}:", i + 1, errors.Count);
+                            writer.WriteLine(e.ToString());
+                            writer.WriteLine();
+                        }
+
+                        throw new AmazonServiceException(writer.ToString());
+                    }
+                }
+
+                return cachedCredentials;
+            }
+            finally
+            {
+                cachedCredentialsLock.ExitWriteLock();
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
This PR adds locking around the cached credentials and refrains from saving temporary credential state in a static variable to avoid race conditions.

## Motivation and Context
If called from multiple threads, the cached credentials in `FallbackCredentialsFactory` can be set to `null` temporarily for failing credential generators, and this can override successfully retrieved credentials from the other threads, causing false negative errors in retrieving credentials. 

Similarly, if the factory cache is reset while getting credentials, the `GetCredentials` method might throw an exception even when it has an actual credential.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement