### PR TITLE
Add MetadataCachingMode configuration to DynamoDB High-Level Programming Models

### DIFF
--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -45,7 +45,7 @@ namespace Amazon
     ///   &lt;proxy host="localhost" port="8888" username="1" password="1" /&gt;
     ///   
     ///   &lt;dynamoDB&gt;
-    ///     &lt;dynamoDBContext tableNamePrefix="Prod-"&gt;
+    ///     &lt;dynamoDBContext tableNamePrefix="Prod-" metadataCachingMode="Default"&gt;
     /// 
     ///       &lt;tableAliases&gt;
     ///         &lt;alias fromTable="FakeTable" toTable="People" /&gt;

--- a/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
@@ -144,6 +144,18 @@ namespace Amazon.Util
         public Dictionary<Type, TypeMapping> TypeMappings { get; private set; }
 
         /// <summary>
+        /// The object persistence API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// <see cref="IAmazonDynamoDB.DescribeTable(string)"/> internally to populate the cache.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
+        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
+        /// </remarks>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
+
+        /// <summary>
         /// Adds a TableAlias to the TableAliases property.
         /// An exception is thrown if there is already a TableAlias with the same FromTable configured.
         /// </summary>
@@ -177,6 +189,7 @@ namespace Amazon.Util
             if (section != null && section.ElementInformation.IsPresent)
             {
                 TableNamePrefix = section.TableNamePrefix;
+                MetadataCachingMode = section.MetadataCachingMode;
 
                 InternalSDKUtils.FillDictionary(section.TypeMappings.Items, t => t.Type, t => new TypeMapping(t), TypeMappings);
                 InternalSDKUtils.FillDictionary(section.TableAliases.Items, t => t.FromTable, t => t.ToTable, TableAliases);
@@ -394,6 +407,7 @@ namespace Amazon.Util
         private const string tableNamePrefixKey = "tableNamePrefix";
         private const string tableAliasesKey = "tableAliases";
         private const string mappingsKey = "mappings";
+        private const string metadataCachingModeKey = "metadataCachingMode";
 
         [ConfigurationProperty(tableNamePrefixKey)]
         public string TableNamePrefix
@@ -415,6 +429,14 @@ namespace Amazon.Util
             get { return (TypeMappingsCollection)this[mappingsKey]; }
             set { this[mappingsKey] = value; }
         }
+
+        [ConfigurationProperty(metadataCachingModeKey)]
+        public MetadataCachingMode? MetadataCachingMode
+        {
+            get { return (MetadataCachingMode?)this[metadataCachingModeKey]; }
+            set { this[metadataCachingModeKey] = value; }
+        }
+
     }
 
     /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -60,6 +60,7 @@ namespace Amazon.DynamoDBv2.DataModel
         {
             TableNamePrefix = AWSConfigsDynamoDB.Context.TableNamePrefix;
             Conversion = DynamoDBEntryConversion.CurrentConversion;
+            MetadataCachingMode = AWSConfigsDynamoDB.Context.MetadataCachingMode;
         }
 
         /// <summary>
@@ -82,6 +83,18 @@ namespace Amazon.DynamoDBv2.DataModel
         /// table names are used.
         /// </summary>
         public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// <see cref="IAmazonDynamoDB.DescribeTable(string)"/> internally to populate the cache.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
+        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
+        /// </remarks>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
 
         /// <summary>
         /// Property that directs DynamoDBContext to ignore null values
@@ -283,7 +296,8 @@ namespace Amazon.DynamoDBv2.DataModel
             IndexName = null,
             ConditionalOperator = ConditionalOperatorValues.And,
             Conversion = null,
-            IsEmptyStringValueEnabled = null
+            IsEmptyStringValueEnabled = null,
+            MetadataCachingMode = null
         };
         private static DynamoDBContextConfig _emptyContextConfig = new DynamoDBContextConfig
         {
@@ -292,7 +306,8 @@ namespace Amazon.DynamoDBv2.DataModel
             TableNamePrefix = null,
             IgnoreNullValues = null,
             Conversion = null,
-            IsEmptyStringValueEnabled = null
+            IsEmptyStringValueEnabled = null,
+            MetadataCachingMode = null
         };
 
         public DynamoDBFlatConfig(DynamoDBOperationConfig operationConfig, DynamoDBContextConfig contextConfig)
@@ -317,6 +332,7 @@ namespace Amazon.DynamoDBv2.DataModel
             List<ScanCondition> queryFilter = operationConfig.QueryFilter ?? new List<ScanCondition>();
             ConditionalOperatorValues conditionalOperator = operationConfig.ConditionalOperator;
             DynamoDBEntryConversion conversion = operationConfig.Conversion ?? contextConfig.Conversion ?? DynamoDBEntryConversion.CurrentConversion;
