### PR TITLE
Validate security credentials obtained from Instance Metadata Service

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/URIBasedRefreshingCredentialHelper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/URIBasedRefreshingCredentialHelper.cs
@@ -85,9 +85,12 @@ namespace Amazon.Runtime
                 Amazon.Util.Internal.JsonSerializerContext,
 #endif
                 new()
+            where T : SecurityBase
         {
             string json = GetContents(uri, proxy, headers);
-            return JsonSerializerHelper.Deserialize<T>(json, new TC());
+            var result = JsonSerializerHelper.Deserialize<T>(json, new TC());
+            ValidateResponse(result);
+            return result;
         }
 
         protected static void ValidateResponse(SecurityBase response)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Getting security credentials from Instance Metadata Service fails when an EC2 instance does not have permissions to assume a role. When that happens, we get a very unhelpful error message `Value cannot be null. (Parameter 'awsAccessKeyId')` Do response validation so that we get better exception message.

See also https://github.com/aws/aws-cli/issues/2060

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement