### PR TITLE
Fix regression in 3.7.300 where the DataModel stop mapping to non public properties.

### DIFF
--- a/generator/.DevConfigs/fix-datamodel-regression-2023-11-15.json
+++ b/generator/.DevConfigs/fix-datamodel-regression-2023-11-15.json
@@ -1,0 +1,9 @@
+{
+    "services": [
+      {
+        "serviceName": "DynamoDBv2",
+        "type": "patch",
+        "changeLogMessages": [ "Fix regression in 3.7.300 where the DataModel stop mapping to non public properties." ]
+      }
+    ]
+  }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -323,7 +323,7 @@ namespace Amazon.DynamoDBv2.DataModel
             Dictionary<string, MemberInfo> dictionary = new Dictionary<string, MemberInfo>(StringComparer.Ordinal);
 
             var members = type
-                .GetMembers()
+                .GetMembers(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
                 .Where(IsValidMemberInfo)
                 .ToList();
             foreach (var member in members)
@@ -773,7 +773,7 @@ namespace Amazon.DynamoDBv2.DataModel
             if (AWSConfigsDynamoDB.Context.TableAliases.TryGetValue(config.TableName, out tableAlias))
                 config.TableName = tableAlias;
 
-            foreach (var member in type.GetMembers())
+            foreach (var member in type.GetMembers(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
             {
                 if (!StorageConfig.IsValidMemberInfo(member))
                     continue;

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -1563,7 +1563,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             public virtual string Name { get; set; }
             public string MiddleName { get; set; }
             // Range key
-            public virtual int Age { get; set; }
+            internal virtual int Age { get; set; }
 
             public virtual string CompanyName { get; set; }
             public virtual int Score { get; set; }
@@ -1587,7 +1587,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
             // Range key
             [DynamoDBRangeKey]
-            public override int Age { get; set; }
+            internal override int Age { get; set; }
 
             [DynamoDBGlobalSecondaryIndexHashKey("GlobalIndex", AttributeName = "Company")]
             public override string CompanyName { get; set; }
@@ -1610,7 +1610,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
             // Range key
             [DynamoDBRangeKey]
-            public override int Age { get; set; }
+            internal override int Age { get; set; }
 
             [DynamoDBGlobalSecondaryIndexHashKey("GlobalIndex")]
             public override string CompanyName { get; set; }


### PR DESCRIPTION
With the recent 3.7.300 release we removed the usage of the `TypeWrapper` abstraction and directly used the `Type` class. There was an unintended change in behavior with DDB DataModel library that when it was doing its reflection it changed from getting all instance properties including non public properties to only getting public. This PR restores the reflection to get members including non-public properties.

I also searched the SDK for other usages of `GetMember` from the `Type` class in case there was other regressions but found no usages.

CI build pending. 