### PR TITLE
For .NET 8 use HttpClient's sync Send method

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
@@ -507,16 +507,6 @@ namespace Amazon.Runtime
 
                 throw;
             }
-            catch (OperationCanceledException canceledException)
-            {
-                if (canceledException.InnerException != null)
-                {
-                    throw canceledException.InnerException;
-                }
-
-                throw;
-            }
-
         }
 #else
         public IWebResponseData GetResponse()

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
@@ -483,6 +483,42 @@ namespace Amazon.Runtime
         /// Returns the HTTP response.
         /// </summary>
         /// <returns>The HTTP response.</returns>
+#if NET8_0_OR_GREATER
+        public IWebResponseData GetResponse()
+        {
+            try
+            {
+                var responseMessage = _httpClient.Send(_request, HttpCompletionOption.ResponseHeadersRead);
+
+                return ProcessHttpResponseMessage(responseMessage);
+            }
+            catch (HttpRequestException httpException)
+            {
+                if (httpException.InnerException != null)
+                {
+                    if (httpException.InnerException is IOException)
+                    {
+                        throw httpException.InnerException;
+                    }
+
+                    if (httpException.InnerException is WebException)
+                        throw httpException.InnerException;
+                }
+
+                throw;
+            }
+            catch (OperationCanceledException canceledException)
+            {
+                if (canceledException.InnerException != null)
+                {
+                    throw canceledException.InnerException;
+                }
+
+                throw;
+            }
+
+        }
+#else
         public IWebResponseData GetResponse()
         {
             try
@@ -494,6 +530,7 @@ namespace Amazon.Runtime
                 throw e.InnerException;
             }
         }
+#endif
 
         /// <summary>
         /// Aborts the HTTP request.
@@ -515,23 +552,7 @@ namespace Amazon.Runtime
                 var responseMessage = await _httpClient.SendAsync(_request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);
 
-                bool disposeClient = ClientConfig.DisposeHttpClients(_clientConfig);
-                // If AllowAutoRedirect is set to false, HTTP 3xx responses are returned back as response.
-                if (!_clientConfig.AllowAutoRedirect &&
-                    responseMessage.StatusCode >= HttpStatusCode.Ambiguous &&
-                    responseMessage.StatusCode < HttpStatusCode.BadRequest)
-                {
-                    return new HttpClientResponseData(responseMessage, _httpClient, disposeClient);
-                }
-
-                if (!responseMessage.IsSuccessStatusCode)
-                {
-                    // For all responses other than HTTP 2xx, return an exception.
-                    throw new Amazon.Runtime.Internal.HttpErrorResponseException(
-                        new HttpClientResponseData(responseMessage, _httpClient, disposeClient));
-                }
-
-                return new HttpClientResponseData(responseMessage, _httpClient, disposeClient);
+                return ProcessHttpResponseMessage(responseMessage);
             }
             catch (HttpRequestException httpException)
             {
@@ -564,6 +585,27 @@ namespace Amazon.Runtime
 
                 throw;
             }
+        }
+
+        private HttpClientResponseData ProcessHttpResponseMessage(HttpResponseMessage responseMessage)
+        {
+            bool disposeClient = ClientConfig.DisposeHttpClients(_clientConfig);
+            // If AllowAutoRedirect is set to false, HTTP 3xx responses are returned back as response.
+            if (!_clientConfig.AllowAutoRedirect &&
+                responseMessage.StatusCode >= HttpStatusCode.Ambiguous &&
+                responseMessage.StatusCode < HttpStatusCode.BadRequest)
+            {
+                return new HttpClientResponseData(responseMessage, _httpClient, disposeClient);
+            }
+
+            if (!responseMessage.IsSuccessStatusCode)
+            {
+                // For all responses other than HTTP 2xx, return an exception.
+                throw new Amazon.Runtime.Internal.HttpErrorResponseException(
+                    new HttpClientResponseData(responseMessage, _httpClient, disposeClient));
+            }
+
+            return new HttpClientResponseData(responseMessage, _httpClient, disposeClient);
         }
 
         /// <summary>


### PR DESCRIPTION
The .NET Core request pipeline has always had both a sync and async code path. Since .NET Core did not originally have a sync Send method on the `HttpClient` the pipeline would call the async code path and then block. Now that we are adding a .NET 8 target we can use the new sync `Send` method on the `HttpClient` instead of the blocking async approach.

A later discussion can be head on whether we should make the service methods public for .NET 8.

CI dry run was successful for this branch.