### PR TITLE
Update versions on extension packages

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
+++ b/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.CrtIntegration</id>
     <title>AWSSDK - Extensions for AWS Common Runtime Integration</title>
-    <version>3.7.1.9</version>
+    <version>3.7.300</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with the AWS Common Runtime</description>
     <language>en-US</language>
@@ -13,17 +13,17 @@
     <icon>images\AWSLogo.png</icon>
     <dependencies>
       <group targetFramework="net35">
-        <dependency id="AWSSDK.Core" version="3.7.8" />
+        <dependency id="AWSSDK.Core" version="3.7.300" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>
       <group targetFramework="net45">
-        <dependency id="AWSSDK.Core" version="3.7.8" />
+        <dependency id="AWSSDK.Core" version="3.7.300" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="3.7.8" />
+        <dependency id="AWSSDK.Core" version="3.7.300" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.csproj
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.7" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.300" />
   </ItemGroup>
 
 </Project>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.NETCore.Setup</id>
     <title>AWSSDK - Extensions for NETCore Setup</title>
-    <version>3.7.7</version>
+    <version>3.7.300</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with .NET Core configuration and dependency injection frameworks.</description>
     <language>en-US</language>
@@ -14,7 +14,7 @@
 	
     <dependencies>
       <group>
-        <dependency id="AWSSDK.Core" version="3.7.6" />
+        <dependency id="AWSSDK.Core" version="3.7.300" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />

--- a/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
+++ b/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
@@ -142,7 +142,7 @@ namespace NETCore.SetupTests
             Assert.Equal(TimeSpan.FromMilliseconds(1000), options.DefaultClientConfig.Timeout);
             Assert.Equal("us-east-1", options.DefaultClientConfig.AuthenticationRegion);
             Assert.Equal(DefaultConfigurationMode.Standard, options.DefaultConfigurationMode);
-            Assert.Equal("https://localhost:9021", options.DefaultClientConfig.ServiceURL);
+            Assert.Equal("https://localhost:9021/", options.DefaultClientConfig.ServiceURL);
 
             IAmazonS3 client = options.CreateServiceClient<IAmazonS3>();
             Assert.NotNull(client);
@@ -152,7 +152,7 @@ namespace NETCore.SetupTests
             Assert.Equal("us-east-1", client.Config.AuthenticationRegion);
             Assert.Equal(DefaultConfigurationMode.Standard, client.Config.DefaultConfigurationMode);
             Assert.Equal(RequestRetryMode.Standard, client.Config.RetryMode);
-            Assert.Equal("https://localhost:9021", client.Config.ServiceURL);
+            Assert.Equal("https://localhost:9021/", client.Config.ServiceURL);
 
             // Verify that setting the standard mode doesn't override explicit settings of retry mode to a non-legacy mode.
             options.DefaultClientConfig.RetryMode = RequestRetryMode.Adaptive;

--- a/generator/.DevConfigs/update-extensions-2023-11-14.json
+++ b/generator/.DevConfigs/update-extensions-2023-11-14.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Update .NET 8 targeted versions of AWSSDK.Extensions.CrtIntegration and AWSSDK.Extensions.NETCore.Setup to have a dependency on AWSSDK.Core version 3.7.300."
+    ],
+    "type": "patch",
+    "updateMinimum": false
+  }
+}


### PR DESCRIPTION
Update the `AWSSDK.Extensions.NETCore.Setup` and `AWSSDK.Extensions.CrtIntegration` to version 3.7.300 and pick up the latest versions of Core.


Dry run build is successful. 