### PR TITLE
Fix: update CloudFrontKeyValueStore client to use AWS4aSignerCRTWrapper

### DIFF
--- a/generator/.DevConfigs/9dba8c79-b860-4427-9ea4-f8625d376658.json
+++ b/generator/.DevConfigs/9dba8c79-b860-4427-9ea4-f8625d376658.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+      {
+          "serviceName": "CloudFrontKeyValueStore",
+          "type": "patch",
+          "changeLogMessages": [
+              "Fixed CloudFrontKeyValueStore to use Sigv4a instead of Sigv4."
+          ]
+      }
+  ]
+}

--- a/generator/ServiceClientGeneratorLib/GeneratorHelpers.cs
+++ b/generator/ServiceClientGeneratorLib/GeneratorHelpers.cs
@@ -17,6 +17,8 @@ namespace ServiceClientGenerator
                     // we should not continue to add new hardcoded service specific signers
                     // and instead implement a solution based on a signer selection specification
                     return "EventBridgeSigner";
+                case "CloudFrontKeyValueStore":
+                    return "AWS4aSignerCRTWrapper";
             }
 
             switch (signatureVersion)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
CloudFrontKeyValueStore latest version requires SigV4a, however our code is still using SigV4 because C2J still has Sigv4 as the `SignatureVersion`.
This PR forces CloudFrontKeyValueStore client to use AWS4aSignerCRTWrapper till we get SRA identity and auth in place.
## Motivation and Context
A customer raised this issue https://github.com/aws/aws-sdk-net/issues/3143 when using CloudFrontKeyValueStore

## Testing
* Tested the same code that was included in the issue and `ListKeysAsync` method returned the keys and didn't throw an exception.
* Did a full dry run

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement