### PR TITLE
Update changelog message for S3 bug fix

### DIFF
--- a/generator/.DevConfigs/a3b04c16-1bb0-4caa-ba7c-391c18a4dc77.json
+++ b/generator/.DevConfigs/a3b04c16-1bb0-4caa-ba7c-391c18a4dc77.json
@@ -3,7 +3,7 @@
     {
       "serviceName": "S3",
       "type": "patch",
-      "changeLogMessages": ["Update CopyObject and CopyPart requests not to remove leading slash from object keys"]
+      "changeLogMessages": ["BREAKING CHANGE: Update CopyObject and CopyPart requests not to remove leading slash from object keys"]
     }
   ]
 }


### PR DESCRIPTION
Update change log message for S3 to include `BREAKING CHANGE` as a prefix.

## License
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement