### PR TITLE
Handle passing path with leading "/" to AmazonCloudFrontCookieSigner

### DIFF
--- a/sdk/src/Services/CloudFront/Custom/AmazonCloudFrontCookieSigner.cs
+++ b/sdk/src/Services/CloudFront/Custom/AmazonCloudFrontCookieSigner.cs
@@ -295,6 +295,8 @@ namespace Amazon.CloudFront
                                                    string distributionDomain,
                                                    string path)
         {
+            path = path.TrimStart('/');
+            
             if (protocol == 0)
             {
                 // Uninitialized protocol value.


### PR DESCRIPTION
Make it possible to pass a path with a leading "/" when signing cookies using AmazonCloudFrontCookieSigner.

## Description
Currently, passing a path with a leading "/" to any cookie signing method in AmazonCloudFrontCookieSigner results in an AccessDenied error from CloudFront due to the double dash "//" in the signed URL. This error lacks context, making it confusing for users. The ACFCookieSigner expects paths without a leading "/", automatically appending one without documenting this behavior.

## Motivation and Context
The motivation behind this change is to make it possible to pass a path with a leading "/" when signing cookies using AmazonCloudFrontCookieSigner without encountering AccessDenied errors from CloudFront. Currently, if a path with a leading "/" is provided, the resulting signed URL will contain a double dash "//," triggering an AccessDenied response from CloudFront. This adjustment aims to address this issue and provide clarity by allowing paths with a leading "/" while avoiding the mentioned error.

## Testing
Test Case 1: Passed a path without a leading "/" to the cookie signing method in AmazonCloudFrontCookieSigner to verify the existing behavior.
Test Case 2: Passed a path with a leading "/" to the cookie signing method to confirm the occurrence of AccessDenied errors from CloudFront.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement