### PR TITLE
AOT Work: Mark PaginatedResourceFactory for BCL only

### DIFF
--- a/sdk/src/Core/Amazon.Util/PaginatedResourceFactory.cs
+++ b/sdk/src/Core/Amazon.Util/PaginatedResourceFactory.cs
@@ -27,6 +27,7 @@ using System.Globalization;
 
 using Amazon.Util.Internal;
 
+#if BCL
 namespace Amazon.Util
 {
     public static class PaginatedResourceFactory
@@ -294,3 +295,4 @@ namespace Amazon.Util
         }
     }
 }
+#endif

--- a/sdk/src/Core/GlobalSuppressions.cs
+++ b/sdk/src/Core/GlobalSuppressions.cs
@@ -351,7 +351,9 @@ using System.Diagnostics.CodeAnalysis;
 [module: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Amazon.Runtime.Internal.RuntimePipeline.#ReplaceHandler`1(Amazon.Runtime.IPipelineHandler)")]
 [module: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Amazon.Runtime.Internal.RuntimePipeline.#AddHandlerBefore`1(Amazon.Runtime.IPipelineHandler)")]
 [module: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Amazon.Runtime.Internal.DefaultRetryPolicy.#IsInnerException`1(System.Exception)")]
+#if BCL
 [module: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Amazon.Util.PaginatedResourceFactory.#Create`3(Amazon.Util.PaginatedResourceInfo)")]
+#endif
 [module: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Amazon.Runtime.Internal.ServiceClientHelpers.#CreateServiceFromAnother`2(Amazon.Runtime.AmazonServiceClient)")]
 [module: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Amazon.Util.Internal.PlatformServices.ServiceFactory.#RegisterService`1(System.Type)")]
 


### PR DESCRIPTION
The `PaginatedResourceFactory` is an old internal paginator implementation only used in the S3 File IO abstraction which is only available for .NET Framework. This class uses a lot of reflection that is not compatible with AOT compilation. This PR makes the class only available in .NET Framework to remove the AOT trim warnings.

The service client paginators are not affected by this because they are generated without any reflection and do not use the `PaginatedResourceFactory` class. 

I confirmed the fix by ensuring the .NET Standard and .NET Framework solutions still compile after removing `PaginatedResourceFactory` from the .NET Standard/Core targets.