### PR TITLE
Improve exceptions thrown when making DynamoDB queries using object-mapper programming model with DisableFetchingTableMetadata and missing index definitions

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
@@ -160,9 +160,10 @@ namespace Amazon.Util
         /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
         /// </summary>
         /// <remarks>
-        /// Setting this to true can avoid latency and potential deadlocks due to the internal  <see cref="DescribeTableRequest"/> call that is used to populate the SDK's cache of 
-        /// table metadata. It requires that the table's index schema be fully described via the above methods, otherwise exceptions may be thrown and/or 
-        /// the results of certain DynamoDB operations may change. It is recommended to test your application prior to setting it to true in production code.
+        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
+        /// <see cref="IAmazonDynamoDB.DescribeTable(string)"/> calls that are used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
+        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
         /// </remarks>
         public bool? DisableFetchingTableMetadata { get; set; }
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -121,12 +121,13 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <summary>
         /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
-        /// defined by<see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
+        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
         /// </summary>
         /// <remarks>
-        /// Setting this to true can avoid latency and potential deadlocks due to the internal  <see cref="DescribeTableRequest"/> call that is used to populate the SDK's cache of 
-        /// table metadata. It requires that the table's index schema be fully described via the above methods, otherwise exceptions may be thrown and/or 
-        /// the results of certain DynamoDB operations may change. It is recommended to test your application prior to setting it to true in production code.
+        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
+        /// <see cref="IAmazonDynamoDB.DescribeTable(string)"/> calls that are used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
+        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
         /// </remarks>
         public bool? DisableFetchingTableMetadata { get; set; }
     }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -858,6 +858,13 @@ namespace Amazon.DynamoDBv2.DataModel
             if (hashKeyValue == null)
                 throw new ArgumentNullException("hashKeyValue");
 
+            if (storageConfig.HashKeyPropertyNames == null || storageConfig.HashKeyPropertyNames.Count == 0)
+            {
+                throw new InvalidOperationException($"Attempted to make a query without a defined hash key attribute. " +
+                    $"If using {nameof(DynamoDBContextConfig.DisableFetchingTableMetadata)}, ensure that the table's hash key " +
+                    $"is annotated with {nameof(DynamoDBHashKeyAttribute)}.");
+            }
+
             // Set hash key property name
             // In case of index queries, if GSI, different key could be used
             string hashKeyProperty = storageConfig.HashKeyPropertyNames[0];
@@ -916,6 +923,13 @@ namespace Amazon.DynamoDBv2.DataModel
             {
                 foreach (QueryCondition condition in conditions)
                 {
+                    if (string.IsNullOrEmpty(condition.PropertyName))
+                    {
+                        throw new InvalidOperationException($"Attempted to make a query with a range key condition without a defined range attribute. " +
+                            $"If using {nameof(DynamoDBContextConfig.DisableFetchingTableMetadata)}, ensure that the table's range key(s) " +
+                            $"are annotated with {nameof(DynamoDBRangeKeyAttribute)}, {nameof(DynamoDBLocalSecondaryIndexRangeKeyAttribute)}, " +
+                            $"or {nameof(DynamoDBGlobalSecondaryIndexRangeKeyAttribute)}.");
+                    }
                     object[] conditionValues = condition.Values;
                     PropertyStorage conditionProperty = storageConfig.GetPropertyStorage(condition.PropertyName);
                     if (conditionProperty.IsLSIRangeKey || conditionProperty.IsGSIKey)

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
@@ -583,12 +583,15 @@ namespace Amazon.DynamoDBv2.DocumentModel
                     KeyType = KeyType.HASH
                 });
 
-                var rangeKeyProperty = itemStorageConfig.GetPropertyStorage(gsi.RangeKeyPropertyName);
-                indexDescription.KeySchema.Add(new KeySchemaElement()
+                if (!string.IsNullOrEmpty(gsi.RangeKeyPropertyName))
                 {
-                    AttributeName = rangeKeyProperty.AttributeName,
-                    KeyType = KeyType.RANGE
-                });
+                    var rangeKeyProperty = itemStorageConfig.GetPropertyStorage(gsi.RangeKeyPropertyName);
+                    indexDescription.KeySchema.Add(new KeySchemaElement()
+                    {
+                        AttributeName = rangeKeyProperty.AttributeName,
+                        KeyType = KeyType.RANGE
+                    });
+                }
 
                 table.GlobalSecondaryIndexes[gsiIndexName] = indexDescription;
             }


### PR DESCRIPTION
## Description
* Throws exceptions when building DynamoDB queries for the object-mapper model when:
    1. `DisableFetchingTableMetadata` is true
    2. The table's hash and/or range keys are not accurately provided
* Updates some docs for `DisableFetchingTableMetadata` to match what we did in #3055 
* Updates the code that builds a `Table` from the attributed class to support GSI's without a range key
    * This is implicitly tested by the new `DisableFetchingTableMetadata_QueryWithMissingRangeKey_ThrowsException`, though that throws an exception later in the code path.

## Motivation and Context
DOTNET-7182 - we want to avoid any null reference or index out of range exceptions when accessing the SDK's internal cache of table metadata

## Testing
* Added new tests assert our expected exception type for a few cases
* Existing net35/net45 DDB unit and integration tests pass locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [ ] All new and existing tests passed - still need to do an internal dry-run

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement