### PR TITLE
Add mime code mapping for .csv file extension.

### DIFF
--- a/generator/.DevConfigs/8f5e3c3c-85c7-438e-9671-ade8d1d5b5ae.json
+++ b/generator/.DevConfigs/8f5e3c3c-85c7-438e-9671-ade8d1d5b5ae.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Add mime code mapping for .csv file extension."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
@@ -69,6 +69,7 @@ namespace Amazon.S3.Util
             { ".cs", "text/plain" },
             { ".csh", "application/x-csh" },
             { ".css", "text/css" },
+            { ".csv", "text/csv" },
             { ".dcr", "application/x-director" },
             { ".dir", "application/x-director" },
             { ".dms", "application/octet-stream" },


### PR DESCRIPTION


## Description
Add mime code mapping for .csv file extension in the dictionary of known file extensions.

## Motivation and Context
This will be useful for developers using this sdk in a way that they will not have to write workaround code for inferring mime code for files with .csv extension, which is common file extension.
Issue https://github.com/aws/aws-sdk-net/issues/3213

## Testing
Builds locally.

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement