### PR TITLE
Remove Net35 from manifest file

### DIFF
--- a/generator/ServiceClientGeneratorLib/GeneratorDriver.cs
+++ b/generator/ServiceClientGeneratorLib/GeneratorDriver.cs
@@ -82,7 +82,6 @@ namespace ServiceClientGenerator
         private readonly HashSet<string> _processedUnmarshallers = new HashSet<string>();
         private readonly HashSet<string> _processedMarshallers = new HashSet<string>();
 
-        private const string Bcl35SubFolder = "_bcl35";
         private const string Bcl45SubFolder = "_bcl45";
         private const string NetStandardSubFolder = "_netstandard";
         private string PaginatorsSubFolder = string.Format("Model{0}_bcl45+netstandard", Path.AltDirectorySeparatorChar);
@@ -153,10 +152,6 @@ namespace ServiceClientGenerator
                 Directory.Delete(GeneratedFilesRoot, true);
                 Directory.CreateDirectory(GeneratedFilesRoot);
             }
-
-            // .NET Framework 3.5 version
-            ExecuteGenerator(new ServiceClients(), "Amazon" + Configuration.ClassName + "Client.cs", Bcl35SubFolder);
-            ExecuteGenerator(new ServiceInterface(), "IAmazon" + Configuration.ClassName + ".cs", Bcl35SubFolder);
 
             // .NET Framework 4.5 version
             ExecuteGenerator(new ServiceClients45(), "Amazon" + Configuration.ClassName + "Client.cs", Bcl45SubFolder);

--- a/generator/ServiceClientGeneratorLib/Generators/ProjectFiles/VS2017ProjectFile.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/ProjectFiles/VS2017ProjectFile.cs
@@ -16,7 +16,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+    #line 1 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class VS2017ProjectFile : VS2017ProjectFileBase
     {
@@ -29,7 +29,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("<Project Sdk=\"Microsoft.NET.Sdk\">\r\n  <PropertyGroup>\r\n   <RunAnalyzersDuringBuild" +
                     " Condition=\"\'$(RunAnalyzersDuringBuild)\'==\'\'\">true</RunAnalyzersDuringBuild>\r\n");
             
-            #line 7 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 7 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if (this.Project.TargetFrameworks.Count() == 1)
     {
@@ -39,14 +39,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <TargetFramework>");
             
-            #line 11 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 11 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.TargetFrameworks.Single()));
             
             #line default
             #line hidden
             this.Write("</TargetFramework>\r\n");
             
-            #line 12 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 12 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     else
@@ -57,14 +57,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <TargetFrameworks>");
             
-            #line 17 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 17 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(string.Join(";", this.Project.TargetFrameworks)));
             
             #line default
             #line hidden
             this.Write("</TargetFrameworks>\r\n");
             
-            #line 19 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 19 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -73,14 +73,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <DefineConstants>$(DefineConstants);");
             
-            #line 22 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 22 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(string.Join(";", this.Project.DefineConstants)));
             
             #line default
             #line hidden
             this.Write("</DefineConstants>\r\n");
             
-            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 24 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if (this.Project.TargetFrameworks.Contains("netstandard2.0"))
     {
@@ -91,7 +91,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("    <DefineConstants Condition=\"\'$(TargetFramework)\' == \'netstandard2.0\'\">$(Defin" +
                     "eConstants);NETSTANDARD20;AWS_ASYNC_ENUMERABLES_API</DefineConstants>\r\n");
             
-            #line 29 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 29 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if (this.Project.TargetFrameworks.Contains("netcoreapp3.1"))
@@ -103,7 +103,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("    <DefineConstants Condition=\"\'$(TargetFramework)\' == \'netcoreapp3.1\'\">$(Define" +
                     "Constants);AWS_ASYNC_ENUMERABLES_API</DefineConstants>\r\n");
             
-            #line 35 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 35 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if (this.Project.TargetFrameworks.Contains("net8.0"))
@@ -115,7 +115,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("    <DefineConstants Condition=\"\'$(TargetFramework)\' == \'net8.0\'\">$(DefineConstan" +
                     "ts);AWS_ASYNC_ENUMERABLES_API</DefineConstants>\r\n");
             
-            #line 41 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 41 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -125,14 +125,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("    <DebugType>portable</DebugType>\r\n    <GenerateDocumentationFile>true</Generat" +
                     "eDocumentationFile>\r\n    <AssemblyName>");
             
-            #line 46 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 46 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.AssemblyName));
             
             #line default
             #line hidden
             this.Write("</AssemblyName>\r\n    <PackageId>");
             
-            #line 47 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 47 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.AssemblyName));
             
             #line default
@@ -151,7 +151,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
 
 ");
             
-            #line 59 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 59 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if (!string.IsNullOrEmpty(this.Project.FrameworkPathOverride))
     {
@@ -162,28 +162,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("    <!-- workaround per https://github.com/Microsoft/msbuild/issues/1333 -->\r\n   " +
                     " <FrameworkPathOverride>");
             
-            #line 64 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 64 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.FrameworkPathOverride));
             
             #line default
             #line hidden
             this.Write("</FrameworkPathOverride>\r\n");
             
-            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
-
-    }
-
-    if (this.Project.TargetFrameworks.Contains("net35"))
-    {
-
-            
-            #line default
-            #line hidden
-            this.Write("    <!-- workaround per https://github.com/dotnet/msbuild/issues/5985 -->\r\n    <A" +
-                    "utomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssembl" +
-                    "yPackages>\r\n");
-            
-            #line 73 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 65 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -195,14 +181,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <NoWarn>");
             
-            #line 79 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 71 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.SupressWarnings));
             
             #line default
             #line hidden
             this.Write("</NoWarn>\r\n");
             
-            #line 80 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 72 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -215,14 +201,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>\r" +
                     "\n    <OutputPath>");
             
-            #line 87 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 79 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.OutputPathOverride));
             
             #line default
             #line hidden
             this.Write("</OutputPath>\r\n");
             
-            #line 88 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 80 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -231,7 +217,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </PropertyGroup>\r\n");
             
-            #line 92 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 84 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if (this.Project.TargetFrameworks.Contains("netstandard2.0"))
     {
@@ -243,7 +229,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
                     "ramework)\' == \'netstandard2.0\'\">\r\n    <LangVersion>8.0</LangVersion>\r\n  </Proper" +
                     "tyGroup>\r\n");
             
-            #line 100 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 92 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -257,7 +243,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
                     "rors>IL2026,IL2075</WarningsAsErrors>\r\n    <IsTrimmable>true</IsTrimmable>\r\n  </" +
                     "PropertyGroup>\r\n");
             
-            #line 110 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 102 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -265,7 +251,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line default
             #line hidden
             
-            #line 113 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 105 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
 	if (!this.Project.AssemblyName.Contains("UnitTests"))
 	{
@@ -276,7 +262,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("  <PropertyGroup Condition=\" \'$(RuleSetFileForBuild)\' == \'false\' Or \'$(RuleSetFil" +
                     "eForBuild)\' == \'\' \">\r\n\t<CodeAnalysisRuleSet>");
             
-            #line 118 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 110 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.FxcopAnalyzerRuleSetFilePath));
             
             #line default
@@ -284,14 +270,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("</CodeAnalysisRuleSet>\r\n  </PropertyGroup>\r\n  <PropertyGroup Condition=\" \'$(RuleS" +
                     "etFileForBuild)\' == \'true\' \">\r\n\t<CodeAnalysisRuleSet>");
             
-            #line 121 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 113 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.FxcopAnalyzerRuleSetFilePathForBuild));
             
             #line default
             #line hidden
             this.Write("</CodeAnalysisRuleSet>\r\n  </PropertyGroup>\r\n\r\n");
             
-            #line 124 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 116 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
 	}
     if (this.Project.SignBinaries)
@@ -303,7 +289,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("  <Choose>\r\n    <When Condition=\" \'$(AWSKeyFile)\' == \'\' \">\r\n      <PropertyGroup>" +
                     "\r\n");
             
-            #line 132 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 124 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if(this.Project.AssemblyName == "AWSSDK.UnitTests.Net35" || this.Project.AssemblyName == "AWSSDK.UnitTests.Net45")
     {
@@ -314,7 +300,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("        <AssemblyOriginatorKeyFile>../../awssdk.dll.snk</AssemblyOriginatorKeyFil" +
                     "e>\r\n");
             
-            #line 137 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 129 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -322,7 +308,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line default
             #line hidden
             
-            #line 140 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 132 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     else
     {
@@ -333,7 +319,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("        <AssemblyOriginatorKeyFile>../../../awssdk.dll.snk</AssemblyOriginatorKey" +
                     "File>\r\n");
             
-            #line 145 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 137 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -344,7 +330,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
                     "    <AssemblyOriginatorKeyFile>$(AWSKeyFile)</AssemblyOriginatorKeyFile>\r\n      " +
                     "</PropertyGroup>\r\n    </Otherwise>\r\n  </Choose>\r\n\r\n");
             
-            #line 157 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 149 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if(this.Project.CustomRoslynAnalyzersDllDirectory != null)
@@ -355,14 +341,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup Condition=\"$(RunAnalyzersDuringBuild)\">\r\n    <Analyzer Include= \"");
             
-            #line 163 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 155 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.CustomRoslynAnalyzersDllDirectory));
             
             #line default
             #line hidden
             this.Write("\" />\r\n  </ItemGroup>\r\n");
             
-            #line 165 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 157 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if(this.Project.IndividualFileIncludes != null)
@@ -373,7 +359,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 171 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 163 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     foreach (var compileIncludeEntry in this.Project.IndividualFileIncludes)
     {
@@ -383,14 +369,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Compile Include=\"");
             
-            #line 175 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 167 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(compileIncludeEntry));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 176 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 168 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -399,7 +385,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n");
             
-            #line 180 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 172 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -411,7 +397,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 187 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 179 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     foreach (var compileRemoveEntry in this.Project.CompileRemoveList)
     {
@@ -423,21 +409,21 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Compile Remove=\"**/");
             
-            #line 193 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 185 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(compileRemoveEntry));
             
             #line default
             #line hidden
             this.Write("/**\"/>\r\n\t<None Remove=\"**/");
             
-            #line 194 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 186 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(compileRemoveEntry));
             
             #line default
             #line hidden
             this.Write("/**\" />\r\n");
             
-            #line 195 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 187 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     continue;
         }
@@ -447,14 +433,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Compile Remove=\"**/");
             
-            #line 199 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 191 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(compileRemoveEntry));
             
             #line default
             #line hidden
             this.Write("/**\"/>\r\n");
             
-            #line 200 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 192 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -463,7 +449,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n\r\n");
             
-            #line 205 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 197 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -471,7 +457,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line default
             #line hidden
             
-            #line 208 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 200 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if (this.Project.ProjectReferences != null)
     {
@@ -481,7 +467,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 213 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 205 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     foreach (var projectReference in this.Project.ProjectReferences)
     {
@@ -491,14 +477,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <ProjectReference Include=\"");
             
-            #line 217 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 209 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(projectReference.IncludePath));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 210 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -507,7 +493,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n\r\n");
             
-            #line 223 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 215 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -515,7 +501,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line default
             #line hidden
             
-            #line 226 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 218 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if (this.Project.PackageReferences != null)
     {
@@ -525,7 +511,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup Condition=\"$(RunAnalyzersDuringBuild)\">\r\n");
             
-            #line 231 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 223 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         foreach(var package in this.Project.PackageReferences.Where(p => p.IsAnalyzer))
         {
@@ -537,28 +523,28 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("        <PackageReference Include=\"");
             
-            #line 237 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 229 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Include));
             
             #line default
             #line hidden
             this.Write("\" Version=\"");
             
-            #line 237 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 229 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Version));
             
             #line default
             #line hidden
             this.Write("\">\r\n            <PrivateAssets>");
             
-            #line 238 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 230 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.PrivateAssets));
             
             #line default
             #line hidden
             this.Write("</PrivateAssets>\r\n        </PackageReference>\r\n");
             
-            #line 240 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 232 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
             }
             else
@@ -569,21 +555,21 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("\t    <PackageReference Include=\"");
             
-            #line 245 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 237 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Include));
             
             #line default
             #line hidden
             this.Write("\" Version=\"");
             
-            #line 245 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 237 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Version));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 246 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 238 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
 		    }
         }
@@ -593,7 +579,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n  <ItemGroup>\r\n");
             
-            #line 252 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 244 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         foreach(var package in this.Project.PackageReferences.Where(p => !p.IsAnalyzer))
         {
@@ -605,28 +591,28 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("        <PackageReference Include=\"");
             
-            #line 258 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 250 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Include));
             
             #line default
             #line hidden
             this.Write("\" Version=\"");
             
-            #line 258 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 250 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Version));
             
             #line default
             #line hidden
             this.Write("\">\r\n            <PrivateAssets>");
             
-            #line 259 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 251 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.PrivateAssets));
             
             #line default
             #line hidden
             this.Write("</PrivateAssets>\r\n        </PackageReference>\r\n");
             
-            #line 261 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 253 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
             }
             else
@@ -637,21 +623,21 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("\t    <PackageReference Include=\"");
             
-            #line 266 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 258 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Include));
             
             #line default
             #line hidden
             this.Write("\" Version=\"");
             
-            #line 266 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 258 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Version));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 267 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 259 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
 		    }
         }
@@ -661,7 +647,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n\r\n");
             
-            #line 273 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 265 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if (this.Project.ReferenceDependencies != null)
@@ -672,7 +658,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 279 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 271 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         foreach (var reference in this.Project.ReferenceDependencies)
         {
@@ -684,14 +670,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Reference Include=\"");
             
-            #line 285 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 277 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(reference.Name));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 286 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 278 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
             }
             else
@@ -702,21 +688,21 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Reference Include=\"");
             
-            #line 291 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 283 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(reference.Name));
             
             #line default
             #line hidden
             this.Write("\">\r\n        <HintPath>");
             
-            #line 292 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 284 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(reference.HintPath));
             
             #line default
             #line hidden
             this.Write("</HintPath>\r\n    </Reference>\r\n");
             
-            #line 294 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 286 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
             }
         }
@@ -726,7 +712,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n\r\n");
             
-            #line 300 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 292 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if (this.Project.EmbeddedResources != null)
@@ -737,7 +723,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 306 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 298 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     foreach (var resource in this.Project.EmbeddedResources)
     {
@@ -747,14 +733,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <EmbeddedResource Include=\"");
             
-            #line 310 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 302 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resource));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 311 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 303 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -763,7 +749,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n");
             
-            #line 315 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 307 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -775,7 +761,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 322 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 314 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         foreach (var service in this.Project.Services)
         {
@@ -785,14 +771,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Service Include=\"");
             
-            #line 326 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 318 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(service));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 327 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 319 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         }
 
@@ -801,7 +787,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n");
             
-            #line 331 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 323 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -812,7 +798,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 337 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+        #line 329 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     public Project Project { get; set; }
     public ServiceConfiguration ServiceConfiguration { get; set; }

--- a/generator/ServiceClientGeneratorLib/Generators/ProjectFiles/VS2017ProjectFile.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/ProjectFiles/VS2017ProjectFile.tt
@@ -65,14 +65,6 @@
 <#
     }
 
-    if (this.Project.TargetFrameworks.Contains("net35"))
-    {
-#>
-    <!-- workaround per https://github.com/dotnet/msbuild/issues/5985 -->
-    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-<#
-    }
-
     if (!string.IsNullOrEmpty(this.Project.SupressWarnings))
     {
 #>

--- a/generator/ServiceClientGeneratorLib/SolutionFileCreator.cs
+++ b/generator/ServiceClientGeneratorLib/SolutionFileCreator.cs
@@ -2,11 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
 using System.Text.RegularExpressions;
-
 using ServiceClientGenerator.Generators.ProjectFiles;
-using System.Xml;
 
 namespace ServiceClientGenerator
 {
@@ -15,40 +12,24 @@ namespace ServiceClientGenerator
         public GeneratorOptions Options { get; set; }
         public IEnumerable<ProjectFileConfiguration> ProjectFileConfigurations { get; set; }
 
-        /// Regex check to identify framework of a project.
-        private static readonly Regex FrameworkRegex = new Regex(@"<TargetFramework[^>]*>(.*?)<\/TargetFramework>");
-
         /// <summary>
         /// The set of project 'types' (or platforms) that we generate the SDK against.
         /// These type names form part of the project filename.
         /// </summary>
         public abstract class ProjectTypes
         {
-            public const string Net35 = "Net35";
             public const string Net45 = "Net45";
             public const string NetStandard = "NetStandard";
             public const string Partial = "partial";
-
         }
 
-        // build configuration platforms used for net 3.5, 4.5 and portable project types
+        /// <summary>
+        /// Standard configuration platforms used for all project types.
+        /// </summary>
         static readonly List<string> StandardPlatformConfigurations = new List<string>
         {
             "Debug|Any CPU",
             "Release|Any CPU"
-        };
-
-        // build configuration platforms used for phone/RT project types
-        static readonly List<string> PhoneRtPlatformConfigurations = new List<string>
-        {
-            "Debug|Any CPU",
-            "Debug|ARM",
-            "Debug|x64",
-            "Debug|x86",
-            "Release|Any CPU",
-            "Release|ARM",
-            "Release|x64",
-            "Release|x86",
         };
 
         private const string GeneratorLibProjectGuid = "{7BEE7C44-BE12-43CC-AFB9-B5852A1F43C8}";
@@ -57,14 +38,8 @@ namespace ServiceClientGenerator
         private const string CommonTestProjectGuid = "{66F78F86-68D7-4538-8EA5-A669A08E1C19}";
         private const string CommonTestProjectName = "AWSSDK.CommonTest";
 
-        private const string UnitTestUtilityProjectFileName35 = "AWSSDK.UnitTestUtilities.Net35";
-        private const string UtilityProjectFileGuid35 = "{A23CE153-A4A3-4D3A-A6DC-0DD1B207118E}";
-
         private const string UnitTestUtilityProjectFileName45 = "AWSSDK.UnitTestUtilities.Net45";
         private const string UtilityProjectFileGuid45 = "{002B183F-E568-49CD-9D06-CBCFF2C2921F}";
-
-        private const string IntegrationTestUtilityName35 = "AWSSDK.IntegrationTestUtilities.Net35";
-        private const string IntegrationTestUtilityGuid35 = "{924D2906-70D6-4D77-8603-816648B2CCA6}";
 
         private const string IntegrationTestUtilityName45 = "AWSSDK.IntegrationTestUtilities.Net45";
         private const string IntegrationTestUtilityGuid45 = "{7AB0DA1C-CA0E-4579-BA82-2B41A9DA15C7}";
@@ -75,13 +50,6 @@ namespace ServiceClientGenerator
             = new ProjectFileCreator.ProjectConfigurationData
             {
                 ProjectGuid = GeneratorLibProjectGuid,
-                ConfigurationPlatforms = StandardPlatformConfigurations
-            };
-
-        private static readonly ProjectFileCreator.ProjectConfigurationData CommonTestProjectConfig
-            = new ProjectFileCreator.ProjectConfigurationData
-            {
-                ProjectGuid = CommonTestProjectGuid,
                 ConfigurationPlatforms = StandardPlatformConfigurations
             };
 
@@ -114,28 +82,12 @@ namespace ServiceClientGenerator
             RelativePath = Utils.PathCombineAlt("..", "..", "..", "test", "Common", $"{CommonTestProjectName}.csproj")
         };
 
-        private static readonly Project UnitTestUtilityProject35 = new Project
-        {
-            Name = UnitTestUtilityProjectFileName35,
-            ProjectGuid = UtilityProjectFileGuid35,
-            ProjectPath = Utils.PathCombineAlt("..", "..", "..", "..", "sdk", "test", "UnitTests", "Custom", $"{UnitTestUtilityProjectFileName35}.csproj"),
-            RelativePath = Utils.PathCombineAlt("..", "..", "..", "test", "UnitTests", "Custom", $"{UnitTestUtilityProjectFileName35}.csproj")
-        };
-
         private static readonly Project UnitTestUtilityProject45 = new Project
         {
             Name = UnitTestUtilityProjectFileName45,
             ProjectGuid = UtilityProjectFileGuid45,
             ProjectPath = Utils.PathCombineAlt("..", "..", "..", "..", "sdk", "test", "UnitTests", "Custom", $"{UnitTestUtilityProjectFileName45}.csproj"),
             RelativePath = Utils.PathCombineAlt("..", "..", "..", "test", "UnitTests", "Custom", $"{UnitTestUtilityProjectFileName45}.csproj")
-        };
-
-        private static readonly Project IntegrationTestUtility35Project = new Project
-        {
-            Name = IntegrationTestUtilityName35,
-            ProjectGuid = IntegrationTestUtilityGuid35,
-            ProjectPath = Utils.PathCombineAlt("..", "..", "..", "..", "sdk", "test", "IntegrationTests", $"{IntegrationTestUtilityName35}.csproj"),
-            RelativePath = Utils.PathCombineAlt("..", "..", "..", "test", "IntegrationTests", $"{IntegrationTestUtilityName35}.csproj")
         };
 
         private static readonly Project IntegrationTestUtility45Project = new Project
@@ -146,25 +98,20 @@ namespace ServiceClientGenerator
             RelativePath = Utils.PathCombineAlt("..", "..", "..", "test", "IntegrationTests", $"{IntegrationTestUtilityName45}.csproj")
         };
 
-        private static readonly List<Project> CoreProjects = new List<Project>{ 
-        new Project
+        private static readonly List<Project> CoreProjects = new List<Project>
         {
-            Name = "AWSSDK.Core.Net35",
-            ProjectGuid = "{1FACE5D0-97BF-4069-B4F7-0FE28BB160F8}",
-            ProjectPath = Utils.PathCombineAlt("..", "..", "Core", "AWSSDK.Core.Net35.csproj")
-        },
-        new Project
-        {
-            Name = "AWSSDK.Core.Net45",
-            ProjectGuid = "{7DE3AFA0-1B2D-41B1-82BD-120B8B210B43}",
-            ProjectPath = Utils.PathCombineAlt("..", "..", "Core", "AWSSDK.Core.Net45.csproj")
-        },
-        new Project
-        {
-            Name = "AWSSDK.Core.NetStandard",
-            ProjectGuid = "{A855B58E-ED32-40AE-AE8F-054F448B9F2C}",
-            ProjectPath = Utils.PathCombineAlt("..", "..", "Core", "AWSSDK.Core.NetStandard.csproj")
-        }
+            new Project
+            {
+                Name = "AWSSDK.Core.Net45",
+                ProjectGuid = "{7DE3AFA0-1B2D-41B1-82BD-120B8B210B43}",
+                ProjectPath = Utils.PathCombineAlt("..", "..", "Core", "AWSSDK.Core.Net45.csproj")
+            },
+            new Project
+            {
+                Name = "AWSSDK.Core.NetStandard",
+                ProjectGuid = "{A855B58E-ED32-40AE-AE8F-054F448B9F2C}",
+                ProjectPath = Utils.PathCombineAlt("..", "..", "Core", "AWSSDK.Core.NetStandard.csproj")
+            }
         };
         private readonly Dictionary<string, ProjectFileCreator.ProjectConfigurationData> _allProjects
             = new Dictionary<string, ProjectFileCreator.ProjectConfigurationData>();
@@ -183,22 +130,18 @@ namespace ServiceClientGenerator
             AddSupportProjects();
             ScanForExistingProjects();
 
-            // build project configuraitons for each solution
-            var net35ProjectConfigs = new List<ProjectFileConfiguration> { GetProjectConfig(ProjectTypes.Net35) };
+            // Build project configurations for each solution
             var net45ProjectConfigs = new List<ProjectFileConfiguration> { GetProjectConfig(ProjectTypes.Net45) };
+            var netStandardProjectConfigs = new List<ProjectFileConfiguration>
+            {
+                GetProjectConfig(ProjectTypes.NetStandard)
+            };
 
-            var netStandardProjectConfigs = new List<ProjectFileConfiguration> {
-                    GetProjectConfig(ProjectTypes.NetStandard)
-                };
-
-            GenerateVS2017ServiceSolution(net35ProjectConfigs);
-            GenerateVS2017Solution("AWSSDK.Net35.sln", true, false, net35ProjectConfigs);
+            GenerateVS2017ServiceSolution(net45ProjectConfigs);
             GenerateVS2017Solution("AWSSDK.Net45.sln", true, false, net45ProjectConfigs);
-
             GenerateVS2017Solution("AWSSDK.NetStandard.sln", true, false, netStandardProjectConfigs);
 
             // Include solutions that Travis CI can build
-            GenerateVS2017Solution("AWSSDK.Net35.Travis.sln", false, true, net35ProjectConfigs);
             GenerateVS2017Solution("AWSSDK.Net45.Travis.sln", false, true, net45ProjectConfigs);
         }
 
@@ -234,7 +177,7 @@ namespace ServiceClientGenerator
                     var projectConfig = new ProjectFileCreator.ProjectConfigurationData
                     {
                         ProjectGuid = Utils.GetProjectGuid(projectFile),
-                        ConfigurationPlatforms = GetProjectPlatforms(projectName, projectFile)
+                        ConfigurationPlatforms = StandardPlatformConfigurations
                     };
 
                     _allProjects.Add(projectName, projectConfig);
@@ -249,82 +192,11 @@ namespace ServiceClientGenerator
             return config;
         }
 
-        private static IEnumerable<string> GetProjectPlatformsFromFile(string projectFile)
-        {
-            var platforms = new List<string>();
-
-            var content = File.ReadAllText(projectFile);
-            var doc = new XmlDocument();
-            doc.LoadXml(content);
-
-            var searchPhrase = "$(Configuration)|$(Platform)";
-            var propertyGroups = doc.GetElementsByTagName("PropertyGroup");
-            foreach (XmlNode pg in propertyGroups)
-            {
-                var conditionAttribute = pg.Attributes["Condition"];
-                if (conditionAttribute != null)
-                {
-                    var condition = conditionAttribute.Value;
-                    if (condition.IndexOf(searchPhrase, StringComparison.Ordinal) >= 0)
-                    {
-                        var thirdQuote = condition.IndexOfNthOccurrence('\'', 0, 3);
-                        var fourthQuote = condition.IndexOf('\'', thirdQuote);
-                        var platform = condition.Substring(thirdQuote, fourthQuote - thirdQuote);
-                        // Project files use the string "AnyCPU", solution files use "Any CPU"
-                        platform = platform.Replace("AnyCPU", "Any CPU");
-                        platforms.Add(platform);
-                    }
-                }
-            }
-
-            return platforms;
-        }
-        private static IEnumerable<string> GetProjectPlatforms(string projectName, string projectFile)
-        {
-            string projectType = GetProjectType(projectName);
-
-            var platformConfigurations = GetPlatformConfigurations(projectType);
-            // Identify the framework of the project file if not already identified.
-            return IdentifyProjectConfigurations(projectFile, platformConfigurations, projectType);
-        }
-
         private static string GetProjectType(string projectName)
         {
             var projectTypeStart = projectName.LastIndexOf('.');
             var projectType = projectName.Substring(projectTypeStart + 1);
             return projectType;
-        }
-
-        private static IEnumerable<string> GetPlatformConfigurations(string projectType)
-        {
-            switch (projectType)
-            {
-                case ProjectTypes.Net35:
-                case ProjectTypes.Net45:
-                case ProjectTypes.NetStandard:
-                case ProjectTypes.Partial:
-                    return StandardPlatformConfigurations;
-                default:
-                    return null;
-            }
-        }
-        /// <summary>
-        /// Method that opens the project file and does a Regex match for <TargetFramework></TargetFramework>
-        /// to identify the framework of the csproj.
-        /// </summary>
-        private static IEnumerable<string> IdentifyProjectConfigurations(string projectFile, IEnumerable<string> configurations, string projectType)
-        {
-            if (!string.IsNullOrEmpty(projectFile) && (configurations == null))
-            {
-                var fileContent = File.ReadAllText(projectFile);
-                var match = FrameworkRegex.Match(fileContent);
-                configurations = GetPlatformConfigurations(match.Groups[1].ToString());
-            }
-
-            if (configurations != null)
-                return configurations;
-            else
-                throw new Exception(string.Format("Unrecognized platform type in project name - '{0}'", projectType));
         }
 
         private static IDictionary<string, string> GetItemGuidDictionary(string solutionsFilePath)
@@ -473,7 +345,7 @@ namespace ServiceClientGenerator
                         });
                     }
 
-                    if (configuration.Name.Equals(ProjectTypes.Net35, StringComparison.Ordinal) || configuration.Name.Equals(ProjectTypes.Net45, StringComparison.Ordinal))
+                    if (configuration.Name.Equals(ProjectTypes.Net45, StringComparison.Ordinal))
                     {
                         testProjects.Add(GeneratorLibProject);
                         SelectBuildConfigurationsForProject(GeneratorLibProjectName, buildConfigurations);
@@ -511,7 +383,7 @@ namespace ServiceClientGenerator
         }
 
         /// <summary>
-        /// Service specific solution generator. A single sln file is created that contains csproj for net35,net45,netstandard and their corresponding integ and unit tests.
+        /// Service specific solution generator. A single sln file is created that contains csproj for all target frameworks and their corresponding integ and unit tests.
         /// </summary>
         private void GenerateVS2017ServiceSolution(IEnumerable<ProjectFileConfiguration> projectFileConfigurations)
         {
@@ -545,10 +417,9 @@ namespace ServiceClientGenerator
                     folder.ProjectGuid = projectGuidDictionary[serviceDirectory.Name];
                 }
 
-                // Include only net35,net45,netstandard service csproj
-                // in the service specific solutions
+                // Include only the service csproj files in the service specific solution.
                 foreach (var projectFile in Directory.EnumerateFiles(servicePath, "*.*", SearchOption.TopDirectoryOnly)
-                    .Where(s => s.Contains("NetStandard") || s.Contains("Net35") || s.Contains("Net45")).OrderBy(f => f))
+                    .Where(s => s.Contains("NetStandard") || s.Contains("Net45")).OrderBy(f => f))
                 {
                     var projectFileAlt = Utils.ConvertPathAlt(projectFile);
                     serviceProjectDependencies.AddRange(AddProjectDependencies(projectFileAlt, serviceDirectory.Name, new List<string>()));
@@ -624,9 +495,9 @@ namespace ServiceClientGenerator
         /// This method converts the test projects path from being generator sln relative to the service specific sln
         /// relative path
         /// Ex
-        /// ../../../../sdk/test/Services/{ServiceName}/UnitTests/AWSSDK.UnitTests.{ServiceName}.Net35.csproj
+        /// ../../../../sdk/test/Services/{ServiceName}/UnitTests/AWSSDK.UnitTests.{ServiceName}.csproj
         /// becomes
-        /// ../../../test/Services/{ServiceName}/UnitTests/AWSSDK.UnitTests.{ServiceName}.Net35.csproj
+        /// ../../../test/Services/{ServiceName}/UnitTests/AWSSDK.UnitTests.{ServiceName}.csproj
         /// </summary>
         private static void ConvertToSlnRelativePath(List<Project> testProjects, string solutionPath)
         {
@@ -651,7 +522,12 @@ namespace ServiceClientGenerator
             var testProjectsRoot = Utils.PathCombineAlt(Options.SdkRootFolder, GeneratorDriver.TestsSubFoldername, GeneratorDriver.ServicesSubFoldername, serviceDirectory.Name);
             foreach (var configuration in projectFileConfigurations)
             {
-                string filePattern = string.Format("*.csproj");
+                // TODO: At the moment the project files for net35 have not been deleted yet, so the previous file pattern ("*.csproj") would include them in the service solution.
+                // We'll filter for the current target framework (similar to what's done for the CRT project), but this method is only invoked for net45.
+                //
+                // We should revert the filter later so that the service specific solution includes all tests files (including any we eventually add for .NET Standard).
+                string filePattern = string.Format($"*.{configuration.Name}.csproj");
+                
                 foreach (var projectFile in Directory.GetFiles(testProjectsRoot, filePattern, SearchOption.AllDirectories).OrderBy(f => f))
                 {
                     var projectFileAlt = Utils.ConvertPathAlt(projectFile);
@@ -676,19 +552,14 @@ namespace ServiceClientGenerator
                     });
                 }
 
-                if (configuration.Name.Equals(ProjectTypes.Net35, StringComparison.Ordinal) || configuration.Name.Equals(ProjectTypes.Net45, StringComparison.Ordinal))
+                if (configuration.Name.Equals(ProjectTypes.Net45, StringComparison.Ordinal))
                 {
                     testProjects.Add(ServiceSlnGeneratorLibProject);
                     SelectBuildConfigurationsForProject(GeneratorLibProjectName, buildConfigurations);
 
-                    testProjects.Add(UnitTestUtilityProject35);
                     testProjects.Add(UnitTestUtilityProject45);
-
-                    testProjects.Add(IntegrationTestUtility35Project);
-                    dependentProjects.AddRange(AddProjectDependencies
-                        (IntegrationTestUtility35Project.ProjectPath, serviceDirectory.Name, new List<string>()));
-
                     testProjects.Add(IntegrationTestUtility45Project);
+
                     dependentProjects.AddRange(AddProjectDependencies
                         (IntegrationTestUtility45Project.ProjectPath, serviceDirectory.Name, new List<string>()));
                 }
@@ -732,26 +603,6 @@ namespace ServiceClientGenerator
             return depsProjects;
         }
 
-        private void AddExtraTestProjects(ProjectFileConfiguration projectConfig, Dictionary<string, ProjectFileCreator.ProjectConfigurationData> solutionProjects, List<Project> testProjects)
-        {
-            foreach (var extraTestProject in projectConfig.ExtraTestProjects)
-            {
-                var projectPath = Utils.PathCombineAlt("..", "..", "..", "..", "sdk", extraTestProject);
-
-                var projectGuid = Utils.GetProjectGuid(projectPath);
-                var testProject = ProjectFromFile(extraTestProject, projectGuid);
-
-                var testProjectConfig = new ProjectFileCreator.ProjectConfigurationData
-                {
-                    ProjectGuid = projectGuid,
-                    ConfigurationPlatforms = GetProjectPlatformsFromFile(projectPath).ToList()
-                };
-
-                solutionProjects.Add(testProject.Name, testProjectConfig);
-                testProjects.Add(testProject);
-            }
-        }
-
         void SelectProjectAndConfigurationsForSolution(string projectFile,
                                                ISet<string> buildConfigurations)
         {
@@ -765,54 +616,6 @@ namespace ServiceClientGenerator
             {
                 buildConfigurations.Add(cp);
             }
-        }
-
-        Project CoreProjectFromFile(string projectFile)
-        {
-            var fi = new FileInfo(projectFile);
-            var projectName = Path.GetFileNameWithoutExtension(fi.Name);
-            return new Project
-            {
-                Name = Path.GetFileNameWithoutExtension(projectFile),
-                ProjectGuid = this._allProjects[projectName].ProjectGuid,
-                ProjectPath = Utils.PathCombineAlt("src", "Core", fi.Name)
-            };
-        }
-
-        Project TestProjectFromFile(string folderName, string projectFile)
-        {
-            var fi = new FileInfo(projectFile);
-            var projectName = Path.GetFileNameWithoutExtension(fi.Name);
-            return new Project
-            {
-                Name = Path.GetFileNameWithoutExtension(projectFile),
-                ProjectGuid = _allProjects[projectName].ProjectGuid,
-                ProjectPath = Utils.PathCombineAlt("test", folderName, fi.Name)
-            };
-        }
-
-        Project ServiceProjectFromFile(string folderName, string projectFile)
-        {
-            var fi = new FileInfo(projectFile);
-            var projectName = Path.GetFileNameWithoutExtension(fi.Name);
-            return new Project
-            {
-                Name = Path.GetFileNameWithoutExtension(projectFile),
-                ProjectGuid = this._allProjects[projectName].ProjectGuid,
-                ProjectPath = Utils.PathCombineAlt("src", "Services", folderName, fi.Name)
-            };
-        }
-
-        Project ProjectFromFile(string projectFile, string projectGuid)
-        {
-            var fi = new FileInfo(projectFile);
-            var projectName = Path.GetFileNameWithoutExtension(fi.Name);
-            return new Project
-            {
-                Name = Path.GetFileNameWithoutExtension(projectFile),
-                ProjectGuid = projectGuid,
-                ProjectPath = projectFile
-            };
         }
 
         ServiceSolutionFolder ServiceSolutionFolderFromPath(string folderName)

--- a/generator/ServiceModels/_manifest.json
+++ b/generator/ServiceModels/_manifest.json
@@ -1,33 +1,6 @@
 {
     "projects": [
         {
-            "name": "Net35",
-            "targetFrameworks": [ "net35" ],
-            "defineConstants": [ "BCL", "BCL35", "AWS_APM_API", "CODE_ANALYSIS"],
-            "template": "VS2017ProjectFile",
-            "excludeFolders": [ "_async", "_bcl45", "_bcl45+netstandard", "_netstandard", "obj"],
-            "nugetTargetPlatform": "net35",
-            "frameworkPathOverride" : "C:\\Program Files (x86)\\Reference Assemblies\\Microsoft\\Framework\\.NETFramework\\v3.5\\Profile\\Client",
-            "frameworkReferences" : [
-                {"name": "System.Configuration"},
-                {"name": "System.Data.Entity", "hintPath" : "C:\\Program Files (x86)\\Reference Assemblies\\Microsoft\\Framework\\v3.5\\System.Data.Entity.dll"}
-            ],
-            "packageReferences": [
-                {
-                    "include": "Microsoft.CodeAnalysis.FxCopAnalyzers",
-                    "version": "2.9.3",
-                    "privateAssets": "all",
-                    "analyzer": true
-                },
-                {
-                    "include": "Microsoft.DotNet.Analyzers.Compatibility",
-                    "version": "0.2.12-alpha",
-                    "privateAssets": "all",
-                    "analyzer": true
-                }
-            ]
-        },
-        {
             "name": "Net45",
             "targetFrameworks": [ "net45" ],
             "defineConstants": [ "BCL", "BCL45", "AWS_ASYNC_API", "CODE_ANALYSIS" ],
@@ -77,53 +50,6 @@
         }        
     ],
     "unittestprojects":[
-        {
-            "name": "Net35",
-            "targetFrameworks": [ "net45" ],
-            "defineConstants": [ "TRACE", "BCL", "BCL35", "AWS_APM_API"],
-            "excludeFolders": ["_bcl45", "obj", "_bcl45+netstandard"],
-            "visualStudioServices" : ["{82a7f48d-3b50-4b1e-b82e-3ada8210c358}"],
-            "embeddedResources" : [
-                "Custom\\Runtime\\TestResponses\\*.txt",
-                "Custom\\Runtime\\EventStreams\\test_vectors\\*",
-                "Custom\\Runtime\\TestEndpoints\\*.json",
-                "Custom\\TestTools\\ComparerTest.json",
-                "..\\Services\\CloudFront\\UnitTests\\Custom\\EmbeddedResource\\sample.rsa.private.key.txt"
-            ],
-            "packageReferences" : [
-                {
-                    "include": "Moq",
-                    "version": "4.8.3"
-                },
-                {
-                    "include" : "MSTest.TestAdapter",
-                    "version" : "1.4.0"
-                },
-                {
-                    "include" : "Microsoft.NET.Test.Sdk",
-                    "version" : "15.9.0"
-                },
-                {
-                    "include": "MSTest.TestFramework",
-                    "version": "1.4.0"
-                },
-                {
-                    "include": "AutoFixture",
-                    "version": "3.51.0"
-                },
-                {
-                    "include": "AutoFixture.AutoMoq",
-                    "version": "3.51.0"
-                }
-            ],
-            "frameworkReferences" : [
-                {
-                    "name": "System.Configuration"
-                }
-            ],
-          "noWarn": "CS1591",
-          "outputPathOverride" :  "bin\\$(Configuration)\\net35"
-        },
         {
             "name": "Net45",
             "targetFrameworks": [ "net45" ],


### PR DESCRIPTION
## Description
This PR:
- Removes the `Net35` entry in the manifest file
- Updates the `GeneratorDriver` not to create service clients and interfaces for `net35` (important: it _does not_ delete the existing project files yet)
- Updates the `SolutionFileCreator` not to include any `net35` assets (this class changed the most, I ended up deleting some unused code which didn't impact the generated files - see review comments)

There were a lot of generated files modified, I included a few in a separate commit so it's easier to see the changes: https://github.com/aws/aws-sdk-net/commit/73cb2288ca1634c563cafc2d20f6a5323cf928d4

## Testing
- Ran generator locally (`msbuild .\buildtools\build.proj /t:run-generator`)
- Confirmed the modified solutions built successfully (`dotnet build -c Release .\sdk\src\Services\AccessAnalyzer\AccessAnalyzer.sln` and `dotnet build -c Release .\sdk\src\Services\S3\S3.sln`)

## Screenshots (if appropriate)
Service solution before:
![before](https://github.com/aws/aws-sdk-net/assets/3842788/f6447eeb-9060-4dbe-bed7-9f072baf70c1)

Service solution after:
![after](https://github.com/aws/aws-sdk-net/assets/3842788/a1ee426c-4734-4ff2-b2aa-f22b98a2f2b7)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
