### PR TITLE
Set assembly versions to 3.7.300 for .NET 8 release

### DIFF
--- a/generator/.DevConfigs/feature-net8.json
+++ b/generator/.DevConfigs/feature-net8.json
@@ -1,8 +1,11 @@
 {
   "core": {
-    "changeLogMessages": ["Add trimming support for .NET 8."],
-    "type": "patch",
-    "updateMinimum": true,
+    "changeLogMessages": [
+		"Add .NET 8 framework target for core and service projects.",
+		"For .NET 8 mark all SDK assemblies as trimmable and address all trim warnings.",
+		"For .NET 8 prevent the System.Uri class from canonicalizing the resource path. This broke scenarios with S3 object keys like `foo/../bar.txt`.",
+		"For .NET 8 use the System.Net.Http.HttpClient synchronous `Send` method when then internal synchronous service request methods are invoked."
+	],
     "backwardIncompatibilitiesToIgnore": [
       "Amazon.Util.PaginatedResourceFactory/TypeRemoved",
       "Amazon.Runtime.URIBasedRefreshingCredentialHelper/MethodOverloadAdded",
@@ -10,5 +13,6 @@
       "Amazon.Util.PaginatedResourceInfo/TypeRemoved",
       "Amazon.Runtime.Internal.Settings.SettingsCollection/MethodRemoved"
     ]
-  }
+  },
+  "overrideVersion": "3.7.300.0"
 }

--- a/generator/.DevConfigs/feature-net8.json
+++ b/generator/.DevConfigs/feature-net8.json
@@ -4,7 +4,7 @@
 		"Add .NET 8 framework target for core and service projects.",
 		"For .NET 8 mark all SDK assemblies as trimmable and address all trim warnings.",
 		"For .NET 8 prevent the System.Uri class from canonicalizing the resource path. This broke scenarios with S3 object keys like `foo/../bar.txt`.",
-		"For .NET 8 use the System.Net.Http.HttpClient synchronous `Send` method when then internal synchronous service request methods are invoked."
+		"For .NET 8 the System.Net.Http.HttpClient's synchronous `Send` method is used when the internal synchronous service request methods are invoked. This replaces the SDK blocking on the SendAsync method."
 	],
     "backwardIncompatibilitiesToIgnore": [
       "Amazon.Util.PaginatedResourceFactory/TypeRemoved",


### PR DESCRIPTION
Update the DevConfig file for the .NET 8 release to set 3.7.300.0 so all SDK assemblies will have the same version number at the point .NET 8 support was added.