### PR TITLE
[WIP] Add runtime dependency registry to avoid assembly reflection load of types

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
@@ -28,7 +28,13 @@ namespace Amazon.Runtime.Internal
         public const string KMS_ASSEMBLY_NAME = "AWSSDK.KeyManagementService";
         public const string KMS_SERVICE_CLASS_NAME = "Amazon.KeyManagementService.AmazonKeyManagementServiceClient";
 
+
+#if NET6_0_OR_GREATER
+        public static TClient CreateServiceFromAnother<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] TClient, 
+                                    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] TConfig>(AmazonServiceClient originalServiceClient)
+#else
         public static TClient CreateServiceFromAnother<TClient, TConfig>(AmazonServiceClient originalServiceClient)
+#endif
             where TConfig : ClientConfig, new ()
             where TClient : AmazonServiceClient
         {
@@ -48,6 +54,9 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
+#endif
         public static TClient CreateServiceFromAssembly<TClient>(string assemblyName, string serviceClientClassName,
             RegionEndpoint region)
             where TClient : class
@@ -64,6 +73,9 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
+#endif
         public static TClient CreateServiceFromAssembly<TClient>(string assemblyName, string serviceClientClassName, 
             AWSCredentials credentials, RegionEndpoint region)
             where TClient : class
@@ -81,6 +93,9 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
+#endif
         public static TClient CreateServiceFromAssembly<TClient>(string assemblyName, string serviceClientClassName,
             AWSCredentials credentials, ClientConfig config)
             where TClient : class
@@ -98,6 +113,9 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
+#endif
         public static TClient CreateServiceFromAssembly<TClient>(string assemblyName, string serviceClientClassName, AmazonServiceClient originalServiceClient)
             where TClient : class
         {
@@ -117,6 +135,9 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
+#endif
         public static ClientConfig CreateServiceConfig(string assemblyName, string serviceConfigClassName)
         {
             var typeInfo = LoadServiceConfigType(assemblyName, serviceConfigClassName);
@@ -127,16 +148,25 @@ namespace Amazon.Runtime.Internal
             return config as ClientConfig;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
+#endif
         private static Type LoadServiceClientType(string assemblyName, string serviceClientClassName)
         {
             return LoadTypeFromAssembly(assemblyName, serviceClientClassName);
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
+#endif
         private static Type LoadServiceConfigType(string assemblyName, string serviceConfigClassName)
         {
             return LoadTypeFromAssembly(assemblyName, serviceConfigClassName);
         }
 
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
+#endif
         internal static Type LoadTypeFromAssembly(string assemblyName, string className)
         {
             var assembly = GetSDKAssembly(assemblyName);
@@ -145,6 +175,9 @@ namespace Amazon.Runtime.Internal
             return type;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
+#endif
         private static Assembly GetSDKAssembly(string assemblyName)
         {
             return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => string.Equals(x.GetName().Name, assemblyName, StringComparison.Ordinal))

--- a/sdk/src/Core/RuntimeDependencyRegistry.cs
+++ b/sdk/src/Core/RuntimeDependencyRegistry.cs
@@ -1,0 +1,166 @@
+﻿using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using AWSSDK.Runtime.Internal.Util;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Amazon
+{
+    /// <summary>
+    /// Their are some features of the AWS .NET SDK that at runtime load dependencies from assemblies. The most common
+    /// example is using credential profiles that require the service client from the AWSSDK.SecurityToken package.
+    /// Normally these runtime dependencies are resolved by using reflection to load the assembly and the type,
+    /// In Native AOT with trimming turned on that will not worked because the dependency would be trimmed out.
+    /// 
+    /// The RuntimeDependencyRegistry is used to work around this limitation by allowing users to explicitly register
+    /// the runtime dependency instance into the SDK removing any use of reflection.
+    /// </summary>
+    public class RuntimeDependencyRegistry : IDisposable
+    {
+        private static readonly RuntimeDependencyRegistry _instance = new RuntimeDependencyRegistry();
+        public static RuntimeDependencyRegistry Instance { get { return _instance; } }
+
+        internal RuntimeDependencyRegistry() 
+        { 
+        }
+
+        private ReaderWriterLockSlim _rwlock = new ReaderWriterLockSlim();
+        private IDictionary<string, object> _runtimeDependency = new Dictionary<string, object>();
+        private bool disposedValue;
+
+        /// <summary>
+        /// Register the Checksum provider. This should be an instance of AWSSDK.Extensions.CrtIntegration.CrtChecksums from AWSSDK.Extensions.CrtIntegration package.
+        /// </summary>
+        /// <param name="instance"></param>
+        public void RegisterChecksumProvider(object instance)
+        {
+            RegisterInstance(ChecksumCRTWrapper.CRT_WRAPPER_ASSEMBLY_NAME, ChecksumCRTWrapper.CRT_WRAPPER_CLASS_NAME, instance);
+        }
+
+        /// <summary>
+        /// Register the Amazon.KeyManagementService.AmazonKeyManagementServiceClient instance from AWSSDK.KeyManagementService package.
+        /// </summary>
+        /// <param name="instance"></param>
+        public void RegisterKeyManagementServiceClient(object instance)
+        {
+            RegisterInstance(ServiceClientHelpers.KMS_ASSEMBLY_NAME, ServiceClientHelpers.KMS_SERVICE_CLASS_NAME, instance);
+        }
+
+        /// <summary>
+        /// Register the Amazon.SecurityToken.AmazonSecurityTokenServiceClient instance from the AWSSDK.SecurityToken package.
+        /// </summary>
+        /// <param name="instance"></param>
+        public void RegisterSecurityTokenServiceClient(object instance)
+        {
+            RegisterInstance(ServiceClientHelpers.STS_ASSEMBLY_NAME, ServiceClientHelpers.STS_SERVICE_CLASS_NAME, instance);
+        }
+
+        private void RegisterInstance(string assemblyName, string className, object instance)
+        {
+            try
+            {
+                _rwlock.EnterWriteLock();
+
+                _runtimeDependency[FormatKey(assemblyName, className)] = instance;
+            }
+            finally
+            {
+                if (_rwlock.IsWriteLockHeld)
+                {
+                    _rwlock.ExitWriteLock();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the registerd runtime dependency instance. This method is used by the SDK's core package and for service packages 
+        /// to get a reference to another service package service client.
+        /// </summary>
+        /// <typeparam name="T">The type that should be returned from the registry.</typeparam>
+        /// <param name="assemblyName"></param>
+        /// <param name="className"></param>
+        /// <returns></returns>
+        public T GetInstance<T>(string assemblyName, string className)
+            where T : class
+        {
+            try
+            {
+                _rwlock.EnterReadLock();
+
+                if (_runtimeDependency.TryGetValue(FormatKey(assemblyName, className), out object instance))
+                {
+                    return instance as T;
+                }
+
+                return null;
+            }
+            finally
+            {
+                if(_rwlock.IsReadLockHeld)
+                {
+                    _rwlock.ExitReadLock();
+                }
+            }
+        }
+
+        private string FormatKey(string assemblyName, string className) => $"{assemblyName}_{className}";
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _rwlock.Dispose();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Dispose the instance.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    /// <summary>
+    /// This exception is thrown when the SDK is used as part of an application compiled for Native AOT with trimming turned on.
+    /// In this environment assemblies can not be dynamically loaded and the usual ServiceClientHelpers operations will fail.
+    /// </summary>
+    public class MissingRuntimeDependencyException : AmazonClientException
+    {
+
+        public MissingRuntimeDependencyException(string packageName, string className, string registerMethod)
+            : base("Operation failed because of missing runtime dependency. In Native AOT builds runtime dependencies can not be " +
+                  "dynamically loaded from assembles. Instead the runtime dependency needs to be explicitly registered. " +
+                  $"To complete this operation register an instance of {className} from package {packageName} using the " +
+                  $"operation Amazon.RuntimeDependencyRegistry.Instance.{registerMethod}.")
+        {
+            this.PackageName = packageName;
+            this.ClassName = className;
+            this.RegisterMethod = registerMethod;
+        }
+
+        /// <summary>
+        /// The package containing the runtime dependency
+        /// </summary>
+        public string PackageName { get; set; }
+
+        /// <summary>
+        /// The class that must be instantiated and registered to Amazon.RuntimeDependencyRegistry
+        /// </summary>
+        public string ClassName { get; set; }
+
+        /// <summary>
+        /// The method on Amazon.RuntimeDependencyRegistry that should be called with an instance of the type referred by the ClassName property.
+        /// </summary>
+        public string RegisterMethod { get; set; }
+    }
+}


### PR DESCRIPTION
There are a few use cases like `AssumeRole` where the SDK relies on runtime dependencies where the dependency is load via assembly load and type search via class names. This is done in the SDK either to solve circular dependency issues or not wanting to include a dependency for all scenarios when only used in a small subset of features. This approach does not work for Native AOT with trimming enable because the runtime dependency would be trimmed out of the Native AOT application.

The solution this PR is to create a registry Native AOT users can use to explicit register instances of the runtime dependency the SDK needs. The PR is WIP using the registry to address 2 of the instances where runtime dependencies are used. The goal is get consensus of the approach before using for all of the other scenarios.

## Example
Lets say a user is using a credential provide that requires the STS service client. Before the STS service client is used the user would call.

```
Amazon.RuntimeDependencyRegistry.Instance.RegisterSecuirtyTokenServiceClient(new AmazonSecurityTokenService());
```

Then when the SDK needs it needs an STS client it will check the `RuntimeDependencyRegistry` for an instance. If one exist use it otherwise fallback on the usual reflection based method. If the Native AOT application has trimming enabled, which is the default, the reflection method will fail. A `MissingRuntimeDependencyException` exception will be thrown which will inform the user how to fix the problem. This is similar to the non Native AOT scenario when the user doesn't add the dependency to the runtime dependency on their application.

## Changes

* In `ServiceClientHelpers` which does the reflection work mark the methods with the `RequiresUnreferencedCode` attribute.
* In `RuntimeDependencyRegistry` add specific public register methods for each runtime dependency potential needed. This was done as opposed of a generic method because it avoided users having to understand how the dependency is hashed. It also provides a place to provide specific documentation for the scenario to help users.
* In the areas where `ServiceClientHelpers` is used add a check first for the dependency in the `RuntimeDependencyRegistry`. If an instance exist then use it. If an instance does not exist fallback to using the `ServiceClientHelpers` in case the user has trimming turned off for the SDK forcing all of the SDK into the Native AOT executable. The fallback to `ServiceClientHelpers` also include warning suppressions for AOT warnings since we are trying to handle the situation via the `RuntimeDependencyRegistry`
* If the fallback to `ServiceClientHelpers` throws an error and the environment is a Native AOT environment then throw a new `MissingRuntimeDependencyException` exception.
