### PR TITLE
Petesong/sso token fix

### DIFF
--- a/generator/.DevConfigs/petesong-sso-token-fix.json
+++ b/generator/.DevConfigs/petesong-sso-token-fix.json
@@ -1,0 +1,14 @@
+{
+  "core":{
+    "changeLogMessages":["Update SSO Token Manager to generate a new token if the token's client registration has expired."],
+    "type": "patch",
+    "updateMinimum":true
+  },
+  "services": [
+    {
+      "serviceName": "SSOOIDC",
+      "type": "patch",
+      "changeLogMessages": ["Add RegistrationExpiresAt field to GetSsoTokenResponse."]
+    }
+  ]
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SSOTokenManager.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SSOTokenManager.cs
@@ -144,7 +144,11 @@ namespace Amazon.Runtime.Credentials.Internal
                     {
                         throw new AmazonClientException("SSO Token has expired and can not be refreshed");
                     }
-
+                    //if registration is within 5 minutes of expiration, generate a new token
+                    if (ssoToken.RegisteredClientExpired() && options.SupportsGettingNewToken)
+                    {
+                        return GenerateNewToken(options);
+                    }
                     // did we recently try to refresh the token?
                     if (true == inMemoryToken?.RefreshState.IsInRefreshCoolDown())
                     {
@@ -332,7 +336,11 @@ namespace Amazon.Runtime.Credentials.Internal
                     {
                         throw new AmazonClientException("SSO Token has expired and can not be refreshed");
                     }
-
+                    //if registration is within 5 minutes of expiration, generate a new token
+                    if (ssoToken.RegisteredClientExpired() && options.SupportsGettingNewToken)
+                    {
+                        return await GenerateNewTokenAsync(options, cancellationToken).ConfigureAwait(false);
+                    }
                     // did we recently try to refresh the token?
                     if (true == inMemoryToken?.RefreshState.IsInRefreshCoolDown())
                     {

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SsoTokenUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SsoTokenUtils.cs
@@ -92,6 +92,21 @@ namespace Amazon.Runtime.Credentials.Internal
             return ToJson(token);
         }
 
+        /// <summary>
+        /// This determines whether the <seealso cref="SsoToken.RegistrationExpiresAt"/> field is 5 minutes within expiration
+        /// </summary>
+        /// <param name="token">The sso token</param>
+        /// <returns>This returns true if <seealso cref="SsoToken.RegistrationExpiresAt"/> is within 5 minutes of expiration. False otherwise</returns>
+        public static bool RegisteredClientExpired(this SsoToken token)
+        {
+            if (null == token)
+                throw new ArgumentNullException(nameof(token));
+            DateTime dateTime = ConvertRFC3339StringToDateTime(token.RegistrationExpiresAt);
+#pragma warning disable CS0618 // Type or member is obsolete
+            return AWSSDKUtils.CorrectedUtcNow >= dateTime.AddMinutes(-5);
+#pragma warning restore CS0618 // Type or member is obsolete               
+        }
+
         #endregion
 
         /// <summary>
@@ -162,5 +177,21 @@ namespace Amazon.Runtime.Credentials.Internal
             
             return token;
         }
+        #region private methods
+        /// <summary>
+        /// This method takes in an RFC3339 string representing a datetime and converts it to a DateTime object 
+        /// </summary>
+        /// <param name="stringFormattedDate">The RFC3339 formatted string</param>
+        /// <returns>Returns the datetime object serialized to UTC</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        private static DateTime ConvertRFC3339StringToDateTime(string stringFormattedDate)
+        {
+            if (string.IsNullOrEmpty(stringFormattedDate))
+            {
+                throw new ArgumentNullException(nameof(stringFormattedDate));
+            }
+            return XmlConvert.ToDateTime(stringFormattedDate, XmlDateTimeSerializationMode.Utc);
+        }
+        #endregion
     }
 }

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -172,10 +172,9 @@ namespace Amazon.Util
         /// The RFC822Date Format string. Used when parsing date objects
         /// </summary>
         public const string RFC822DateFormat = "ddd, dd MMM yyyy HH:mm:ss \\G\\M\\T";
-
 #endregion
 
-#region Internal Methods
+        #region Internal Methods
 
         /// <summary>
         /// Returns an extension of a path.

--- a/sdk/src/Services/SSOOIDC/Custom/Internal/_bcl45+netstandard/CoreAmazonSSOOIDC.cs
+++ b/sdk/src/Services/SSOOIDC/Custom/Internal/_bcl45+netstandard/CoreAmazonSSOOIDC.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.SharedInterfaces;
@@ -101,13 +102,14 @@ namespace Amazon.SSOOIDC.Internal
                 startDeviceAuthorizationResponse.Interval,
                 deviceCodeExpiration,
                 context);
-
+            var clientSecretExpiresAtString = XmlConvert.ToString(AWSSDKUtils.ConvertFromUnixEpochSeconds((int)registerClientResponse.ClientSecretExpiresAt), XmlDateTimeSerializationMode.Utc);
             return new GetSsoTokenResponse
             {
                 AccessToken = ssoToken.AccessToken,
                 Region = client.Config.RegionEndpoint.SystemName,
                 ClientId = registerClientResponse.ClientId,
                 ClientSecret = registerClientResponse.ClientSecret,
+                RegistrationExpiresAt = clientSecretExpiresAtString,
                 RefreshToken = ssoToken.RefreshToken,
                 ExpiresAt = DateTime.UtcNow.AddSeconds(ssoToken.ExpiresIn),
                 StartUrl = request.StartUrl
@@ -176,17 +178,19 @@ namespace Amazon.SSOOIDC.Internal
                 startDeviceAuthorizationResponse.Interval,
                 deviceCodeExpiration,
                 context).ConfigureAwait(false);
-
+            var clientSecretExpiresAtString = XmlConvert.ToString(AWSSDKUtils.ConvertFromUnixEpochSeconds((int)registerClientResponse.ClientSecretExpiresAt), XmlDateTimeSerializationMode.Utc);
             return new GetSsoTokenResponse
             {
                 AccessToken = ssoToken.AccessToken,
                 Region = client.Config.RegionEndpoint.SystemName,
                 ClientId = registerClientResponse.ClientId,
                 ClientSecret = registerClientResponse.ClientSecret,
+                RegistrationExpiresAt = clientSecretExpiresAtString,
                 RefreshToken = ssoToken.RefreshToken,
                 ExpiresAt = DateTime.UtcNow.AddSeconds(ssoToken.ExpiresIn),
                 StartUrl = request.StartUrl
             };
+            
         }
 
 #if BCL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds `RegistrationExpiresAt` to the SSOToken that is returned when `GetTokenAsync` is called. This value is then used to generate a new SSO token if the registrationExpiresAt is within 5 minutes of expiration.


## Motivation and Context
This change is for a better user experience within the VSToolkit for AWS

## Testing
Dry Run successful

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement