### PR TITLE
Update ChecksumUtils not to fail when adding duplicate trailing header key

### DIFF
--- a/generator/.DevConfigs/192db733-ae1c-4466-b8c6-0927fd5bc16a.json
+++ b/generator/.DevConfigs/192db733-ae1c-4466-b8c6-0927fd5bc16a.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "updateMinimum": true,
+        "type": "Patch",
+        "changeLogMessages": [
+            "Update request checksum not to add duplicate trailing header key on retries"
+        ]
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
@@ -80,7 +80,7 @@ namespace Amazon.Runtime.Internal.Util
                 // The header key is required upfront for calculating the total length of
                 // the wrapper stream, which we need to send as the Content-Length header
                 // before the wrapper stream is transmitted.
-                request.TrailingHeaders.Add(checksumHeaderKey, string.Empty);
+                request.TrailingHeaders[checksumHeaderKey] = string.Empty;
                 request.SelectedChecksum = coreChecksumAlgoritm;
             }
             else // calculate and set the checksum in the request headers


### PR DESCRIPTION
Fixes #3154 

## Testing
Dry-run: `DRY_RUN-fddc13c7-f993-4eba-9934-2ea0c7d57ab2`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license