### PR TITLE
chore: Improve documentation for InstanceProfileAWSCredentials constructors

### DIFF
--- a/generator/.DevConfigs/37c0790d-5c5a-407f-9f54-f7c7b00e7b9f.json
+++ b/generator/.DevConfigs/37c0790d-5c5a-407f-9f54-f7c7b00e7b9f.json
@@ -1,0 +1,7 @@
+{
+    "core": {
+      "changeLogMessages": ["Improve documentation for InstanceProfileAWSCredentials constructors"],
+      "type": "patch",
+      "updateMinimum": false
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/InstanceProfileAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/InstanceProfileAWSCredentials.cs
@@ -154,16 +154,17 @@ namespace Amazon.Runtime
         #region Constructors
 
         /// <summary>
-        /// Constructs a InstanceProfileAWSCredentials object for specific role
+        /// Constructs <see cref="InstanceProfileAWSCredentials"/> for the specified role.
         /// </summary>
-        /// <param name="role">Role to use</param>
+        /// <param name="role">Name of the role to use</param>
         public InstanceProfileAWSCredentials(string role)
             : this(role, null) { }
 
         /// <summary>
-        /// Constructs a InstanceProfileAWSCredentials object for specific role
+        /// Constructs <see cref="InstanceProfileAWSCredentials"/> for the specified role.
         /// </summary>
-        /// <param name="role">Role to use</param>
+        /// <param name="role">Name of the role to use</param>
+        /// <param name="proxy">Proxy used to process requests to the instance metadata service</param>
         public InstanceProfileAWSCredentials(string role, IWebProxy proxy)
         {
             _logger = Logger.GetLogger(GetType());
@@ -180,14 +181,19 @@ namespace Amazon.Runtime
         }
 
         /// <summary>
-        /// Constructs a InstanceProfileAWSCredentials object for the first found role
+        /// Constructs <see cref="InstanceProfileAWSCredentials"/> for the first found role.
         /// </summary>
+        /// <remarks>This makes an IMDS call to retrieve the name of the IAM role associated with the instance during construction.</remarks>
+        /// <exception cref="AmazonServiceException">Thrown when unable to retrieve the name of the IAM role.</exception>
         public InstanceProfileAWSCredentials()
             : this(proxy: null) { }
 
         /// <summary>
-        /// Constructs a InstanceProfileAWSCredentials object for the first found role
+        /// Constructs <see cref="InstanceProfileAWSCredentials"/> for the first found role.
         /// </summary>
+        /// <remarks>This makes an IMDS call to retrieve the name of the IAM role associated with the instance during construction.</remarks>
+        /// <param name="proxy">Proxy used to process requests to the instance metadata service</param>
+        /// <exception cref="AmazonServiceException">Thrown when unable to retrieve the name of the IAM role.</exception>
         public InstanceProfileAWSCredentials(IWebProxy proxy)
             : this(GetFirstRole(proxy), proxy) { }
 


### PR DESCRIPTION
## Description
Improves documentation for `InstanceProfileAWSCredentials` constructors

## Motivation and Context
Internal ticket V1053866934 pointed out that it's unclear that the two constructors that do not take in the `role` are making a network call to IMDS which can fail. This adds `remarks` and the `exception` comments explaining this.

## Testing
Pending sanity dry-run


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement