### PR TITLE
For .NET 8 disable canonicalization in System.Uri

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
+++ b/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
@@ -623,9 +623,21 @@ namespace Amazon.Runtime
             }
             
             var hasSlash = url.AbsoluteUri.EndsWith("/", StringComparison.Ordinal) || parameterizedPath.StartsWith("/", StringComparison.Ordinal);
-            var uri = hasSlash
-                ? new Uri(url.AbsoluteUri + parameterizedPath)
-                : new Uri(url.AbsoluteUri + "/" + parameterizedPath);
+
+            var strUri = hasSlash
+                ? url.AbsoluteUri + parameterizedPath
+                : url.AbsoluteUri + "/" + parameterizedPath;
+
+#if NET8_0_OR_GREATER
+            // The UriCreationOptions and DangerousDisablePathAndQueryCanonicalization were added in .NET 6 and allows
+            // us to turn off the Uri behavior of canonicalizing Uri. For example if the resource path was "foo/../bar.txt"
+            // the URI class will change the canonicalize path to bar.txt. This behavior of changing the Uri after the 
+            // request has been signed will trigger a signature mismatch error. It is valid especially for S3 for the resource
+            // path to contain ".." segments.W
+            var uri = new Uri(strUri, new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
+#else
+            var uri = new Uri(strUri);
+#endif
             DontUnescapePathDotsAndSlashes(uri);
             return uri;
         }

--- a/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
+++ b/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
@@ -633,7 +633,7 @@ namespace Amazon.Runtime
             // us to turn off the Uri behavior of canonicalizing Uri. For example if the resource path was "foo/../bar.txt"
             // the URI class will change the canonicalize path to bar.txt. This behavior of changing the Uri after the 
             // request has been signed will trigger a signature mismatch error. It is valid especially for S3 for the resource
-            // path to contain ".." segments.W
+            // path to contain ".." segments.
             var uri = new Uri(strUri, new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
 #else
             var uri = new Uri(strUri);

--- a/sdk/src/Services/S3/Custom/Model/AbortMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/AbortMultipartUploadRequest.cs
@@ -145,9 +145,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/AbortMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/AbortMultipartUploadRequest.cs
@@ -144,15 +144,19 @@ namespace Amazon.S3.Model
         /// The key of the S3 object that was being uploaded.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
@@ -318,15 +318,19 @@ namespace Amazon.S3.Model
         /// The key of the S3 object that was being uploaded.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
@@ -319,9 +319,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
@@ -582,15 +582,19 @@ namespace Amazon.S3.Model
         /// The key to be given to the copy of the source object.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string DestinationKey
         {
@@ -769,15 +773,19 @@ namespace Amazon.S3.Model
         /// The key of the object to copy.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string SourceKey
         {

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
@@ -583,9 +583,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string DestinationKey
         {
@@ -759,15 +764,20 @@ namespace Amazon.S3.Model
         {
             return !System.String.IsNullOrEmpty(this.srcBucket);
         }
-        
+
         /// <summary>
         /// The key of the object to copy.
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string SourceKey
         {

--- a/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
@@ -81,15 +81,19 @@ namespace Amazon.S3.Model
         /// The key of the object to copy.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string SourceKey
         {
@@ -171,15 +175,19 @@ namespace Amazon.S3.Model
         /// The key to be given to the copy of the source object.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string DestinationKey
         {

--- a/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
@@ -82,9 +82,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string SourceKey
         {
@@ -167,9 +172,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string DestinationKey
         {

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectRequest.cs
@@ -158,15 +158,19 @@ namespace Amazon.S3.Model
         /// The key identifying the object to delete.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectRequest.cs
@@ -159,9 +159,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectTaggingRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectTaggingRequest.cs
@@ -119,9 +119,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectTaggingRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectTaggingRequest.cs
@@ -118,15 +118,19 @@ namespace Amazon.S3.Model
         /// The key identifying the object tagging to delete.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetACLRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetACLRequest.cs
@@ -107,15 +107,19 @@ namespace Amazon.S3.Model
         /// The key of the S3 object to be queried.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key { get; set; }
 

--- a/sdk/src/Services/S3/Custom/Model/GetACLRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetACLRequest.cs
@@ -108,9 +108,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key { get; set; }
 

--- a/sdk/src/Services/S3/Custom/Model/GetObjectLegalHoldRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectLegalHoldRequest.cs
@@ -113,9 +113,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectLegalHoldRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectLegalHoldRequest.cs
@@ -112,15 +112,19 @@ namespace Amazon.S3.Model
         /// </para>
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
@@ -359,9 +359,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
@@ -358,15 +358,19 @@ namespace Amazon.S3.Model
         /// The key of the object.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectRequest.cs
@@ -403,9 +403,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectRequest.cs
@@ -402,15 +402,19 @@ namespace Amazon.S3.Model
         /// Gets and sets the Key property. This is the user defined key that identifies the object in the bucket.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectRetentionRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectRetentionRequest.cs
@@ -113,9 +113,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectRetentionRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectRetentionRequest.cs
@@ -112,15 +112,19 @@ namespace Amazon.S3.Model
         /// </para>
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectTaggingRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectTaggingRequest.cs
@@ -127,15 +127,19 @@ namespace Amazon.S3.Model
         /// </para>
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectTaggingRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectTaggingRequest.cs
@@ -128,9 +128,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectTorrentRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectTorrentRequest.cs
@@ -54,9 +54,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectTorrentRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectTorrentRequest.cs
@@ -53,15 +53,19 @@ namespace Amazon.S3.Model
         /// The key identifying the object.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetPreSignedUrlRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetPreSignedUrlRequest.cs
@@ -88,15 +88,19 @@ namespace Amazon.S3.Model
         /// The key to the object for which a pre-signed url should be created.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/GetPreSignedUrlRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetPreSignedUrlRequest.cs
@@ -89,9 +89,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
@@ -475,15 +475,19 @@ namespace Amazon.S3.Model
         /// The key of the object to create or update.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
@@ -476,9 +476,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/ListPartsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListPartsRequest.cs
@@ -185,9 +185,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/ListPartsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListPartsRequest.cs
@@ -184,15 +184,19 @@ namespace Amazon.S3.Model
         /// The object key for which the multipart upload was initiated.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/PutACLRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutACLRequest.cs
@@ -393,9 +393,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/PutACLRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutACLRequest.cs
@@ -392,15 +392,19 @@ namespace Amazon.S3.Model
         /// </para>
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/PutObjectLegalHoldRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectLegalHoldRequest.cs
@@ -146,15 +146,19 @@ namespace Amazon.S3.Model
         /// </para>
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/PutObjectLegalHoldRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectLegalHoldRequest.cs
@@ -147,9 +147,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/PutObjectRetentionRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectRetentionRequest.cs
@@ -179,15 +179,19 @@ namespace Amazon.S3.Model
         /// </para>
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/PutObjectRetentionRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectRetentionRequest.cs
@@ -180,9 +180,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/PutObjectTaggingRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectTaggingRequest.cs
@@ -202,15 +202,19 @@ namespace Amazon.S3.Model
         /// Gets and sets Key property. This key is used to identify the object in S3.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/PutObjectTaggingRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectTaggingRequest.cs
@@ -203,9 +203,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/RestoreObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/RestoreObjectRequest.cs
@@ -435,15 +435,19 @@ namespace Amazon.S3.Model
         /// Gets and sets the Key property. This key indicates the S3 object to restore.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/RestoreObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/RestoreObjectRequest.cs
@@ -436,9 +436,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
@@ -386,9 +386,14 @@ namespace Amazon.S3.Model
         /// </summary>
         /// <remarks>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
-        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. For further information view the documentation for 
-        /// the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
+        /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
+        /// is interpreted as use parent directory. 
+        /// 
+        /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
+        /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
+        /// 
+        /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
         /// </remarks>
         public string Key
         {

--- a/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
@@ -385,15 +385,19 @@ namespace Amazon.S3.Model
         /// The key of the object.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property will be used as part of the resource path of the HTTP request. In .NET the System.Uri class
         /// is used to construct the uri for the request. The System.Uri class will canonicalize the uri string by compacting characters like "..". 
         /// For example an object key of "foo/../bar/file.txt" will be transformed into "bar/file.txt" because the ".." 
-        /// is interpreted as use parent directory. 
-        /// 
+        /// is interpreted as use parent directory.
+        /// </para>
+        /// <para>
         /// Starting with .NET 8, the AWS .NET SDK disables System.Uri's feature of canonicalizing the resource path. This allows S3 keys like
         /// "foo/../bar/file.txt" to work correctly with the AWS .NET SDK.
-        /// 
+        /// </para>
+        /// <para>
         /// For further information view the documentation for the Uri class: https://docs.microsoft.com/en-us/dotnet/api/system.uri
+        /// </para>
         /// </remarks>
         public string Key
         {


### PR DESCRIPTION
The .NET SDK has never been able to handle S3 keys like `bar/../foo.txt` because the .NET System.Uri class used by the HttpClient would canonicalize the string turning it into `foo.txt`. Which changes the S3 key and breaks the signature of the request.

As part of .NET 6 Microsoft added a new `DangerousDisablePathAndQueryCanonicalization` for our use case of the resource path should always should never be changed because that is how we sign and in cases like S3 it is valid to have ".." segments in the path.

This PR takes advantage of the `DangerousDisablePathAndQueryCanonicalization` property for our upcoming .NET 8 target. 

I tested this by creating a new integ only used for .NET 8 that uses a S3 key that would have been canonicalized and then run a dry run test to confirm all existing tests still pass.