### PR TITLE
Add ContextAttributes property to IRequestContext

### DIFF
--- a/generator/.DevConfigs/c151b18e-41df-4204-aad3-6d579847c11a.json
+++ b/generator/.DevConfigs/c151b18e-41df-4204-aad3-6d579847c11a.json
@@ -1,0 +1,11 @@
+{
+  "core": {
+    "changeLogMessages": ["Add ContextAttributes property to IRequestContext to store request state in custom pipeline handlers."],
+    "type": "patch",
+    "updateMinimum": true,
+    "backwardIncompatibilitiesToIgnore": [
+		"Amazon.Runtime.Internal.RequestContext/MethodIsNowSealed", 
+		"Amazon.Runtime.IRequestContext/MethodAbstractMethodAdded"
+	]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
@@ -25,7 +25,7 @@ namespace Amazon.Runtime
 {
     public interface IRequestContext
     {
-        AmazonWebServiceRequest OriginalRequest { get; }
+        AmazonWebServiceRequest OriginalRequest { get; set; }
         string RequestName { get; }
         IMarshaller<IRequest, AmazonWebServiceRequest> Marshaller { get; }
         ResponseUnmarshaller Unmarshaller { get; }
@@ -53,6 +53,8 @@ namespace Amazon.Runtime
         bool IsLastExceptionRetryable { get; set; }
 
         Guid InvocationId { get; }
+
+        IDictionary<string, object> ContextAttributes { get; }
     }
 
     public interface IResponseContext
@@ -95,6 +97,7 @@ namespace Amazon.Runtime.Internal
     {
         private IServiceMetadata _serviceMetadata;
         AbstractAWSSigner clientSigner;
+        IDictionary<string, object> _contextAttributes;
 
         public RequestContext(bool enableMetrics, AbstractAWSSigner clientSigner)
         {
@@ -168,6 +171,19 @@ namespace Amazon.Runtime.Internal
         public bool IsLastExceptionRetryable { get; set; }
 
         public Guid InvocationId { get; private set; }
+
+        public IDictionary<string, object> ContextAttributes 
+        { 
+            get
+            {
+                if(_contextAttributes == null)
+                {
+                    _contextAttributes = new Dictionary<string, object>();
+                }
+
+                return _contextAttributes;
+            }
+        }
     }
 
     public class AsyncRequestContext : RequestContext, IAsyncRequestContext

--- a/sdk/test/UnitTests/Custom/Runtime/HttpHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/HttpHandlerTests.cs
@@ -120,6 +120,18 @@ namespace AWSSDK.UnitTests
             Assert.IsTrue(httpRequest.IsDisposed);
         }
 
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestStoringContextAttributes()
+        {
+            var requestContext = new RequestContext(true, new NullSigner());
+
+            requestContext.ContextAttributes["foo"] = "bar";
+            Assert.AreEqual("bar", requestContext.ContextAttributes["foo"]);
+        }
+
+
 #elif !BCL45 && BCL
 
         [TestMethod][TestCategory("UnitTest")]


### PR DESCRIPTION
## Description
For teams that want to customize the SDK's request pipeline this feature allows them to add custom request level request state. This is similar to the Java SDK's ExecutionAttributes collection. Also allow the ability to swap out the original request in case the team customizing the pipeline want to transform the request before being marshalling.
