### PR TITLE
TransferUtilityDownloadDirectoryRequest is missing SSE-C properties

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
@@ -98,7 +98,10 @@ namespace Amazon.S3.Transfer.Internal
             downloadRequest.Key = s3Object.Key;
             var file = s3Object.Key.Substring(prefixLength).Replace('/', Path.DirectorySeparatorChar);
             downloadRequest.FilePath = Path.Combine(this._request.LocalDirectory, file);
-                        
+            downloadRequest.ServerSideEncryptionCustomerMethod = this._request.ServerSideEncryptionCustomerMethod;
+            downloadRequest.ServerSideEncryptionCustomerProvidedKey = this._request.ServerSideEncryptionCustomerProvidedKey;
+            downloadRequest.ServerSideEncryptionCustomerProvidedKeyMD5 = this._request.ServerSideEncryptionCustomerProvidedKeyMD5;
+
             //Ensure the target file is a rooted within LocalDirectory. Otherwise error.
             if(!InternalSDKUtils.IsFilePathRootedWithDirectoryPath(downloadRequest.FilePath, _request.LocalDirectory))
             {

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryRequest.cs
@@ -27,6 +27,7 @@ using System.Text;
 using System.Linq;
 using Amazon.S3.Model;
 using Amazon.Util;
+using Amazon.Runtime.Internal;
 using System.Globalization;
 
 
@@ -46,6 +47,10 @@ namespace Amazon.S3.Transfer
         private DateTime? modifiedSinceDateUtc;
         private DateTime? unmodifiedSinceDateUtc;
         private bool disableSlashCorrection = false;
+
+        private ServerSideEncryptionCustomerMethod serverSideCustomerEncryption;
+        private string serverSideEncryptionCustomerProvidedKey;
+        private string serverSideEncryptionCustomerProvidedKeyMD5;
 
         /// <summary>
         /// 	Gets or sets the name of the bucket.
@@ -253,6 +258,47 @@ namespace Amazon.S3.Transfer
         {
             get { return this.disableSlashCorrection; }
             set { this.disableSlashCorrection = value; }
+        }
+
+        /// <summary>
+        /// The Server-side encryption algorithm to be used with the customer provided key.
+        /// </summary>
+        public ServerSideEncryptionCustomerMethod ServerSideEncryptionCustomerMethod
+        {
+            get { return this.serverSideCustomerEncryption; }
+            set { this.serverSideCustomerEncryption = value; }
+        }
+
+        /// <summary>
+        /// The base64-encoded encryption key for Amazon S3 to use to decrypt the object
+        /// <para>
+        /// Using the encryption key you provide as part of your request Amazon S3 manages both the encryption, as it writes 
+        /// to disks, and decryption, when you access your objects. Therefore, you don't need to maintain any data encryption code. The only 
+        /// thing you do is manage the encryption keys you provide.
+        /// </para>
+        /// <para>
+        /// When you retrieve an object, you must provide the same encryption key as part of your request. Amazon S3 first verifies 
+        /// the encryption key you provided matches, and then decrypts the object before returning the object data to you.
+        /// </para>
+        /// <para>
+        /// Important: Amazon S3 does not store the encryption key you provide.
+        /// </para>
+        /// </summary>
+        [AWSProperty(Sensitive = true)]
+        public string ServerSideEncryptionCustomerProvidedKey
+        {
+            get { return this.serverSideEncryptionCustomerProvidedKey; }
+            set { this.serverSideEncryptionCustomerProvidedKey = value; }
+        }
+
+        /// <summary>
+        /// The MD5 of the customer encryption key specified in the ServerSideEncryptionCustomerProvidedKey property. The MD5 is
+        /// base 64 encoded. This field is optional, the SDK will calculate the MD5 if this is not set.
+        /// </summary>
+        public string ServerSideEncryptionCustomerProvidedKeyMD5
+        {
+            get { return this.serverSideEncryptionCustomerProvidedKeyMD5; }
+            set { this.serverSideEncryptionCustomerProvidedKeyMD5 = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
TransferUtilityDownloadDirectoryRequest is missing the three SSE-C properties:
TransferUtilityUploadDirectoryRequest  already manage this feature.

## Description
<!--- Describe your changes in detail -->
Add the three ServerSideEncryptionCustomer properties (Method, Key, KeyMD5) to the TransferUtilityUploadDirectoryRequest. And pass them in the DownloadDirectoryCommand to the TransferUtilityUploadDownload..

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
fixes https://github.com/aws/aws-sdk-net/issues/3147

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues/3147
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement