### PR TITLE
Add AoT support to NETCore.Setup

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.NetStandard.csproj
+++ b/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.NetStandard.csproj
@@ -18,7 +18,7 @@
     <Compile Remove="**/obj/**" />
   </ItemGroup>
 	
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <WarningsAsErrors>IL2026,IL2075</WarningsAsErrors>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>  	

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
@@ -12,24 +12,14 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-using Amazon;
+using System.Diagnostics.CodeAnalysis;
 using Amazon.Runtime;
-
-using Amazon.Extensions.NETCore.Setup;
 
 namespace Amazon.Extensions.NETCore.Setup
 {
     /// <summary>
     /// The options used to construct AWS service clients like the Amazon.S3.AmazonS3Client.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.Extensions.NETCore.Setup.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class AWSOptions
     {
         /// <summary>
@@ -103,10 +93,30 @@ namespace Amazon.Extensions.NETCore.Setup
         /// </summary>
         /// <typeparam name="T">The service interface that a service client will be created for.</typeparam>
         /// <returns>The service client that implements the service interface.</returns>
+#if NET8_0_OR_GREATER
+        [RequiresUnreferencedCode(InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
         public T CreateServiceClient<T>() where T : IAmazonService
         {
             return (T)ClientFactory.CreateServiceClient(null, typeof(T), this);
         }
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Create a service client for the specified service using the specified options.
+        /// For example if T is set to AmazonS3 then the AmazonS3ServiceClient which implements IAmazonS3 is created
+        /// and returned.
+        /// </summary>
+        /// <typeparam name="TClient">The service interface that a service client will be created for.</typeparam>
+        /// <typeparam name="TConfiguration">The type of the service configuration the client will be created with.</typeparam>
+        /// <returns>The service client of the specified type.</returns>
+        public TClient CreateServiceClient<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfiguration>()
+            where TClient : class, IAmazonService
+            where TConfiguration : ClientConfig, new()
+        {
+            return ClientFactory.CreateServiceClient<TClient, TConfiguration>(null, this);
+        }
+#endif
 
         /// <summary>
         /// Container for logging settings of the SDK

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.csproj
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.csproj
@@ -14,10 +14,14 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
 	
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <WarningsAsErrors>IL2026,IL2075</WarningsAsErrors>
     <IsTrimmable>true</IsTrimmable>
-  </PropertyGroup>  
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
 
   <Choose>
     <When Condition=" '$(AWSKeyFile)' == '' ">
@@ -36,6 +40,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+  </ItemGroup>
+	
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
@@ -21,6 +21,7 @@ using Amazon.Util;
 
 using Amazon.Extensions.NETCore.Setup;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.Configuration
 {
@@ -28,9 +29,6 @@ namespace Microsoft.Extensions.Configuration
     /// This class adds extension methods to IConfiguration making it easier to pull out
     /// AWS configuration options.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.Extensions.NETCore.Setup.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public static class ConfigurationExtensions
     {
         /// <summary>
@@ -65,7 +63,11 @@ namespace Microsoft.Extensions.Configuration
         /// <typeparam name="TConfig">The AWS client config to be used in creating clients, like AmazonS3Config.</typeparam>
         /// <param name="config"></param>
         /// <returns>The AWSOptions containing the values set in configuration system.</returns>
+#if NET8_0_OR_GREATER
+        public static AWSOptions GetAWSOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TConfig>(this IConfiguration config) where TConfig : ClientConfig, new()
+#else
         public static AWSOptions GetAWSOptions<TConfig>(this IConfiguration config) where TConfig : ClientConfig, new()
+#endif
         {
             return GetAWSOptions<TConfig>(config, DEFAULT_CONFIG_SECTION);
         }
@@ -77,7 +79,11 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="config"></param>
         /// <param name="configSection">The config section to extract AWS options from.</param>
         /// <returns>The AWSOptions containing the values set in configuration system.</returns>
+#if NET8_0_OR_GREATER
+        public static AWSOptions GetAWSOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TConfig>(this IConfiguration config, string configSection) where TConfig : ClientConfig, new()
+#else
         public static AWSOptions GetAWSOptions<TConfig>(this IConfiguration config, string configSection) where TConfig : ClientConfig, new()
+#endif
         {
             var options = new AWSOptions
             {

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/InternalConstants.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/InternalConstants.cs
@@ -17,6 +17,6 @@ namespace Amazon.Extensions.NETCore.Setup
 {
     internal static class InternalConstants
     {
-        internal const string RequiresUnreferencedCodeMessage = "The AWSSDK.Extensions.NETCore.Setup package has not been updated to support Native AOT compilations.";
+        internal const string RequiresUnreferencedCodeMessage = "This method requires code to be dynamically loaded and is not supported in applications using Native AOT compilation.";
     }
 }

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
@@ -14,13 +14,9 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-using Microsoft.Extensions.DependencyInjection;
-
-using Amazon.Runtime;
+using System.Diagnostics.CodeAnalysis;
 using Amazon.Extensions.NETCore.Setup;
+using Amazon.Runtime;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -29,9 +25,6 @@ namespace Microsoft.Extensions.DependencyInjection
     /// This class adds extension methods to IServiceCollection making it easier to add Amazon service clients
     /// to the NET Core dependency injection framework.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.Extensions.NETCore.Setup.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public static class ServiceCollectionExtensions
     {
         /// <summary>
@@ -75,6 +68,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection"></param>
         /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+#if NET8_0_OR_GREATER
+        [RequiresUnreferencedCode(InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
         public static IServiceCollection AddAWSService<T>(this IServiceCollection collection, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
             return AddAWSService<T>(collection, null, lifetime);
@@ -90,6 +86,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
         /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+#if NET8_0_OR_GREATER
+        [RequiresUnreferencedCode(InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
         public static IServiceCollection AddAWSService<T>(this IServiceCollection collection, AWSOptions options, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
             Func<IServiceProvider, object> factory =
@@ -109,6 +108,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection"></param>
         /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+#if NET8_0_OR_GREATER
+        [RequiresUnreferencedCode(InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
         public static IServiceCollection TryAddAWSService<T>(this IServiceCollection collection, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
             return TryAddAWSService<T>(collection, null, lifetime);
@@ -124,6 +126,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
         /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+#if NET8_0_OR_GREATER
+        [RequiresUnreferencedCode(InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
         public static IServiceCollection TryAddAWSService<T>(this IServiceCollection collection, AWSOptions options, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
             Func<IServiceProvider, object> factory =
@@ -133,5 +138,166 @@ namespace Microsoft.Extensions.DependencyInjection
             collection.TryAdd(descriptor);
             return collection;
         }
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework. The Amazon service client is not
+        /// created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection AddAWSService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfiguration>(
+            this IServiceCollection collection,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TClient : class, IAmazonService
+            where TConfiguration : ClientConfig, new()
+        {
+            return AddAWSService<TClient, TConfiguration>(collection, null, lifetime);
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework. The Amazon service client is not
+        /// created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection AddAWSService<TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfiguration>(
+            this IServiceCollection collection,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TClient : IAmazonService
+            where TImplementation : class, IAmazonService
+            where TConfiguration : ClientConfig, new()
+        {
+            return AddAWSService<TClient, TImplementation, TConfiguration>(collection, null, lifetime);
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework. The Amazon service client is not
+        /// created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection AddAWSService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfiguration>(
+            this IServiceCollection collection,
+            AWSOptions options,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TClient : class, IAmazonService
+            where TConfiguration : ClientConfig, new()
+        {
+            Func<IServiceProvider, object> factory = (provider) =>
+                ClientFactory.CreateServiceClient<TClient, TConfiguration>(provider, options);
+
+            var descriptor = new ServiceDescriptor(typeof(TClient), factory, lifetime);
+            collection.Add(descriptor);
+            return collection;
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework. The Amazon service client is not
+        /// created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection AddAWSService<TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfiguration>(
+            this IServiceCollection collection,
+            AWSOptions options,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TClient : IAmazonService
+            where TImplementation : class, IAmazonService
+            where TConfiguration : ClientConfig, new()
+        {
+            Func<IServiceProvider, object> factory = (provider) =>
+                ClientFactory.CreateServiceClient<TImplementation, TConfiguration>(provider, options);
+
+            var descriptor = new ServiceDescriptor(typeof(TClient), factory, lifetime);
+            collection.Add(descriptor);
+            return collection;
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework if the service type hasn't already been registered.
+        /// The Amazon service client is not created until it is requested. If the ServiceLifetime property is set to Singleton,
+        /// the default, then the same instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection TryAddAWSService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfiguration>(
+            this IServiceCollection collection,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TClient : class, IAmazonService
+            where TConfiguration : ClientConfig, new()
+        {
+            return TryAddAWSService<TClient, TConfiguration>(collection, null, lifetime);
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework if the service type hasn't already been registered.
+        /// The Amazon service client is not created until it is requested. If the ServiceLifetime property is set to Singleton,
+        /// the default, then the same instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection TryAddAWSService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfiguration>(
+            this IServiceCollection collection,
+            AWSOptions options,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TClient : class, IAmazonService
+            where TConfiguration : ClientConfig, new()
+        {
+            Func<IServiceProvider, object> factory = (provider) =>
+                ClientFactory.CreateServiceClient<TClient, TConfiguration>(provider, options);
+
+            var descriptor = new ServiceDescriptor(typeof(TClient), factory, lifetime);
+            collection.TryAdd(descriptor);
+            return collection;
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework if the service type hasn't already been registered.
+        /// The Amazon service client is not created until it is requested. If the ServiceLifetime property is set to Singleton,
+        /// the default, then the same instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="TClient">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <typeparam name="TImplementation">The AWS service implementation, like AmazonS3Client.</typeparam>
+        /// <typeparam name="TConfiguration"></typeparam>
+        /// <param name="collection"></param>
+        /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection TryAddAWSService<TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfiguration>(
+            this IServiceCollection collection,
+            AWSOptions options,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TClient : IAmazonService
+            where TImplementation : class, IAmazonService
+            where TConfiguration : ClientConfig, new()
+        {
+            Func<IServiceProvider, object> factory = (provider) =>
+                ClientFactory.CreateServiceClient<TImplementation, TConfiguration>(provider, options);
+
+            var descriptor = new ServiceDescriptor(typeof(TClient), factory, lifetime);
+            collection.TryAdd(descriptor);
+            return collection;
+        }
+#endif
     }
 }

--- a/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
+++ b/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
@@ -1,15 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-using Microsoft.Extensions.Configuration;
-
-using Xunit;
-
 using Amazon;
-using Amazon.S3;
 using Amazon.Runtime;
+using Amazon.S3;
+using Microsoft.Extensions.Configuration;
+using Xunit;
 
 namespace NETCore.SetupTests
 {
@@ -247,5 +241,236 @@ namespace NETCore.SetupTests
             Assert.NotNull(clientConfig);
             Assert.True(clientConfig.ForcePathStyle);
         }
+
+#if NET8_0_OR_GREATER
+        [Fact]
+        public void GetProfileAndRegionForNativeAot()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetProfileAndRegionTest.json");
+
+            IConfiguration config = builder.Build();
+            var options = config.GetAWSOptions();
+
+            Assert.Equal(RegionEndpoint.USWest2, options.Region);
+            Assert.Equal("myProfile", options.Profile);
+            Assert.Equal("myProfileLocation", options.ProfilesLocation);
+
+            IAmazonS3 client = options.CreateServiceClient<AmazonS3Client, AmazonS3Config>();
+            Assert.NotNull(client);
+            Assert.Equal(RegionEndpoint.USWest2, client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void GetRoleNameAndSessionNameForNativeAot()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetRoleNameAndSessionNameTest.json");
+
+            IConfiguration config = builder.Build();
+            var options = config.GetAWSOptions();
+
+            Assert.Equal(RegionEndpoint.USWest2, options.Region);
+            Assert.Equal("arn:aws:iam::123456789012:role/fake_role", options.SessionRoleArn);
+            Assert.Equal("TestSessionName", options.SessionName);
+
+            IAmazonS3 client = options.CreateServiceClient<AmazonS3Client, AmazonS3Config>();
+            Assert.NotNull(client);
+            Assert.Equal(RegionEndpoint.USWest2, client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void LegacyNamesTestForNativeAot()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/LegacyNamesTest.json");
+
+            IConfiguration config = builder.Build();
+            var options = config.GetAWSOptions();
+
+            Assert.Equal(RegionEndpoint.USWest2, options.Region);
+            Assert.Equal("myProfile", options.Profile);
+            Assert.Equal("myProfileLocation", options.ProfilesLocation);
+
+            IAmazonS3 client = options.CreateServiceClient<AmazonS3Client, AmazonS3Config>();
+            Assert.NotNull(client);
+            Assert.Equal(RegionEndpoint.USWest2, client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void NonDefaultSectionTestForNativeAot()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/NonDefaultSectionTest.json");
+
+            IConfiguration config = builder.Build();
+            var options = config.GetAWSOptions("AWSNonStandard");
+
+            Assert.Equal(RegionEndpoint.EUCentral1, options.Region);
+
+            IAmazonS3 client = options.CreateServiceClient<AmazonS3Client, AmazonS3Config>();
+            Assert.NotNull(client);
+            Assert.Equal(RegionEndpoint.EUCentral1, client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void GetClientConfigSettingsTestForNativeAot()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+            var options = config.GetAWSOptions();
+
+            Assert.Equal(RegionEndpoint.USWest2, options.Region);
+            Assert.True(options.DefaultClientConfig.UseHttp);
+            Assert.Equal(6, options.DefaultClientConfig.MaxErrorRetry);
+            Assert.Equal(TimeSpan.FromMilliseconds(1000), options.DefaultClientConfig.Timeout);
+            Assert.Equal("us-east-1", options.DefaultClientConfig.AuthenticationRegion);
+            Assert.Equal(DefaultConfigurationMode.Standard, options.DefaultConfigurationMode);
+            Assert.Equal(RequestRetryMode.Standard, options.DefaultClientConfig.RetryMode);
+
+            IAmazonS3 client = options.CreateServiceClient<AmazonS3Client, AmazonS3Config>();
+            Assert.NotNull(client);
+            Assert.Equal(RegionEndpoint.USWest2, client.Config.RegionEndpoint);
+            Assert.True(client.Config.UseHttp);
+            Assert.Equal(6, client.Config.MaxErrorRetry);
+            Assert.Equal(TimeSpan.FromMilliseconds(1000), client.Config.Timeout);
+            Assert.Equal("us-east-1", client.Config.AuthenticationRegion);
+            Assert.Equal(DefaultConfigurationMode.Standard, client.Config.DefaultConfigurationMode);
+            Assert.Equal(RequestRetryMode.Standard, client.Config.RetryMode);
+
+            // Verify that setting the standard mode doesn't override explicit settings of retry mode to a non-legacy mode.
+            options.DefaultClientConfig.RetryMode = RequestRetryMode.Adaptive;
+            client = options.CreateServiceClient<AmazonS3Client, AmazonS3Config>();
+            Assert.Equal(DefaultConfigurationMode.Standard, client.Config.DefaultConfigurationMode);
+            Assert.Equal(RequestRetryMode.Adaptive, client.Config.RetryMode);
+
+            // verify S3 config specific settings are not configured
+            var clientConfig = client.Config as AmazonS3Config;
+            Assert.NotNull(clientConfig);
+            Assert.False(clientConfig.ForcePathStyle);
+        }
+
+        [Fact]
+        public void GetClientConfigSettingsCaseInsensitiveTestForNativeAot()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsCaseInsensitiveTest.json");
+
+            IConfiguration config = builder.Build();
+            var options = config.GetAWSOptions();
+
+            Assert.True(options.DefaultClientConfig.UseHttp);
+            Assert.Equal(6, options.DefaultClientConfig.MaxErrorRetry);
+            Assert.Equal(TimeSpan.FromMilliseconds(1000), options.DefaultClientConfig.Timeout);
+            Assert.Equal("us-east-1", options.DefaultClientConfig.AuthenticationRegion);
+            Assert.Equal(DefaultConfigurationMode.Standard, options.DefaultConfigurationMode);
+            Assert.Equal("https://localhost:9021/", options.DefaultClientConfig.ServiceURL);
+
+            IAmazonS3 client = options.CreateServiceClient<IAmazonS3>();
+            Assert.NotNull(client);
+            Assert.True(client.Config.UseHttp);
+            Assert.Equal(6, client.Config.MaxErrorRetry);
+            Assert.Equal(TimeSpan.FromMilliseconds(1000), client.Config.Timeout);
+            Assert.Equal("us-east-1", client.Config.AuthenticationRegion);
+            Assert.Equal(DefaultConfigurationMode.Standard, client.Config.DefaultConfigurationMode);
+            Assert.Equal(RequestRetryMode.Standard, client.Config.RetryMode);
+            Assert.Equal("https://localhost:9021/", client.Config.ServiceURL);
+
+            // Verify that setting the standard mode doesn't override explicit settings of retry mode to a non-legacy mode.
+            options.DefaultClientConfig.RetryMode = RequestRetryMode.Adaptive;
+            client = options.CreateServiceClient<IAmazonS3>();
+            Assert.Equal(DefaultConfigurationMode.Standard, client.Config.DefaultConfigurationMode);
+            Assert.Equal(RequestRetryMode.Adaptive, client.Config.RetryMode);
+        }
+
+        [Fact]
+        public void EnableLoggingTestForNativeAot()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/EnableLoggingTest.json");
+
+            IConfiguration config = builder.Build();
+            var options = config.GetAWSOptions();
+
+            Assert.Equal(RegionEndpoint.USWest2, options.Region);
+            Assert.Equal(LoggingOptions.Console, options.Logging.LogTo);
+            Assert.Equal(ResponseLoggingOption.OnError, options.Logging.LogResponses);
+            Assert.Equal(2000, options.Logging.LogResponsesSizeLimit);
+            Assert.True(options.Logging.LogMetrics);
+
+            // Create first service client to force logging settings to be applied
+            IAmazonS3 client = options.CreateServiceClient<IAmazonS3>();
+            Assert.NotNull(client);
+            Assert.Equal(RegionEndpoint.USWest2, client.Config.RegionEndpoint);
+
+            Assert.Equal(LoggingOptions.Console, AWSConfigs.LoggingConfig.LogTo);
+            Assert.Equal(ResponseLoggingOption.OnError, AWSConfigs.LoggingConfig.LogResponses);
+            Assert.Equal(2000, AWSConfigs.LoggingConfig.LogResponsesSizeLimit);
+            Assert.True(AWSConfigs.LoggingConfig.LogMetrics);
+        }
+
+        [Fact]
+        public void TestRegionFoundFromEnvironmentVariableForNativeAot()
+        {
+            var existingValue = Environment.GetEnvironmentVariable("AWS_REGION");
+            try
+            {
+                FallbackRegionFactory.Reset();
+                Environment.SetEnvironmentVariable("AWS_REGION", RegionEndpoint.APSouth1.SystemName);
+
+                var builder = new ConfigurationBuilder();
+                IConfiguration config = builder.Build();
+                var options = config.GetAWSOptions();
+
+                IAmazonS3 client = options.CreateServiceClient<IAmazonS3>();
+                Assert.Equal(RegionEndpoint.APSouth1, client.Config.RegionEndpoint);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", existingValue);
+                FallbackRegionFactory.Reset();
+            }
+        }
+
+        [Fact]
+        public void ClientConfigTypeOverloadTestForNativeAot()
+        {
+            var config = new ConfigurationBuilder()
+                .AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json")
+                .Build();
+
+            var options = config.GetAWSOptions<AmazonS3Config>();
+
+            Assert.Equal(RegionEndpoint.USWest2, options.Region);
+            Assert.True(options.DefaultClientConfig.UseHttp);
+            Assert.Equal(6, options.DefaultClientConfig.MaxErrorRetry);
+            Assert.Equal(TimeSpan.FromMilliseconds(1000), options.DefaultClientConfig.Timeout);
+            Assert.Equal("us-east-1", options.DefaultClientConfig.AuthenticationRegion);
+            Assert.Equal(DefaultConfigurationMode.Standard, options.DefaultConfigurationMode);
+
+            var client = options.CreateServiceClient<IAmazonS3>();
+            Assert.NotNull(client);
+            Assert.Equal(RegionEndpoint.USWest2, client.Config.RegionEndpoint);
+            Assert.True(client.Config.UseHttp);
+            Assert.Equal(6, client.Config.MaxErrorRetry);
+            Assert.Equal(TimeSpan.FromMilliseconds(1000), client.Config.Timeout);
+            Assert.Equal("us-east-1", client.Config.AuthenticationRegion);
+            Assert.Equal(DefaultConfigurationMode.Standard, client.Config.DefaultConfigurationMode);
+            Assert.Equal(RequestRetryMode.Standard, client.Config.RetryMode);
+
+            // Verify that setting the standard mode doesn't override explicit settings of retry mode to a non-legacy mode.
+            options.DefaultClientConfig.RetryMode = RequestRetryMode.Adaptive;
+            client = options.CreateServiceClient<IAmazonS3>();
+            Assert.Equal(DefaultConfigurationMode.Standard, client.Config.DefaultConfigurationMode);
+            Assert.Equal(RequestRetryMode.Adaptive, client.Config.RetryMode);
+
+            // verify S3 config specific settings are configured
+            var clientConfig = client.Config as AmazonS3Config;
+            Assert.NotNull(clientConfig);
+            Assert.True(clientConfig.ForcePathStyle);
+        }
+#endif
     }
 }

--- a/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
+++ b/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
@@ -1,13 +1,10 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-
-using Xunit;
-
-using Amazon;
-using Amazon.S3;
+﻿using Amazon;
 using Amazon.Extensions.NETCore.Setup;
+using Amazon.S3;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using System;
+using Xunit;
 
 namespace DependencyInjectionTests
 {
@@ -149,10 +146,146 @@ namespace DependencyInjectionTests
             Assert.Equal(expectRegion, controller.S3Client.Config.RegionEndpoint);
         }
 
+#if NET8_0_OR_GREATER
+        [Fact]
+        public void InjectS3ClientWithDefaultConfigForNativeAotWithClientType()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddAWSService<AmazonS3Client, AmazonS3Config>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestControllerWithConcreteType>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.USWest2, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void InjectS3ClientWithDefaultConfigForNativeAotWithInterfaceAndClientTypes()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddAWSService<IAmazonS3, AmazonS3Client, AmazonS3Config>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.USWest2, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void InjectS3ClientWithoutDefaultConfigForNativeAot()
+        {
+            ServiceCollection services = new ServiceCollection();
+            services.AddAWSService<IAmazonS3, AmazonS3Client, AmazonS3Config>(new AWSOptions { Region = RegionEndpoint.USEast1 });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.USEast1, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void InjectS3ClientWithOverridingConfigForNativeAot()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddAWSService<IAmazonS3, AmazonS3Client, AmazonS3Config>(new AWSOptions { Region = RegionEndpoint.EUCentral1 });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.EUCentral1, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void TryAddServiceDontOverrideWhenAlreadySetupForNativeAot()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+
+            var mockS3 = Mock.Of<IAmazonS3>();
+            services.AddSingleton(mockS3);
+
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.TryAddAWSService<IAmazonS3, AmazonS3Client, AmazonS3Config>(new AWSOptions { Region = RegionEndpoint.EUCentral1 });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            var s3 = controller.S3Client;
+            Assert.NotNull(s3);
+            Assert.True(s3.GetType() == mockS3.GetType());
+        }
+
+        [Fact]
+        public void InjectS3ClientWithFactoryBuiltConfigForNativeAot()
+        {
+            var expectRegion = RegionEndpoint.APSouth1;
+            var expectProfile = "MockProfile";
+
+            var services = new ServiceCollection();
+            services.AddSingleton(new AWSSetting
+            {
+                Region = expectRegion,
+                Profile = expectProfile
+            });
+
+            services.AddDefaultAWSOptions(sp => {
+                var setting = sp.GetRequiredService<AWSSetting>();
+                return new AWSOptions
+                {
+                    Region = setting.Region,
+                    Profile = setting.Profile
+                };
+            });
+
+            services.AddAWSService<IAmazonS3, AmazonS3Client, AmazonS3Config>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(expectRegion, controller.S3Client.Config.RegionEndpoint);
+        }
+#endif
+
         public class TestController
         {
             public IAmazonS3 S3Client { get; private set; }
             public TestController(IAmazonS3 s3Client)
+            {
+                S3Client = s3Client;
+            }
+        }
+
+        public class TestControllerWithConcreteType
+        {
+            public AmazonS3Client S3Client { get; private set; }
+            public TestControllerWithConcreteType(AmazonS3Client s3Client)
             {
                 S3Client = s3Client;
             }

--- a/extensions/test/NETCore.SetupTests/NETCore.SetupTests.csproj
+++ b/extensions/test/NETCore.SetupTests/NETCore.SetupTests.csproj
@@ -30,5 +30,11 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
+	
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageReference Update="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

Update AWSSDK.Extensions.NETCore.Setup to support native AoT.

## Motivation and Context

Fix AoT warnings in the AWSSDK.Extensions.NETCore.Setup assembly by adding new overloads that accept a type parameter.

I was testing an internal application using `Amazon.AspNetCore.DataProtection.SSM` with native AoT to see what compatibility warnings there were, and the transient dependency on `AWSSDK.Extensions.NETCore.Setup` flagged warnings due to the lack of AoT support.

These changes fix the AoT warnings in the assembly, but the approach may not be what the maintainers would prefer, so this is just a draft for now to solicit feedback on the approach.

If the changes are eventually merged and released, I can do a follow-up PR to `Amazon.AspNetCore.DataProtection.SSM` to consume the updated package version and make any code changes needed.

Based on the initial commit in this PR, that would changing [this line of code](https://github.com/aws/aws-ssm-data-protection-provider-for-aspnet/blob/fbda43c7415b2227e866cafc39471dfa65c0dd55/src/Amazon.AspNetCore.DataProtection.SSM/ExtensionMethods.cs#L65C13-L65C81):

```diff
- builder.Services.TryAddAWSService<IAmazonSimpleSystemsManagement>();
+ builder.Services.TryAddAWSService<IAmazonSimpleSystemsManagement, AmazonSimpleSystemsManagementClient, AmazonSimpleSystemsManagementConfig>();
```

## Testing

New unit tests added. Further tests can be added once/if the changes are otherwise acceptable.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
