### PR TITLE
Register new client device if token's registrationExpiresAt field is …

### DIFF
--- a/generator/.DevConfigs/petesong1039ahsso.json
+++ b/generator/.DevConfigs/petesong1039ahsso.json
@@ -1,0 +1,7 @@
+{
+    "core":{
+      "changeLogMessages":["SSO Token manager will register a new client device if the RegistrationExpiresAt field is null"],
+      "type": "patch",
+      "updateMinimum":true
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SsoTokenUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SsoTokenUtils.cs
@@ -49,7 +49,7 @@ namespace Amazon.Runtime.Credentials.Internal
         public static bool IsExpired(this SsoToken token)
         {
             if (null == token)
-                throw new ArgumentNullException(nameof(token));
+                return true;
 
 #pragma warning disable CS0618 // Type or member is obsolete
             var currentTime = AWSSDKUtils.CorrectedUtcNow;
@@ -99,6 +99,8 @@ namespace Amazon.Runtime.Credentials.Internal
 
         /// <summary>
         /// This determines whether the <seealso cref="SsoToken.RegistrationExpiresAt"/> field is 5 minutes within expiration
+        /// Existing cached tokens, or tokens written out by other systems may contain null values for the RegistrationExpiresAt field.
+        /// In these cases we treat the client registration as expired and generate a new token.
         /// </summary>
         /// <param name="token">The sso token</param>
         /// <returns>This returns true if <seealso cref="SsoToken.RegistrationExpiresAt"/> is within 5 minutes of expiration. False otherwise</returns>
@@ -106,6 +108,8 @@ namespace Amazon.Runtime.Credentials.Internal
         {
             if (null == token)
                 throw new ArgumentNullException(nameof(token));
+            if (string.IsNullOrEmpty(token.RegistrationExpiresAt))
+                    return true;
             DateTime dateTime = ConvertRFC3339StringToDateTime(token.RegistrationExpiresAt);
 #pragma warning disable CS0618 // Type or member is obsolete
             return AWSSDKUtils.CorrectedUtcNow >= dateTime.AddMinutes(-5);


### PR DESCRIPTION
…null

<!--- Provide a general summary of your changes in the Title above -->
This is to provide backwards compatibility as mentioned in [this pr] (https://github.com/aws/aws-sdk-net/pull/3083). Some systems may generate tokens where the `RegistrationExpiresAt` field is null so in that case we should just say that the clientRegistration is expired and generate a new token.

## Description
If the `registrationExpiresAt` field is null or empty, treat the token as expired and generate a new token.

## Motivation and Context
Solves backwards compatibility issues, where a null RegistrationExpiresAt was previously valid.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement