### PR TITLE
feat: Add support for retrieving DateTime attributes in UTC timezone from a DynamoDB table

### DIFF
--- a/generator/.DevConfigs/ac013f8a-bdb9-4a20-8d70-a9b60fe8c011.json
+++ b/generator/.DevConfigs/ac013f8a-bdb9-4a20-8d70-a9b60fe8c011.json
@@ -1,0 +1,18 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Add support for retrieving DateTime attributes in UTC timezone from a DynamoDB table."
+        ],
+        "type": "patch",
+        "updateMinimum": false
+    },
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Add support for retrieving DateTime attributes in UTC timezone from a DynamoDB table."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -45,7 +45,7 @@ namespace Amazon
     ///   &lt;proxy host="localhost" port="8888" username="1" password="1" /&gt;
     ///   
     ///   &lt;dynamoDB&gt;
-    ///     &lt;dynamoDBContext tableNamePrefix="Prod-" metadataCachingMode="Default" disableFetchingTableMetadata="false"&gt;
+    ///     &lt;dynamoDBContext tableNamePrefix="Prod-" metadataCachingMode="Default" disableFetchingTableMetadata="false" retrieveDateTimeInUtc="false"&gt;
     /// 
     ///       &lt;tableAliases&gt;
     ///         &lt;alias fromTable="FakeTable" toTable="People" /&gt;

--- a/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
@@ -168,6 +168,11 @@ namespace Amazon.Util
         public bool? DisableFetchingTableMetadata { get; set; }
 
         /// <summary>
+        /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
+        /// </summary>
+        public bool? RetrieveDateTimeInUtc { get; set; }
+
+        /// <summary>
         /// Adds a TableAlias to the TableAliases property.
         /// An exception is thrown if there is already a TableAlias with the same FromTable configured.
         /// </summary>
@@ -203,6 +208,7 @@ namespace Amazon.Util
                 TableNamePrefix = section.TableNamePrefix;
                 MetadataCachingMode = section.MetadataCachingMode;
                 DisableFetchingTableMetadata = section.DisableFetchingTableMetadata;
+                RetrieveDateTimeInUtc = section.RetrieveDateTimeInUtc;
 
                 InternalSDKUtils.FillDictionary(section.TypeMappings.Items, t => t.Type, t => new TypeMapping(t), TypeMappings);
                 InternalSDKUtils.FillDictionary(section.TableAliases.Items, t => t.FromTable, t => t.ToTable, TableAliases);
@@ -422,6 +428,7 @@ namespace Amazon.Util
         private const string mappingsKey = "mappings";
         private const string metadataCachingModeKey = "metadataCachingMode";
         private const string disableFetchingTableMetadataKey = "disableFetchingTableMetadata";
+        private const string retrieveDateTimeInUtcKey = "retrieveDateTimeInUtc";
 
         [ConfigurationProperty(tableNamePrefixKey)]
         public string TableNamePrefix
@@ -458,6 +465,12 @@ namespace Amazon.Util
             set { this[disableFetchingTableMetadataKey] = value; }
         }
 
+        [ConfigurationProperty(retrieveDateTimeInUtcKey)]
+        public bool? RetrieveDateTimeInUtc
+        {
+            get { return (bool?)this[retrieveDateTimeInUtcKey]; }
+            set { this[retrieveDateTimeInUtcKey] = value; }
+        }
     }
 
     /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
@@ -170,6 +170,7 @@ namespace Amazon.Util
         /// <summary>
         /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
         /// </summary>
+        /// <remarks>This setting is only applicable to the high-level library. Service calls made via <see cref="AmazonDynamoDBClient"/> will always return <see cref="DateTime"/> attributes in UTC.</remarks>
         public bool? RetrieveDateTimeInUtc { get; set; }
 
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -62,6 +62,7 @@ namespace Amazon.DynamoDBv2.DataModel
             Conversion = DynamoDBEntryConversion.CurrentConversion;
             MetadataCachingMode = AWSConfigsDynamoDB.Context.MetadataCachingMode;
             DisableFetchingTableMetadata = AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata;
+            RetrieveDateTimeInUtc = AWSConfigsDynamoDB.Context.RetrieveDateTimeInUtc;
         }
 
         /// <summary>
@@ -130,6 +131,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
         /// </remarks>
         public bool? DisableFetchingTableMetadata { get; set; }
+
+        /// <summary>
+        /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
+        /// </summary>
+        public bool? RetrieveDateTimeInUtc { get; set; }
     }
 
     /// <summary>
@@ -334,6 +340,7 @@ namespace Amazon.DynamoDBv2.DataModel
             bool skipVersionCheck = operationConfig.SkipVersionCheck ?? contextConfig.SkipVersionCheck ?? false;
             bool ignoreNullValues = operationConfig.IgnoreNullValues ?? contextConfig.IgnoreNullValues ?? false;
             bool disableFetchingTableMetadata = contextConfig.DisableFetchingTableMetadata ?? false;
+            bool retrieveDateTimeInUtc = contextConfig.RetrieveDateTimeInUtc ?? false;
 
             bool isEmptyStringValueEnabled = operationConfig.IsEmptyStringValueEnabled ?? contextConfig.IsEmptyStringValueEnabled ?? false;
             string overrideTableName =
@@ -362,6 +369,7 @@ namespace Amazon.DynamoDBv2.DataModel
             Conversion = conversion;
             MetadataCachingMode = metadataCachingMode;
             DisableFetchingTableMetadata = disableFetchingTableMetadata;
+            RetrieveDateTimeInUtc = retrieveDateTimeInUtc;
 
             State = new OperationState();
         }
@@ -453,6 +461,9 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc cref="DynamoDBContextConfig.DisableFetchingTableMetadata"/>
         public bool DisableFetchingTableMetadata { get; set; }
+
+        /// <inheritdoc cref="DynamoDBContextConfig.RetrieveDateTimeInUtc"/>
+        public bool RetrieveDateTimeInUtc { get; set; }
 
         // Checks if the IndexName is set on the config
         internal bool IsIndexOperation { get { return !string.IsNullOrEmpty(IndexName); } }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -135,6 +135,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
         /// </summary>
+        /// <remarks>This setting is only applicable to the high-level library. Service calls made via <see cref="AmazonDynamoDBClient"/> will always return <see cref="DateTime"/> attributes in UTC.</remarks>
         public bool? RetrieveDateTimeInUtc { get; set; }
     }
 
@@ -340,7 +341,7 @@ namespace Amazon.DynamoDBv2.DataModel
             bool skipVersionCheck = operationConfig.SkipVersionCheck ?? contextConfig.SkipVersionCheck ?? false;
             bool ignoreNullValues = operationConfig.IgnoreNullValues ?? contextConfig.IgnoreNullValues ?? false;
             bool disableFetchingTableMetadata = contextConfig.DisableFetchingTableMetadata ?? false;
-            bool retrieveDateTimeInUtc = contextConfig.RetrieveDateTimeInUtc ?? false;
+            bool retrieveDateTimeInUtc = operationConfig.RetrieveDateTimeInUtc ?? contextConfig.RetrieveDateTimeInUtc ?? false;
 
             bool isEmptyStringValueEnabled = operationConfig.IsEmptyStringValueEnabled ?? contextConfig.IsEmptyStringValueEnabled ?? false;
             string overrideTableName =

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -463,7 +463,14 @@ namespace Amazon.DynamoDBv2.DataModel
             var targetType = propertyStorage.MemberType;
             
             if (conversion.HasConverter(targetType))
-                return conversion.ConvertFromEntry(targetType, entry);
+            {
+                var output = conversion.ConvertFromEntry(targetType, entry);
+                if (targetType == typeof(DateTime) && flatConfig.RetrieveDateTimeInUtc)
+                {
+                    return ((DateTime)output).ToUniversalTime();
+                }
+                return output;
+            }
             else
             {
                 if (entry is DynamoDBNull)

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBEntry.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBEntry.cs
@@ -609,6 +609,16 @@ namespace Amazon.DynamoDBv2.DocumentModel
         {
             throw new InvalidCastException();
         }
+
+        /// <summary>
+        /// Explicitly convert DynamoDBEntry to DateTime in UTC
+        /// </summary>
+        /// <returns>DateTime value of this object in UTC</returns>
+        public virtual DateTime AsDateTimeUtc()
+        {
+            throw new InvalidCastException();
+        }
+
         /// <summary>
         /// Implicitly convert DateTime to DynamoDBEntry
         /// </summary>
@@ -1150,6 +1160,15 @@ namespace Amazon.DynamoDBv2.DocumentModel
         public override DateTime AsDateTime()
         {
             return (DateTime)System.Convert.ChangeType(Value, typeof(DateTime), CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Return the value as a DateTime in UTC.
+        /// </summary>
+        /// <returns>DateTime value of this object in UTC</returns>
+        public override DateTime AsDateTimeUtc()
+        {
+            return AsDateTime().ToUniversalTime();
         }
 
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Primitive.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Primitive.cs
@@ -605,6 +605,16 @@ namespace Amazon.DynamoDBv2.DocumentModel
         {
             return V1Conversion.ConvertFromEntry<DateTime>(this);
         }
+
+        /// <summary>
+        /// Explicitly convert Primitive to DateTime in UTC
+        /// </summary>
+        /// <returns>DateTime value of this object in UTC</returns>
+        public override DateTime AsDateTimeUtc()
+        {
+            return AsDateTime().ToUniversalTime();
+        }
+
         /// <summary>
         /// Implicitly convert DateTime to Primitive
         /// </summary>

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -158,6 +158,74 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.AreEqual(employee.Age, storedEmployee.Age);
         }
 
+        /// <summary>
+        /// Tests that the DynamoDB operations can be invoked successfully based on a Datetime attribute as the hash key that is stored as epoch.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void TestContext_RetrieveDateTimeInUtc(bool retrieveDateTimeInUtc)
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            var config = new DynamoDBContextConfig
+            {
+                Conversion = DynamoDBEntryConversion.V2,
+                RetrieveDateTimeInUtc = retrieveDateTimeInUtc
+            };
+            Context = new DynamoDBContext(Client, config);
+
+            var currTime = DateTime.Now;
+
+            var employee = new AnnotatedNumericEpochEmployee
+            {
+                Name = "Bob",
+                Age = 45,
+                CreationTime = currTime,
+                EpochDate2 = currTime,
+                NonEpochDate1 = currTime,
+                NonEpochDate2 = currTime
+            };
+
+            Context.Save(employee);
+            var expectedCurrTime = retrieveDateTimeInUtc ? currTime.ToUniversalTime() : currTime.ToLocalTime();
+
+            // Load 
+            var storedEmployee = Context.Load<AnnotatedNumericEpochEmployee>(employee.CreationTime, employee.Name);
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.CreationTime);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+
+            // Query
+            QueryFilter filter = new QueryFilter();
+            filter.AddCondition("CreationTime", QueryOperator.Equal, currTime);
+            storedEmployee = Context.FromQuery<AnnotatedNumericEpochEmployee>(new QueryOperationConfig { Filter = filter }).First();
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.CreationTime);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+
+            // Scan
+            storedEmployee = Context.Scan<AnnotatedNumericEpochEmployee>().First();
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.CreationTime);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+        }
+
 
         /// <summary>
         /// Runs the same object-mapper integration tests as <see cref="TestContextWithEmptyStringEnabled"/>,

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -159,7 +159,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
         }
 
         /// <summary>
-        /// Tests that the DynamoDB operations can be invoked successfully based on a Datetime attribute as the hash key that is stored as epoch.
+        /// Tests that the DynamoDB operations can retrieve <see cref="DateTime"/> attributes in UTC and local timezone.
         /// </summary>
         [TestMethod]
         [TestCategory("DynamoDBv2")]
@@ -226,6 +226,144 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.AreEqual(employee.Age, storedEmployee.Age);
         }
 
+        /// <summary>
+        /// Tests that if a custom <see cref="DateTime"/> converter is used, then the <see cref="DynamoDBContextConfig.RetrieveDateTimeInUtc"/> is ignored.
+        /// </summary>
+        /// <param name="retrieveDateTimeInUtc"></param>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void TestContext_CustomDateTimeConverter(bool retrieveDateTimeInUtc)
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            var config = new DynamoDBContextConfig
+            {
+                Conversion = DynamoDBEntryConversion.V2,
+                RetrieveDateTimeInUtc = retrieveDateTimeInUtc
+            };
+            Context = new DynamoDBContext(Client, config);
+
+            // Add a custom DateTime converter
+            Context.ConverterCache.Add(typeof(DateTime), new DateTimeUtcConverter());
+
+            var currTime = DateTime.Now;
+
+            var employee = new AnnotatedNumericEpochEmployee
+            {
+                Name = "Bob",
+                Age = 45,
+                CreationTime = currTime,
+                EpochDate2 = currTime,
+                NonEpochDate1 = currTime,
+                NonEpochDate2 = currTime
+            };
+
+            Context.Save(employee);
+
+            // Since we are adding a custom DateTimeUtcConverter, the expected time will always be in the UTC time zone.
+            // regardless of RetrieveDateTimeInUtc value.
+            var expectedCurrTime = currTime.ToUniversalTime();
+
+            // Load 
+            var storedEmployee = Context.Load<AnnotatedNumericEpochEmployee>(employee.CreationTime, employee.Name);
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.CreationTime);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+
+            // Query
+            QueryFilter filter = new QueryFilter();
+            filter.AddCondition("CreationTime", QueryOperator.Equal, currTime);
+            storedEmployee = Context.FromQuery<AnnotatedNumericEpochEmployee>(new QueryOperationConfig { Filter = filter }).First();
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.CreationTime);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+
+            // Scan
+            storedEmployee = Context.Scan<AnnotatedNumericEpochEmployee>().First();
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.CreationTime);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+        }
+
+        /// <summary>
+        /// Tests that the DynamoDB operations can retrieve <see cref="DateTime"/> attributes in UTC and local timezone using the <see cref="DynamoDBOperationConfig"/>
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void TestContext_RetrieveDateTimeInUtc_OperationConfig(bool retrieveDateTimeInUtc)
+        {
+            TableCache.Clear();
+            CleanupTables();
+            TableCache.Clear();
+
+            Context = new DynamoDBContext(Client, new DynamoDBContextConfig { Conversion = DynamoDBEntryConversion.V2 });
+            var operationConfig = new DynamoDBOperationConfig { RetrieveDateTimeInUtc = retrieveDateTimeInUtc };
+
+            var currTime = DateTime.Now;
+
+            var employee = new AnnotatedNumericEpochEmployee
+            {
+                Name = "Bob",
+                Age = 45,
+                CreationTime = currTime,
+                EpochDate2 = currTime,
+                NonEpochDate1 = currTime,
+                NonEpochDate2 = currTime
+            };
+
+            Context.Save(employee);
+            var expectedCurrTime = retrieveDateTimeInUtc ? currTime.ToUniversalTime() : currTime.ToLocalTime();
+
+            // Load 
+            var storedEmployee = Context.Load<AnnotatedNumericEpochEmployee>(employee.CreationTime, employee.Name, operationConfig);
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.CreationTime);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+
+            // Query
+            QueryFilter filter = new QueryFilter();
+            filter.AddCondition("CreationTime", QueryOperator.Equal, currTime);
+            storedEmployee = Context.FromQuery<AnnotatedNumericEpochEmployee>(new QueryOperationConfig { Filter = filter }, operationConfig).First();
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.CreationTime);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+
+            // Scan
+            storedEmployee = Context.Scan<AnnotatedNumericEpochEmployee>(new List<ScanCondition>(), operationConfig).First();
+            Assert.IsNotNull(storedEmployee);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.CreationTime);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.AreEqual(employee.Name, storedEmployee.Name);
+            Assert.AreEqual(employee.Age, storedEmployee.Age);
+        }
 
         /// <summary>
         /// Runs the same object-mapper integration tests as <see cref="TestContextWithEmptyStringEnabled"/>,
@@ -1765,6 +1903,17 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
             [DynamoDBRangeKey]
             public override string Name { get; set; }
+        }
+
+        public class DateTimeUtcConverter : IPropertyConverter
+        {
+            public DynamoDBEntry ToEntry(object value) => (DateTime)value;
+
+            public object FromEntry(DynamoDBEntry entry)
+            {
+                var dateTime = entry.AsDateTime();
+                return dateTime.ToUniversalTime();
+            }
         }
 
         #endregion

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -383,6 +383,16 @@ namespace AWSSDK_DotNet35.UnitTests
             AWSConfigsDynamoDB.Context.DisableFetchingTableMetadata = false;
         }
 
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void TestRetrieveDateTimeInUtc_UsingGlobalContext()
+        {
+            AWSConfigsDynamoDB.Context.RetrieveDateTimeInUtc = true;
+            var config = new DynamoDBContextConfig();
+            Assert.AreEqual(true, config.RetrieveDateTimeInUtc);
+            AWSConfigsDynamoDB.Context.RetrieveDateTimeInUtc = false;
+        }
+
         public class Parent
         {
             [DynamoDBProperty("actualPropertyName")]


### PR DESCRIPTION
## Description
This PR adds support for retrieving `DateTime` attributes in UTC timezone from a DynamoDB table.

While working in the data model mode, this PR introduces a boolean flag called `RetrieveDateTimeInUtc` as part of the `DynamoDBContextConfig` as well as the global `AWSConfigsDynamoDB.Context`. If set to `true`, then all `DateTime` attributes are retrieved in the UTC timezone.

While working in the document model mode, Each `Document` object stores attributes as a `DynamoDBEntry`. The SDK already has the `AsDateTime` virtual method that is used to convert a `DynamoDBEntry` to a `DateTime` object. This PR also introduces a `AsDateTimeUtc` method to retrieve all `DateTime` attributes in the UTC timezone.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes https://github.com/aws/aws-sdk-net/issues/1450 and DOTNET-7259

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new unit and integration tests.
Successful dry-run (build-id: `39a8ce27-a0db-4976-8ee4-5bd6f6a41004` and `693449ba-8bf6-4280-bf21-fc8ec0bdf2d3`)

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement