### PR TITLE
[WIP] Adds a TableBuilder for the document and/or object-mapper DynamoDB programming models

### DIFF
--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -45,7 +45,7 @@ namespace Amazon
     ///   &lt;proxy host="localhost" port="8888" username="1" password="1" /&gt;
     ///   
     ///   &lt;dynamoDB&gt;
-    ///     &lt;dynamoDBContext tableNamePrefix="Prod-" metadataCachingMode="Default"&gt;
+    ///     &lt;dynamoDBContext tableNamePrefix="Prod-" metadataCachingMode="Default" disableFetchingTableMetadata="false"&gt;
     /// 
     ///       &lt;tableAliases&gt;
     ///         &lt;alias fromTable="FakeTable" toTable="People" /&gt;

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -334,6 +334,11 @@ namespace Amazon.DynamoDBv2
             return ConverterCache.HasConverter(type);
         }
 
+        internal bool TryGetConverter(Type type, out Converter converter)
+        {
+            return ConverterCache.TryGetConverter(type, out converter);
+        }
+
         internal IEnumerable<DynamoDBEntry> ConvertToEntries(Type elementType, IEnumerable values)
         {
             if (values == null) throw new ArgumentNullException("values");

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -61,6 +61,7 @@ namespace Amazon.DynamoDBv2.DataModel
             TableNamePrefix = AWSConfigsDynamoDB.Context.TableNamePrefix;
             Conversion = DynamoDBEntryConversion.CurrentConversion;
             MetadataCachingMode = AWSConfigsDynamoDB.Context.MetadataCachingMode;
+            DisableFetchingTableMetadata = AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata;
         }
 
         /// <summary>
@@ -117,6 +118,17 @@ namespace Amazon.DynamoDBv2.DataModel
         /// .NET and DynamoDB types happens.
         /// </summary>
         public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <summary>
+        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
+        /// defined by<see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true can avoid latency and potential deadlocks due to the internal  <see cref="DescribeTableRequest"/> call that is used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be fully described via the above methods, otherwise exceptions may be thrown and/or 
+        /// the results of certain DynamoDB operations may change. It is recommended to test your application prior to setting it to true in production code.
+        /// </remarks>
+        public bool? DisableFetchingTableMetadata { get; set; }
     }
 
     /// <summary>
@@ -320,6 +332,8 @@ namespace Amazon.DynamoDBv2.DataModel
             bool consistentRead = operationConfig.ConsistentRead ?? contextConfig.ConsistentRead ?? false;
             bool skipVersionCheck = operationConfig.SkipVersionCheck ?? contextConfig.SkipVersionCheck ?? false;
             bool ignoreNullValues = operationConfig.IgnoreNullValues ?? contextConfig.IgnoreNullValues ?? false;
+            bool disableFetchingTableMetadata = contextConfig.DisableFetchingTableMetadata ?? false;
+
             bool isEmptyStringValueEnabled = operationConfig.IsEmptyStringValueEnabled ?? contextConfig.IsEmptyStringValueEnabled ?? false;
             string overrideTableName =
                 !string.IsNullOrEmpty(operationConfig.OverrideTableName) ? operationConfig.OverrideTableName : string.Empty;
@@ -346,6 +360,7 @@ namespace Amazon.DynamoDBv2.DataModel
             ConditionalOperator = conditionalOperator;
             Conversion = conversion;
             MetadataCachingMode = metadataCachingMode;
+            DisableFetchingTableMetadata = disableFetchingTableMetadata;
 
             State = new OperationState();
         }
@@ -434,6 +449,9 @@ namespace Amazon.DynamoDBv2.DataModel
         /// .NET and DynamoDB types happens.
         /// </summary>
         public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <inheritdoc cref="DynamoDBContextConfig.DisableFetchingTableMetadata"/>
+        public bool DisableFetchingTableMetadata { get; set; }
 
         // Checks if the IndexName is set on the config
         internal bool IsIndexOperation { get { return !string.IsNullOrEmpty(IndexName); } }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -650,7 +650,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
                     if (tableCache == null)
                     {
-                        var baseStorageConfig = CreateStorageConfig(type, actualTableName: null);
+                        var baseStorageConfig = CreateStorageConfig(type, actualTableName: null, flatConfig);
                         tableCache = new ConfigTableCache(baseStorageConfig);
                         Cache[type] = tableCache;
                     }
@@ -671,7 +671,7 @@ namespace Amazon.DynamoDBv2.DataModel
                     return config;
                 }
 
-                config = CreateStorageConfig(type, actualTableName);
+                config = CreateStorageConfig(type, actualTableName, flatConfig);
                 tableCache.Cache[actualTableName] = config;
 
                 return config;
@@ -689,7 +689,8 @@ namespace Amazon.DynamoDBv2.DataModel
         {
             return (config.LowerCamelCaseProperties ? Utils.ToLowerCamelCase(value) : value);
         }
-        private ItemStorageConfig CreateStorageConfig(Type baseType, string actualTableName)
+
+        private ItemStorageConfig CreateStorageConfig(Type baseType, string actualTableName, DynamoDBFlatConfig flatConfig)
         {
             if (baseType == null) throw new ArgumentNullException("baseType");
             ITypeInfo typeInfo = TypeFactory.GetTypeInfo(baseType);
@@ -704,7 +705,7 @@ namespace Amazon.DynamoDBv2.DataModel
                 Table table;
                 try
                 {
-                    table = Context.GetUnconfiguredTable(actualTableName);
+                    table = Context.GetUnconfiguredTable(actualTableName, flatConfig.DisableFetchingTableMetadata);
                 }
                 catch
                 {
@@ -718,6 +719,21 @@ namespace Amazon.DynamoDBv2.DataModel
             }
 
             config.Denormalize(Context);
+
+            if (flatConfig.DisableFetchingTableMetadata)
+            {
+                if (string.IsNullOrEmpty(actualTableName))
+                {
+                    actualTableName = DynamoDBContext.GetTableName(config.TableName, flatConfig);
+                }
+                var emptyConfig = new TableConfig(actualTableName, conversion: null, consumer: Table.DynamoDBConsumer.DataModel,
+                    storeAsEpoch: null, isEmptyStringValueEnabled: false, metadataCachingMode: flatConfig.MetadataCachingMode);
+                var table = Table.CreateTableFromItemStorageConfig(Context.Client, emptyConfig, config, flatConfig);
+
+                // The table info must be cached under the actual table name exactly how it exists in the DynamoDB service.
+                // This is done to mimic the caching behavior when DisableFetchingTableMetadata is set to false.
+                Context.StoreUnconfiguredTable(actualTableName, table);
+            }
             return config;
         }
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ITableBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ITableBuilder.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.DynamoDBv2.DocumentModel
+{
+    /// <summary>
+    /// Interface for a builder that constructs a <see cref="Table"/>
+    /// </summary>
+    public interface ITableBuilder
+    {
+        /// <summary>
+        /// Call at the end to retrieve the new <see cref="Table"/>
+        /// </summary>
+        /// <returns>Built table</returns>
+        Table Build();
+
+        /// <summary>
+        /// Adds the primary key definition to the table
+        /// </summary>
+        /// <param name="hashKeyAttribute">Name of the attribute used as the partition key</param>
+        /// <param name="type">Type of that attribute</param>
+        ITableBuilder AddHashKey(string hashKeyAttribute, DynamoDBEntryType type);
+
+        /// <summary>
+        /// Adds a sort key definition to the table
+        /// </summary>
+        /// <param name="rangeKeyAttribute">Name of the attribute used as the sort key</param>
+        /// <param name="type">Type of that attribute </param>
+        ITableBuilder AddRangeKey(string rangeKeyAttribute, DynamoDBEntryType type);
+
+        /// <summary>
+        /// Adds a local secondary index definition to the table
+        /// </summary>
+        /// <param name="indexName">Name of the local secondary index</param>
+        /// <param name="rangeKeyAttribute">Name of the attribute used as the sort key in the local secondary index</param>
+        /// <param name="type">Type of that attribute</param>
+        ITableBuilder AddLocalSecondaryIndex(string indexName, string rangeKeyAttribute, DynamoDBEntryType type);
+
+        /// <summary>
+        /// Adds a global secondary index definition to the table
+        /// </summary>
+        /// <param name="indexName">Name of the global secondary index</param>
+        /// <param name="hashkeyAttribute">Name of the attribute used as the partition key in the GSI</param>
+        /// <param name="hashKeyType">Type of the hash key attribute</param>
+        /// <param name="rangeKeyAttribute">Name of the attribute used as the sort key in the GSI</param>
+        /// <param name="rangeKeyType">Type of the sort key attribute</param>
+        ITableBuilder AddGlobalSecondaryIndex(string indexName, string hashkeyAttribute, DynamoDBEntryType hashKeyType, string rangeKeyAttribute, DynamoDBEntryType rangeKeyType);
+    }
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
@@ -340,7 +340,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 throw new InvalidOperationException("Only one of the conditonal properties Expected, ExpectedState and ConditionalExpression can be set.");
         }
 
-        private void ClearTableData()
+        internal void ClearTableData()
         {
             Keys = new Dictionary<string, KeyDescription>();
             HashKeys = new List<string>();
@@ -399,7 +399,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         #region Constructor/factory
 
-        private Table(IAmazonDynamoDB ddbClient, TableConfig config)
+        internal Table(IAmazonDynamoDB ddbClient, TableConfig config)
         {
             if (config == null)
                 throw new ArgumentNullException("config");

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableBuilder.cs
@@ -1,0 +1,260 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using Amazon.DynamoDBv2.Model;
+using System;
+using System.Collections.Generic;
+
+namespace Amazon.DynamoDBv2.DocumentModel
+{
+    /// <summary>
+    /// Builder that constructs a <see cref="Table"/>
+    /// </summary>
+    public class TableBuilder : ITableBuilder
+    {
+        /// <summary>
+        /// The <see cref="Table"/> object that is built and then returned from <see cref="Build"/>
+        /// </summary>
+        private Table _table;
+
+        /// <summary>
+        /// Keeps track internally of attributes that have already been saved in <see cref="Table.Attributes"/>,
+        /// since they can be shared by different indices.
+        /// </summary>
+        private HashSet<string> _attributesAlreadyProcessed; 
+
+        /// <summary>
+        /// Creates a builder object to construct a <see cref="Table"/>
+        /// </summary>
+        /// <param name="ddbClient">Client to use to access DynamoDB.</param>
+        /// <param name="tableName">Table name</param>
+        public TableBuilder(IAmazonDynamoDB ddbClient, string tableName) :
+             this(ddbClient, tableName, DynamoDBEntryConversion.CurrentConversion, false, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a builder object to construct a <see cref="Table"/>
+        /// </summary>
+        /// <param name="ddbClient">Client to use to access DynamoDB.</param>
+        /// <param name="tableName">Table name</param>
+        /// <param name="conversion">Conversion to use for converting .NET values to DynamoDB values.</param>
+        /// <param name="isEmptyStringValueEnabled">If the property is false, empty string values will be interpreted as null values.</param>
+        /// <param name="metadataCachingMode">The document API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// <see cref="IAmazonDynamoDB.DescribeTable(string)"/> internally to populate the cache.</param>
+        public TableBuilder(IAmazonDynamoDB ddbClient, string tableName, DynamoDBEntryConversion conversion, bool isEmptyStringValueEnabled, MetadataCachingMode? metadataCachingMode)
+            : this (ddbClient, new TableConfig(tableName, conversion, Table.DynamoDBConsumer.DocumentModel, null, isEmptyStringValueEnabled, metadataCachingMode))
+        {
+        }
+
+        /// <summary>
+        /// Creates a builder object to construct a <see cref="Table"/>
+        /// </summary>
+        /// <param name="ddbClient">Client to use to access DynamoDB.</param>
+        /// <param name="config">Configuration to use for the table.</param>
+        public TableBuilder(IAmazonDynamoDB ddbClient, TableConfig config)
+        {
+            _table = new Table(ddbClient, config);
+            _table.ClearTableData(); // initializes internal collections
+            _attributesAlreadyProcessed = new HashSet<string>();
+        }
+
+        /// <inheritdoc/>
+        public Table Build()
+        {
+            if (_table.HashKeys.Count == 0)
+            {
+                throw new ArgumentOutOfRangeException("A partition key definition is required, call AddHashKey before Build.");
+            }
+
+            return _table;
+        }
+
+        /// <inheritdoc/>
+        public ITableBuilder AddHashKey(string hashKeyAttribute, DynamoDBEntryType type)
+        {
+            if (string.IsNullOrEmpty(hashKeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(hashKeyAttribute), "The name of the partition key attribute is required.");
+            }
+            
+            if (_table.HashKeys.Count != 0)
+            {
+                throw new ArgumentOutOfRangeException("Only a single partition key is supported, and one has already been added.");
+            }
+
+            _table.HashKeys.Add(hashKeyAttribute);
+
+            _table.Keys.Add(hashKeyAttribute, new KeyDescription
+            {
+                IsHash = true,
+                Type = type
+            });
+
+            if (!_attributesAlreadyProcessed.Contains(hashKeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(hashKeyAttribute, dynamoDBEntryTypeToScalarAttributeType(type)));
+                _attributesAlreadyProcessed.Add(hashKeyAttribute);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ITableBuilder AddRangeKey(string rangeKeyAttribute, DynamoDBEntryType type)
+        {
+            if (string.IsNullOrEmpty(rangeKeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(rangeKeyAttribute), "The name of the sort key attribute is required.");
+            }
+
+            if (_table.RangeKeys.Count != 0)
+            {
+                throw new ArgumentOutOfRangeException("Only a single sort key is supported, and one has already been added.");
+            }
+
+            _table.RangeKeys.Add(rangeKeyAttribute);
+
+            _table.Keys.Add(rangeKeyAttribute, new KeyDescription
+            {
+                IsHash = false,
+                Type = type
+            });
+
+            if (!_attributesAlreadyProcessed.Contains(rangeKeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(rangeKeyAttribute, dynamoDBEntryTypeToScalarAttributeType(type)));
+                _attributesAlreadyProcessed.Add(rangeKeyAttribute);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ITableBuilder AddLocalSecondaryIndex(string indexName, string rangeKeyAttribute, DynamoDBEntryType type)
+        {
+            if (string.IsNullOrEmpty(indexName))
+            {
+                throw new ArgumentNullException(nameof(indexName), "The name of the local secondary index is required");
+            }
+
+            if (_table.LocalSecondaryIndexes.ContainsKey(indexName))
+            {
+                throw new ArgumentException($"An local secondary index with name {indexName} has already been defined.");
+            }
+
+            if (string.IsNullOrEmpty(rangeKeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(rangeKeyAttribute), "The attribute name of the range key within the local secondary index is required.");
+            }
+
+            if (_table.HashKeys.Count == 0)
+            {
+                throw new ArgumentException("A local secondary index uses the table's partition key, which was not provided. Call AddHashKey prior to AddLocalSecondaryIndex.");
+
+            }            
+
+            _table.LocalSecondaryIndexNames.Add(indexName);
+
+            _table.LocalSecondaryIndexes.Add(indexName, new LocalSecondaryIndexDescription
+            {
+                IndexName = indexName,
+                KeySchema = new List<KeySchemaElement>()
+                {
+                    new KeySchemaElement { AttributeName = _table.HashKeys[0], KeyType = KeyType.HASH },
+                    new KeySchemaElement { AttributeName = rangeKeyAttribute, KeyType = KeyType.RANGE }
+                }
+            });
+
+            if (!_attributesAlreadyProcessed.Contains(rangeKeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(rangeKeyAttribute, dynamoDBEntryTypeToScalarAttributeType(type)));
+                _attributesAlreadyProcessed.Add(rangeKeyAttribute);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ITableBuilder AddGlobalSecondaryIndex(string indexName, string hashkeyAttribute, DynamoDBEntryType hashKeyType, string rangeKeyAttribute, DynamoDBEntryType rangeKeyType)
+        {
+            if (string.IsNullOrEmpty(indexName))
+            {
+                throw new ArgumentNullException(nameof(indexName), "The name of the global secondary index is required");
+            }
+
+            if (_table.GlobalSecondaryIndexes.ContainsKey(indexName))
+            {
+                throw new ArgumentException($"An global secondary index with name {indexName} has already been defined.");
+            }
+
+            if (string.IsNullOrEmpty(hashkeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(hashkeyAttribute), "The attribute name of the partition key within the global secondary index is required.");
+            }
+
+            if (string.IsNullOrEmpty(rangeKeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(rangeKeyAttribute), "The attribute name of the range key within the global secondary index is required.");
+            }
+
+            _table.GlobalSecondaryIndexNames.Add(indexName);
+
+            _table.GlobalSecondaryIndexes.Add(indexName, new GlobalSecondaryIndexDescription
+            {
+                IndexName = indexName,
+                KeySchema = new List<KeySchemaElement>()
+                {
+                    new KeySchemaElement { AttributeName = hashkeyAttribute, KeyType = KeyType.HASH },
+                    new KeySchemaElement { AttributeName = rangeKeyAttribute, KeyType = KeyType.RANGE }
+                }
+            });
+
+            if (!_attributesAlreadyProcessed.Contains(hashkeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(hashkeyAttribute, dynamoDBEntryTypeToScalarAttributeType(hashKeyType)));
+                _attributesAlreadyProcessed.Add(hashkeyAttribute);
+            }
+
+            if (!_attributesAlreadyProcessed.Contains(rangeKeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(rangeKeyAttribute, dynamoDBEntryTypeToScalarAttributeType(rangeKeyType)));
+                _attributesAlreadyProcessed.Add(rangeKeyAttribute);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Maps the document model's <see cref="DynamoDBEntryType"/> to the corresponding, low-level <see cref="ScalarAttributeType"/>
+        /// </summary>
+        /// <param name="entryType">Document model attribute type</param>
+        /// <returns>Corresponding low-level attribute type</returns>
+        private static ScalarAttributeType dynamoDBEntryTypeToScalarAttributeType(DynamoDBEntryType entryType)
+        {
+            switch (entryType)
+            {
+                case DynamoDBEntryType.String:
+                    return ScalarAttributeType.S;
+                case DynamoDBEntryType.Numeric:
+                    return ScalarAttributeType.N;
+                case DynamoDBEntryType.Binary:
+                    return ScalarAttributeType.B;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(entryType), "Not a valid ScalarAttributeType");
+            }
+        }
+    }
+}

--- a/sdk/src/Services/DynamoDBv2/GlobalSuppressions.cs
+++ b/sdk/src/Services/DynamoDBv2/GlobalSuppressions.cs
@@ -4,9 +4,10 @@
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DataModel.ItemStorageConfigCache.CreateStorageConfig(System.Type,System.String)~Amazon.DynamoDBv2.DataModel.ItemStorageConfig")]
+using System.Diagnostics.CodeAnalysis;
+
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DocumentModel.Document.DateTimeToEpochSeconds(Amazon.DynamoDBv2.DocumentModel.DynamoDBEntry,System.String)~Amazon.DynamoDBv2.DocumentModel.DynamoDBEntry")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DocumentModel.Document.EpochSecondsToDateTime(Amazon.DynamoDBv2.DocumentModel.DynamoDBEntry,System.String)~Amazon.DynamoDBv2.DocumentModel.DynamoDBEntry")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DocumentModel.Table.TryLoadTable(Amazon.DynamoDBv2.IAmazonDynamoDB,Amazon.DynamoDBv2.DocumentModel.TableConfig,Amazon.DynamoDBv2.DocumentModel.Table@)~System.Boolean")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1720:Identifier contains type name", Scope = "type", Target = "~T:Amazon.DynamoDBv2.DocumentModel.DynamoDBEntryType")]
-
+[assembly: SuppressMessage("Design", "CA1031:Do not catch general exception types", Scope = "member", Target = "~M:Amazon.DynamoDBv2.DataModel.ItemStorageConfigCache.CreateStorageConfig(System.Type,System.String,Amazon.DynamoDBv2.DataModel.DynamoDBFlatConfig)~Amazon.DynamoDBv2.DataModel.ItemStorageConfig")]

--- a/sdk/test/IntegrationTests/Config/35/App.config
+++ b/sdk/test/IntegrationTests/Config/35/App.config
@@ -35,6 +35,12 @@
             <property name="InternalId" ignore="true" />
             <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.Net35" />
           </map>
+          <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+PartiallyAnnotatedEmployee, AWSSDK.IntegrationTests.Net35" targetTable="HashRangeTable">
+            <property name="ManagerName" attribute="Manager" />
+            <property name="CompanyName" attribute="Company" />
+            <property name="InternalId" ignore="true" />
+            <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.Net35" />
+          </map>
           <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+VersionedEmployee, AWSSDK.IntegrationTests.Net35" targetTable="FakeTable">
             <property name="Version" version="true" />
           </map>

--- a/sdk/test/IntegrationTests/Config/45/App.config
+++ b/sdk/test/IntegrationTests/Config/45/App.config
@@ -35,6 +35,12 @@
                         <property name="InternalId" ignore="true" />
                         <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.Net45" />
                     </map>
+                    <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+PartiallyAnnotatedEmployee, AWSSDK.IntegrationTests.Net45" targetTable="HashRangeTable">
+                        <property name="ManagerName" attribute="Manager" />
+                        <property name="CompanyName" attribute="Company" />
+                        <property name="InternalId" ignore="true" />
+                        <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.Net45" />
+                    </map>
                     <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+VersionedEmployee, AWSSDK.IntegrationTests.Net45" targetTable="FakeTable">
                         <property name="Version" version="true" />
                     </map>

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/Config/35/App.config
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/Config/35/App.config
@@ -36,6 +36,12 @@
             <property name="InternalId" ignore="true" />
             <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.DynamoDBv2.Net35" />
           </map>
+          <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+PartiallyAnnotatedEmployee, AWSSDK.IntegrationTests.DynamoDBv2.Net35" targetTable="HashRangeTable">
+            <property name="ManagerName" attribute="Manager" />
+            <property name="CompanyName" attribute="Company" />
+            <property name="InternalId" ignore="true" />
+            <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.DynamoDBv2.Net35" />
+          </map>
           <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+VersionedEmployee, AWSSDK.IntegrationTests.DynamoDBv2.Net35" targetTable="FakeTable">
             <property name="Version" version="true" />
           </map>

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/Config/45/App.config
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/Config/45/App.config
@@ -36,6 +36,12 @@
             <property name="InternalId" ignore="true" />
             <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.DynamoDBv2.Net45" />
           </map>
+          <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+PartiallyAnnotatedEmployee, AWSSDK.IntegrationTests.DynamoDBv2.Net45" targetTable="HashRangeTable">
+            <property name="ManagerName" attribute="Manager" />
+            <property name="CompanyName" attribute="Company" />
+            <property name="InternalId" ignore="true" />
+            <property name="CurrentStatus" attribute="Status" converter="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+StatusConverter, AWSSDK.IntegrationTests.DynamoDBv2.Net45" />
+          </map>
           <map type="AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB.DynamoDBTests+VersionedEmployee, AWSSDK.IntegrationTests.DynamoDBv2.Net45" targetTable="FakeTable">
             <property name="Version" version="true" />
           </map>

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -44,7 +44,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 TestEnums(conversion);
 
                 TestHashObjects();
-                TestHashRangeObjects();
+                TestHashRangeObjects<Employee>();
                 TestOtherContextOperations();
                 TestBatchOperations();
                 TestTransactionOperations();
@@ -72,6 +72,92 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
             TestEmptyStringsWithFeatureDisabled();
         }
+
+        /// <summary>
+        /// Tests that the DynamoDB operations can be invoked successfully based on the table info 
+        /// supplied only via class attributes.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestContext_DisableFetchingTableMetadata_WithFullAttributes()
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            CreateContext(DynamoDBEntryConversion.V2, true, true);
+
+            TestHashRangeObjects<AnnotatedEmployee>();
+        }
+
+        /// <summary>
+        /// Tests that the DynamoDB operations can be invoked successfully based on the table info 
+        /// supplied via a combination of class attributes and the app config.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestContext_DisableFetchingTableMetadata_WithPartialAttributes()
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            CreateContext(DynamoDBEntryConversion.V2, true, true);
+
+            TestHashRangeObjects<PartiallyAnnotatedEmployee>();
+        }
+
+        /// <summary>
+        /// Tests that the DynamoDB operations can be invoked successfully based on the table info 
+        /// supplied via attributes on the parent class.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestContext_DisableFetchingTableMetadata_WithNonAnnotatedChildClass()
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            CreateContext(DynamoDBEntryConversion.V2, true, true);
+
+            TestHashRangeObjects<EmployeeChild>();
+        }
+
+        /// <summary>
+        /// Tests that the DynamoDB operations can be invoked successfully based on a Datetime attribute as the hash key that is stored as epoch.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestContext_DisableFetchingTableMetadata_DateTimeAsHashKey()
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            CreateContext(DynamoDBEntryConversion.V2, true, true);
+
+            var employee = new AnnotatedNumericEpochEmployee
+            {
+                Name = "Bob",
+                Age = 45,
+                CreationTime = EpochDate,
+                EpochDate2 = EpochDate,
+                NonEpochDate1 = EpochDate,
+                NonEpochDate2 = EpochDate
+            };
+
+            Context.Save(employee);
+            var storedEmployee = Context.Load<AnnotatedNumericEpochEmployee>(employee.CreationTime, employee.Name);
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(EpochDate, storedEmployee.CreationTime);
+            ApproximatelyEqual(EpochDate, storedEmployee.EpochDate2);
+            ApproximatelyEqual(EpochDate, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(EpochDate, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+        }
+
 
         private static void TestEmptyStringsWithFeatureEnabled()
         {
@@ -655,10 +741,10 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             }
         }
 
-        private void TestHashRangeObjects()
+        private void TestHashRangeObjects<T>() where T : Employee, new()
         {
             // Create and save item
-            Employee employee = new Employee
+            T employee = new T
             {
                 Name = "Alan",
                 Age = 31,
@@ -673,7 +759,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Context.Save(employee);
 
             // Load item
-            Employee retrieved = Context.Load(employee);
+            T retrieved = Context.Load(employee);
             Assert.AreEqual(employee.Name, retrieved.Name);
             Assert.AreEqual(employee.Age, retrieved.Age);
             Assert.AreEqual(employee.CompanyName, retrieved.CompanyName);
@@ -697,7 +783,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.AreEqual(employee.Data.Length, retrieved.Data.Length);
 
             // Create more items
-            Employee employee2 = new Employee
+            T employee2 = new T
             {
                 Name = "Diane",
                 Age = 40,
@@ -713,7 +799,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             employee2.Score = 101;
             Context.Save(employee2);
 
-            retrieved = Context.Load<Employee>("Alan", 31);
+            retrieved = Context.Load<T>("Alan", 31);
             Assert.AreEqual(retrieved.Name, "Alan");
             retrieved = Context.Load(employee);
             Assert.AreEqual(retrieved.Name, "Chuck");
@@ -722,35 +808,35 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.AreEqual(retrieved.Age, 24);
 
             // Scan for all items
-            var employees = Context.Scan<Employee>().ToList();
+            var employees = Context.Scan<T>().ToList();
             Assert.AreEqual(4, employees.Count);
 
             // Query for items with Hash-Key = "Diane"
-            employees = Context.Query<Employee>("Diane").ToList();
+            employees = Context.Query<T>("Diane").ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Query for items with Hash-Key = "Diane" and Range-Key > 30
-            employees = Context.Query<Employee>("Diane", QueryOperator.GreaterThan, 30).ToList();
+            employees = Context.Query<T>("Diane", QueryOperator.GreaterThan, 30).ToList();
             Assert.AreEqual(1, employees.Count);
 
             
             // Index Query
 
             // Query local index for items with Hash-Key = "Diane"
-            employees = Context.Query<Employee>("Diane", new DynamoDBOperationConfig { IndexName = "LocalIndex" }).ToList();
+            employees = Context.Query<T>("Diane", new DynamoDBOperationConfig { IndexName = "LocalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Query local index for items with Hash-Key = "Diane" and Range-Key = "Eva"
-            employees = Context.Query<Employee>("Diane", QueryOperator.Equal, new object[] { "Eva" },
+            employees = Context.Query<T>("Diane", QueryOperator.Equal, new object[] { "Eva" },
                 new DynamoDBOperationConfig { IndexName = "LocalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Query global index for item with Hash-Key (Company) = "Big River"
-            employees = Context.Query<Employee>("Big River", new DynamoDBOperationConfig { IndexName = "GlobalIndex" }).ToList();
+            employees = Context.Query<T>("Big River", new DynamoDBOperationConfig { IndexName = "GlobalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Query global index for item with Hash-Key (Company) = "Big River", with QueryFilter for CurrentStatus = Status.Active
-            employees = Context.Query<Employee>("Big River",
+            employees = Context.Query<T>("Big River",
                 new DynamoDBOperationConfig
                 {
                     IndexName = "GlobalIndex",
@@ -765,13 +851,13 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             // Index Scan
 
             // Scan local index for items with Hash-Key = "Diane"
-            employees = Context.Scan<Employee>(
+            employees = Context.Scan<T>(
                 new List<ScanCondition> { new ScanCondition("Name", ScanOperator.Equal, "Diane") },
                 new DynamoDBOperationConfig { IndexName = "LocalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Scan local index for items with Hash-Key = "Diane" and Range-Key = "Eva"
-            employees = Context.Scan<Employee>(
+            employees = Context.Scan<T>(
                 new List<ScanCondition>
                 {
                     new ScanCondition("Name", ScanOperator.Equal, "Diane"),
@@ -781,13 +867,13 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.AreEqual(2, employees.Count);
 
             // Scan global index for item with Hash-Key (Company) = "Big River"
-            employees = Context.Scan<Employee>(
+            employees = Context.Scan<T>(
                 new List<ScanCondition> { new ScanCondition("CompanyName", ScanOperator.Equal, "Big River") },
                 new DynamoDBOperationConfig { IndexName = "GlobalIndex" }).ToList();
             Assert.AreEqual(2, employees.Count);
 
             // Scan global index for item with Hash-Key (Company) = "Big River", with QueryFilter for CurrentStatus = Status.Active
-            employees = Context.Scan<Employee>(
+            employees = Context.Scan<T>(
                 new List<ScanCondition>
                 {
                     new ScanCondition("CompanyName", ScanOperator.Equal, "Big River"),
@@ -1414,19 +1500,73 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
         public class Employee
         {
             // Hash key
-            public string Name { get; set; }
+            public virtual string Name { get; set; }
             public string MiddleName { get; set; }
             // Range key
-            public int Age { get; set; }
+            public virtual int Age { get; set; }
 
-            public string CompanyName { get; set; }
-            public int Score { get; set; }
-            public string ManagerName { get; set; }
+            public virtual string CompanyName { get; set; }
+            public virtual int Score { get; set; }
+            public virtual string ManagerName { get; set; }
             public byte[] Data { get; set; }
             public Status CurrentStatus { get; set; }
             public List<string> Aliases { get; set; }
 
             public string InternalId { get; set; }
+        }
+
+        /// <summary>
+        /// Same structure as <see cref="Employee"/>, but the indices are fully annotated
+        /// </summary>
+        [DynamoDBTable("HashRangeTable")]
+        public class AnnotatedEmployee : Employee
+        {
+            // Hash key
+            [DynamoDBHashKey]
+            public override string Name { get; set; }
+
+            // Range key
+            [DynamoDBRangeKey]
+            public override int Age { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexHashKey("GlobalIndex", AttributeName = "Company")]
+            public override string CompanyName { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexRangeKey("GlobalIndex")]
+            public override int Score { get; set; }
+
+            [DynamoDBLocalSecondaryIndexRangeKey("LocalIndex", AttributeName = "Manager")]
+            public override string ManagerName { get; set; }
+        }
+
+        /// <summary>
+        /// Same structure as <see cref="AnnotatedEmployee"/>, but it does not have the <see cref="DynamoDBTableAttribute"/> and attribute names overrides.
+        /// </summary>
+        public class PartiallyAnnotatedEmployee : Employee
+        {
+            // Hash key
+            [DynamoDBHashKey]
+            public override string Name { get; set; }
+
+            // Range key
+            [DynamoDBRangeKey]
+            public override int Age { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexHashKey("GlobalIndex")]
+            public override string CompanyName { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexRangeKey("GlobalIndex")]
+            public override int Score { get; set; }
+
+            [DynamoDBLocalSecondaryIndexRangeKey("LocalIndex")]
+            public override string ManagerName { get; set; }
+        }
+
+        /// <summary>
+        /// Child class of <see cref="AnnotatedEmployee"/> without any attributes.
+        /// </summary>
+        public class EmployeeChild : AnnotatedEmployee
+        {
         }
 
         /// <summary>
@@ -1467,7 +1607,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
         public class EpochEmployee : Employee
         {
             [DynamoDBProperty(StoreAsEpoch = true)]
-            public DateTime CreationTime { get; set; }
+            public virtual DateTime CreationTime { get; set; }
 
             public DateTime EpochDate2 { get; set; }
 
@@ -1484,6 +1624,19 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
         public class NumericEpochEmployee : EpochEmployee
         {
 
+        }
+
+        /// <summary>
+        /// Same structure as <see cref="NumericEpochEmployee"/>, but the Hash key is annotated
+        /// </summary>
+        [DynamoDBTable("NumericHashRangeTable")]
+        public class AnnotatedNumericEpochEmployee : EpochEmployee
+        {
+            [DynamoDBHashKey(StoreAsEpoch = true)]
+            public override DateTime CreationTime { get; set; }
+
+            [DynamoDBRangeKey]
+            public override string Name { get; set; }
         }
 
         #endregion

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -159,6 +159,66 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
         }
 
 
+        /// <summary>
+        /// Runs the same object-mapper integration tests as <see cref="TestContextWithEmptyStringEnabled"/>,
+        /// but using table definitions created by <see cref="TableBuilder"/> instead of the internal <see cref="IAmazonDynamoDB.DescribeTable"/> call
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestWithBuilderTables()
+        {
+            foreach (var conversion in new DynamoDBEntryConversion[] { DynamoDBEntryConversion.V1, DynamoDBEntryConversion.V2 })
+            {
+                // Cleanup existing data in the tables
+                CleanupTables();
+
+                // Clear existing SDK-wide cache
+                TableCache.Clear();
+
+                // Redeclare Context, which will start with empty caches
+                Context = new DynamoDBContext(Client, new DynamoDBContextConfig
+                {
+                    IsEmptyStringValueEnabled = true,
+                    Conversion = conversion
+                });
+
+                Context.RegisterTableDefinition(new TableBuilder(Client, "DotNetTests-HashRangeTable")
+                                                    .AddHashKey("Name", DynamoDBEntryType.String)
+                                                    .AddRangeKey("Age", DynamoDBEntryType.Numeric)
+                                                    .AddGlobalSecondaryIndex("GlobalIndex", "Company", DynamoDBEntryType.String, "Score", DynamoDBEntryType.Numeric)
+                                                    .AddLocalSecondaryIndex("LocalIndex", "Manager", DynamoDBEntryType.String)
+                                                    .Build());
+
+                Context.RegisterTableDefinition(new TableBuilder(Client, "DotNetTests-HashTable")
+                                                    .AddHashKey("Id", DynamoDBEntryType.Numeric)
+                                                    .AddGlobalSecondaryIndex("GlobalIndex", "Company", DynamoDBEntryType.String, "Price", DynamoDBEntryType.Numeric)
+                                                    .Build());
+
+                Context.RegisterTableDefinition(new TableBuilder(Client, "DotNetTests-NumericHashRangeTable")
+                                                    .AddHashKey("CreationTime", DynamoDBEntryType.Numeric)
+                                                    .AddRangeKey("Name", DynamoDBEntryType.String)
+                                                    .Build());
+
+                TestEmptyStringsWithFeatureEnabled();
+
+                TestEnumHashKeyObjects();
+
+                TestEmptyCollections(conversion);
+
+                TestUnsupportedTypes();
+                TestEnums(conversion);
+
+                TestHashObjects();
+                TestHashRangeObjects();
+                TestOtherContextOperations();
+                TestBatchOperations();
+                TestTransactionOperations();
+                TestMultiTableTransactionOperations();
+
+                TestStoreAsEpoch();
+            }
+        }
+
         private static void TestEmptyStringsWithFeatureEnabled()
         {
             var product = new Product

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DynamoDBTestsBase.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DynamoDBTestsBase.cs
@@ -90,13 +90,14 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ClearTable(numericHashRangeTableName);
         }
 
-        public static void CreateContext(DynamoDBEntryConversion conversion, bool isEmptyStringValueEnabled)
+        public static void CreateContext(DynamoDBEntryConversion conversion, bool isEmptyStringValueEnabled, bool disableFetchingTableMetadata = false)
         {
             var config = new DynamoDBContextConfig
             {
                 //IgnoreNullValues = true
                 IsEmptyStringValueEnabled = isEmptyStringValueEnabled,
-                Conversion = conversion
+                Conversion = conversion,
+                DisableFetchingTableMetadata = disableFetchingTableMetadata
             };
             Context = new DynamoDBContext(Client, config);
         }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -15,6 +15,7 @@ using Amazon.DynamoDBv2.Model;
 using ThirdParty.Json.LitJson;
 
 using Moq;
+using Amazon;
 
 namespace AWSSDK_DotNet35.UnitTests
 {
@@ -328,6 +329,60 @@ namespace AWSSDK_DotNet35.UnitTests
             Assert.AreEqual(document["V"].AsInt(), 1);
         }
 
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestGetTargetTable_DisableFetchingTableMetadata()
+        {
+            var dynamoDBContextConfig = new DynamoDBContextConfig
+            {
+                DisableFetchingTableMetadata = true,
+                TableNamePrefix = "DotnetTest-"
+            };
+            var dynamoDBClient = new Mock<IAmazonDynamoDB>();
+            var dynamoDBContext = new DynamoDBContext(dynamoDBClient.Object, dynamoDBContextConfig);
+
+            var table = dynamoDBContext.GetTargetTable<Employee>();
+            Assert.IsNotNull(table);
+            Assert.AreEqual("DotnetTest-EmployeeDetails", table.TableName);
+            Assert.AreEqual(2, table.Keys.Count);
+            Assert.IsTrue(table.Keys.ContainsKey("Name"));
+            Assert.IsTrue(table.Keys.ContainsKey("Age"));
+
+            Assert.AreEqual(1, table.HashKeys.Count);
+            Assert.AreEqual("Name", table.HashKeys[0]);
+
+            Assert.AreEqual(1, table.RangeKeys.Count);
+            Assert.AreEqual("Age", table.RangeKeys[0]);
+
+            Assert.AreEqual(1, table.GlobalSecondaryIndexes.Count);
+            var gsi = table.GlobalSecondaryIndexes["GlobalIndex"];
+            Assert.AreEqual("GlobalIndex", gsi.IndexName);
+            Assert.AreEqual(2, gsi.KeySchema.Count);
+            Assert.AreEqual("Company", gsi.KeySchema[0].AttributeName);
+            Assert.AreEqual(KeyType.HASH, gsi.KeySchema[0].KeyType);
+            Assert.AreEqual("Score", gsi.KeySchema[1].AttributeName);
+            Assert.AreEqual(KeyType.RANGE, gsi.KeySchema[1].KeyType);
+
+            Assert.AreEqual(1, table.LocalSecondaryIndexes.Count);
+            var lsi = table.LocalSecondaryIndexes["LocalIndex"];
+            Assert.AreEqual("LocalIndex", lsi.IndexName);
+            Assert.AreEqual(2, lsi.KeySchema.Count);
+            Assert.AreEqual("Name", lsi.KeySchema[0].AttributeName);
+            Assert.AreEqual(KeyType.HASH, lsi.KeySchema[0].KeyType);
+            Assert.AreEqual("Manager", lsi.KeySchema[1].AttributeName);
+            Assert.AreEqual(KeyType.RANGE, lsi.KeySchema[1].KeyType);
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestDisableFetchingTableMetadata_UsingGlobalContext()
+        {
+            AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata = true;
+            var config = new DynamoDBContextConfig();
+            Assert.AreEqual(true, config.DisableFetchingTableMetadata);
+            AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata = false;
+        }
+
         public class Parent
         {
             [DynamoDBProperty("actualPropertyName")]
@@ -340,6 +395,27 @@ namespace AWSSDK_DotNet35.UnitTests
         public class Child : Parent
         {
             public override string Property1 { get; set; }
+        }
+
+        [DynamoDBTable("EmployeeDetails")]
+        public class Employee
+        {
+            // Hash key
+            [DynamoDBHashKey]
+            public string Name { get; set; }
+
+            // Range key
+            [DynamoDBRangeKey]
+            public int Age { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexHashKey("GlobalIndex", AttributeName = "Company")]
+            public string CompanyName { get; set; }
+
+            [DynamoDBGlobalSecondaryIndexRangeKey("GlobalIndex")]
+            public int Score { get; set; }
+
+            [DynamoDBLocalSecondaryIndexRangeKey("LocalIndex", AttributeName = "Manager")]
+            public string ManagerName { get; set; }
         }
 
 #if ASYNC_AWAIT

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/TableBuilderTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/TableBuilderTests.cs
@@ -1,0 +1,189 @@
+﻿using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DocumentModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace AWSSDK_DotNet35.UnitTests
+{
+    /// <summary>
+    /// Tests for <see cref="TableBuilder"/>
+    /// </summary>
+    [TestClass]
+    public class TableBuilderTests
+    {
+        private IAmazonDynamoDB _amazonDynamoDBClient = new AmazonDynamoDBClient();
+
+        /// <summary>
+        /// Asserts that the table requires a partition key definition
+        /// </summary>
+        [TestMethod]
+        public void MissingPrimaryKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => builder.Build());
+        }
+
+        /// <summary>
+        /// Asserts that the partition key requires a non-null attribute
+        /// </summary>
+        [TestMethod]
+        public void NullPrimaryKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddHashKey("", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when more that one partition key is defined
+        /// </summary>
+        [TestMethod]
+        public void MoreThanOnePrimaryKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => builder.AddHashKey("Id2", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the partition key requires a non-null attribute
+        /// </summary>
+        [TestMethod]
+        public void NullRangeKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddRangeKey("", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when more that one sort key is defined
+        /// </summary>
+        [TestMethod]
+        public void MoreThanOneRangeKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddRangeKey("Date", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => builder.AddRangeKey("Date2", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a LSI is defined before the partition key is,
+        /// since the LSI reuses the partition key
+        /// </summary>
+        [TestMethod]
+        public void LSIWithoutPrimaryKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            Assert.ThrowsException<ArgumentException>(() => builder.AddLocalSecondaryIndex("LSI", "Date", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a LSI is defined without an index name
+        /// </summary>
+        [TestMethod]
+        public void MissingLSIIndexName_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddLocalSecondaryIndex("", "Date", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a LSI is defined without an attribute name
+        /// </summary>
+        [TestMethod]
+        public void MissingLSIAttribute_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddLocalSecondaryIndex("LSI", "", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a duplicate LSI is defined
+        /// </summary>
+        [TestMethod]
+        public void DuplicateLSIName_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+            builder.AddLocalSecondaryIndex("LSI", "Date", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentException>(() => builder.AddLocalSecondaryIndex("LSI", "Date2", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder only stores key attributes once when reused in an LSI
+        /// </summary>
+        [TestMethod]
+        public void AttributeReusedViaLSI_OnlyStoredOnce()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+
+            // Add a GSI with two new attributes
+            builder.AddGlobalSecondaryIndex("GSI", "Date", DynamoDBEntryType.String, "OrderNumber", DynamoDBEntryType.Numeric);
+
+            // Add a LSI that reuses one of those, which shouldn't be stored in table.Attributes again
+            builder.AddLocalSecondaryIndex("LSI", "OrderNumber", DynamoDBEntryType.Numeric);
+
+            var table = builder.Build();
+
+            Assert.AreEqual(3, table.Attributes.Count);
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when any of the required GSI identifiers are null
+        /// </summary>
+        public void GSINullNames_ThrowException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            // Null GSI index name
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddGlobalSecondaryIndex("", "Id", DynamoDBEntryType.String, "Date", DynamoDBEntryType.String));
+
+            // Null partition key
+            Assert.ThrowsException<ArgumentException>(() => builder.AddGlobalSecondaryIndex("GSI", "", DynamoDBEntryType.String, "Date", DynamoDBEntryType.String));
+
+            // Null sort key
+            Assert.ThrowsException<ArgumentException>(() => builder.AddGlobalSecondaryIndex("GSI", "Id", DynamoDBEntryType.String, "", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a duplicate GSI is defined
+        /// </summary>
+        [TestMethod]
+        public void DuplicateGSIName_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddGlobalSecondaryIndex("GSI", "Id", DynamoDBEntryType.String, "Date", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentException>(() => builder.AddGlobalSecondaryIndex("GSI", "Id", DynamoDBEntryType.String, "Date", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder only stores key attributes once when they are reused in a GSI
+        /// </summary>
+        [TestMethod]
+        public void AttributesResuedViaGSI_OnlyStoredOnce()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+            builder.AddRangeKey("Date", DynamoDBEntryType.String);
+
+            // Add a GSI that uses those same two attributes
+            builder.AddGlobalSecondaryIndex("GSI", "Date", DynamoDBEntryType.String, "Id", DynamoDBEntryType.String);
+
+            var table = builder.Build();
+
+            Assert.AreEqual(2, table.Attributes.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This may be an approach that partially addresses https://github.com/aws/aws-sdk-net/issues/1476. 

Users can use the new `TableBuilder` to populate the internal SDK cache of table structures that drive the DynamoDB document and object-mapper programming models.
* **Document**: Instead of `Table.Load`, call `new TableBuilder().<table info>.Build()`
* **Object mapper**: Call `context.RegisterTableDefinition(<Table>);`

## Motivation and Context
This allows users to pre-populate the internal cache, which prevents the internal `DescribeTable` call the SDK makes. This avoids the sync-over-async issues discussed in https://github.com/aws/aws-sdk-net/issues/1476.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Did a quick copy of existing document and mapper integration tests using the new table initialization mode, which pass. We likely still need to explore edge cases and failure modes around when the table structure in code does not match the actual table.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement