### PR TITLE
Add "DisableTrimmingLeadingSlash" flag to CopyObject / CopyPart requests

### DIFF
--- a/generator/.DevConfigs/de54e083-dbdb-4eb6-878d-ef22adb44f15.json
+++ b/generator/.DevConfigs/de54e083-dbdb-4eb6-878d-ef22adb44f15.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Add `DisableTrimmingLeadingSlash` flag to CopyObject and CopyPart requests, used to determine if the service client should remove leading slashes from object keys"
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
@@ -311,6 +311,8 @@ namespace Amazon.S3.Model
         private string copySourceServerSideEncryptionCustomerProvidedKey;
         private string copySourceServerSideEncryptionCustomerProvidedKeyMD5;
 
+        private bool disableTrimmingLeadingSlash = false;
+
         /// <summary>
         /// A canned access control list (CACL) to apply to the object.
         /// Please refer to <see cref="T:Amazon.S3.S3CannedACL"/> for
@@ -1076,6 +1078,16 @@ namespace Amazon.S3.Model
         internal bool IsSetChecksumAlgorithm()
         {
             return this._checksumAlgorithm != null;
+        }
+
+        /// <summary>
+        /// If this is set to true then the Amazon S3 client will not remove leading slashes from <see cref="SourceKey"/> and <see cref="DestinationKey"/>. 
+        /// The default value is false.
+        /// </summary>
+        public bool DisableTrimmingLeadingSlash
+        {
+            get { return this.disableTrimmingLeadingSlash; }
+            set { this.disableTrimmingLeadingSlash = value; }
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
@@ -58,6 +58,8 @@ namespace Amazon.S3.Model
         private string copySourceServerSideEncryptionCustomerProvidedKey;
         private string copySourceServerSideEncryptionCustomerProvidedKeyMD5;
 
+        private bool disableTrimmingLeadingSlash = false;
+
         /// <summary>
         /// The name of the bucket containing the object to copy.
         /// </summary>
@@ -609,6 +611,16 @@ namespace Amazon.S3.Model
         internal bool IsSetRequestPayer()
         {
             return requestPayer != null;
+        }
+
+        /// <summary>
+        /// If this is set to true then the Amazon S3 client will not remove leading slashes from <see cref="SourceKey"/> and <see cref="DestinationKey"/>. 
+        /// The default value is false.
+        /// </summary>
+        public bool DisableTrimmingLeadingSlash
+        {
+            get { return this.disableTrimmingLeadingSlash; }
+            set { this.disableTrimmingLeadingSlash = value; }
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
@@ -36,8 +36,15 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
         public IRequest Marshall(CopyObjectRequest copyObjectRequest)
         {
-            var sourceKey = AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.SourceKey);
-            var destinationKey = AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.DestinationKey);
+            var sourceKey = 
+                copyObjectRequest.DisableTrimmingLeadingSlash ?
+                copyObjectRequest.SourceKey :
+                AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.SourceKey);
+
+            var destinationKey = 
+                copyObjectRequest.DisableTrimmingLeadingSlash ?
+                copyObjectRequest.DestinationKey:
+                AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.DestinationKey);
             
             IRequest request = new DefaultRequest(copyObjectRequest, "AmazonS3");
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
@@ -37,8 +37,17 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         public IRequest Marshall(CopyPartRequest copyPartRequest)
         {
             IRequest request = new DefaultRequest(copyPartRequest, "AmazonS3");
-            var sourceKey = AmazonS3Util.RemoveLeadingSlash(copyPartRequest.SourceKey);
-            var destinationKey = AmazonS3Util.RemoveLeadingSlash(copyPartRequest.DestinationKey);
+
+            var sourceKey =
+                copyPartRequest.DisableTrimmingLeadingSlash ?
+                copyPartRequest.SourceKey :
+                AmazonS3Util.RemoveLeadingSlash(copyPartRequest.SourceKey);
+
+            var destinationKey =
+                copyPartRequest.DisableTrimmingLeadingSlash ?
+                copyPartRequest.DestinationKey :
+                AmazonS3Util.RemoveLeadingSlash(copyPartRequest.DestinationKey);
+
             request.HttpMethod = "PUT";
 
             if (copyPartRequest.IsSetSourceBucket())

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/CopyObjectTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/CopyObjectTests.cs
@@ -1,0 +1,70 @@
+using Amazon.ConfigService.Model;
+using Amazon.S3;
+using Amazon.S3.Model;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.DNXCore.IntegrationTests.S3
+{
+    public class CopyObjectTests : TestBase<AmazonS3Client>
+    {
+        private readonly string bucketName;
+        private readonly string testContent = "This is some sample text.!!";
+
+        private const string testKey = "testKey.txt";
+        private const string testKeyWithSlash = "/sourceTestKey.txt";
+
+        public CopyObjectTests()
+        {
+            bucketName = UtilityMethods.CreateBucketAsync(Client, "CopyObjectTest").Result;
+
+            Client.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                ContentBody = testContent,
+                Key = testKey
+            }).Wait();
+
+            Client.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                ContentBody = testContent,
+                Key = testKeyWithSlash
+            }).Wait();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            UtilityMethods.DeleteBucketWithObjectsAsync(Client, bucketName).Wait();
+            base.Dispose(disposing);
+        }
+
+        [Theory]
+        [InlineData(false, testKey, "/destinationTestKey1.txt", "destinationTestKey1.txt")]
+        [InlineData(true, testKeyWithSlash, "/destinationTestKey2.txt", "/destinationTestKey2.txt")]
+        [Trait(CategoryAttribute, "S3")]
+        public async Task CopyObjectTestWithLeadingSlash(bool disableTrimmingLeadingSlash, string sourceKey, string destinationKey, string expectedKey)
+        {
+            var copyResponse = await Client.CopyObjectAsync(new CopyObjectRequest
+            {
+                SourceBucket = bucketName,
+                SourceKey = sourceKey,
+
+                DestinationBucket = bucketName,
+                DestinationKey = destinationKey,
+
+                DisableTrimmingLeadingSlash = disableTrimmingLeadingSlash
+            });
+            Assert.Equal(HttpStatusCode.OK, copyResponse.HttpStatusCode);
+
+            using (var getResponse = await Client.GetObjectAsync(bucketName, expectedKey))
+            using (var reader = new StreamReader(getResponse.ResponseStream))
+            {
+                var actualContent = reader.ReadToEnd();
+                Assert.Equal(testContent, actualContent);
+            }
+        }
+    }
+}

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/CopyObjectTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/CopyObjectTests.cs
@@ -44,6 +44,7 @@ namespace Amazon.DNXCore.IntegrationTests.S3
         [Theory]
         [InlineData(false, testKey, "/destinationTestKey1.txt", "destinationTestKey1.txt")]
         [InlineData(true, testKeyWithSlash, "/destinationTestKey2.txt", "/destinationTestKey2.txt")]
+        [InlineData(true, testKeyWithSlash, "/", "/")]
         [Trait(CategoryAttribute, "S3")]
         public async Task CopyObjectTestWithLeadingSlash(bool disableTrimmingLeadingSlash, string sourceKey, string destinationKey, string expectedKey)
         {

--- a/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
@@ -26,7 +26,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         {
             usEastClient = new AmazonS3Client(RegionEndpoint.USEast1);
             eastBucketName = S3TestUtils.CreateBucketWithWait(usEastClient);
-            
+
             usEastClient.PutObject(new PutObjectRequest
             {
                 BucketName = eastBucketName,
@@ -68,6 +68,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 
         [DataRow(false, testKey, "/destinationTestKey1.txt", "destinationTestKey1.txt")]
         [DataRow(true, testKeyWithSlash, "/destinationTestKey2.txt", "/destinationTestKey2.txt")]
+        [DataRow(true, testKeyWithSlash, "/", "/")]
         [DataTestMethod]
         [TestCategory("S3")]
         public void TestCopyObjectWithLeadingSlash(bool disableTrimmingLeadingSlash, string sourceKey, string destinationKey, string expectedKey)
@@ -79,7 +80,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 
                 DestinationBucket = westBucketName,
                 DestinationKey = destinationKey,
-                
+
                 DisableTrimmingLeadingSlash = disableTrimmingLeadingSlash
             });
             Assert.AreEqual(HttpStatusCode.OK, copyObjectResponse.HttpStatusCode);

--- a/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
@@ -5,6 +5,7 @@ using Amazon.S3.Util;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Net;
 
 namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 {
@@ -13,6 +14,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
     {
         private const string testContent = "This is the content body!";
         private const string testKey = "testKey.txt";
+        private const string testKeyWithSlash = "/sourceTestKey.txt";
 
         private string eastBucketName;
         private string westBucketName;
@@ -24,12 +26,21 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         {
             usEastClient = new AmazonS3Client(RegionEndpoint.USEast1);
             eastBucketName = S3TestUtils.CreateBucketWithWait(usEastClient);
+            
             usEastClient.PutObject(new PutObjectRequest
             {
                 BucketName = eastBucketName,
                 Key = testKey,
                 ContentBody = testContent
             });
+
+            usEastClient.PutObject(new PutObjectRequest
+            {
+                BucketName = eastBucketName,
+                Key = testKeyWithSlash,
+                ContentBody = testContent
+            });
+
             var usWestClient = new AmazonS3Client(RegionEndpoint.USWest1);
             westBucketName = S3TestUtils.CreateBucketWithWait(usWestClient);
         }
@@ -53,6 +64,38 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 DestinationBucket = westBucketName,
                 DestinationKey = testKey
             });
+        }
+
+        [DataRow(false, testKey, "/destinationTestKey1.txt", "destinationTestKey1.txt")]
+        [DataRow(true, testKeyWithSlash, "/destinationTestKey2.txt", "/destinationTestKey2.txt")]
+        [DataTestMethod]
+        [TestCategory("S3")]
+        public void TestCopyObjectWithLeadingSlash(bool disableTrimmingLeadingSlash, string sourceKey, string destinationKey, string expectedKey)
+        {
+            var copyObjectResponse = usEastClient.CopyObject(new CopyObjectRequest
+            {
+                SourceBucket = eastBucketName,
+                SourceKey = sourceKey,
+
+                DestinationBucket = westBucketName,
+                DestinationKey = destinationKey,
+                
+                DisableTrimmingLeadingSlash = disableTrimmingLeadingSlash
+            });
+            Assert.AreEqual(HttpStatusCode.OK, copyObjectResponse.HttpStatusCode);
+
+            var getObjectResponse = Client.GetObject(new GetObjectRequest
+            {
+                BucketName = westBucketName,
+                Key = expectedKey
+            });
+
+            using (getObjectResponse.ResponseStream)
+            using (var reader = new StreamReader(getObjectResponse.ResponseStream))
+            {
+                var actualText = reader.ReadToEnd();
+                Assert.AreEqual(testContent, actualText);
+            }
         }
     }
 }

--- a/sdk/test/Services/S3/IntegrationTests/CopyPartTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyPartTests.cs
@@ -1,0 +1,115 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+
+namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
+{
+    [TestClass]
+    public class CopyPartTests : TestBase<AmazonS3Client>
+    {
+        private const string testContent = "This is the content body!";
+        private const string testKeyWithSlash = "/sourceTestKey.txt";
+
+        private string bucketName;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            bucketName = S3TestUtils.CreateBucketWithWait(Client);
+
+            Client.PutObject(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = testKeyWithSlash,
+                ContentBody = testContent
+            });
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            AmazonS3Util.DeleteS3BucketWithObjects(Client, bucketName);
+            BaseClean();
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void TestCopyPartWithLeadingSlash()
+        {
+            var destinationKeyWithSlash = "/destinationTestKey.txt";
+            string uploadId = null;
+
+            try
+            {
+                var multiPartUploadResponse = Client.InitiateMultipartUpload(new InitiateMultipartUploadRequest
+                {
+                    BucketName = bucketName,
+                    Key = destinationKeyWithSlash,
+                });
+
+                uploadId = multiPartUploadResponse.UploadId;
+                var copyPartResponse = Client.CopyPart(new CopyPartRequest
+                {
+                    DestinationBucket = bucketName,
+                    DestinationKey = destinationKeyWithSlash,
+                    
+                    SourceBucket = bucketName,
+                    SourceKey = testKeyWithSlash,
+
+                    UploadId = uploadId,
+                    PartNumber = 1,
+
+                    DisableTrimmingLeadingSlash = true
+                });
+                Assert.IsNotNull(copyPartResponse.ETag);
+                Assert.IsTrue(copyPartResponse.ETag != null && copyPartResponse.ETag.Length > 0);
+                Assert.IsTrue(copyPartResponse.PartNumber == 1);
+
+                var completeUploadResponse = Client.CompleteMultipartUpload(new CompleteMultipartUploadRequest
+                {
+                    BucketName = bucketName,
+                    Key = destinationKeyWithSlash,
+                    UploadId = uploadId,
+                    PartETags = new List<PartETag>
+                    {
+                        new PartETag
+                        {
+                            ETag = copyPartResponse.ETag,
+                            PartNumber = copyPartResponse.PartNumber
+                        }
+                    }
+                });
+                Assert.AreEqual(HttpStatusCode.OK, completeUploadResponse.HttpStatusCode);
+
+                var getObjectResponse = Client.GetObject(new GetObjectRequest
+                {
+                    BucketName = bucketName,
+                    Key = destinationKeyWithSlash
+                });
+
+                using (getObjectResponse.ResponseStream)
+                using (var reader = new StreamReader(getObjectResponse.ResponseStream))
+                {
+                    var actualText = reader.ReadToEnd();
+                    Assert.AreEqual(testContent, actualText);
+                }
+            }
+            finally
+            {
+                if (uploadId != null)
+                {
+                    Client.AbortMultipartUpload(new AbortMultipartUploadRequest
+                    {
+                        BucketName = bucketName,
+                        Key = destinationKeyWithSlash,
+                        UploadId = uploadId
+                    });
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Another attempt at `Fix S3 Copy not working with "/"` (`DOTNET-4410`), but this time using a flag so customers must opt in to the new behavior.

## Testing
- Dry-run: `DRY_RUN-908e18a7-4077-4ea2-816d-c45561112a63`
- Manually tested the PowerShell changes:
  - Cloned the PowerShell repository (https://github.com/aws/aws-tools-for-powershell/)
  - Downloaded assemblies from dry-run and placed them in the `Include\sdk\assemblies` folder
  - Ran `dotnet msbuild ./buildtools/build.proj /t:preview-build /p:RunTests=true /p:CleanSdkReferences=false`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement