### PR TITLE
Use [GeneratedRegex] with .NET 8

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/HostPrefixUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/HostPrefixUtils.cs
@@ -26,9 +26,17 @@ namespace Amazon.Runtime.Internal.Util
     /// <summary>
     /// Utilities for validating label values for host prefix templates
     /// </summary>
-    public static class HostPrefixUtils
+    public static partial class HostPrefixUtils
     {
-        private static Regex labelValidationRegex = new Regex(@"^[A-Za-z0-9\-]+$", RegexOptions.Compiled | RegexOptions.Singleline);
+        private const string LabelValidationRegexPattern = @"^[A-Za-z0-9\-]+$";
+
+#if NET8_0_OR_GREATER
+        [GeneratedRegex(LabelValidationRegexPattern, RegexOptions.Singleline)]
+        private static partial Regex LabelValidationRegex();
+#else
+        private static Regex LabelValidationRegex() => _labelValidationRegex;
+        private static Regex _labelValidationRegex = new Regex(LabelValidationRegexPattern, RegexOptions.Compiled | RegexOptions.Singleline);
+#endif
 
         /// <summary>
         /// Validates a label value
@@ -46,7 +54,7 @@ namespace Amazon.Runtime.Internal.Util
             // Check that the value only contains:
             //  uppercase letters, lowercase letters, numbers,
             //  dashes (-)
-            if (!labelValidationRegex.IsMatch(value))
+            if (!LabelValidationRegex().IsMatch(value))
                 return false;
 
             return true;

--- a/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
@@ -36,7 +36,15 @@ namespace Amazon.Util.Internal
         const string USER_AGENT_VERSION = "ua/2.0";
 
         // Define a regular expression to match disallowed characters
-        private static readonly Regex DisallowedCharactersRegex = new Regex("[^ /!#$%&'*+-.^_`|~\\w\\d]", RegexOptions.Compiled);
+        private const string DisallowedCharactersRegexPattern = "[^ /!#$%&'*+-.^_`|~\\w\\d]";
+
+#if NET8_0_OR_GREATER
+        [GeneratedRegex(DisallowedCharactersRegexPattern)]
+        private static partial Regex DisallowedCharactersRegex();
+#else
+        private static Regex DisallowedCharactersRegex() => _disallowedCharactersRegex;
+        private static readonly Regex _disallowedCharactersRegex = new Regex(DisallowedCharactersRegexPattern, RegexOptions.Compiled);
+#endif
 
         public static void SetUserAgent(string productName, string versionNumber)
         {
@@ -60,7 +68,7 @@ namespace Amazon.Util.Internal
         internal static string ReplaceInvalidUserAgentCharacters(string userAgent)
         {
             // Use the regular expression to replace disallowed characters by a hyphen
-            var validUserAgent = DisallowedCharactersRegex.Replace(userAgent, "-");
+            var validUserAgent = DisallowedCharactersRegex().Replace(userAgent, "-");
 
             return validUserAgent;
         }

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Uri.cs
@@ -30,9 +30,17 @@ namespace Amazon.S3.Util
     /// Uri wrapper that can parse out information (bucket, key, region, style) from an
     /// S3 URI.
     /// </summary>
-    public class AmazonS3Uri
+    public partial class AmazonS3Uri
     {
-        private static readonly Regex EndpointRegexMatch = new Regex(@"^(.+\.)?(?:s3|s3express)[.-]([a-z0-9-]+)\.", RegexOptions.Compiled);
+        private const string EndpointRegexPattern = @"^(.+\.)?(?:s3|s3express)[.-]([a-z0-9-]+)\.";
+
+#if NET8_0_OR_GREATER
+        [GeneratedRegex(EndpointRegexPattern)]
+        private static partial Regex EndpointRegexMatch();
+#else
+        private static Regex EndpointRegexMatch() => _endpointRegexMatch;
+        private static readonly Regex _endpointRegexMatch = new Regex(EndpointRegexPattern, RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// True if the URI contains the bucket in the path, false if it contains the bucket in the authority.
@@ -93,7 +101,7 @@ namespace Amazon.S3.Util
                 return;
             }
 
-            var match = EndpointRegexMatch.Match(uri.Host);
+            var match = EndpointRegexMatch().Match(uri.Host);
             if (!match.Success)
                 throw new ArgumentException("Invalid S3 URI - hostname does not appear to be a valid S3 endpoint");
 
@@ -269,7 +277,7 @@ namespace Amazon.S3.Util
 
             if (uri.IsAbsoluteUri && (uri.Host.EndsWith("amazonaws.com", StringComparison.OrdinalIgnoreCase) || uri.Host.EndsWith("amazonaws.com.cn", StringComparison.OrdinalIgnoreCase)))
             {
-                return EndpointRegexMatch.Match(uri.Host).Success;
+                return EndpointRegexMatch().Match(uri.Host).Success;
             }
             else if (uri.IsAbsoluteUri && uri.Scheme == "s3") // For S3 scheme URI, URI Authority is bucket name
             {

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
@@ -474,24 +474,37 @@ namespace Amazon.S3.Util
             }
 
             // Check not IPv4-like
-            Regex ipv4 = new Regex("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$");
-            if (ipv4.IsMatch(bucketName))
+            if (IPv4Regex().IsMatch(bucketName))
             {
                 return false;
             }
 
             // Check each label
-            Regex v2Regex = new Regex("^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?$");
             string[] labels = bucketName.Split("\\.".ToCharArray());
             foreach (string label in labels)
             {
-                if (!v2Regex.IsMatch(label))
+                if (!LabelRegex().IsMatch(label))
                 {
                     return false;
                 }
             }
             return true;
         }
+
+        private const string IPv4RegexPattern = "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$";
+        private const string LabelRegexPattern = "^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?$";
+
+#if NET8_0_OR_GREATER
+        [GeneratedRegex(IPv4RegexPattern)]
+        private static partial Regex IPv4Regex();
+        [GeneratedRegex(LabelRegexPattern)]
+        private static partial Regex LabelRegex();
+#else
+        private static Regex IPv4Regex() => _ipV4Regex;
+        private static Regex LabelRegex() => _labelRegex;
+        private static readonly Regex _ipV4Regex = new Regex(IPv4RegexPattern);
+        private static readonly Regex _labelRegex = new Regex(LabelRegexPattern);
+#endif
 
         internal static void AddQueryStringParameter(StringBuilder queryString, string parameterName, string parameterValue)
         {

--- a/sdk/src/Services/SecurityToken/Custom/SAML/ADFSAuthenticationHandlers.cs
+++ b/sdk/src/Services/SecurityToken/Custom/SAML/ADFSAuthenticationHandlers.cs
@@ -27,7 +27,7 @@ namespace Amazon.SecurityToken.SAML
     /// Implementation of IAuthenticationController, allowing authentication calls against
     /// an AD FS endpoint.
     /// </summary>
-    internal class AdfsAuthenticationController : IAuthenticationController
+    internal partial class AdfsAuthenticationController : IAuthenticationController
     {
         /// <summary>
         /// Authenticates the user with the specified AD FS endpoint and 
@@ -215,7 +215,7 @@ namespace Amazon.SecurityToken.SAML
     /// Implementation of IAuthenticationResponseParser, allowing parsing of the responses for 
     /// successful authentication calls against AD FS endpoints.
     /// </summary>
-    internal class AdfsAuthenticationResponseParser : IAuthenticationResponseParser
+    internal partial class AdfsAuthenticationResponseParser : IAuthenticationResponseParser
     {
         /// <summary>
         /// Parses the authentication response (html) and extracts the SAML response (xml)
@@ -231,8 +231,7 @@ namespace Amazon.SecurityToken.SAML
         {
             var samlAssertion = string.Empty;
 
-            var reg = new Regex("SAMLResponse\\W+value\\=\\\"([^\\\"]+)\\\"");
-            var matches = reg.Matches(authenticationResponse);
+            var matches = SamlResponseRegex().Matches(authenticationResponse);
             foreach (Match m in matches)
             {
                 var last = m.Groups[1].Value;
@@ -241,5 +240,15 @@ namespace Amazon.SecurityToken.SAML
 
             return new SAMLAssertion(samlAssertion);
         }
+
+        private const string SamlResponseRegexPattern = "SAMLResponse\\W+value\\=\\\"([^\\\"]+)\\\"";
+
+#if NET8_0_OR_GREATER
+        [GeneratedRegex(SamlResponseRegexPattern)]
+        private static partial Regex SamlResponseRegex();
+#else
+        private static Regex SamlResponseRegex() => _samlResponseRegex;
+        private static readonly Regex _samlResponseRegex = new Regex(SamlResponseRegexPattern);
+#endif
     }
 }

--- a/sdk/src/Services/SimpleNotificationService/Custom/Util/Message.cs
+++ b/sdk/src/Services/SimpleNotificationService/Custom/Util/Message.cs
@@ -23,7 +23,7 @@ namespace Amazon.SimpleNotificationService.Util
     /// <summary>
     /// This class reads in JSON formatted Amazon SNS messages into Message objects. The messages can also be verified using the IsMessageSignatureValid operation.
     /// </summary>
-    public class Message
+    public partial class Message
     {
         private const int MAX_RETRIES = 3;
         private const string SHA1_SIGNATURE_VERSION = "1";
@@ -237,6 +237,16 @@ namespace Amazon.SimpleNotificationService.Util
             private set;
         }
 
+        private const string CertUrlRegexPattern = @"^sns\.[a-zA-Z0-9\-]{3,}\.amazonaws\.com(\.cn)?$";
+
+#if NET8_0_OR_GREATER
+        [GeneratedRegex(CertUrlRegexPattern)]
+        private static partial Regex CertUrlRegex();
+#else
+        private static Regex CertUrlRegex() => _certUrlRegex;
+        private static readonly Regex _certUrlRegex = new Regex(CertUrlRegexPattern);
+#endif
+
         /// <summary>
         /// Verifies that the signing certificate url is from a recognizable source. 
         /// Returns the cert url if it cen be verified, otherwise throws an exception.
@@ -248,9 +258,7 @@ namespace Amazon.SimpleNotificationService.Util
             var uri = new Uri(certUrl);
             if (uri.Scheme == "https" && certUrl.EndsWith(".pem", StringComparison.Ordinal))
             {
-                const string pattern = @"^sns\.[a-zA-Z0-9\-]{3,}\.amazonaws\.com(\.cn)?$";
-                var regex = new Regex(pattern);
-                if (regex.IsMatch(uri.Host))
+                if (CertUrlRegex().IsMatch(uri.Host))
                     return certUrl;
             }
 


### PR DESCRIPTION
## Description

Use `[GeneratedRegex]` for constant patterns when targeting `net8.0`.

Resolves #3156.

## Motivation and Context

Improve performance of the SDK in .NET 8+ applications.

I haven't changed any of the generator code as no `Regex` instances appear to be created for generated code. I also haven't tried to adjust any use of `Regex` in the tests.

## Testing

Locally compiled the build. I haven't _yet_ run the unit tests, but I would expect them to find any issues.

## Screenshots (if appropriate)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement