### PR TITLE
Mark the following features as not supported for Native AOT

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
@@ -27,6 +27,9 @@ namespace Amazon.Extensions.NETCore.Setup
     /// <summary>
     /// The options used to construct AWS service clients like the Amazon.S3.AmazonS3Client.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.Extensions.NETCore.Setup.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class AWSOptions
     {
         /// <summary>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.csproj
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>AWSSDK.Extensions.NETCore.Setup</AssemblyName>
     <PackageId>AWSSDK.Extensions.NETCore.Setup</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -13,6 +13,10 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
+	
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>	
 
   <Choose>
     <When Condition=" '$(AWSKeyFile)' == '' ">

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
@@ -26,6 +26,9 @@ namespace Amazon.Extensions.NETCore.Setup
     /// <summary>
     /// The factory class for creating AWS service clients from the AWS SDK for .NET.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.Extensions.NETCore.Setup.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class ClientFactory
     {
         private static readonly Type[] EMPTY_TYPES = Array.Empty<Type>();

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Extensions.Configuration
     /// This class adds extension methods to IConfiguration making it easier to pull out
     /// AWS configuration options.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.Extensions.NETCore.Setup.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public static class ConfigurationExtensions
     {
         /// <summary>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/InternalConstants.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/InternalConstants.cs
@@ -1,0 +1,22 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.Extensions.NETCore.Setup
+{
+    internal static class InternalConstants
+    {
+        internal const string RequiresUnreferencedCodeMessage = "The AWSSDK.Extensions.NETCore.Setup package has not been updated to support Native AOT compilations.";
+    }
+}

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Extensions.DependencyInjection
     /// This class adds extension methods to IServiceCollection making it easier to add Amazon service clients
     /// to the NET Core dependency injection framework.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.Extensions.NETCore.Setup.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public static class ServiceCollectionExtensions
     {
         /// <summary>

--- a/sdk/src/Services/CognitoSync/Custom/AmazonCognitoSyncClient.Extensions.cs
+++ b/sdk/src/Services/CognitoSync/Custom/AmazonCognitoSyncClient.Extensions.cs
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.CognitoSync
+{
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Amazon Cognito Sync has not been updated to support Native AOT compilations.")]
+#endif
+    public partial class AmazonCognitoSyncClient
+    { 
+    }
+}

--- a/sdk/src/Services/CognitoSync/Custom/Internal/CognitoCredentialsRetriever.cs
+++ b/sdk/src/Services/CognitoSync/Custom/Internal/CognitoCredentialsRetriever.cs
@@ -38,6 +38,9 @@ namespace Amazon.CognitoSync.Internal
     /// the service client is using the CognitoAWSCredentials credentials object it makes sure that all
     /// CognitoSync calls have the latest identity id and identity pool id.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Amazon CognitoSync has not been updated to support Native AOT compilations.")]
+#endif
     public class CognitoCredentialsRetriever : CredentialsRetriever
     {
         /// <summary>
@@ -96,11 +99,17 @@ namespace Amazon.CognitoSync.Internal
         /// A cache of objects that store the reflection objects. This is done so that reflection is only used once in order to 
         /// set the fields on the request.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("CognitoSync has not been updated to support Native AOT compilations.")]
+#endif
         private static class CSRequestCache
         {
             /// <summary>
             /// This class holds on to the reflection objects to invoke the setters for IdentityId and IdentityPoolId for the given type.
             /// </summary>
+#if NET6_0_OR_GREATER
+            [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("CognitoSync has not been updated to support Native AOT compilations.")]
+#endif
             private class CSRequest
             {
                 private Type requestType;

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -71,6 +71,9 @@ namespace Amazon.DynamoDBv2
     /// A collection of converters capable of converting between
     /// .NET and DynamoDB objects.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class DynamoDBEntryConversion
     {
         #region Static members
@@ -406,7 +409,12 @@ namespace Amazon.DynamoDBv2
         {
             ConverterCache.AddConverter(converter, this);
         }
+
+#if NET6_0_OR_GREATER        
+        internal void AddConverter([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+#else
         internal void AddConverter(Type type)
+#endif
         {
             var converter = Activator.CreateInstance(type) as Converter;
             AddConverter(converter);
@@ -447,7 +455,7 @@ namespace Amazon.DynamoDBv2
             }
         }
 
-        #endregion
+#endregion
     }
 
     internal abstract class Converter

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
@@ -30,6 +30,9 @@ namespace Amazon.DynamoDBv2
 {
     #region Basic converters
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class ByteConverterV1 : Converter<byte>
     {
         protected override bool TryTo(byte value, out Primitive p)
@@ -43,6 +46,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class SByteConverterV1 : Converter<SByte>
     {
         protected override bool TryTo(sbyte value, out Primitive p)
@@ -56,6 +62,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class UInt16ConverterV1 : Converter<UInt16>
     {
         protected override bool TryTo(ushort value, out Primitive p)
@@ -69,6 +78,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class Int16ConverterV1 : Converter<Int16>
     {
         protected override bool TryTo(short value, out Primitive p)
@@ -82,6 +94,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class UInt32ConverterV1 : Converter<UInt32>
     {
         protected override bool TryTo(uint value, out Primitive p)
@@ -95,6 +110,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class Int32ConverterV1 : Converter<Int32>
     {
         protected override bool TryTo(int value, out Primitive p)
@@ -108,6 +126,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class UInt64ConverterV1 : Converter<UInt64>
     {
         protected override bool TryTo(ulong value, out Primitive p)
@@ -121,6 +142,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class Int64ConverterV1 : Converter<Int64>
     {
         protected override bool TryTo(long value, out Primitive p)
@@ -134,6 +158,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class SingleConverterV1 : Converter<Single>
     {
         protected override bool TryTo(float value, out Primitive p)
@@ -147,6 +174,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class DoubleConverterV1 : Converter<Double>
     {
         protected override bool TryTo(double value, out Primitive p)
@@ -160,6 +190,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class DecimalConverterV1 : Converter<Decimal>
     {
         protected override bool TryTo(decimal value, out Primitive p)
@@ -173,6 +206,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class CharConverterV1 : Converter<Char>
     {
         protected override bool TryTo(char value, out Primitive p)
@@ -186,6 +222,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class StringConverterV1 : Converter<String>
     {
         protected override bool TryTo(string value, out Primitive p)
@@ -200,6 +239,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class DateTimeConverterV1 : Converter<DateTime>
     {
         protected override bool TryTo(DateTime value, out Primitive p)
@@ -218,6 +260,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class GuidConverterV1 : Converter<Guid>
     {
         protected override bool TryTo(Guid value, out Primitive p)
@@ -232,6 +277,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class BytesConverterV1 : Converter<byte[]>
     {
         protected override bool TryTo(byte[] value, out Primitive p)
@@ -246,6 +294,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class MemoryStreamConverterV1 : Converter<MemoryStream>
     {
         protected override bool TryTo(MemoryStream value, out Primitive p)
@@ -267,6 +318,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class EnumConverterV1 : Converter<Enum>
     {
         protected override bool TryTo(Enum value, out Primitive p)
@@ -347,6 +401,9 @@ namespace Amazon.DynamoDBv2
     /// A boolean converter which reads booleans as N or BOOL types,
     /// but writes out N type (1 if true, 0 if false).
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class BoolConverterV1 : Converter<bool>
     {
         protected override bool TryTo(bool value, out Primitive p)
@@ -366,6 +423,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal abstract class CollectionConverter : Converter
     {
         private IEnumerable<Type> targetTypes;
@@ -408,6 +468,9 @@ namespace Amazon.DynamoDBv2
     /// A collection converter which reads both sets of collections (sets and lists)
     /// and writes out sets (NS, SS, BS)
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class PrimitiveCollectionConverterV1 : CollectionConverter
     {
         public PrimitiveCollectionConverterV1()
@@ -446,6 +509,9 @@ namespace Amazon.DynamoDBv2
     /// Converts from Dictionary{string,object} to DynamoDBEntry.
     /// Does NOT convert from DynamoDBEntry to Dictionary{string,object}.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class DictionaryConverterV1 : Converter
     {
         public override IEnumerable<Type> GetTargetTypes()

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
@@ -110,6 +110,9 @@ namespace Amazon.DynamoDBv2
     /// HashSet input - converts to a DynamoDB set (NS, SS, BS)
     /// Any other IEnumerable input - converts to a DynamoDB list (L)
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif    
     internal class CollectionConverterV2 : PrimitiveCollectionConverterV1
     {
         private static Type setTypeInfo = typeof(HashSet<>);
@@ -163,6 +166,9 @@ namespace Amazon.DynamoDBv2
         }
     }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class DynamoDBListConverter : CollectionConverter
     {
         public DynamoDBListConverter()

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/V1PropertyConverters.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/V1PropertyConverters.cs
@@ -38,6 +38,9 @@ namespace Amazon.DynamoDBv2
     /// to use a different conversion scheme for converting individual elements.
     /// The default value for this field is the standard V1 conversion.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif    
     public class SetPropertyConverter<TCollection, TElement> : IPropertyConverter
         where TCollection : ICollection<TElement>, new()
     {
@@ -147,6 +150,9 @@ namespace Amazon.DynamoDBv2
     /// Use this converter to bypass the default schema behavior for a particular
     /// property.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class BoolAsNConverter : IPropertyConverter
     {
         private static BoolConverterV1 v1Converter = new BoolConverterV1();

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -51,6 +51,9 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Configuration object for setting options on the DynamoDBContext.
     /// and individual operations.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class DynamoDBContextConfig
     {
         /// <summary>
@@ -267,7 +270,9 @@ namespace Amazon.DynamoDBv2.DataModel
         #endregion
     }
 
-
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class DynamoDBFlatConfig
     {
         public static string DefaultIndexName = string.Empty;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -28,6 +28,9 @@ using System.Globalization;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public partial class DynamoDBContext
     {
         #region Versioning

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -35,6 +35,9 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Basic property storage information
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class SimplePropertyStorage
     {
         // local property name
@@ -72,6 +75,9 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// DynamoDB property storage information
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif    
     internal class PropertyStorage : SimplePropertyStorage
     {
         // flags
@@ -188,6 +194,9 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Storage information for a single item
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class ItemStorage
     {
         public Document Document { get; set; }
@@ -224,6 +233,9 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Storage information for a specific class
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class StorageConfig
     {
         // normalized PropertyStorage objects
@@ -340,10 +352,13 @@ namespace Amazon.DynamoDBv2.DataModel
                     "Type {0} is unsupported, it has no supported members", targetType.FullName));
         }
     }
-    
+
     /// <summary>
     /// Storage information for a specific class that is associated with a table
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class ItemStorageConfig : StorageConfig
     {
         // table
@@ -570,6 +585,9 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Cache of ItemStorageConfig objects
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal class ItemStorageConfigCache : IDisposable
     {
         // Cache of ItemStorageConfig objects per table and the

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3Link.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3Link.cs
@@ -12,6 +12,9 @@ namespace Amazon.DynamoDBv2.DataModel
     /// S3Link is an object that provides a connection to an S3 resource
     /// that can be stored in a DynamoDB field through DynamoDBContext
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public partial class S3Link
     {
         #region Statics
@@ -213,6 +216,9 @@ namespace Amazon.DynamoDBv2.DataModel
         #endregion
 
         #region Helper Classes
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
 
         internal class S3LinkConverter : IPropertyConverter
         {

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
@@ -77,6 +77,9 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a strongly-typed object for writing/deleting/version-checking multiple items
     /// in a single DynamoDB table in a transaction.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif    
     public class TransactWrite<T> : TransactWrite
     {
         #region Public Combine methods

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
@@ -27,6 +27,9 @@ using Amazon.DynamoDBv2.DocumentModel;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     internal static class Utils
     {
         private static readonly Type[] EmptyTypes = new Type[0];

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
@@ -29,6 +29,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// A collection of attribute key-value pairs that defines
     /// an item in DynamoDB.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class Document : DynamoDBEntry, IDictionary<string, DynamoDBEntry>
     {
         #region Private/internal members

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
@@ -5,6 +5,9 @@ using ThirdParty.Json.LitJson;
 
 namespace Amazon.DynamoDBv2.DocumentModel
 {
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public static class DocumentExtensions
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBEntry.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBEntry.cs
@@ -29,6 +29,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Abstract class representing an arbitrary DynamoDB attribute value
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public abstract class DynamoDBEntry : ICloneable
     {
         internal class AttributeConversionConfig

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBList.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBList.cs
@@ -26,6 +26,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// A DynamoDBEntry that represents a DynamoDB list (L) type.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class DynamoDBList : DynamoDBEntry
     {
         private static DynamoDBEntryConversion conversion = CreateConversion();

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpectedState.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpectedState.cs
@@ -27,6 +27,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// Expected state of an attribute in DynamoDB.
     /// Exists cannot be set at the same time as Comparison and Values.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif    
     public class ExpectedValue
     {
         /// <summary>
@@ -125,6 +128,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Expected state of an item in DynamoDB.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class ExpectedState
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
@@ -26,6 +26,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Expressions are used for conditional deletes and filtering for query and scan operations.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class Expression
     {
         private Dictionary<string, string> _expressionAttributeNames = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Filter.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Filter.cs
@@ -25,6 +25,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Filter for use with scan and query operations
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class Filter
     {
         #region Private members
@@ -32,6 +35,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <summary>
         /// Filter conditions
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
         protected class FilterCondition
         {
             /// <summary>
@@ -332,6 +338,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Scan filter.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class ScanFilter : Filter
     {
         /// <summary>
@@ -374,6 +383,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Query filter.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class QueryFilter : Filter
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
@@ -28,6 +28,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Utility methods to handle conversion from/to JSON
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif    
     internal static class JsonUtils
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Primitive.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Primitive.cs
@@ -46,6 +46,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// A DynamoDBEntry that represents a scalar DynamoDB type
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class Primitive : DynamoDBEntry, IEquatable<Primitive>
     {
         #region Private members

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/PrimitiveList.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/PrimitiveList.cs
@@ -27,6 +27,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// A DynamoDBEntry that represents a primitive list DynamoDB type
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class PrimitiveList : DynamoDBEntry, IEquatable<PrimitiveList>
     {
         private static DynamoDBEntryConversion V1Conversion = DynamoDBEntryConversion.V1;

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
@@ -30,6 +30,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Search response object
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public partial class Search
     {
         #region Internal constructors

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
@@ -36,6 +36,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// The Table class is the starting object when using the Document API. It is used to Get documents from the DynamnoDB table
     /// and write documents back to the DynamoDB table.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public partial class Table
     {
         #region Private/internal members

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
@@ -23,6 +23,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Configuration for the Table.PutItem operation
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class TableConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableOperationConfigs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableOperationConfigs.cs
@@ -146,6 +146,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Configuration for the Table.Scan operation
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class ScanOperationConfig
     {
         /// <summary>
@@ -266,6 +269,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Configuration for the Table.Query operation
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
     public class QueryOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/Internal/InternalConstants.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Internal/InternalConstants.cs
@@ -1,0 +1,22 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.DynamoDBv2.Custom.Internal
+{
+    internal static class InternalConstants
+    {
+        internal const string RequiresUnreferencedCodeMessage = "The Amazon DynamoDB high level libraries in the DocumentModel and DataModel namespace have not been updated to support Native AOT.";
+    }
+}

--- a/sdk/src/Services/Glacier/Custom/Transfer/ArchiveTransferManager.cs
+++ b/sdk/src/Services/Glacier/Custom/Transfer/ArchiveTransferManager.cs
@@ -30,6 +30,9 @@ namespace Amazon.Glacier.Transfer
     /// Provides a high level API for managing transfers to and from Amazon Glacier. This removes 
     /// complexities such as breaking files into parts and computing check sums.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ArchiveTransferManager has not been updated to support Native AOT compilations.")]
+#endif    
     public partial class ArchiveTransferManager : IDisposable
     {
         #region Private/internal members

--- a/sdk/src/Services/Glacier/Custom/Transfer/Internal/DownloadFileCommand.cs
+++ b/sdk/src/Services/Glacier/Custom/Transfer/Internal/DownloadFileCommand.cs
@@ -38,6 +38,9 @@ using ThirdParty.Json.LitJson;
 
 namespace Amazon.Glacier.Transfer.Internal
 {
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ArchiveTransferManager has not been updated to support Native AOT compilations.")]
+#endif
     internal partial class DownloadFileCommand : IDisposable
     {
         internal const int MAX_OPERATION_RETRY = 5;

--- a/sdk/src/Services/Glacier/Custom/Transfer/Internal/_async/DownloadJobCommand.async.cs
+++ b/sdk/src/Services/Glacier/Custom/Transfer/Internal/_async/DownloadJobCommand.async.cs
@@ -25,6 +25,9 @@ using System.Globalization;
 
 namespace Amazon.Glacier.Transfer.Internal
 {
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ArchiveTransferManager has not been updated to support Native AOT compilations.")]
+#endif
     internal partial class DownloadJobCommand
     {
 


### PR DESCRIPTION
Mark the features in the SDK that use unbounded reflection that do not support trimming with the `RequiresUnreferencedCode` attribute. This will tell users of the SDK who are compiling for Native AOT with trimming that they should not use these APIs. This doesn't mean we will never support them for Native AOT but these features require significant work and potentially redesign to get to work in Native AOT and in first phase of SDK AOT support we want to focus on identifying the areas that should be avoid when using Native AOT.

## DynamoDB high level libraries
These libraries use a lot of reflection over user's types that doesn't work in Native AOT. We would probably need to develop some sort of source generator approach like was done with JSON. Also there is a code doing full assembly type scans looking for converters that isn't supported in a trimmed environment.

## CognitioSync service client
There is a pipeline handler injected into the service client that uses reflection over all of the incoming requests to look for the identity from the incoming request object and set it on the `CognitoAWSCredentials`.

## Glacier high level library
It does some JSON deserialization to a `Dictionary<string, object>` and having the `object` as the value in the collection makes it not work for Native AOT trimming.

## AWSSDK.Extensions.NETCore.Setup
This is a tough one to not support but it does a lot of reflection to copy values from a generic service config to a the actual service config. Even worse users register via the service client interface and then library uses string manipulation from the interface name to service client name and then load the service client type via that string name. This will need to be completely reworked to fit in a Native AOT trimmed environment.