+            MetadataCachingMode metadataCachingMode = operationConfig.MetadataCachingMode ?? contextConfig.MetadataCachingMode ?? DynamoDBv2.MetadataCachingMode.Default;
 
             ConsistentRead = consistentRead;
             SkipVersionCheck = skipVersionCheck;
@@ -329,6 +345,7 @@ namespace Amazon.DynamoDBv2.DataModel
             QueryFilter = queryFilter;
             ConditionalOperator = conditionalOperator;
             Conversion = conversion;
+            MetadataCachingMode = metadataCachingMode;
 
             State = new OperationState();
         }
@@ -353,6 +370,13 @@ namespace Amazon.DynamoDBv2.DataModel
         /// table names are used.
         /// </summary>
         public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// The object mapping API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// <see cref="IAmazonDynamoDB.DescribeTable(string)"/> internally to populate the cache.
+        /// </summary>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
 
         /// <summary>
         /// Property that directs DynamoDBContext to ignore null values

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -140,7 +140,8 @@ namespace Amazon.DynamoDBv2.DataModel
             ValidateConfigAgainstTable(storageConfig, unconfiguredTable);
 
             var tableConfig = new TableConfig(tableName, flatConfig.Conversion, consumer,
-                storageConfig.AttributesToStoreAsEpoch, flatConfig.IsEmptyStringValueEnabled);
+                storageConfig.AttributesToStoreAsEpoch, flatConfig.IsEmptyStringValueEnabled,
+                flatConfig.MetadataCachingMode);
             var table = unconfiguredTable.Copy(tableConfig);
             return table;
         }
@@ -180,7 +181,7 @@ namespace Amazon.DynamoDBv2.DataModel
                 }
 
                 var emptyConfig = new TableConfig(tableName, conversion: null, consumer: Table.DynamoDBConsumer.DataModel,
-                    storeAsEpoch: null, isEmptyStringValueEnabled: false);
+                    storeAsEpoch: null, isEmptyStringValueEnabled: false, metadataCachingMode: Config.MetadataCachingMode);
                 table = Table.LoadTable(Client, emptyConfig);
                 tablesMap[tableName] = table;
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
@@ -16,8 +16,6 @@
 using System;
 using System.Collections.Generic;
 
-using Amazon.DynamoDBv2.Model;
-
 namespace Amazon.DynamoDBv2.DocumentModel
 {
     /// <summary>
@@ -29,6 +27,18 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// Name of the table.
         /// </summary>
         public string TableName { get; set; }
+
+        /// <summary>
+        /// The document API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// <see cref="IAmazonDynamoDB.DescribeTable(string)"/> internally to populate the cache.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
+        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
+        /// </remarks>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
 
         /// <summary>
         /// Conversion to use for converting .NET values to DynamoDB values.
@@ -54,16 +64,17 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <param name="tableName">Name of the table.</param>
         public TableConfig(string tableName)
             : this(tableName, DynamoDBEntryConversion.CurrentConversion, Table.DynamoDBConsumer.DocumentModel, null,
-                false)
+                false, metadataCachingMode: DynamoDBv2.MetadataCachingMode.Default)
         {
         }
 
         internal TableConfig(string tableName, DynamoDBEntryConversion conversion, Table.DynamoDBConsumer consumer,
-            IEnumerable<string> storeAsEpoch, bool isEmptyStringValueEnabled)
+            IEnumerable<string> storeAsEpoch, bool isEmptyStringValueEnabled, MetadataCachingMode? metadataCachingMode)
         {
             if (string.IsNullOrEmpty(tableName)) throw new ArgumentNullException("tableName");
 
             TableName = tableName;
+            MetadataCachingMode = metadataCachingMode;
             Conversion = conversion;
             Consumer = consumer;
             IsEmptyStringValueEnabled = isEmptyStringValueEnabled;

--- a/sdk/src/Services/DynamoDBv2/Custom/DynamoDBEnumerations.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DynamoDBEnumerations.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.DynamoDBv2
+{
+    /// <summary>
+    /// The higher-level programming models found in the DocumentModel and DataModel namespaces 
+    /// rely on an internal cache of the DynamoDB table's metadata to construct and validate requests.
+    /// This controls how the cache key is derived, which influences 
+    /// when the SDK will call <see cref="IAmazonDynamoDB.DescribeTable(string)"/> internally to populate the cache.
+    /// </summary>
+    public enum MetadataCachingMode
+    {
+        /// <summary>
+        /// The cache key will be a combination of the table name, credentials, region and service URL.
+        /// This ensures applications using tables with the same name but different definitions have their own metadata cached in the application. 
+        /// This will require additional <see cref="IAmazonDynamoDB.DescribeTable(string)"/> API calls as credentials are refreshed.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// The cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints
+        /// (such as a multi-tenant application).
+        /// </summary>
+        TableNameOnly
+    }
+}

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/TableCacheModeTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/TableCacheModeTests.cs
@@ -1,0 +1,247 @@
+﻿using Amazon;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AWSSDK_DotNet35.UnitTests
+{
+    /// <summary>
+    /// Tests the behavior determined by <see cref="MetadataCachingMode"/>, 
+    /// which controls how the internal DescribeTable result is cached
+    /// </summary>
+    [TestClass]
+    public class TableCacheModeTests
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            // These tests rely on the static SDK-wide cache, so we must reset
+            // it before each case or else relevant state will be shared
+            SdkCache.Clear();
+        }
+
+        /// <summary>
+        /// Asserts that DescribeTable is called twice for different credentials for default behavior
+        /// </summary>
+        [DataTestMethod, TestCategory("DynamoDBv2")]
+        [DataRow(null)]
+        [DataRow(MetadataCachingMode.Default)]
+        public void DataModel_DefaultWithDifferentCredentials_DescribeTableCalledTwice(MetadataCachingMode? metadataCachingMode)
+        {
+            var config = new DynamoDBContextConfig
+            {
+                MetadataCachingMode = metadataCachingMode
+            };
+
+            var client1 = CreateMockedClient(new BasicAWSCredentials("test", "test"));  
+            var client2 = CreateMockedClient(new BasicAWSCredentials("test2", "test2"));
+
+            new DynamoDBContext(client1.Object, config).GetTargetTable<ItemClass>();
+            new DynamoDBContext(client2.Object, config).GetTargetTable<ItemClass>();
+
+            client1.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+            client2.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+        }
+
+        /// <summary>
+        /// Asserts that DescribeTable is called once for the same credentials for default behavior
+        /// </summary>
+        /// <param name="metadataCachingMode"></param>
+        [DataTestMethod, TestCategory("DynamoDBv2")]
+        [DataRow(null)]
+        [DataRow(MetadataCachingMode.Default)]
+        public void DataModel_DefaultWithSameCredentials_DescribeTableCalledOnce(MetadataCachingMode? metadataCachingMode)
+        {
+            var config = new DynamoDBContextConfig
+            {
+                MetadataCachingMode = metadataCachingMode
+            };
+
+            var client1 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+            var client2 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+
+            new DynamoDBContext(client1.Object, config).GetTargetTable<ItemClass>();
+            new DynamoDBContext(client2.Object, config).GetTargetTable<ItemClass>();
+
+            client1.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+            client2.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Asserts that DescribeTable is called once for different credentials when using <see cref="MetadataCachingMode.TableNameOnly"/>
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DataModel_TableNameOnlyWithDifferentCredentials_DescribeTableCalledOnce()
+        {
+            var config = new DynamoDBContextConfig
+            {
+                MetadataCachingMode = MetadataCachingMode.TableNameOnly,
+            };
+
+            var client1 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+            var client2 = CreateMockedClient(new BasicAWSCredentials("test2", "test2"));
+
+            new DynamoDBContext(client1.Object, config).GetTargetTable<ItemClass>();
+            new DynamoDBContext(client2.Object, config).GetTargetTable<ItemClass>();
+
+            client1.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+            client2.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Asserts that DescribeTable is called once for different credentials when using <see cref="MetadataCachingMode.TableNameOnly"/>
+        /// when it is set via <see cref="AWSConfigsDynamoDB"/> instead of the context-specific <see cref="DynamoDBContextConfig"/>
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DataModel_TableNameOnlyViaConfigWithDifferentCredentials_DescribeTableCalledOnce()
+        {
+            AWSConfigsDynamoDB.Context.MetadataCachingMode = MetadataCachingMode.TableNameOnly;
+
+            var client1 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+            var client2 = CreateMockedClient(new BasicAWSCredentials("test2", "test2"));
+
+            new DynamoDBContext(client1.Object, new DynamoDBContextConfig()).GetTargetTable<ItemClass>();
+            new DynamoDBContext(client2.Object, new DynamoDBContextConfig()).GetTargetTable<ItemClass>();
+
+            client1.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+            client2.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Asserts that DescribeTable is called once for the same credentials when using <see cref="MetadataCachingMode.TableNameOnly"/>
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DataModel_TableNameOnlyWithSameCredentials_DescribeTableCalledOnce()
+        {
+            var config = new DynamoDBContextConfig
+            {
+                MetadataCachingMode = MetadataCachingMode.TableNameOnly,
+            };
+
+            var client1 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+            var client2 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+
+            new DynamoDBContext(client1.Object, config).GetTargetTable<ItemClass>();
+            new DynamoDBContext(client2.Object, config).GetTargetTable<ItemClass>();
+
+            client1.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+            client2.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Asserts that DescribeTable is called twice for different credentials for default behavior
+        /// </summary>
+        [DataTestMethod, TestCategory("DynamoDBv2")]
+        [DataRow(null)]
+        [DataRow(MetadataCachingMode.Default)]
+        public void DocumentModel_DefaultWithDifferentCredentials_DescribeTableCalledTwice(MetadataCachingMode? metadataCachingMode)
+        {
+            var tableConfig = new TableConfig("MockTable") 
+            { 
+                MetadataCachingMode = metadataCachingMode 
+            };
+
+            var client1 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+            var client2 = CreateMockedClient(new BasicAWSCredentials("test2", "test2"));
+
+            var table1 = Table.LoadTable(client1.Object, tableConfig);
+            var table2 = Table.LoadTable(client2.Object, tableConfig);
+
+            client1.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+            client2.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+        }
+
+        /// <summary>
+        /// Asserts that DescribeTable is called once for the same credentials for default behavior
+        /// </summary>
+        [DataTestMethod, TestCategory("DynamoDBv2")]
+        [DataRow(null)]
+        [DataRow(MetadataCachingMode.Default)]
+        public void DocumentModel_DefaultWithSameCredentials_DescribeTableCalledOnce(MetadataCachingMode? metadataCachingMode)
+        {
+            var tableConfig = new TableConfig("MockTable")
+            {
+                MetadataCachingMode = metadataCachingMode
+            };
+
+            var client1 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+            var client2 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+
+            var table1 = Table.LoadTable(client1.Object, tableConfig);
+            var table2 = Table.LoadTable(client2.Object, tableConfig);
+
+            client1.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+            client2.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Asserts that DescribeTable is called once for different credentials when using <see cref="MetadataCachingMode.TableNameOnly"/>
+        /// </summary>
+        [DataTestMethod, TestCategory("DynamoDBv2")]
+        public void DocumentModel_TableNameOnlyWithDifferentCredentials_DescribeTableCalledOnce()
+        {
+            var tableConfig = new TableConfig("MockTable")
+            {
+                MetadataCachingMode = MetadataCachingMode.TableNameOnly
+            };
+
+            var client1 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+            var client2 = CreateMockedClient(new BasicAWSCredentials("test2", "test2"));
+
+            var table1 = Table.LoadTable(client1.Object, tableConfig);
+            var table2 = Table.LoadTable(client2.Object, tableConfig);
+
+            client1.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+            client2.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Asserts that DescribeTable is called once for the same credentials when using <see cref="MetadataCachingMode.TableNameOnly"/>
+        /// </summary>
+        [DataTestMethod, TestCategory("DynamoDBv2")]
+        public void DocumentModel_TableNameOnlyWithSameCredentials_DescribeTableCalledOnce()
+        {
+            var tableConfig = new TableConfig("MockTable")
+            {
+                MetadataCachingMode = MetadataCachingMode.TableNameOnly
+            };
+
+            var client1 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+            var client2 = CreateMockedClient(new BasicAWSCredentials("test", "test"));
+
+            var table1 = Table.LoadTable(client1.Object, tableConfig);
+            var table2 = Table.LoadTable(client2.Object, tableConfig);
+
+            client1.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Once());
+            client2.Verify(x => x.DescribeTable(It.IsAny<DescribeTableRequest>()), Times.Never());
+        }
+
+        [DynamoDBTable("MockTable")]
+        private class ItemClass
+        {
+            public string Id { get; set; }
+        }
+
+        private Mock<AmazonDynamoDBClient> CreateMockedClient(BasicAWSCredentials credentials)
+        {
+            var client = new Mock<AmazonDynamoDBClient>(credentials);
+
+            client.Setup(x => x.DescribeTable(It.IsAny<DescribeTableRequest>())).Returns(
+                new DescribeTableResponse()
+                {
+                    Table = new TableDescription()
+                }
+            );
+
+            return client;
+        }
+    }
+}


### PR DESCRIPTION
DOTNET-7070

## Description
Builds on https://github.com/aws/aws-sdk-net/pull/3002 by adding `MetadataCachingMode` to the configuration for the document and object mapper DynamoDB programming models. This controls how the cache key is derived for the SDK's internal cache of table metadata, which is used by these APIs to build and validate requests.

## Motivation and Context
Currently when caching the table description, the key is a combination of the table name as well as credentials, region, and service URL.

For users who are switching credentials often in a multi-tenant scenario but still accessing the same table or identically structured tables, this should reduce cache misses. This may ease the symptoms of https://github.com/aws/aws-sdk-net/issues/1476 in some scenarios, though doesn't remove the internal `DescribeTable` call entirely.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new unit tests for both document and mapping models.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed - internal dry-run build on https://github.com/aws/aws-sdk-net/pull/3025/commits/8a4f5a780d437debec1f38696b9dc2f069b991c1 passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement