### PR TITLE
Fix null pointer exception using S3 ConstantClass with implicit string conversion

### DIFF
--- a/generator/.DevConfigs/F9150D61-CF05-4F5C-A404-C6158B778AB5.json
+++ b/generator/.DevConfigs/F9150D61-CF05-4F5C-A404-C6158B778AB5.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fix bug with S3 ConstantClass enumerations not working with implicit string conversion"
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/S3/Custom/S3Enumerations.cs
+++ b/sdk/src/Services/S3/Custom/S3Enumerations.cs
@@ -1764,7 +1764,7 @@ namespace Amazon.S3
         /// Construct instance of RestoreObjectRequestGlacierJobTier
         /// </summary>
         /// <param name="value"></param>
-        private GlacierJobTier(string value)
+        public GlacierJobTier(string value)
             : base(value)
         {
         }
@@ -1867,7 +1867,7 @@ namespace Amazon.S3
         /// </summary>
         public static readonly RequestPayer Requester = new RequestPayer("requester");
 
-        private RequestPayer(string value)
+        public RequestPayer(string value)
             : base(value)
         {
         }
@@ -1899,7 +1899,7 @@ namespace Amazon.S3
         /// </summary>
         public static readonly RequestCharged Requester = new RequestCharged("requester");
 
-        private RequestCharged(string value)
+        public RequestCharged(string value)
             : base(value)
         {
         }
@@ -2110,7 +2110,7 @@ namespace Amazon.S3
         /// </summary>
         public static readonly FileHeaderInfo None = new FileHeaderInfo("NONE");
 
-        private FileHeaderInfo(string value)
+        public FileHeaderInfo(string value)
             : base(value)
         {
         }
@@ -2149,7 +2149,7 @@ namespace Amazon.S3
         /// </summary>
         public static readonly ExistingObjectReplicationStatus Disabled = new ExistingObjectReplicationStatus("Disabled");
 
-        private ExistingObjectReplicationStatus(string value)
+        public ExistingObjectReplicationStatus(string value)
             : base(value)
         {
         }
@@ -2188,7 +2188,7 @@ namespace Amazon.S3
         /// </summary>
         public static readonly QuoteFields AsNeeded = new QuoteFields("ASNEEDED");
 
-        private QuoteFields(string value)
+        public QuoteFields(string value)
             : base(value)
         {
         }
@@ -2222,7 +2222,7 @@ namespace Amazon.S3
         /// </summary>
         public static readonly ExpressionType SQL = new ExpressionType("SQL");
 
-        private ExpressionType(string value)
+        public ExpressionType(string value)
             : base(value)
         {
         }
@@ -2253,7 +2253,7 @@ namespace Amazon.S3
     {
         public static readonly RestoreRequestType SELECT = new RestoreRequestType("SELECT");
 
-        private RestoreRequestType(string value)
+        public RestoreRequestType(string value)
             : base(value)
         {
         }
@@ -2283,7 +2283,7 @@ namespace Amazon.S3
         public static readonly JsonType Document = new JsonType("DOCUMENT");
         public static readonly JsonType Lines = new JsonType("LINES");
 
-        private JsonType(string value)
+        public JsonType(string value)
             : base(value)
         {
         }
@@ -2314,7 +2314,7 @@ namespace Amazon.S3
         public static readonly CompressionType Gzip = new CompressionType("GZIP");
         public static readonly CompressionType Bzip2 = new CompressionType("BZIP2");
 
-        private CompressionType(string value)
+        public CompressionType(string value)
             : base(value)
         {
         }
@@ -2545,7 +2545,7 @@ namespace Amazon.S3
     /// </summary>
     public sealed class MetricsStatus : ConstantClass
     {
-        private MetricsStatus(string value)
+        public MetricsStatus(string value)
             : base(value)
         {
 
@@ -2586,7 +2586,7 @@ namespace Amazon.S3
     /// </summary>
     public sealed class ObjectOwnership : ConstantClass
     {
-        private ObjectOwnership(string value)
+        public ObjectOwnership(string value)
             : base(value)
         {
 
@@ -2629,7 +2629,7 @@ namespace Amazon.S3
 
     public sealed class IntelligentTieringStatus : ConstantClass
     {
-        private IntelligentTieringStatus(string value)
+        public IntelligentTieringStatus(string value)
             : base(value)
         {
 
@@ -2667,7 +2667,7 @@ namespace Amazon.S3
 
     public sealed class IntelligentTieringAccessTier : ConstantClass
     {
-        private IntelligentTieringAccessTier(string value)
+        public IntelligentTieringAccessTier(string value)
             : base(value)
         {
 
@@ -2751,7 +2751,7 @@ namespace Amazon.S3
 
     public sealed class ReplicaModificationsStatus : ConstantClass
     {
-        private ReplicaModificationsStatus(string value)
+        public ReplicaModificationsStatus(string value)
             : base(value)
         {
 


### PR DESCRIPTION
## Description
Fix a bug with some of the newer S3 ConstantClass enumerations that were incorrectly using private constructors. The way the implicit string conversion works is by relying on the public constructor. Without the public constructor a NPE is thrown invoking the exception. The generator used for all other service's ConstantClass enumerations always puts in a public constructor.


## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3158

## Testing
Have confirmed the repo in the GitHub issue now works. I'm starting a dry run on the build.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement