### PR TITLE
Addressed performance degradation in Amazon.Runtime.ClientConfig

### DIFF
--- a/generator/.DevConfigs/20198df3-ff3a-44e2-a5d1-da81581bf0e1.json
+++ b/generator/.DevConfigs/20198df3-ff3a-44e2-a5d1-da81581bf0e1.json
@@ -1,7 +1,7 @@
 {
     "core": {
       "changeLogMessages": [
-        "Addressed performance degradation in Amazon.Runtime.ClientConfig ServiceURL"
+        "Addressed performance degradation in Amazon.Runtime.ClientConfig (Configuration files were being read unnecessarily)"
       ],
       "type": "patch",
       "updateMinimum": true

--- a/generator/.DevConfigs/20198df3-ff3a-44e2-a5d1-da81581bf0e1.json
+++ b/generator/.DevConfigs/20198df3-ff3a-44e2-a5d1-da81581bf0e1.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Addressed performance degradation in Amazon.Runtime.ClientConfig ServiceURL"
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -264,13 +264,11 @@ namespace Amazon.Runtime
 
                     if (Environment.GetEnvironmentVariable(serviceSpecificTransformedEnvironmentVariable) != null)
                     {
-                        didProcessServiceURL = true;
                         Logger.GetLogger(GetType()).InfoFormat($"ServiceURL configured from service specific environment variable: {serviceSpecificTransformedEnvironmentVariable}.");
                         this.ServiceURL = Environment.GetEnvironmentVariable(serviceSpecificTransformedEnvironmentVariable);                    
                     }
                     else if (Environment.GetEnvironmentVariable(EnvironmentVariables.GLOBAL_ENDPOINT_ENVIRONMENT_VARIABLE) != null)
                     {
-                        didProcessServiceURL = true;
                         this.ServiceURL = Environment.GetEnvironmentVariable(EnvironmentVariables.GLOBAL_ENDPOINT_ENVIRONMENT_VARIABLE);
                         Logger.GetLogger(GetType()).InfoFormat($"ServiceURL configured from global environment variable: {EnvironmentVariables.GLOBAL_ENDPOINT_ENVIRONMENT_VARIABLE}.");
                     }
@@ -295,7 +293,6 @@ namespace Amazon.Runtime
                                 {
                                     Logger.GetLogger(GetType()).InfoFormat($"ServiceURL configured from service specific endpoint url in " +
                                     $"profile {profile.Name} from key {transformedConfigServiceId}.");
-                                    didProcessServiceURL = true;
                                     this.ServiceURL = endpointUrlValue;
                                 }
 
@@ -304,12 +301,12 @@ namespace Amazon.Runtime
                             {
                                 Logger.GetLogger(GetType()).InfoFormat($"ServiceURL configured from global endpoint url" +
                                     $"in profile {profile.Name} from key {SettingsConstants.EndpointUrl}.");
-                                didProcessServiceURL = true;
                                 this.ServiceURL = profile.EndpointUrl;
                             }
                         }
 
                     }
+                    didProcessServiceURL = true;
                 }
                 return this.serviceURL;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Performance degradation was reported https://github.com/aws/aws-sdk-net/issues/3122. The performance of creating a client was ~25 times slower in the AWS Core after https://github.com/aws/aws-sdk-net/releases/tag/3.7.588.0.

## Description
There is a bug in Amazon.Runtime ClientConfig's ServiceURL getter where it reads the profile file multiple times even though there were protections in place to read it only once. This PR fixes the bug to only read profile once.

Below code was used for the benchmarks.
```
_s3Client = new AmazonS3Client(_accessKeyId, _secretAccessKey, _sessionToken, RegionEndpoint.USEast1);
GetPreSignedUrlRequest request = new()
{
    BucketName = _bucketName,
    Key = _sourceKey,
    Expires = DateTime.Now.AddMinutes(5)
};
return _s3Client.GetPreSignedURL(request);
```
Before regression File Reads Count:
| File Name| Count| 
|------------------ |---------:|
| AppData\Local\AWSToolkit\RegisteredAccounts.json| 6|
|.aws\credentials|12|
|.aws\config|18|

After regression File Reads Count:
| File Name| Count| 
|------------------ |---------:|
| AppData\Local\AWSToolkit\RegisteredAccounts.json| 24|
|.aws\credentials|48|
|.aws\config|72|

As can be seen, the file reads counts grew 4 times after Product Version 3.7.588.0 was released.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

This fixes https://github.com/aws/aws-sdk-net/issues/3122

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Successful DRY RUN in the build system.

Below are the performance benchmarks for `main-staging` and `slowperfclientconfig` branches.
main-staging: (Before)
| Method            | Mean     | Error     | StdDev    | Allocated |
|------------------ |---------:|----------:|----------:|----------:|
| GenerateSignedUrl | 1.003 ms | 0.0407 ms | 0.0106 ms | 247.14 KB |

slowperfclientconfig: (After)
| Method            | Mean     | Error    | StdDev   | Allocated |
|------------------ |---------:|---------:|---------:|----------:|
| GenerateSignedUrl | 16.71 us | 2.384 us | 0.619 us |  55.43 KB |

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement