### PR TITLE
Remove duplicate RSA call from AmazonCloudFrontUrlSigner

### DIFF
--- a/generator/.DevConfigs/36b119c0-a4f6-4944-81d0-856a037b43e4.json
+++ b/generator/.DevConfigs/36b119c0-a4f6-4944-81d0-856a037b43e4.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "CloudFront",
+      "type": "patch",
+      "changeLogMessages": [
+        "Remove duplicate `RSA.ImportParameters` call from AmazonCloudFrontUrlSigner (which caused a performance regression issue in OpenSSL 3.0)"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/CloudFront/Custom/AmazonCloudFrontUrlSigner.cs
+++ b/sdk/src/Services/CloudFront/Custom/AmazonCloudFrontUrlSigner.cs
@@ -525,9 +525,6 @@ namespace Amazon.CloudFront
             {
                 throw new AmazonClientException("Invalid RSA Private Key", e);
             }
-
-            var rsa = RSA.Create();
-            rsa.ImportParameters(rsaParams);
             return rsaParams;
         }
 

--- a/sdk/test/Services/CloudFront/UnitTests/Custom/CookieSignerTest.cs
+++ b/sdk/test/Services/CloudFront/UnitTests/Custom/CookieSignerTest.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using Amazon.CloudFront;
+
+namespace AWSSDK_DotNet35.UnitTests
+{
+    [TestClass]
+    public class CookieSignerTest
+    {
+        private static StreamReader privateRSAKeyStreamReader = null;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            privateRSAKeyStreamReader = new StreamReader(Utils.GetResourceStream("sample.rsa.private.key.txt"));
+        }
+
+        [TestMethod]
+        [TestCategory("CloudFront")]
+        public void CannedPolicyValidation()
+        {
+            string expectedSignature = 
+                "IGIL8ItK6uqLzFAR1338Mf5RqqU9VIhG9G0nUmgl4VPdozBDS5fyRMZH39cFqWfK7gXSCOGBGt9X0yYRwqO-yikx5f9eQUQ3pyNukf-iQ~cp4upSVG6ETsR8NQQ1eeiP3DruH4hzwXqmh-ozD~bSzqbvbFW24LclBFG8f6QH~QY_";
+            string expectedKeyPair = "CannedKeyPairId";
+
+            var cookies = AmazonCloudFrontCookieSigner.GetCookiesForCannedPolicy(
+                "http://awesome.dot.com/amazing/uri/",
+                expectedKeyPair,
+                privateRSAKeyStreamReader,
+                new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc)
+            );
+            Assert.IsNotNull(cookies);
+
+            Assert.AreEqual("CloudFront-Expires", cookies.Expires.Key);
+            Assert.AreEqual("1704110400", cookies.Expires.Value);
+
+            Assert.AreEqual("CloudFront-Signature", cookies.Signature.Key);
+            Assert.AreEqual(expectedSignature, cookies.Signature.Value);
+
+            Assert.AreEqual("CloudFront-Key-Pair-Id", cookies.KeyPairId.Key);
+            Assert.AreEqual(expectedKeyPair, cookies.KeyPairId.Value);
+        }
+
+        [TestMethod]
+        [TestCategory("CloudFront")]
+        public void CustomPolicyValidation()
+        {
+            // This is the base64 representation of the IAM policy:
+            // {"Statement": [{"Resource":"https://awesome.dot.com/amazing/uri","Condition":{"DateLessThan":{"AWS:EpochTime":1704110400},"IpAddress":{"AWS:SourceIp":"192.0.2.0/24"}}}]}
+            string expectedPolicy =
+                "eyJTdGF0ZW1lbnQiOiBbeyJSZXNvdXJjZSI6Imh0dHBzOi8vYXdlc29tZS5kb3QuY29tL2FtYXppbmcvdXJpIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNzA0MTEwNDAwfSwiSXBBZGRyZXNzIjp7IkFXUzpTb3VyY2VJcCI6IjE5Mi4wLjIuMC8yNCJ9fX1dfQ__";
+            string expectedSignature =
+                "V1yosye5qeoTsErf40Z1cDxYHthvcaaLcw2P53GwklJrYI6ojYyeq2a5HyUDzd2H62sQzzt9SxXmZLzpsgVWa3dc1KWX2TSR8qLQ7oikHkyRem6JAyLp19zou29tTdVySF2~b7LPP3NxgtJZqIlOtTOMVshawUhp~PGv9alE7R8_";
+            string expectedKeyPair = "CustomKeyPairId";
+
+            var cookies = AmazonCloudFrontCookieSigner.GetCookiesForCustomPolicy(
+                AmazonCloudFrontCookieSigner.Protocols.Https,
+                "awesome.dot.com", 
+                privateRSAKeyStreamReader,
+                "amazing/uri",
+                expectedKeyPair, 
+                new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+                "192.0.2.0/24"
+            );
+            Assert.IsNotNull(cookies);
+
+            Assert.AreEqual("CloudFront-Policy", cookies.Policy.Key);
+            Assert.AreEqual(expectedPolicy, cookies.Policy.Value);
+
+            Assert.AreEqual("CloudFront-Signature", cookies.Signature.Key);
+            Assert.AreEqual(expectedSignature, cookies.Signature.Value);
+
+            Assert.AreEqual("CloudFront-Key-Pair-Id", cookies.KeyPairId.Key);
+            Assert.AreEqual(expectedKeyPair, cookies.KeyPairId.Value);
+        }
+    }
+}

--- a/sdk/test/Services/CloudFront/UnitTests/Custom/URLSignerTest.cs
+++ b/sdk/test/Services/CloudFront/UnitTests/Custom/URLSignerTest.cs
@@ -95,12 +95,12 @@ namespace AWSSDK_DotNet35.UnitTests
             var resourcePath = "http://*";
             var dateTime = new DateTime(2013, 1, 1, 10, 00, 0, DateTimeKind.Utc);
             var ipRange = "192.0.2.0/24";
-            var cookies = AmazonCloudFrontUrlSigner.BuildPolicyForSignedUrl(
+            var policyDocument = AmazonCloudFrontUrlSigner.BuildPolicyForSignedUrl(
                                     resourcePath,
                                     dateTime,
                                     ipRange);
 
-            var jsonObject = JsonMapper.ToObject(cookies);
+            var jsonObject = JsonMapper.ToObject(policyDocument);
 
             var statementList = jsonObject["Statement"];
             Assert.IsTrue(statementList.IsArray);


### PR DESCRIPTION
## Description
Our `AmazonCloudFrontUrlSigner` helper class invokes the `RSACryptoServiceProvider.ImportParameters` method twice, but it ignores the results of the first call. Customers using OpenSSL 3 have reported a performance regression as that operation is slower than previous versions of OpenSSL (see #3165 and #3172).

## Testing
- Dry-run: `DRY_RUN-4b9e956b-2815-4fc2-9d55-656d5938c53d`
- With the dry-run artifacts, I ran benchmark tests on an Ubuntu 2022 EC2 instance (benchmarks are based on the example from #3172):

```
$ uname -a
Linux ip-172-31-37-170 6.2.0-1018-aws #18~22.04.1-Ubuntu SMP Wed Jan 10 22:54:16 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux

$ openssl version
OpenSSL 3.0.2 15 Mar 2022 (Library: OpenSSL 3.0.2 15 Mar 2022)

$ curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type
m7i.large
```

Before:
```
BenchmarkDotNet v0.13.12, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
Intel Xeon Platinum 8488C, 1 CPU, 2 logical cores and 1 physical core
.NET SDK 8.0.101
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
```
| Method                      | Mean     | Error    | StdDev   | Allocated |
|---------------------------- |---------:|---------:|---------:|----------:|
| CloudFrontGenerateSignedUrl | 63.64 ms | 0.102 ms | 0.086 ms |  37.29 KB |
| WildCardCloudFrontSignedUrl | 63.62 ms | 0.093 ms | 0.077 ms |  38.84 KB |

After:
```
BenchmarkDotNet v0.13.12, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
Intel Xeon Platinum 8488C, 1 CPU, 2 logical cores and 1 physical core
.NET SDK 8.0.101
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
```
| Method                      | Mean     | Error    | StdDev   | Allocated |
|---------------------------- |---------:|---------:|---------:|----------:|
| CloudFrontGenerateSignedUrl | 32.10 ms | 0.092 ms | 0.077 ms |  30.53 KB |
| WildCardCloudFrontSignedUrl | 32.11 ms | 0.081 ms | 0.072 ms |  32.02 KB |


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license