### PR TITLE
Normj/net8 ci changes

### DIFF
--- a/extensions/test/CrtIntegrationTests/CrtIntegrationTests.csproj
+++ b/extensions/test/CrtIntegrationTests/CrtIntegrationTests.csproj
@@ -17,10 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 
 </Project>

--- a/extensions/test/CrtIntegrationTests/CrtIntegrationTests.csproj
+++ b/extensions/test/CrtIntegrationTests/CrtIntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyName>CrtIntegrationTests</AssemblyName>
     <PackageId>CrtIntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/extensions/test/NETCore.SetupTests/NETCore.SetupTests.csproj
+++ b/extensions/test/NETCore.SetupTests/NETCore.SetupTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyName>NETCore.SetupTests</AssemblyName>
     <PackageId>NETCore.SetupTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/extensions/test/NETCore.SetupTests/NETCore.SetupTests.csproj
+++ b/extensions/test/NETCore.SetupTests/NETCore.SetupTests.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>NETCore.SetupTests</AssemblyName>
     <PackageId>NETCore.SetupTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -23,13 +22,13 @@
 
   <ItemGroup>
 	<PackageReference Include="AWSSDK.S3" Version="3.7.7.21" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
 </Project>

--- a/generator/.DevConfigs/feature-net8.json
+++ b/generator/.DevConfigs/feature-net8.json
@@ -2,6 +2,13 @@
   "core": {
     "changeLogMessages": ["Add trimming support for .NET 8."],
     "type": "patch",
-    "updateMinimum": true
+    "updateMinimum": true,
+    "backwardIncompatibilitiesToIgnore": [
+      "Amazon.Util.PaginatedResourceFactory/TypeRemoved",
+      "Amazon.Runtime.URIBasedRefreshingCredentialHelper/MethodOverloadAdded",
+      "Amazon.Util.Internal.ITypeInfo/MethodRemoved",
+      "Amazon.Util.PaginatedResourceInfo/TypeRemoved",
+      "Amazon.Runtime.Internal.Settings.SettingsCollection/MethodRemoved"
+    ]
   }
 }

--- a/generator/.DevConfigs/feature-net8.json
+++ b/generator/.DevConfigs/feature-net8.json
@@ -1,0 +1,7 @@
+{
+  "core": {
+    "changeLogMessages": ["Add trimming support for .NET 8."],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
@@ -182,9 +182,17 @@ namespace Amazon.Runtime.Internal
                 {
                     convertedValue = int.Parse(value);
                 }
+                else if (typeof(T) == typeof(long))
+                {
+                    convertedValue = long.Parse(value);
+                }
                 else if (typeof(T).IsEnum)
                 {
-                    convertedValue = Enum.Parse(typeof(T), value);
+                    convertedValue = Enum.Parse(typeof(T), value, true);
+                }
+                else if (typeof(T) == typeof(string))
+                {
+                    convertedValue = value.ToString();
                 }
                 else
                 {

--- a/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
@@ -144,6 +144,23 @@ namespace Amazon.Util.Internal
             }
         }
 
+        // Depending on how System.Types are loaded they are not guaranteed to be compare as equal even when they
+        // are the same type. In particular an interface loaded from a Type.GetInterfaces() call will not compare
+        // equal to the same interface loaded via typeof(<interface-name>).
+        //
+        // This method was needed a result of the removal of SDK's TypeInfo wrapper done as part of the trimmable work.
+        public static bool AreTypesEqual(Type type1, Type type2)
+        {
+            if (type1.Assembly != type2.Assembly)
+                return false;
+            if (type1.Namespace != type2.Namespace)
+                return false;
+            if (type1.Name != type2.Name)
+                return false;
+
+            return true;
+        }
+
         public static void AddToDictionary<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {
             if (dictionary.ContainsKey(key))

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
@@ -365,7 +365,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
             foreach (var inter in targetType.GetInterfaces())
             {
-                if (object.Equals(inter, interfaceType))
+                if (InternalSDKUtils.AreTypesEqual(inter, interfaceType))
                     return true;
                 if (inter.IsGenericTypeDefinition && inter.IsGenericType)
                 {

--- a/sdk/test/CSMTest/Tests/IntegrationTests/AWSSDK.CSM.IntegrationTests.NetStandard.csproj
+++ b/sdk/test/CSMTest/Tests/IntegrationTests/AWSSDK.CSM.IntegrationTests.NetStandard.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1;net8.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <DefineConstants>$(DefineConstants);$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/sdk/test/CSMTest/Tests/IntegrationTests/AWSSDK.CSM.IntegrationTests.NetStandard.csproj
+++ b/sdk/test/CSMTest/Tests/IntegrationTests/AWSSDK.CSM.IntegrationTests.NetStandard.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1;net8.0</TargetFramework>
     <DebugType>portable</DebugType>
     <DefineConstants>$(DefineConstants);$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/sdk/test/CSMTest/Tests/UnitTests/FallBackConfigTests/AWSSDK.EnvFallBackTests.NetStandard.csproj
+++ b/sdk/test/CSMTest/Tests/UnitTests/FallBackConfigTests/AWSSDK.EnvFallBackTests.NetStandard.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1;net8.0</TargetFramework>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>AWSSDK.EnvFallBackTests.NetStandard</AssemblyName>

--- a/sdk/test/CSMTest/Tests/UnitTests/FallBackConfigTests/AWSSDK.EnvFallBackTests.NetStandard.csproj
+++ b/sdk/test/CSMTest/Tests/UnitTests/FallBackConfigTests/AWSSDK.EnvFallBackTests.NetStandard.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1;net8.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>AWSSDK.EnvFallBackTests.NetStandard</AssemblyName>

--- a/sdk/test/CSMTest/Tests/UnitTests/FallBackConfigTests/AWSSDK.SharedProfileTests.NetStandard.csproj
+++ b/sdk/test/CSMTest/Tests/UnitTests/FallBackConfigTests/AWSSDK.SharedProfileTests.NetStandard.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/sdk/test/NetStandard/Common/AWSSDK.CommonTest.NetStandard.csproj
+++ b/sdk/test/NetStandard/Common/AWSSDK.CommonTest.NetStandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(DefineConstants)</DefineConstants>
     <LangVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">8.0</LangVersion>

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests.NetStandard.csproj
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests.NetStandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <AssemblyName>IntegrationTests</AssemblyName>
     <PackageId>IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests.NetStandard.csproj
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests.NetStandard.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/Route53Domains.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/Route53Domains.cs
@@ -45,11 +45,11 @@ namespace Amazon.DNXCore.IntegrationTests
             var domains = (await Client.ListDomainsAsync()).Domains;
             if (domains.Count > 0)
             {
-                await TestTagging(Client, domains[0].DomainName);
+                await TestTaggingAsync(Client, domains[0].DomainName);
             }
         }
 
-        private async Task TestTagging(AmazonRoute53DomainsClient client, string domain)
+        private async Task TestTaggingAsync(AmazonRoute53DomainsClient client, string domain)
         {
             var existingTags = (await client.ListTagsForDomainAsync(domain)).TagList;
 

--- a/sdk/test/NetStandard/UnitTests/AWSSDK.UnitTests.Custom.NetStandard.csproj
+++ b/sdk/test/NetStandard/UnitTests/AWSSDK.UnitTests.Custom.NetStandard.csproj
@@ -41,7 +41,7 @@ This project file should not be used as part of a release pipeline.
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/sdk/test/NetStandard/UnitTests/UnitTests.NetStandard.csproj
+++ b/sdk/test/NetStandard/UnitTests/UnitTests.NetStandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
     <DebugType>portable</DebugType>
     <AssemblyName>UnitTests</AssemblyName>

--- a/sdk/test/NetStandard/UnitTests/UnitTests.NetStandard.csproj
+++ b/sdk/test/NetStandard/UnitTests/UnitTests.NetStandard.csproj
@@ -33,9 +33,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Moq" Version="4.8.3"/>
   </ItemGroup>
 

--- a/sdk/test/Services/S3/UnitTests/Custom/EncryptionChangeTest.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/EncryptionChangeTest.cs
@@ -23,7 +23,7 @@ namespace AWSSDK.UnitTests
     [TestClass]
     public class EncryptionChangeTest
     {
-        private const string ExpectedHash = "4D0CB6D89DD6320ED4F554B281717800D1554FB438E5768380243BBBD8BAB2FC";
+        private const string ExpectedHash = "7B226418F7D7877680A0E2C10E09AE59CA44E9BC1DBB6A2C10E7E8C0872C4489";
         private const string Message = "Manually run EncryptionInteropTest.cs and EncryptionInteropTest.java.";
 
         private static readonly List<string> SourceFiles = new List<string>

--- a/sdk/test/SmokeTests/AWSSDK.SmokeTests.NetStandard.csproj
+++ b/sdk/test/SmokeTests/AWSSDK.SmokeTests.NetStandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
     <DebugType>portable</DebugType>
     <AssemblyName>AWSSDK.SmokeTests.NetStandard</AssemblyName>


### PR DESCRIPTION
## Description
Changes to make the `feature/net8` build, test and pack in the CI system.

* Add DevConfig file with the ignore list for backwards compact check.
* Add `net8.0` as target framework for test projects.
* Update XUnit and Microsoft.NET.Test.Sdk versions. The .NET 8.0 RC2 install was not working with the old versions.
* Bug fix for unit and integ tests that were failing after running the full test suite for the first time on the `feature/net8.0` branch.


