### PR TITLE
Fix: Single encode resource path components from the endpoint and dou…

### DIFF
--- a/generator/.DevConfigs/a2c8636d-67df-4e85-9d7c-a8bb1181a7ee.json
+++ b/generator/.DevConfigs/a2c8636d-67df-4e85-9d7c-a8bb1181a7ee.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Fix encoding issue where resource path components from the configured endpoint were being double encoded. Resource path components from configured endpoints will be single encoded and resource path components from the request will continue to be double encoded (except for S3)."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }


### PR DESCRIPTION
…ble encode resource path components from the request

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fix ensures that when we canonicalize the resource path we single encode the portion that comes from the configured endpoint (via serviceURL or the default endpoint) and double encode the resource path that comes from the request. ApiGatewayManagementClient allows special characters to be included in the configured endpoint as part of its resource path, which was being incorrectly double encoded because `CanonicalizeResourcePathV2` treated the resource path from the request and the resource path from the endpoint as the same. This change ensures that we separate these two resource paths and encode them accordingly, first encoding the resource path from the request, then concatenating that to the resource path from the endpoint and encoding that altogether.

This change also adds unit tests for these scenarios and also updates the existing unit tests to use the V2 version of `CanonicalizeResourcePath`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes this issue: https://github.com/aws/aws-sdk-net/issues/3132
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Full dry run on prod passed and added unit test coverage for all cases, as well as updated existing unit test with newer method.
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement