### PR TITLE
feat: Adds TableBuilder, which can be used to prepopulate the internal metadata cache used by the document and object-mapper DynamoDB programming models

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -53,6 +53,49 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #endregion
 
+        #region Public methods
+        /// <inheritdoc/>
+        public void RegisterTableDefinition(Table table)
+        {
+            try
+            {
+                _readerWriterLockSlim.EnterReadLock();
+
+                if (tablesMap.ContainsKey(table.TableName))
+                {
+                    return;
+                }
+            }
+            finally
+            {
+                if (_readerWriterLockSlim.IsReadLockHeld)
+                {
+                    _readerWriterLockSlim.ExitReadLock();
+                }
+            }
+
+            try
+            {
+                _readerWriterLockSlim.EnterWriteLock();
+
+                // Check to see if another thread got the write lock before this thread and filled the cache.
+                if (tablesMap.ContainsKey(table.TableName))
+                {
+                    return;
+                }
+
+                tablesMap[table.TableName] = table;
+            }
+            finally
+            {
+                if (_readerWriterLockSlim.IsWriteLockHeld)
+                {
+                    _readerWriterLockSlim.ExitWriteLock();
+                }
+            }
+        }
+        #endregion
+
         #region Constructors
 
 #if !NETSTANDARD

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
@@ -27,6 +27,23 @@ namespace Amazon.DynamoDBv2.DataModel
     /// </summary>
     public partial interface IDynamoDBContext : IDisposable
     {
+        #region Public methods
+        /// <summary>
+        /// Adds a <see cref="Table"/> to this context's internal cache, which
+        /// will avoid the need to fetch table metadata automatically from DynamoDB.
+        /// This may be used in conjunction with an <see cref="ITableBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// Using this method can avoid latency and thread starvation due to blocking asynchronous 
+        /// <see cref="IAmazonDynamoDB.DescribeTable(string)"/> calls that are used to populate 
+        /// the SDK's cache of table metadata. It requires that the table's index schema described accurately, 
+        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change. 
+        /// </remarks>
+        /// <param name="table">Table to add to the internal cache</param>
+        void RegisterTableDefinition(Table table);
+
+        #endregion
+
         #region Save/serialize
 
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ITableBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ITableBuilder.cs
@@ -1,0 +1,69 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.DynamoDBv2.DocumentModel
+{
+    /// <summary>
+    /// Interface for a builder that constructs a <see cref="Table"/>
+    /// </summary>
+    public interface ITableBuilder
+    {
+        /// <summary>
+        /// Call at the end to retrieve the new <see cref="Table"/>
+        /// </summary>
+        /// <returns>Built table</returns>
+        Table Build();
+
+        /// <summary>
+        /// Adds the primary key definition to the table
+        /// </summary>
+        /// <param name="hashKeyAttribute">Name of the attribute used as the partition key</param>
+        /// <param name="type">Type of that attribute</param>
+        ITableBuilder AddHashKey(string hashKeyAttribute, DynamoDBEntryType type);
+
+        /// <summary>
+        /// Adds a sort key definition to the table
+        /// </summary>
+        /// <param name="rangeKeyAttribute">Name of the attribute used as the sort key</param>
+        /// <param name="type">Type of that attribute </param>
+        ITableBuilder AddRangeKey(string rangeKeyAttribute, DynamoDBEntryType type);
+
+        /// <summary>
+        /// Adds a local secondary index definition to the table
+        /// </summary>
+        /// <param name="indexName">Name of the local secondary index</param>
+        /// <param name="rangeKeyAttribute">Name of the attribute used as the sort key in the local secondary index</param>
+        /// <param name="type">Type of that attribute</param>
+        ITableBuilder AddLocalSecondaryIndex(string indexName, string rangeKeyAttribute, DynamoDBEntryType type);
+
+        /// <summary>
+        /// Adds a global secondary index definition to the table
+        /// </summary>
+        /// <param name="indexName">Name of the global secondary index</param>
+        /// <param name="hashkeyAttribute">Name of the attribute used as the partition key in the GSI</param>
+        /// <param name="hashKeyType">Type of the hash key attribute</param>
+        ITableBuilder AddGlobalSecondaryIndex(string indexName, string hashkeyAttribute, DynamoDBEntryType hashKeyType);
+
+        /// <summary>
+        /// Adds a global secondary index definition to the table
+        /// </summary>
+        /// <param name="indexName">Name of the global secondary index</param>
+        /// <param name="hashkeyAttribute">Name of the attribute used as the partition key in the GSI</param>
+        /// <param name="hashKeyType">Type of the hash key attribute</param>
+        /// <param name="rangeKeyAttribute">Name of the attribute used as the sort key in the GSI</param>
+        /// <param name="rangeKeyType">Type of the sort key attribute</param>
+        ITableBuilder AddGlobalSecondaryIndex(string indexName, string hashkeyAttribute, DynamoDBEntryType hashKeyType, string rangeKeyAttribute, DynamoDBEntryType rangeKeyType);
+    }
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
@@ -340,7 +340,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 throw new InvalidOperationException("Only one of the conditonal properties Expected, ExpectedState and ConditionalExpression can be set.");
         }
 
-        private void ClearTableData()
+        internal void ClearTableData()
         {
             Keys = new Dictionary<string, KeyDescription>();
             HashKeys = new List<string>();
@@ -399,7 +399,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         #region Constructor/factory
 
-        private Table(IAmazonDynamoDB ddbClient, TableConfig config)
+        internal Table(IAmazonDynamoDB ddbClient, TableConfig config)
         {
             if (config == null)
                 throw new ArgumentNullException("config");

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableBuilder.cs
@@ -1,0 +1,298 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using Amazon.DynamoDBv2.Model;
+using System;
+using System.Collections.Generic;
+
+namespace Amazon.DynamoDBv2.DocumentModel
+{
+    /// <summary>
+    /// Builder that constructs a <see cref="Table"/>
+    /// </summary>
+    public class TableBuilder : ITableBuilder
+    {
+        /// <summary>
+        /// The <see cref="Table"/> object that is built and then returned from <see cref="Build"/>
+        /// </summary>
+        private Table _table;
+
+        /// <summary>
+        /// Keeps track internally of attributes that have already been saved in <see cref="Table.Attributes"/>,
+        /// since they can be shared by different indices.
+        /// </summary>
+        private HashSet<string> _attributesAlreadyProcessed; 
+
+        /// <summary>
+        /// Creates a builder object to construct a <see cref="Table"/>
+        /// </summary>
+        /// <param name="ddbClient">Client to use to access DynamoDB.</param>
+        /// <param name="tableName">Table name</param>
+        public TableBuilder(IAmazonDynamoDB ddbClient, string tableName) :
+             this(ddbClient, tableName, DynamoDBEntryConversion.CurrentConversion, false, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a builder object to construct a <see cref="Table"/>
+        /// </summary>
+        /// <param name="ddbClient">Client to use to access DynamoDB.</param>
+        /// <param name="tableName">Table name</param>
+        /// <param name="conversion">Conversion to use for converting .NET values to DynamoDB values.</param>
+        /// <param name="isEmptyStringValueEnabled">If the property is false, empty string values will be interpreted as null values.</param>
+        /// <param name="metadataCachingMode">The document API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// <see cref="IAmazonDynamoDB.DescribeTable(string)"/> internally to populate the cache.</param>
+        public TableBuilder(IAmazonDynamoDB ddbClient, string tableName, DynamoDBEntryConversion conversion, bool isEmptyStringValueEnabled, MetadataCachingMode? metadataCachingMode)
+            : this (ddbClient, new TableConfig(tableName, conversion, Table.DynamoDBConsumer.DocumentModel, null, isEmptyStringValueEnabled, metadataCachingMode))
+        {
+        }
+
+        /// <summary>
+        /// Creates a builder object to construct a <see cref="Table"/>
+        /// </summary>
+        /// <param name="ddbClient">Client to use to access DynamoDB.</param>
+        /// <param name="config">Configuration to use for the table.</param>
+        public TableBuilder(IAmazonDynamoDB ddbClient, TableConfig config)
+        {
+            _table = new Table(ddbClient, config);
+            _table.ClearTableData(); // initializes internal collections
+            _attributesAlreadyProcessed = new HashSet<string>();
+        }
+
+        /// <inheritdoc/>
+        public Table Build()
+        {
+            if (_table.HashKeys.Count == 0)
+            {
+                throw new ArgumentOutOfRangeException("A hash key definition is required, call AddHashKey before Build.");
+            }
+
+            return _table;
+        }
+
+        /// <inheritdoc/>
+        public ITableBuilder AddHashKey(string hashKeyAttribute, DynamoDBEntryType type)
+        {
+            if (string.IsNullOrEmpty(hashKeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(hashKeyAttribute), "The name of the hash key attribute is required.");
+            }
+            
+            if (_table.HashKeys.Count != 0)
+            {
+                throw new ArgumentOutOfRangeException("Only a single hash key is supported, and one has already been added.");
+            }
+
+            _table.HashKeys.Add(hashKeyAttribute);
+
+            _table.Keys.Add(hashKeyAttribute, new KeyDescription
+            {
+                IsHash = true,
+                Type = type
+            });
+
+            if (!_attributesAlreadyProcessed.Contains(hashKeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(hashKeyAttribute, dynamoDBEntryTypeToScalarAttributeType(type)));
+                _attributesAlreadyProcessed.Add(hashKeyAttribute);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ITableBuilder AddRangeKey(string rangeKeyAttribute, DynamoDBEntryType type)
+        {
+            if (string.IsNullOrEmpty(rangeKeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(rangeKeyAttribute), "The name of the range key attribute is required.");
+            }
+
+            if (_table.RangeKeys.Count != 0)
+            {
+                throw new ArgumentOutOfRangeException("Only a single range key is supported, and one has already been added.");
+            }
+
+            _table.RangeKeys.Add(rangeKeyAttribute);
+
+            _table.Keys.Add(rangeKeyAttribute, new KeyDescription
+            {
+                IsHash = false,
+                Type = type
+            });
+
+            if (!_attributesAlreadyProcessed.Contains(rangeKeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(rangeKeyAttribute, dynamoDBEntryTypeToScalarAttributeType(type)));
+                _attributesAlreadyProcessed.Add(rangeKeyAttribute);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ITableBuilder AddLocalSecondaryIndex(string indexName, string rangeKeyAttribute, DynamoDBEntryType type)
+        {
+            if (string.IsNullOrEmpty(indexName))
+            {
+                throw new ArgumentNullException(nameof(indexName), "The name of the local secondary index is required");
+            }
+
+            if (_table.LocalSecondaryIndexes.ContainsKey(indexName))
+            {
+                throw new ArgumentException($"An local secondary index with name {indexName} has already been defined.");
+            }
+
+            if (string.IsNullOrEmpty(rangeKeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(rangeKeyAttribute), "The attribute name of the range key within the local secondary index is required.");
+            }
+
+            if (_table.HashKeys.Count == 0)
+            {
+                throw new ArgumentException("A local secondary index uses the table's hash key, which was not provided. Call AddHashKey prior to AddLocalSecondaryIndex.");
+
+            }            
+
+            _table.LocalSecondaryIndexNames.Add(indexName);
+
+            _table.LocalSecondaryIndexes.Add(indexName, new LocalSecondaryIndexDescription
+            {
+                IndexName = indexName,
+                KeySchema = new List<KeySchemaElement>()
+                {
+                    new KeySchemaElement { AttributeName = _table.HashKeys[0], KeyType = KeyType.HASH },
+                    new KeySchemaElement { AttributeName = rangeKeyAttribute, KeyType = KeyType.RANGE }
+                }
+            });
+
+            if (!_attributesAlreadyProcessed.Contains(rangeKeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(rangeKeyAttribute, dynamoDBEntryTypeToScalarAttributeType(type)));
+                _attributesAlreadyProcessed.Add(rangeKeyAttribute);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ITableBuilder AddGlobalSecondaryIndex(string indexName, string hashkeyAttribute, DynamoDBEntryType hashKeyType)
+        {
+            if (string.IsNullOrEmpty(indexName))
+            {
+                throw new ArgumentNullException(nameof(indexName), "The name of the global secondary index is required");
+            }
+
+            if (_table.GlobalSecondaryIndexes.ContainsKey(indexName))
+            {
+                throw new ArgumentException($"An global secondary index with name {indexName} has already been defined.");
+            }
+
+            if (string.IsNullOrEmpty(hashkeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(hashkeyAttribute), "The attribute name of the hash key within the global secondary index is required.");
+            }
+
+            _table.GlobalSecondaryIndexNames.Add(indexName);
+
+            _table.GlobalSecondaryIndexes.Add(indexName, new GlobalSecondaryIndexDescription
+            {
+                IndexName = indexName,
+                KeySchema = new List<KeySchemaElement>()
+                {
+                    new KeySchemaElement { AttributeName = hashkeyAttribute, KeyType = KeyType.HASH }
+                }
+            });
+
+            if (!_attributesAlreadyProcessed.Contains(hashkeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(hashkeyAttribute, dynamoDBEntryTypeToScalarAttributeType(hashKeyType)));
+                _attributesAlreadyProcessed.Add(hashkeyAttribute);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ITableBuilder AddGlobalSecondaryIndex(string indexName, string hashkeyAttribute, DynamoDBEntryType hashKeyType, string rangeKeyAttribute, DynamoDBEntryType rangeKeyType)
+        {
+            if (string.IsNullOrEmpty(indexName))
+            {
+                throw new ArgumentNullException(nameof(indexName), "The name of the global secondary index is required");
+            }
+
+            if (_table.GlobalSecondaryIndexes.ContainsKey(indexName))
+            {
+                throw new ArgumentException($"An global secondary index with name {indexName} has already been defined.");
+            }
+
+            if (string.IsNullOrEmpty(hashkeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(hashkeyAttribute), "The attribute name of the hash key within the global secondary index is required.");
+            }
+
+            if (string.IsNullOrEmpty(rangeKeyAttribute))
+            {
+                throw new ArgumentNullException(nameof(rangeKeyAttribute), "The attribute name of the range key within the global secondary index is required.");
+            }
+
+            _table.GlobalSecondaryIndexNames.Add(indexName);
+
+            _table.GlobalSecondaryIndexes.Add(indexName, new GlobalSecondaryIndexDescription
+            {
+                IndexName = indexName,
+                KeySchema = new List<KeySchemaElement>()
+                {
+                    new KeySchemaElement { AttributeName = hashkeyAttribute, KeyType = KeyType.HASH },
+                    new KeySchemaElement { AttributeName = rangeKeyAttribute, KeyType = KeyType.RANGE }
+                }
+            });
+
+            if (!_attributesAlreadyProcessed.Contains(hashkeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(hashkeyAttribute, dynamoDBEntryTypeToScalarAttributeType(hashKeyType)));
+                _attributesAlreadyProcessed.Add(hashkeyAttribute);
+            }
+
+            if (!_attributesAlreadyProcessed.Contains(rangeKeyAttribute))
+            {
+                _table.Attributes.Add(new AttributeDefinition(rangeKeyAttribute, dynamoDBEntryTypeToScalarAttributeType(rangeKeyType)));
+                _attributesAlreadyProcessed.Add(rangeKeyAttribute);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Maps the document model's <see cref="DynamoDBEntryType"/> to the corresponding, low-level <see cref="ScalarAttributeType"/>
+        /// </summary>
+        /// <param name="entryType">Document model attribute type</param>
+        /// <returns>Corresponding low-level attribute type</returns>
+        private static ScalarAttributeType dynamoDBEntryTypeToScalarAttributeType(DynamoDBEntryType entryType)
+        {
+            switch (entryType)
+            {
+                case DynamoDBEntryType.String:
+                    return ScalarAttributeType.S;
+                case DynamoDBEntryType.Numeric:
+                    return ScalarAttributeType.N;
+                case DynamoDBEntryType.Binary:
+                    return ScalarAttributeType.B;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(entryType), "Not a valid ScalarAttributeType");
+            }
+        }
+    }
+}

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/TableBuilderTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/TableBuilderTests.cs
@@ -1,0 +1,193 @@
+﻿using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DocumentModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace AWSSDK_DotNet35.UnitTests
+{
+    /// <summary>
+    /// Tests for <see cref="TableBuilder"/>
+    /// </summary>
+    [TestClass]
+    public class TableBuilderTests
+    {
+        private IAmazonDynamoDB _amazonDynamoDBClient = new AmazonDynamoDBClient();
+
+        /// <summary>
+        /// Asserts that the table requires a hash key definition
+        /// </summary>
+        [TestMethod]
+        public void MissingPrimaryKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => builder.Build());
+        }
+
+        /// <summary>
+        /// Asserts that the hash key requires a non-null attribute
+        /// </summary>
+        [TestMethod]
+        public void NullPrimaryKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddHashKey("", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when more that one hash key is defined
+        /// </summary>
+        [TestMethod]
+        public void MoreThanOnePrimaryKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => builder.AddHashKey("Id2", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the hash key requires a non-null attribute
+        /// </summary>
+        [TestMethod]
+        public void NullRangeKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddRangeKey("", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when more that one range key is defined
+        /// </summary>
+        [TestMethod]
+        public void MoreThanOneRangeKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddRangeKey("Date", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => builder.AddRangeKey("Date2", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a LSI is defined before the hash key is,
+        /// since the LSI reuses the hash key
+        /// </summary>
+        [TestMethod]
+        public void LSIWithoutPrimaryKey_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            Assert.ThrowsException<ArgumentException>(() => builder.AddLocalSecondaryIndex("LSI", "Date", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a LSI is defined without an index name
+        /// </summary>
+        [TestMethod]
+        public void MissingLSIIndexName_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddLocalSecondaryIndex("", "Date", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a LSI is defined without an attribute name
+        /// </summary>
+        [TestMethod]
+        public void MissingLSIAttribute_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddLocalSecondaryIndex("LSI", "", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a duplicate LSI is defined
+        /// </summary>
+        [TestMethod]
+        public void DuplicateLSIName_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+            builder.AddLocalSecondaryIndex("LSI", "Date", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentException>(() => builder.AddLocalSecondaryIndex("LSI", "Date2", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder only stores key attributes once when reused in an LSI
+        /// </summary>
+        [TestMethod]
+        public void AttributeReusedViaLSI_OnlyStoredOnce()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+
+            // Add a GSI with two new attributes
+            builder.AddGlobalSecondaryIndex("GSI", "Date", DynamoDBEntryType.String, "OrderNumber", DynamoDBEntryType.Numeric);
+
+            // Add a LSI that reuses one of those, which shouldn't be stored in table.Attributes again
+            builder.AddLocalSecondaryIndex("LSI", "OrderNumber", DynamoDBEntryType.Numeric);
+
+            var table = builder.Build();
+
+            Assert.AreEqual(3, table.Attributes.Count);
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when any of the required GSI identifiers are null
+        /// </summary>
+        public void GSINullNames_ThrowException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+
+            // Null GSI index name
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddGlobalSecondaryIndex("", "Id", DynamoDBEntryType.String));
+            Assert.ThrowsException<ArgumentNullException>(() => builder.AddGlobalSecondaryIndex("", "Id", DynamoDBEntryType.String, "Date", DynamoDBEntryType.String));
+
+            // Null hash key
+            Assert.ThrowsException<ArgumentException>(() => builder.AddGlobalSecondaryIndex("GSI", "", DynamoDBEntryType.String));
+            Assert.ThrowsException<ArgumentException>(() => builder.AddGlobalSecondaryIndex("GSI", "", DynamoDBEntryType.String, "Date", DynamoDBEntryType.String));
+
+            // Null range key
+            Assert.ThrowsException<ArgumentException>(() => builder.AddGlobalSecondaryIndex("GSI", "Id", DynamoDBEntryType.String, "", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder throws an exception when a duplicate GSI is defined
+        /// </summary>
+        [TestMethod]
+        public void DuplicateGSIName_ThrowsException()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddGlobalSecondaryIndex("GSI", "Id", DynamoDBEntryType.String, "Date", DynamoDBEntryType.String);
+
+            Assert.ThrowsException<ArgumentException>(() => builder.AddGlobalSecondaryIndex("GSI", "Id", DynamoDBEntryType.String));
+            Assert.ThrowsException<ArgumentException>(() => builder.AddGlobalSecondaryIndex("GSI", "Id", DynamoDBEntryType.String, "Date", DynamoDBEntryType.String));
+        }
+
+        /// <summary>
+        /// Asserts that the builder only stores key attributes once when they are reused in a GSI
+        /// </summary>
+        [TestMethod]
+        public void AttributesResuedViaGSI_OnlyStoredOnce()
+        {
+            var builder = new TableBuilder(_amazonDynamoDBClient, "TestTable");
+            builder.AddHashKey("Id", DynamoDBEntryType.String);
+            builder.AddRangeKey("Date", DynamoDBEntryType.String);
+
+            // Add a GSI that uses those same two attributes
+            builder.AddGlobalSecondaryIndex("GSI-1", "Date", DynamoDBEntryType.String);
+            builder.AddGlobalSecondaryIndex("GSI-2", "Date", DynamoDBEntryType.String, "Id", DynamoDBEntryType.String);
+
+            var table = builder.Build();
+
+            Assert.AreEqual(2, table.Attributes.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This is an approach that partially addresses https://github.com/aws/aws-sdk-net/issues/1476. 

Users can use the new `TableBuilder` to populate the internal SDK cache of table structures that drive the DynamoDB document and object-mapper programming models.
* **Document**: Instead of `Table.Load`, call `new TableBuilder().<table info>.Build()`
* **Object mapper**: Call `context.RegisterTableDefinition(<Table>);`

**Looking for feedback on:** The SDK uses "hash"/"range" in existing structures, as opposed to "partition"/"sort" key, which seem to be used more heavily in DynamoDB documentation. Let me know your thoughts on naming for public methods and arguments in `ITableBuilder`.

## Motivation and Context
This allows users to pre-populate the internal cache, which prevents the internal `DescribeTable` call the SDK makes. This avoids the sync-over-async issues discussed in https://github.com/aws/aws-sdk-net/issues/1476.

## Testing
* Added unit tests exercising the new `TableBuilder`
* Duplicated existing document and object-mapper tests that test CRUD and scan/query operations, but replaced the initialization with the `TableBuilder`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement