### PR TITLE
Fixed an issue where TransferUtility UploadAsync() is not sending metadata or headers with non-seekable stream.

### DIFF
--- a/generator/.DevConfigs/256d6671-cc30-490d-960a-61d6b541b657.json
+++ b/generator/.DevConfigs/256d6671-cc30-490d-960a-61d6b541b657.json
@@ -1,0 +1,9 @@
+{
+    "services": [
+      {
+        "serviceName": "S3",
+        "type": "patch",
+        "changeLogMessages": [ "Fixed an issue where TransferUtility UploadAsync() is not sending metadata or headers with non-seekable stream." ]
+      }
+    ]
+  }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
@@ -154,10 +154,18 @@ namespace Amazon.S3.Transfer.Internal
 
         private CompleteMultipartUploadRequest ConstructCompleteMultipartUploadRequest(InitiateMultipartUploadResponse initResponse)
         {
-            if(this._uploadResponses.Count != this._totalNumberOfParts)
+            return ConstructCompleteMultipartUploadRequest(initResponse, false, null);
+        }
+
+        private CompleteMultipartUploadRequest ConstructCompleteMultipartUploadRequest(InitiateMultipartUploadResponse initResponse, bool skipPartValidation, RequestEventHandler requestEventHandler)
+        {
+            if (!skipPartValidation)
             {
-                throw new InvalidOperationException($"Cannot complete multipart upload request. The total number of completed parts ({this._uploadResponses.Count}) " +
-                    $"does not equal the total number of parts created ({this._totalNumberOfParts}).");
+                if (this._uploadResponses.Count != this._totalNumberOfParts)
+                {
+                    throw new InvalidOperationException($"Cannot complete multipart upload request. The total number of completed parts ({this._uploadResponses.Count}) " +
+                        $"does not equal the total number of parts created ({this._totalNumberOfParts}).");
+                }
             }
 
             var compRequest = new CompleteMultipartUploadRequest()
@@ -174,63 +182,95 @@ namespace Amazon.S3.Transfer.Internal
             }
 
             compRequest.AddPartETags(this._uploadResponses);
-            ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)compRequest).AddBeforeRequestHandler(this.RequestEventHandler);
+
+            if (requestEventHandler != null)
+            {
+                ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)compRequest).AddBeforeRequestHandler(requestEventHandler);
+            }
+            else
+            {
+                ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)compRequest).AddBeforeRequestHandler(this.RequestEventHandler);
+            }
+
             return compRequest;
         }
 
-        private UploadPartRequest ConstructUploadPartRequest(int partNumber, long filePosition, InitiateMultipartUploadResponse initResponse)
+        private UploadPartRequest ConstructUploadPartRequest(int partNumber, long filePosition, InitiateMultipartUploadResponse initiateResponse)
         {
-            var uploadRequest = new UploadPartRequest()
+            UploadPartRequest uploadPartRequest = ConstructGenericUploadPartRequest(initiateResponse);
+
+            uploadPartRequest.PartNumber = partNumber;
+            uploadPartRequest.PartSize = this._partSize;
+
+            if ((filePosition + this._partSize >= this._contentLength)
+                && _s3Client is Amazon.S3.Internal.IAmazonS3Encryption)
+            {
+                uploadPartRequest.IsLastPart = true;
+                uploadPartRequest.PartSize = 0;
+            }
+
+            var progressHandler = new ProgressHandler(this.UploadPartProgressEventCallback);
+            ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)uploadPartRequest).StreamUploadProgressCallback += progressHandler.OnTransferProgress;
+            ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)uploadPartRequest).AddBeforeRequestHandler(this.RequestEventHandler);
+
+            if (this._fileTransporterRequest.IsSetFilePath())
+            {
+                uploadPartRequest.FilePosition = filePosition;
+                uploadPartRequest.FilePath = this._fileTransporterRequest.FilePath;
+            }
+            else
+            {
+                uploadPartRequest.InputStream = this._fileTransporterRequest.InputStream;
+            }
+
+            return uploadPartRequest;
+        }
+
+        private UploadPartRequest ConstructGenericUploadPartRequest(InitiateMultipartUploadResponse initiateResponse)
+        {
+            UploadPartRequest uploadPartRequest = new UploadPartRequest()
             {
                 BucketName = this._fileTransporterRequest.BucketName,
                 Key = this._fileTransporterRequest.Key,
-                UploadId = initResponse.UploadId,
-                PartNumber = partNumber,
-                PartSize = this._partSize,
+                UploadId = initiateResponse.UploadId,
                 ServerSideEncryptionCustomerMethod = this._fileTransporterRequest.ServerSideEncryptionCustomerMethod,
                 ServerSideEncryptionCustomerProvidedKey = this._fileTransporterRequest.ServerSideEncryptionCustomerProvidedKey,
                 ServerSideEncryptionCustomerProvidedKeyMD5 = this._fileTransporterRequest.ServerSideEncryptionCustomerProvidedKeyMD5,
 #if (BCL && !BCL45)
                 Timeout = ClientConfig.GetTimeoutValue(this._config.DefaultTimeout, this._fileTransporterRequest.Timeout),
-#endif                
+#endif
                 DisableMD5Stream = this._fileTransporterRequest.DisableMD5Stream,
                 DisablePayloadSigning = this._fileTransporterRequest.DisablePayloadSigning,
-                ChecksumAlgorithm = this._fileTransporterRequest.ChecksumAlgorithm
+                ChecksumAlgorithm = this._fileTransporterRequest.ChecksumAlgorithm,
+                CalculateContentMD5Header = this._fileTransporterRequest.CalculateContentMD5Header
             };
 
-            if ((filePosition + this._partSize >= this._contentLength)
-                && _s3Client is Amazon.S3.Internal.IAmazonS3Encryption)
-            {
-                uploadRequest.IsLastPart = true;
-                uploadRequest.PartSize = 0;
-            }
-
-            var progressHandler = new ProgressHandler(this.UploadPartProgressEventCallback);
-            ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)uploadRequest).StreamUploadProgressCallback += progressHandler.OnTransferProgress;
-            ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)uploadRequest).AddBeforeRequestHandler(this.RequestEventHandler);
-
-            if (this._fileTransporterRequest.IsSetFilePath())
-            {
-                uploadRequest.FilePosition = filePosition;
-                uploadRequest.FilePath = this._fileTransporterRequest.FilePath;
-            }
-            else
-            {
-                uploadRequest.InputStream = this._fileTransporterRequest.InputStream;
-            }
-
-            // If the InitiateMultipartUploadResponse indicates that this upload is
-            // using KMS, force SigV4 for each UploadPart request
-            bool useSigV4 = initResponse.ServerSideEncryptionMethod == ServerSideEncryptionMethod.AWSKMS || initResponse.ServerSideEncryptionMethod == ServerSideEncryptionMethod.AWSKMSDSSE;
+            // If the InitiateMultipartUploadResponse indicates that this upload is using KMS, force SigV4 for each UploadPart request
+            bool useSigV4 = initiateResponse.ServerSideEncryptionMethod == ServerSideEncryptionMethod.AWSKMS || initiateResponse.ServerSideEncryptionMethod == ServerSideEncryptionMethod.AWSKMSDSSE;
             if (useSigV4)
-                ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)uploadRequest).SignatureVersion = SignatureVersion.SigV4;
+                ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)uploadPartRequest).SignatureVersion = SignatureVersion.SigV4;
 
-            uploadRequest.CalculateContentMD5Header = this._fileTransporterRequest.CalculateContentMD5Header;
+            return uploadPartRequest;
+        }
 
-            return uploadRequest;
+        private UploadPartRequest ConstructUploadPartRequestForNonSeekableStream(Stream inputStream, int partNumber, long partSize, bool isLastPart, InitiateMultipartUploadResponse initiateResponse)
+        {
+            UploadPartRequest uploadPartRequest = ConstructGenericUploadPartRequest(initiateResponse);
+            
+            uploadPartRequest.InputStream = inputStream;
+            uploadPartRequest.PartNumber = partNumber;
+            uploadPartRequest.PartSize = partSize;
+            uploadPartRequest.IsLastPart = isLastPart;
+
+            return uploadPartRequest;
         }
 
         private InitiateMultipartUploadRequest ConstructInitiateMultipartUploadRequest()
+        {
+            return this.ConstructInitiateMultipartUploadRequest(null);
+        }
+
+        private InitiateMultipartUploadRequest ConstructInitiateMultipartUploadRequest(RequestEventHandler requestEventHandler)
         {
             var initRequest = new InitiateMultipartUploadRequest()
             {
@@ -253,7 +293,14 @@ namespace Amazon.S3.Transfer.Internal
             if (this._fileTransporterRequest.IsSetObjectLockRetainUntilDate())
                 initRequest.ObjectLockRetainUntilDate = this._fileTransporterRequest.ObjectLockRetainUntilDate;
 
-            ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)initRequest).AddBeforeRequestHandler(this.RequestEventHandler);
+            if (requestEventHandler != null)
+            {
+                ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)initRequest).AddBeforeRequestHandler(requestEventHandler);
+            }
+            else
+            {
+                ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)initRequest).AddBeforeRequestHandler(this.RequestEventHandler);
+            }
 
             if (this._fileTransporterRequest.Metadata != null && this._fileTransporterRequest.Metadata.Count > 0)
                 initRequest.Metadata = this._fileTransporterRequest.Metadata;


### PR DESCRIPTION
## Description
Fixed an issue where `TransferUtility`'s `UploadAsync()` is not sending metadata or headers with **non-seekable** stream.

## Motivation and Context
Issue: https://github.com/aws/aws-sdk-net/issues/3082

## Changes:
The support for handling non-seekable stream via `TransferUtility` was added in commit https://github.com/aws/aws-sdk-net/commit/305e5c9b70600d89cd54e4876fcef5fa277ea9e2. The logic added does not reuse existing code which already handled adding headers and metadata to `InitiateMultipartUploadRequest`. Instead, for non-seekable steam, it only uses bucket and key [here](https://github.com/aws/aws-sdk-net/blob/0015a303eeba3e74c0c5bdf06003182a36a3c582/sdk/src/Services/S3/Custom/Transfer/Internal/_async/MultipartUploadCommand.async.cs#L198).

The existing [ConstructInitiateMultipartUploadRequest()](https://github.com/aws/aws-sdk-net/blob/488ac37fc1daceb9fad4e7e03a79edbc07312b72/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs#L233) adds `Metadata` and `Headers` in addition to other properties set by user.

This PR includes the following changes:
- Refactors existing code to reuse existing `ConstructInitiateMultipartUploadRequest()` and `ConstructCompleteMultipartUploadRequest()` methods. These are shared between BCL35 (synchronous) and BCL45 (and `async`) versions.
- For non-seekable streams, instead of tracking `PartETag` list for uploaded parts, it would track `UploadPartResponse`. This is done for 2 reasons:
  - For reusability
  - The current logic for non-seekable streams only uses `PartNumber` and `ETag` properties. The [PartETag](https://github.com/aws/aws-sdk-net/blob/488ac37fc1daceb9fad4e7e03a79edbc07312b72/sdk/src/Services/S3/Custom/Model/PartEtag.cs#L31) object also has other **Checksum** related properties, one of which is set if `InitiateMultipartUploadRequest.ChecksumAlgorithm` is set. In such scenario, one of these checksum values must be set in `CompleteMultipartUploadRequest`, else error is returned by S3 service (refer fixed issue https://github.com/aws/aws-sdk-net/issues/3059).
- Adds new helper method `ConstructUploadPartRequestForNonSeekableStream()` in [MultipartUploadCommand](https://github.com/aws/aws-sdk-net/blob/488ac37fc1daceb9fad4e7e03a79edbc07312b72/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs#L40). The logic is shared between `BCL35` and `async` versions.
- Fixes an issue in BCL35 version for non-seekable stream where in [UploadUnseekableStream()](https://github.com/aws/aws-sdk-net/blob/488ac37fc1daceb9fad4e7e03a79edbc07312b72/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl35/MultipartUploadCommand.bcl35.cs#L107), `CompleteMultipartUpload()` is incorrectly placed inside [finally{}](https://github.com/aws/aws-sdk-net/blob/488ac37fc1daceb9fad4e7e03a79edbc07312b72/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl35/MultipartUploadCommand.bcl35.cs#L174C35-L174C58) block. The `finally` block would be invoked in both success and exception conditions. The `CompleteMultipartUpload()` should not be called in exception conditions. Instead, for exception condition, `AbortMultipartUpload()` should be called (which was correctly invoked in outer finally block [here](https://github.com/aws/aws-sdk-net/blob/488ac37fc1daceb9fad4e7e03a79edbc07312b72/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl35/MultipartUploadCommand.bcl35.cs#L189C27-L189C47)).

**Note for reviewer:**
In inner `finally` for both `BCL35` and `async` versions, call to `nextUploadBuffer.Dispose();` is added. I'm unsure if this object should be disposed in `while` loop earlier where this object is re-initialized to new `MemoryStream` object (unsure if I could re-assign new object to a disposed object instance; didn't test it).

## Testing
- Added test case.
  - Tested locally on via Test Explorer for both `BCL35` and `BCL45` targets.
- Dry run completed successfully.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement