### PR TITLE
Update CopyObject and CopyPart requests not to remove leading slash from object keys

### DIFF
--- a/generator/.DevConfigs/a3b04c16-1bb0-4caa-ba7c-391c18a4dc77.json
+++ b/generator/.DevConfigs/a3b04c16-1bb0-4caa-ba7c-391c18a4dc77.json
@@ -1,0 +1,9 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": ["Update CopyObject and CopyPart requests not to remove leading slash from object keys"]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
@@ -36,9 +36,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
         public IRequest Marshall(CopyObjectRequest copyObjectRequest)
         {
-            var sourceKey = AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.SourceKey);
-            var destinationKey = AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.DestinationKey);
-            
             IRequest request = new DefaultRequest(copyObjectRequest, "AmazonS3");
 
             request.HttpMethod = "PUT";
@@ -53,7 +50,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             HeaderACLRequestMarshaller.Marshall(request, copyObjectRequest);
 
             if (copyObjectRequest.IsSetSourceBucket())
-                request.Headers.Add(HeaderKeys.XAmzCopySourceHeader, ConstructCopySourceHeaderValue(copyObjectRequest.SourceBucket, sourceKey, copyObjectRequest.SourceVersionId));
+                request.Headers.Add(HeaderKeys.XAmzCopySourceHeader, ConstructCopySourceHeaderValue(copyObjectRequest.SourceBucket, copyObjectRequest.SourceKey, copyObjectRequest.SourceVersionId));
 
             if (copyObjectRequest.IsSetETagToMatch())
                 request.Headers.Add(HeaderKeys.XAmzCopySourceIfMatchHeader, S3Transforms.ToStringValue(copyObjectRequest.ETagToMatch));
@@ -139,11 +136,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             if (string.IsNullOrEmpty(copyObjectRequest.DestinationBucket))
                 throw new System.ArgumentException("DestinationBucket is a required property and must be set before making this call.", "CopyObjectRequest.DestinationBucket");
-            if (string.IsNullOrEmpty(destinationKey))
+            if (string.IsNullOrEmpty(copyObjectRequest.DestinationKey))
                 throw new System.ArgumentException("DestinationKey is a required property and must be set before making this call.", "CopyObjectRequest.DestinationKey");
 
             request.ResourcePath = string.Format(CultureInfo.InvariantCulture, "/{0}",
-                                                 S3Transforms.ToStringValue(destinationKey));
+                                                 S3Transforms.ToStringValue(copyObjectRequest.DestinationKey));
 
 
             request.UseQueryString = true;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
@@ -37,12 +37,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         public IRequest Marshall(CopyPartRequest copyPartRequest)
         {
             IRequest request = new DefaultRequest(copyPartRequest, "AmazonS3");
-            var sourceKey = AmazonS3Util.RemoveLeadingSlash(copyPartRequest.SourceKey);
-            var destinationKey = AmazonS3Util.RemoveLeadingSlash(copyPartRequest.DestinationKey);
             request.HttpMethod = "PUT";
 
             if (copyPartRequest.IsSetSourceBucket())
-                request.Headers.Add(HeaderKeys.XAmzCopySourceHeader, ConstructCopySourceHeaderValue(copyPartRequest.SourceBucket, sourceKey, copyPartRequest.SourceVersionId));
+                request.Headers.Add(HeaderKeys.XAmzCopySourceHeader, ConstructCopySourceHeaderValue(copyPartRequest.SourceBucket, copyPartRequest.SourceKey, copyPartRequest.SourceVersionId));
 
             if (copyPartRequest.IsSetETagToMatch())
                 request.Headers.Add(HeaderKeys.XAmzCopySourceIfMatchHeader, AWSSDKUtils.Join(copyPartRequest.ETagToMatch));
@@ -92,11 +90,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (string.IsNullOrEmpty(copyPartRequest.DestinationBucket))
                 throw new System.ArgumentException("DestinationBucket is a required property and must be set before making this call.", "CopyPartRequest.DestinationBucket");
 
-            if (string.IsNullOrEmpty(destinationKey))
+            if (string.IsNullOrEmpty(copyPartRequest.DestinationKey))
                 throw new System.ArgumentException("DestinationKey is a required property and must be set before making this call.", "CopyPartRequest.DestinationKey");
 
             request.ResourcePath = string.Format(CultureInfo.InvariantCulture, "/{0}",
-                                                 S3Transforms.ToStringValue(destinationKey));
+                                                 S3Transforms.ToStringValue(copyPartRequest.DestinationKey));
 
             request.AddSubResource("partNumber", S3Transforms.ToStringValue(copyPartRequest.PartNumber));
             request.AddSubResource("uploadId", S3Transforms.ToStringValue(copyPartRequest.UploadId));

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
@@ -570,13 +570,6 @@ namespace Amazon.S3.Util
                 key.EndsWith(S3Constants.EncryptionInstructionfileSuffixV2, StringComparison.Ordinal);
         }
 
-        internal static string RemoveLeadingSlash(string key)
-        {
-            return key.StartsWith("/", StringComparison.Ordinal)
-                                    ? key.Substring(1)
-                                    : key;
-        }
-
         /// <summary>
         /// Check if the request resource is an outpost resource
         /// </summary>

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/CopyObjectTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/CopyObjectTests.cs
@@ -1,0 +1,58 @@
+﻿using Amazon.S3;
+using Amazon.S3.Model;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.DNXCore.IntegrationTests.S3
+{
+    public class CopyObjectTests : TestBase<AmazonS3Client>
+    {
+        private readonly string bucketName;
+        private readonly string testContent = "This is some sample text.!!";
+
+        public CopyObjectTests()
+        {
+            bucketName = UtilityMethods.CreateBucketAsync(Client, "CopyObjectTest").Result;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            UtilityMethods.DeleteBucketWithObjectsAsync(Client, bucketName).Wait();
+            base.Dispose(disposing);
+        }
+
+        [Fact]
+        [Trait(CategoryAttribute, "S3")]
+        public async Task CopyObjectTestWithLeadingSlash()
+        {
+            var sourceKey = "/source-key.txt";
+            var destinationKey = "/destination-key.txt";
+
+            await Client.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                ContentBody = testContent,
+                Key = sourceKey
+            });
+
+            var copyResponse = await Client.CopyObjectAsync(new CopyObjectRequest
+            {
+                SourceBucket = bucketName,
+                SourceKey = sourceKey,
+
+                DestinationBucket = bucketName,
+                DestinationKey = destinationKey
+            });
+            Assert.Equal(HttpStatusCode.OK, copyResponse.HttpStatusCode);
+
+            using (var getResponse = await Client.GetObjectAsync(bucketName, destinationKey))
+            using (var reader = new StreamReader(getResponse.ResponseStream))
+            {
+                var actualContent = reader.ReadToEnd();
+                Assert.Equal(testContent, actualContent);
+            }
+        }
+    }
+}

--- a/sdk/test/Services/S3/IntegrationTests/CopyObjectPartTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyObjectPartTests.cs
@@ -1,0 +1,110 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+
+namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
+{
+    [TestClass]
+    public class CopyObjectPartTests : TestBase<AmazonS3Client>
+    {
+        private const string testContent = "This is the content body!";
+        private const string testKeyWithSlash = "/testsourcekey";
+        private string bucketName;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            bucketName = S3TestUtils.CreateBucketWithWait(Client);
+
+            Client.PutObject(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = testKeyWithSlash,
+                ContentBody = testContent
+            });
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            AmazonS3Util.DeleteS3BucketWithObjects(Client, bucketName);
+            BaseClean();
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void TestCopyObjectPartWithLeadingSlash()
+        {
+            var destinationKeyWithSlash = "/testdestkey";
+            string uploadId = null;
+
+            try
+            {
+                var multiPartUploadResponse = Client.InitiateMultipartUpload(new InitiateMultipartUploadRequest
+                {
+                    BucketName = bucketName,
+                    Key = destinationKeyWithSlash,
+                });
+
+                uploadId = multiPartUploadResponse.UploadId;
+                var copyPartResponse = Client.CopyPart(new CopyPartRequest
+                {
+                    DestinationBucket = bucketName,
+                    DestinationKey = destinationKeyWithSlash,
+                    SourceBucket = bucketName,
+                    SourceKey = testKeyWithSlash,
+                    UploadId = uploadId,
+                    PartNumber = 1,
+                });
+                Assert.IsNotNull(copyPartResponse.ETag);
+                Assert.IsTrue(copyPartResponse.ETag != null && copyPartResponse.ETag.Length > 0);
+                Assert.IsTrue(copyPartResponse.PartNumber == 1);
+
+                var completeUploadResponse = Client.CompleteMultipartUpload(new CompleteMultipartUploadRequest
+                {
+                    BucketName = bucketName,
+                    Key = destinationKeyWithSlash,
+                    UploadId = uploadId,
+                    PartETags = new List<PartETag>
+                    {
+                        new PartETag 
+                        { 
+                            ETag = copyPartResponse.ETag, 
+                            PartNumber = copyPartResponse.PartNumber 
+                        }
+                    }
+                });
+                Assert.AreEqual(HttpStatusCode.OK, completeUploadResponse.HttpStatusCode);
+
+                var getObjectResponse = Client.GetObject(new GetObjectRequest
+                {
+                    BucketName = bucketName,
+                    Key = destinationKeyWithSlash
+                });
+
+                using (getObjectResponse.ResponseStream)
+                using (var reader = new StreamReader(getObjectResponse.ResponseStream))
+                {
+                    var actualText = reader.ReadToEnd();
+                    Assert.AreEqual(testContent, actualText);
+                }
+            }
+            finally
+            {
+                if (uploadId != null)
+                {
+                    Client.AbortMultipartUpload(new AbortMultipartUploadRequest
+                    {
+                        BucketName = bucketName,
+                        Key = destinationKeyWithSlash,
+                        UploadId = uploadId
+                    });
+                }
+            }
+        }
+    }
+}

--- a/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
@@ -3,8 +3,8 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.IO;
+using System.Net;
 
 namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 {
@@ -13,6 +13,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
     {
         private const string testContent = "This is the content body!";
         private const string testKey = "testKey.txt";
+        private const string testKeyWithSlash = "/testkey";
 
         private string eastBucketName;
         private string westBucketName;
@@ -24,12 +25,21 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         {
             usEastClient = new AmazonS3Client(RegionEndpoint.USEast1);
             eastBucketName = S3TestUtils.CreateBucketWithWait(usEastClient);
+            
             usEastClient.PutObject(new PutObjectRequest
             {
                 BucketName = eastBucketName,
                 Key = testKey,
                 ContentBody = testContent
             });
+
+            usEastClient.PutObject(new PutObjectRequest
+            {
+                BucketName = eastBucketName,
+                Key = testKeyWithSlash,
+                ContentBody = testContent
+            });
+
             var usWestClient = new AmazonS3Client(RegionEndpoint.USWest1);
             westBucketName = S3TestUtils.CreateBucketWithWait(usWestClient);
         }
@@ -53,6 +63,33 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 DestinationBucket = westBucketName,
                 DestinationKey = testKey
             });
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void TestCopyObjectWithLeadingSlash()
+        {
+            var copyObjectResponse = usEastClient.CopyObject(new CopyObjectRequest
+            {
+                SourceBucket = eastBucketName,
+                SourceKey = testKeyWithSlash,
+                DestinationBucket = westBucketName,
+                DestinationKey = testKeyWithSlash
+            });
+            Assert.AreEqual(HttpStatusCode.OK, copyObjectResponse.HttpStatusCode);
+
+            var getObjectResponse = Client.GetObject(new GetObjectRequest
+            {
+                BucketName = westBucketName,
+                Key = testKeyWithSlash
+            });
+
+            using (getObjectResponse.ResponseStream)
+            using (var reader = new StreamReader(getObjectResponse.ResponseStream))
+            {
+                var actualText = reader.ReadToEnd();
+                Assert.AreEqual(testContent, actualText);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Fixes #1720 (also internal issue `DOTNET-4410`).

## Motivation and Context
This PR updates the `CopyObject` and `CopyPart` marshallers not to remove leading slashes from the specified object keys.

## Testing
- Dry-run: `DRY_RUN-48cd51a1-d13d-4917-a705-49004234b630`
- Added integration tests
- Also tested the example from the original issue with the built `.nupkg` and confirmed it works (using either a bucket and an access point for `SourceBucket`):

```
var client = new AmazonS3Client(RegionEndpoint.USEast1);

var response = client.CopyObject(new CopyObjectRequest
{
    SourceKey = "/",
    DestinationKey = "/",

    SourceBucket = "bucket1",
    DestinationBucket = "bucket2",
});

// Outputs: OK
Console.WriteLine(response.HttpStatusCode);
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the code style of this project
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement