### PR TITLE
fix: Update endpoint resolution logic in all services to allow the combination of the ServiceURL and AuthenticationRegion on the client config to drive the SDK's internal endpoint selection logic.

### DIFF
--- a/generator/.DevConfigs/17a5eeac-7a3e-4010-9535-0764eb449e16.json
+++ b/generator/.DevConfigs/17a5eeac-7a3e-4010-9535-0764eb449e16.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Update endpoint resolution logic in all services to allow the combination of the ServiceURL and AuthenticationRegion on the client config to drive the SDK's internal endpoint selection logic. This is necessary when working with Amazon S3 buckets on Snowball Edge devices."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+}

--- a/generator/ServiceClientGeneratorLib/Generators/Endpoints/EndpointResolver.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Endpoints/EndpointResolver.cs
@@ -19,7 +19,7 @@ namespace ServiceClientGenerator.Generators.Endpoints
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+    #line 1 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class EndpointResolver : BaseGenerator
     {
@@ -30,7 +30,7 @@ namespace ServiceClientGenerator.Generators.Endpoints
         public override string TransformText()
         {
             
-            #line 7 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 7 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
 
     AddLicenseHeader();
 
@@ -39,7 +39,7 @@ namespace ServiceClientGenerator.Generators.Endpoints
             #line hidden
             this.Write("\r\nusing System;\r\nusing Amazon.");
             
-            #line 12 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 12 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Config.ServiceNameRoot));
             
             #line default
@@ -47,21 +47,21 @@ namespace ServiceClientGenerator.Generators.Endpoints
             this.Write(".Model;\r\nusing Amazon.Runtime;\r\nusing Amazon.Runtime.Internal;\r\nusing Amazon.Runt" +
                     "ime.Endpoints;\r\nusing Amazon.Util;\r\nusing ");
             
-            #line 17 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 17 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Config.Namespace));
             
             #line default
             #line hidden
             this.Write(".Endpoints;\r\n\r\n#pragma warning disable 1591\r\n\r\nnamespace ");
             
-            #line 21 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 21 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Config.Namespace));
             
             #line default
             #line hidden
             this.Write(".Internal\r\n{\r\n    /// <summary>\r\n    /// Amazon ");
             
-            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 24 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -69,14 +69,14 @@ namespace ServiceClientGenerator.Generators.Endpoints
             this.Write(" endpoint resolver.\r\n    /// Custom PipelineHandler responsible for resolving end" +
                     "point and setting authentication parameters for ");
             
-            #line 25 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 25 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write(" service requests.\r\n    /// Collects values for ");
             
-            #line 26 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 26 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -84,7 +84,7 @@ namespace ServiceClientGenerator.Generators.Endpoints
             this.Write("EndpointParameters and then tries to resolve endpoint by calling \r\n    /// Resolv" +
                     "eEndpoint method on GlobalEndpoints.Provider if present, otherwise uses ");
             
-            #line 27 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 27 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -92,7 +92,7 @@ namespace ServiceClientGenerator.Generators.Endpoints
             this.Write("EndpointProvider.\r\n    /// Responsible for setting authentication and http header" +
                     "s provided by resolved endpoint.\r\n    /// </summary>\r\n    public class Amazon");
             
-            #line 30 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 30 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Config.ClassName));
             
             #line default
@@ -101,7 +101,7 @@ namespace ServiceClientGenerator.Generators.Endpoints
                     "erviceSpecificHandler(IExecutionContext executionContext, EndpointParameters par" +
                     "ameters)\r\n        {\r\n");
             
-            #line 34 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 34 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
  if (Config.ServiceId == "S3") {
             
             #line default
@@ -129,21 +129,21 @@ namespace ServiceClientGenerator.Generators.Endpoints
             }
 ");
             
-            #line 56 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 56 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
  } 
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 58 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 58 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
  if (!this.dontInjectHostPrefixForServices.Contains(Config.ServiceId)) {
             
             #line default
             #line hidden
             this.Write("            InjectHostPrefix(executionContext.RequestContext);\r\n");
             
-            #line 60 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 60 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
  } 
             
             #line default
@@ -151,35 +151,35 @@ namespace ServiceClientGenerator.Generators.Endpoints
             this.Write("        }\r\n\r\n        protected override EndpointParameters MapEndpointsParameters" +
                     "(IRequestContext requestContext)\r\n        {\r\n            var config = (Amazon");
             
-            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 65 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Config)requestContext.ClientConfig;\r\n            var result = new ");
             
-            #line 66 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 66 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Config.ClassName));
             
             #line default
             #line hidden
             this.Write("EndpointParameters();\r\n");
             
-            #line 67 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 67 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.AssignBuiltins()));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 68 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 68 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.AssignClientContext()));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 69 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 69 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
 if (Config.EndpointsRuleSet.parameters.ContainsKey("Region")) {
             
             #line default
@@ -188,8 +188,16 @@ if (Config.EndpointsRuleSet.parameters.ContainsKey("Region")) {
             var regionEndpoint = config.RegionEndpoint;
             if (regionEndpoint == null && !string.IsNullOrEmpty(config.ServiceURL))
             {
-                var regionName = AWSSDKUtils.DetermineRegion(config.ServiceURL);
-                result.Region = RegionEndpoint.GetBySystemName(regionName).SystemName;
+                // Use the specified signing region if it was provided alongside a custom ServiceURL
+                if (!string.IsNullOrEmpty(config.AuthenticationRegion))
+                {
+                    result.Region = config.AuthenticationRegion;
+                }
+                else // try to extract a region from the custom ServiceURL
+                {
+                    var regionName = AWSSDKUtils.DetermineRegion(config.ServiceURL);
+                    result.Region = RegionEndpoint.GetBySystemName(regionName).SystemName;
+                }
             }
 
             // To support legacy endpoint overridding rules in the endpoints.json
@@ -206,13 +214,13 @@ if (Config.EndpointsRuleSet.parameters.ContainsKey("Region")) {
 
 ");
             
-            #line 90 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 98 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
 }
             
             #line default
             #line hidden
             
-            #line 91 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 99 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
 if (Config.ClassName == "S3") {
             
             #line default
@@ -226,14 +234,14 @@ if (Config.ClassName == "S3") {
             }
 ");
             
-            #line 99 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 107 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
 }
             
             #line default
             #line hidden
             this.Write("\r\n            // Assign staticContextParams and contextParam per operation\r\n");
             
-            #line 102 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
+            #line 110 "C:\dev\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\EndpointResolver.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.AssignOperationContext()));
             
             #line default

--- a/generator/ServiceClientGeneratorLib/Generators/Endpoints/EndpointResolver.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Endpoints/EndpointResolver.tt
@@ -71,8 +71,16 @@ namespace <#=Config.Namespace#>.Internal
             var regionEndpoint = config.RegionEndpoint;
             if (regionEndpoint == null && !string.IsNullOrEmpty(config.ServiceURL))
             {
-                var regionName = AWSSDKUtils.DetermineRegion(config.ServiceURL);
-                result.Region = RegionEndpoint.GetBySystemName(regionName).SystemName;
+                // Use the specified signing region if it was provided alongside a custom ServiceURL
+                if (!string.IsNullOrEmpty(config.AuthenticationRegion))
+                {
+                    result.Region = config.AuthenticationRegion;
+                }
+                else // try to extract a region from the custom ServiceURL
+                {
+                    var regionName = AWSSDKUtils.DetermineRegion(config.ServiceURL);
+                    result.Region = RegionEndpoint.GetBySystemName(regionName).SystemName;
+                }
             }
 
             // To support legacy endpoint overridding rules in the endpoints.json

--- a/sdk/test/Services/S3Control/UnitTests/Custom/S3ArnSpecialCasesTests.cs
+++ b/sdk/test/Services/S3Control/UnitTests/Custom/S3ArnSpecialCasesTests.cs
@@ -109,5 +109,33 @@ namespace AWSSDK.UnitTests
             Assert.AreEqual("op-01234567890123456", marshalledRequest.Headers["x-amz-outpost-id"]);
             Assert.AreEqual("123456789012", marshalledRequest.Headers["x-amz-account-id"]);
         }
+
+        /// <summary>
+        /// Using S3 Control with Snowball Edge requires setting both a custom serviceURL and
+        /// region to "snow" to invoke the correct endpoint rule. Since we don't allow both, this verifies
+        /// that substituting AuthenticanRegion with "snow" results in the correct endpoint.
+        /// https://docs.aws.amazon.com/snowball/latest/developer-guide/working-s3-snow-buckets.html
+        /// </summary>
+        [TestMethod]
+        [TestCategory("S3Control")]
+        [TestCategory("UnitTest")]
+        public void SnowballEdgeTest()
+        {
+            var s3ControlConfig = new AmazonS3ControlConfig
+            {
+                AuthenticationRegion ="snow",
+                ServiceURL = "https://192.168.1.1"
+            };
+
+            var listRegionalBucketsRequest = new ListRegionalBucketsRequest()
+            {
+                AccountId = "012345678910"
+            };
+
+            var marshalledRequest = S3ControlArnTestUtils.RunMockRequest(listRegionalBucketsRequest, ListRegionalBucketsRequestMarshaller.Instance, s3ControlConfig);
+            Assert.AreEqual(new Uri("https://192.168.1.1"), marshalledRequest.Endpoint);
+            Assert.AreEqual("012345678910", marshalledRequest.Headers["x-amz-account-id"]);
+            Assert.IsTrue(marshalledRequest.Headers["Authorization"].Contains("snow")); // signing region should be "snow"
+        }
     }
 }

--- a/sdk/test/Services/S3Control/UnitTests/Custom/S3ArnSpecialCasesTests.cs
+++ b/sdk/test/Services/S3Control/UnitTests/Custom/S3ArnSpecialCasesTests.cs
@@ -113,7 +113,7 @@ namespace AWSSDK.UnitTests
         /// <summary>
         /// Using S3 Control with Snowball Edge requires setting both a custom serviceURL and
         /// region to "snow" to invoke the correct endpoint rule. Since we don't allow both, this verifies
-        /// that substituting AuthenticanRegion with "snow" results in the correct endpoint.
+        /// that substituting AuthenticationRegion with "snow" results in the correct endpoint.
         /// https://docs.aws.amazon.com/snowball/latest/developer-guide/working-s3-snow-buckets.html
         /// </summary>
         [TestMethod]

--- a/sdk/test/Services/S3Control/UnitTests/Custom/S3ControlArnTestUtils.cs
+++ b/sdk/test/Services/S3Control/UnitTests/Custom/S3ControlArnTestUtils.cs
@@ -16,14 +16,11 @@ using Amazon.Runtime;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Runtime.Internal.Transform;
-using Amazon.Runtime.Internal.Util;
 using Amazon.S3Control;
 using Amazon.S3Control.Internal;
-using System;
+using AWSSDK.UnitTests.Mocking;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using static AWSSDK.UnitTests.Mocking.TestUtils;
 
 namespace AWSSDK.UnitTests
 {
@@ -31,56 +28,16 @@ namespace AWSSDK.UnitTests
     {
         public static IRequest RunMockRequest(AmazonWebServiceRequest request, IMarshaller<IRequest, AmazonWebServiceRequest> marshaller, AmazonS3ControlConfig config)
         {
-            var pipeline = new RuntimePipeline(new List<IPipelineHandler>
+            var pipelineHandlers = new List<IPipelineHandler>
             {
                 new NoopPipelineHandler(),
+                new Signer(),
                 new AmazonS3ControlEndpointResolver(),
                 new Marshaller()
-            });
-
-            var requestContext = new RequestContext(config.LogMetrics, new AWS4Signer())
-            {
-                ClientConfig = config,
-                Marshaller = marshaller,
-                OriginalRequest = request,
-                Unmarshaller = null,
-                IsAsync = false
             };
-            var executionContext = new ExecutionContext(
-                requestContext,
-                new ResponseContext()
-            );
-
-            pipeline.InvokeSync(executionContext);
-
-            return requestContext.Request;
-        }
-
-        public class NoopPipelineHandler : IPipelineHandler
-        {
-            public ILogger Logger { get; set; }
-            public IPipelineHandler InnerHandler { get; set; }
-            public IPipelineHandler OuterHandler { get; set; }
-
-            public void AsyncCallback(IAsyncExecutionContext executionContext)
-            {
-            }
-
-            public IAsyncResult InvokeAsync(IAsyncExecutionContext executionContext)
-            {
-                return null;
-            }
 
 
-            public virtual System.Threading.Tasks.Task<T> InvokeAsync<T>(IExecutionContext executionContext)
-                where T : AmazonWebServiceResponse, new()
-            {
-                return null;
-            }
-
-            public void InvokeSync(IExecutionContext executionContext)
-            {
-            }
+            return TestUtils.RunMockRequest(pipelineHandlers, request, marshaller, null, config, new AWS4Signer());
         }
     }
 }


### PR DESCRIPTION
## Description
The .NET SDK has long disallowed setting both `ServiceURL` and `RegionEndpoint` on a service client configuration. From https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Runtime/TClientConfig.html
> RegionEndpoint and ServiceURL are mutually exclusive properties. Whichever property is set last will cause the other to automatically be reset to null.

However this is problematic after the new endpoint resolution logic introduced in 3.7.100 where AWS services provide rulesets that the SDKs use to resolve the endpoint for a given request. Valid endpoint resolution logic can now use both `ServiceURL` and `RegionEndpoint` as inputs to derive an endpoint.

An example of this is in S3 Control for [Working with S3 buckets on a Snowball Edge device](https://docs.aws.amazon.com/snowball/latest/developer-guide/working-s3-snow-buckets.html). See https://github.com/aws/aws-sdk-net/blob/930216aed32bc39844c8690dd50d459ae86ef582/sdk/src/Services/S3Control/Generated/Internal/AmazonS3ControlEndpointProvider.cs#L63-L76

This change allows `AuthenticationRegion` to be passed to the input to the endpoint resolver for the case where `ServiceURL` is set. It continues to NOT allow both `ServiceURL` and `RegionEndpoint` to be set on a client config.

## Motivation and Context
Internal ticket V1152090454

## Testing
* Added a test case to cover the endpoint resolution for S3 Control and Snowball.
* IN PROGRESS - dry-run on internal CI
* IN PROGRESS - manual testing with PowerShell, since that's where the case originated.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement