### PR TITLE
Fix region in AmazonS3Uri constructor

### DIFF
--- a/generator/.DevConfigs/26510f3f-e823-445b-876f-1beba8a062f4.json
+++ b/generator/.DevConfigs/26510f3f-e823-445b-876f-1beba8a062f4.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fix AmazonS3Uri.EndpointRegexMatch to use non-capturing groups for S3 and S3Express values"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
@@ -32,7 +32,7 @@ namespace Amazon.S3.Util
     /// </summary>
     public class AmazonS3Uri
     {
-        private static readonly Regex EndpointRegexMatch = new Regex(@"^(.+\.)?(s3|s3express)[.-]([a-z0-9-]+)\.", RegexOptions.Compiled);
+        private static readonly Regex EndpointRegexMatch = new Regex(@"^(.+\.)?(?:s3|s3express)[.-]([a-z0-9-]+)\.", RegexOptions.Compiled);
 
         /// <summary>
         /// True if the URI contains the bucket in the path, false if it contains the bucket in the authority.

--- a/sdk/test/Services/S3/UnitTests/Custom/S3UriTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/S3UriTests.cs
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+using Amazon;
 using Amazon.S3.Util;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -39,7 +40,7 @@ namespace AWSSDK.UnitTests
 
         [TestMethod]
         [TestCategory("S3")]
-        public void S3EndpointAbsoluterRegionalS3UriTest()
+        public void S3EndpointAbsoluteRegionalS3UriTest()
         {
             bool isS3Uri = AmazonS3Uri.IsAmazonS3Endpoint("http://mybucket.s3.us-west-2.amazonaws.com/");
             Assert.IsTrue(isS3Uri);
@@ -47,7 +48,7 @@ namespace AWSSDK.UnitTests
 
         [TestMethod]
         [TestCategory("S3")]
-        public void S3EndpointAbsoluterLegacyS3UriTest()
+        public void S3EndpointAbsoluteLegacyS3UriTest()
         {
             bool isS3Uri = AmazonS3Uri.IsAmazonS3Endpoint("https://s3.amazonaws.com/");
             Assert.IsTrue(isS3Uri);
@@ -140,6 +141,26 @@ namespace AWSSDK.UnitTests
 
             Assert.IsFalse(result);
             Assert.IsNull(s3Uri);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void S3EndpointAbsoluteRegionalS3UriWithKeyTest()
+        {
+            var parsed = new AmazonS3Uri("https://my-bucket-name.s3.us-west-2.amazonaws.com/file-name");
+            Assert.AreEqual("my-bucket-name", parsed.Bucket);
+            Assert.AreEqual("file-name", parsed.Key);
+            Assert.AreEqual(RegionEndpoint.USWest2, parsed.Region);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void s3expressEndpointAbsoluteRegionalS3ExpressUriWithKeyTest()
+        {
+            var parsed = new AmazonS3Uri("https://my-bucket-name.s3express.us-west-2.amazonaws.com/file-name");
+            Assert.AreEqual("my-bucket-name", parsed.Bucket);
+            Assert.AreEqual("file-name", parsed.Key);
+            Assert.AreEqual(RegionEndpoint.USWest2, parsed.Region);
         }
     }
 }


### PR DESCRIPTION
Adjust a regex used in AmazonS3Uri constructor so that we get the correct region. This fixes a bug introduced in 374a36f3.

## Motivation and Context

A bug in `AmazonS3Uri` class prevented me from using the latest AWSSDK.S3 nuget package in my own code.

## Testing

I verified that the following test failed before this change and passes after. The last assert is the critical one.
```
        [Test]
        public void ParseS3Uri()
        {
            var parsed = new AmazonS3Uri("https://bucketname.s3.ap-southeast-2.amazonaws.com/keyname");
            Assert.AreEqual("bucketname", parsed.Bucket);
            Assert.AreEqual("keyname", parsed.Key);
            Assert.AreEqual(RegionEndpoint.APSoutheast2, parsed.Region);
        }
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement