### PR TITLE
Update region endpoint provider not to fail when deployed to the root folder

### DIFF
--- a/generator/.DevConfigs/a7c7010c-12f7-42cd-bdee-fe89ff338b59.json
+++ b/generator/.DevConfigs/a7c7010c-12f7-42cd-bdee-fe89ff338b59.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "updateMinimum": true,
+        "type": "Patch",
+        "changeLogMessages": [
+            "Fix `RegionEndpointProviderV3` not to throw an exception when application is deployed to the root folder"
+        ]
+    }
+}

--- a/sdk/src/Core/RegionEndpoint/RegionEndpointProviderV3.cs
+++ b/sdk/src/Core/RegionEndpoint/RegionEndpointProviderV3.cs
@@ -449,7 +449,11 @@ namespace Amazon.Internal
 #endif
             if (!string.IsNullOrEmpty(assemblyLocation))
             {
-                string endpointsPath = Path.Combine(Path.GetDirectoryName(assemblyLocation), ENDPOINT_JSON);
+                // If the application is deployed to the root directory (e.g. "/" in a container), GetDirectoryName will return null (which Path.Combine does not allow).
+                // In that case, we'll use an empty string and look for an endpoints.json file in the current folder.
+                var directoryName = Path.GetDirectoryName(assemblyLocation) ?? string.Empty;
+
+                string endpointsPath = Path.Combine(directoryName, ENDPOINT_JSON);
                 if (File.Exists(endpointsPath))
                 {
                     return File.Open(endpointsPath, FileMode.Open, FileAccess.Read);


### PR DESCRIPTION
Fixes #3110 and #3112 

## Description
Short summary: Update the `RegionEndpointProvider` class not to throw an exception when deployed to the root folder

Long summary:
Inside the AWS SDK's Core module, there's a class called `RegionEndpointProvider`; it was originally responsible for retrieving endpoint information for a given service (for example, to invoke Amplify in the US East N. Virginia region, the SDK should use `amplify.us-east-1.amazonaws.com`).

In newer versions of the SDK (starting with `3.7.100`), endpoint resolution is resolved using request level parameters, but there are still some places in the SDK pipeline (or middleware) where `RegionEndpointProvider` is used (as visible in the stack trace in the original issue, `AWS4Signer.DetermineSigningRegion` is one of them).

When `RegionEndpointProvider` is created, it loads all the endpoint information from the `endpoints.json` file: https://github.com/aws/aws-sdk-net/blob/3.7.692.0/sdk/src/Core/RegionEndpoint/RegionEndpointProviderV3.cs#L440-L463

This file is usually an embedded resource in the `AWSSDK.Core` DLL, but for legacy reasons the SDK also checks if an override exists in the current location where the application is deployed (although, as mentioned earlier in the latest version of the SDK the file won't actually be considered when choosing the endpoint to connect to).

As part of the effort to add .NET 8 and AOT support for the SDK, this was one of the changes we had to make (as `System.Reflection.Assembly.Location` is not compatible with single-file applications):
```
#if NET8_0_OR_GREATER
string assemblyLocation = System.AppContext.BaseDirectory;
#else
string assemblyLocation = typeof(RegionEndpointProviderV3).Assembly.Location;
#endif
```

The root cause for the exception was that `AppContext.BaseDirectory` behaves differently than `Assembly.Location`; when the application DLL is located in the root directory (i.e. `/MyWebApplication.dll`):
* `AppContext.BaseDirectory` returns `/`
* `Assembly.Location` returns `/MyWebApplication.dll`

`Path.GetDirectoryName` returns _null if path denotes a root directory_, and then the SDK was trying to use it in the `Path.Combine` call (which threw the `ArgumentNullException`). That's also why we weren't able to reproduce the issue initially, we were deploying the artifacts to the `/app` folder inside the container.

## Testing
- Dry-run: `DRY_RUN-4b23a6f7-b5b9-47c4-ab0f-d848d1e60734`
- Created a web application with the updated `Core` changes and verified it doesn't crash 

Controller (publishing to Kinesis):
```csharp
string[] Summaries =
[
    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
];

var forecast = new WeatherForecast
{
    Date = DateOnly.FromDateTime(DateTime.Now.AddDays(1)),
    TemperatureC = Random.Shared.Next(-20, 55),
    Summary = Summaries[Random.Shared.Next(Summaries.Length)]
};

var jsonData = JsonSerializer.Serialize(forecast);
using var streamData = new MemoryStream(Encoding.UTF8.GetBytes(jsonData));
_logger.LogInformation(jsonData);

var kinesisClient = new AmazonKinesisClient();
var putResponse = await kinesisClient.PutRecordsAsync(new PutRecordsRequest(...));

_logger.LogInformation($"Failed record count: {putResponse.FailedRecordCount}");
_logger.LogInformation($"HTTP status: {putResponse.HttpStatusCode}");

return forecast;
```

Dockerfile:
```Dockerfile
FROM mcr.microsoft.com/dotnet/aspnet:8.0
COPY ./publish/ .
ENTRYPOINT ["dotnet", "WebApplicationTest.dll"]
```

Before:
```
System.ArgumentNullException: Value cannot be null. (Parameter 'path1')
  at System.ArgumentNullException.Throw(String paramName)
  at System.IO.Path.Combine(String path1, String path2)
  at Amazon.Internal.RegionEndpointProviderV3.GetEndpointJsonSourceStream()
  at Amazon.Internal.RegionEndpointProviderV3..ctor()
  at Amazon.RegionEndpoint.get_RegionEndpointProvider()
  at Amazon.RegionEndpoint.get_InternedRegionEndpoint()
```

After:
```
info: WebApplicationTest.Controllers.WeatherForecastController[0]
{
    "Date": "2023-11-25",
    "TemperatureC": 38,
    "TemperatureF": 100,
    "Summary": "Chilly"
}
info: WebApplicationTest.Controllers.WeatherForecastController[0]
      Failed record count: 0
info: WebApplicationTest.Controllers.WeatherForecastController[0]
      HTTP status: OK
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement