### PR TITLE
[V4] Change value types on model types to be nullable.

### DIFF
--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCStructureMarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCStructureMarshaller.cs
@@ -206,7 +206,7 @@ this.Write("\");\r\n");
         
         #line 50 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCStructureMarshaller.tt"
 
-			string memberProperty = variableName + "." + member.PropertyName + (member.UseNullable ? ".Value" : string.Empty);
+			string memberProperty = variableName + "." + member.PropertyName + (member.IsNullable ? ".Value" : string.Empty);
 			if(member.IsStructure || member.IsList || member.IsMap)
 			{
 				this.ProcessStructure(level, variableName + "." + member.PropertyName, member.Shape);

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCStructureMarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCStructureMarshaller.tt
@@ -48,7 +48,7 @@ namespace <#=        this.Config.Namespace #>.Model.Internal.MarshallTransformat
 <#=new string(' ', level * 4)#>            {
 <#=new string(' ', level * 4)#>                context.Writer.WritePropertyName("<#=member.MarshallName#>");
 <#+
-			string memberProperty = variableName + "." + member.PropertyName + (member.UseNullable ? ".Value" : string.Empty);
+			string memberProperty = variableName + "." + member.PropertyName + (member.IsNullable ? ".Value" : string.Empty);
 			if(member.IsStructure || member.IsList || member.IsMap)
 			{
 				this.ProcessStructure(level, variableName + "." + member.PropertyName, member.Shape);

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlRequestMarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlRequestMarshaller.cs
@@ -467,14 +467,14 @@ this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
         #line hidden
         
         #line 135 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlRequestMarshaller.tt"
-this.Write(this.ToStringHelper.ToStringWithCulture((member.UseNullable ? ".Value" : string.Empty)));
+this.Write(this.ToStringHelper.ToStringWithCulture((member.IsNullable ? ".Value" : string.Empty)));
 
         
         #line default
         #line hidden
         
         #line 135 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlRequestMarshaller.tt"
-this.Write("));\t\t\t\t\t\r\n");
+this.Write("));\r\n");
 
         
         #line default
@@ -809,7 +809,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
         #line hidden
         
         #line 200 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlRequestMarshaller.tt"
-this.Write(this.ToStringHelper.ToStringWithCulture((member.UseNullable ? ".Value" : string.Empty)));
+this.Write(this.ToStringHelper.ToStringWithCulture((member.IsNullable ? ".Value" : string.Empty)));
 
         
         #line default

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlRequestMarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlRequestMarshaller.tt
@@ -132,7 +132,7 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
 			{
 #>
 <#=new string(' ', level * 4)#>				if(<#=variableName#>.IsSet<#=member.PropertyName#>())
-<#=new string(' ', level * 4)#>					xmlWriter.WriteElementString("<#=member.MarshallName#>", "<#=operation.XmlNamespace#>", <#=member.PrimitiveMarshaller#>(<#=variableName#>.<#=member.PropertyName#><#=(member.UseNullable ? ".Value" : string.Empty)#>));					
+<#=new string(' ', level * 4)#>					xmlWriter.WriteElementString("<#=member.MarshallName#>", "<#=operation.XmlNamespace#>", <#=member.PrimitiveMarshaller#>(<#=variableName#>.<#=member.PropertyName#><#=(member.IsNullable ? ".Value" : string.Empty)#>));
 <#+
 				if(member.IsIdempotent)
 				{
@@ -197,7 +197,7 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
 			{
 #>
 <#=new string(' ', level * 4)#>				if(<#=variableName#>.IsSet<#=member.PropertyName#>())
-<#=new string(' ', level * 4)#>					xmlWriter.WriteElementString("<#=member.MarshallName#>", "<#=xmlNamespace#>", <#=member.PrimitiveMarshaller#>(<#=variableName#>.<#=member.PropertyName#><#=(member.UseNullable ? ".Value" : string.Empty)#>));				 
+<#=new string(' ', level * 4)#>					xmlWriter.WriteElementString("<#=member.MarshallName#>", "<#=xmlNamespace#>", <#=member.PrimitiveMarshaller#>(<#=variableName#>.<#=member.PropertyName#><#=(member.IsNullable ? ".Value" : string.Empty)#>));				 
 
 <#+
 			}

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.cs
@@ -337,7 +337,7 @@ if (this.Operation.Paginators.MoreResults != null)
             
             #line default
             #line hidden
-            this.Write(");\r\n");
+            this.Write(".GetValueOrDefault());\r\n");
             
             #line 95 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
@@ -535,7 +535,7 @@ if (this.Operation.Paginators.MoreResults != null)
             
             #line default
             #line hidden
-            this.Write(");\r\n");
+            this.Write(".GetValueOrDefault());\r\n");
             
             #line 156 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.tt
@@ -91,7 +91,7 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
 if (this.Operation.Paginators.MoreResults != null)
 {
 #>
-            while (response.<#=this.Operation.Paginators.MoreResults.PropertyName#>);
+            while (response.<#=this.Operation.Paginators.MoreResults.PropertyName#>.GetValueOrDefault());
 <#
 } 
 else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
@@ -152,7 +152,7 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
 if (this.Operation.Paginators.MoreResults != null)
 {
 #>
-            while (response.<#=this.Operation.Paginators.MoreResults.PropertyName#>);
+            while (response.<#=this.Operation.Paginators.MoreResults.PropertyName#>.GetValueOrDefault());
 <#
 } 
 else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceClientsNetFramework.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceClientsNetFramework.cs
@@ -18,7 +18,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class ServiceClientsNetFramework : BaseGenerator
     {
@@ -29,7 +29,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         public override string TransformText()
         {
             
-            #line 6 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 6 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
     AddLicenseHeader();
 
@@ -40,21 +40,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "g;\r\nusing System.Threading.Tasks;\r\nusing System.Collections.Generic;\r\nusing Syst" +
                     "em.Net;\r\n\r\nusing ");
             
-            #line 18 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 18 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
             #line hidden
             this.Write(".Model;\r\nusing ");
             
-            #line 19 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 19 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
             #line hidden
             this.Write(".Model.Internal.MarshallTransformations;\r\nusing ");
             
-            #line 20 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 20 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
@@ -62,42 +62,42 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write(".Internal;\r\nusing Amazon.Runtime;\r\nusing Amazon.Runtime.Internal;\r\nusing Amazon.R" +
                     "untime.Internal.Auth;\r\nusing Amazon.Runtime.Internal.Transform;\r\n\r\nnamespace ");
             
-            #line 26 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 26 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
             #line hidden
             this.Write("\r\n{\r\n");
             
-            #line 28 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 28 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
     this.FormatServiceClientDocumentation(this.Config.ServiceModel.Documentation); 
             
             #line default
             #line hidden
             this.Write("    public partial class Amazon");
             
-            #line 29 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 29 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client : AmazonServiceClient, IAmazon");
             
-            #line 29 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 29 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("\r\n    {\r\n\t\tprivate static IServiceMetadata serviceMetadata = new Amazon");
             
-            #line 31 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 31 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Metadata();\r\n");
             
-            #line 32 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 32 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
     // Creates paginators for service if available
     if (this.Config.ServiceModel.HasPaginators)
@@ -108,7 +108,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        private I");
             
-            #line 37 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 37 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceNameRoot));
             
             #line default
@@ -116,7 +116,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("PaginatorFactory _paginators;\r\n\r\n        /// <summary>\r\n        /// Paginators fo" +
                     "r the service\r\n        /// </summary>\r\n        public I");
             
-            #line 42 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 42 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceNameRoot));
             
             #line default
@@ -125,7 +125,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "         if (this._paginators == null) \r\n                {\r\n                    " +
                     "this._paginators = new ");
             
-            #line 48 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceNameRoot));
             
             #line default
@@ -133,7 +133,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("PaginatorFactory(this);\r\n                }\r\n                return this._paginato" +
                     "rs;\r\n            }\r\n        }\r\n");
             
-            #line 53 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 53 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
     }
 
@@ -141,7 +141,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line default
             #line hidden
             
-            #line 56 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 56 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
     // Generates basic constructors for the service if enabled in the model
     if(this.Config.GenerateConstructors)
@@ -155,7 +155,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("        #region Constructors\r\n\r\n        /// <summary>\r\n        /// Constructs Ama" +
                     "zon");
             
-            #line 66 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 66 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -176,28 +176,28 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         /// </summary>
         public Amazon");
             
-            #line 80 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 80 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client()\r\n            : base(FallbackCredentialsFactory.GetCredentials(");
             
-            #line 81 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 81 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(fallbackToAnonymousCredentials ? "fallbackToAnonymous: true" : ""));
             
             #line default
             #line hidden
             this.Write("), new Amazon");
             
-            #line 81 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 81 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Config()) { }\r\n\r\n        /// <summary>\r\n        /// Constructs Amazon");
             
-            #line 84 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 84 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -219,7 +219,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         /// <param name=""region"">The region to connect.</param>
         public Amazon");
             
-            #line 99 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 99 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -227,14 +227,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Client(RegionEndpoint region)\r\n            : base(FallbackCredentialsFactory.GetC" +
                     "redentials(");
             
-            #line 100 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 100 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(fallbackToAnonymousCredentials ? "fallbackToAnonymous: true" : ""));
             
             #line default
             #line hidden
             this.Write("), new Amazon");
             
-            #line 100 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 100 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -242,7 +242,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config{RegionEndpoint = region}) { }\r\n\r\n        /// <summary>\r\n        /// Constr" +
                     "ucts Amazon");
             
-            #line 103 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 103 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -263,21 +263,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         /// </summary>
         /// <param name=""config"">The Amazon");
             
-            #line 117 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 117 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client Configuration Object</param>\r\n        public Amazon");
             
-            #line 118 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 118 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client(Amazon");
             
-            #line 118 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 118 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -285,14 +285,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config config)\r\n            : base(FallbackCredentialsFactory.GetCredentials(conf" +
                     "ig");
             
-            #line 119 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 119 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(fallbackToAnonymousCredentials ? ", fallbackToAnonymous: true" : ""));
             
             #line default
             #line hidden
             this.Write("), config){}\r\n\r\n        /// <summary>\r\n        /// Constructs Amazon");
             
-            #line 122 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 122 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -300,14 +300,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Client with AWS Credentials\r\n        /// </summary>\r\n        /// <param name=\"cre" +
                     "dentials\">AWS Credentials</param>\r\n        public Amazon");
             
-            #line 125 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 125 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client(AWSCredentials credentials)\r\n            : this(credentials, new Amazon");
             
-            #line 126 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 126 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -315,7 +315,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config())\r\n        {\r\n        }\r\n\r\n        /// <summary>\r\n        /// Constructs " +
                     "Amazon");
             
-            #line 131 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 131 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -324,7 +324,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "dentials\">AWS Credentials</param>\r\n        /// <param name=\"region\">The region t" +
                     "o connect.</param>\r\n        public Amazon");
             
-            #line 135 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 135 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -332,7 +332,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Client(AWSCredentials credentials, RegionEndpoint region)\r\n            : this(cre" +
                     "dentials, new Amazon");
             
-            #line 136 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 136 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -340,14 +340,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config{RegionEndpoint = region})\r\n        {\r\n        }\r\n\r\n        /// <summary>\r\n" +
                     "        /// Constructs Amazon");
             
-            #line 141 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 141 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client with AWS Credentials and an\r\n        /// Amazon");
             
-            #line 142 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 142 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -356,21 +356,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "edentials\">AWS Credentials</param>\r\n        /// <param name=\"clientConfig\">The A" +
                     "mazon");
             
-            #line 145 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 145 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client Configuration Object</param>\r\n        public Amazon");
             
-            #line 146 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 146 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client(AWSCredentials credentials, Amazon");
             
-            #line 146 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 146 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -378,7 +378,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config clientConfig)\r\n            : base(credentials, clientConfig)\r\n        {\r\n " +
                     "       }\r\n\r\n        /// <summary>\r\n        /// Constructs Amazon");
             
-            #line 152 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 152 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -387,7 +387,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     " /// <param name=\"awsAccessKeyId\">AWS Access Key ID</param>\r\n        /// <param " +
                     "name=\"awsSecretAccessKey\">AWS Secret Access Key</param>\r\n        public Amazon");
             
-            #line 156 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 156 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -395,7 +395,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Client(string awsAccessKeyId, string awsSecretAccessKey)\r\n            : this(awsA" +
                     "ccessKeyId, awsSecretAccessKey, new Amazon");
             
-            #line 157 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 157 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -403,7 +403,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config())\r\n        {\r\n        }\r\n\r\n        /// <summary>\r\n        /// Constructs " +
                     "Amazon");
             
-            #line 162 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 162 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -415,7 +415,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         /// <param name=""region"">The region to connect.</param>
         public Amazon");
             
-            #line 167 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 167 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -423,7 +423,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Client(string awsAccessKeyId, string awsSecretAccessKey, RegionEndpoint region)\r\n" +
                     "            : this(awsAccessKeyId, awsSecretAccessKey, new Amazon");
             
-            #line 168 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 168 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -431,14 +431,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config() {RegionEndpoint=region})\r\n        {\r\n        }\r\n\r\n        /// <summary>\r" +
                     "\n        /// Constructs Amazon");
             
-            #line 173 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 173 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client with AWS Access Key ID, AWS Secret Key and an\r\n        /// Amazon");
             
-            #line 174 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 174 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -448,21 +448,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "ssKey\">AWS Secret Access Key</param>\r\n        /// <param name=\"clientConfig\">The" +
                     " Amazon");
             
-            #line 178 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 178 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client Configuration Object</param>\r\n        public Amazon");
             
-            #line 179 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 179 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client(string awsAccessKeyId, string awsSecretAccessKey, Amazon");
             
-            #line 179 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 179 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -471,7 +471,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "ntConfig)\r\n        {\r\n        }\r\n\r\n        /// <summary>\r\n        /// Constructs" +
                     " Amazon");
             
-            #line 185 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 185 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -483,7 +483,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         /// <param name=""awsSessionToken"">AWS Session Token</param>
         public Amazon");
             
-            #line 190 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 190 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -492,7 +492,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "\n            : this(awsAccessKeyId, awsSecretAccessKey, awsSessionToken, new Ama" +
                     "zon");
             
-            #line 191 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 191 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -500,7 +500,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config())\r\n        {\r\n        }\r\n\r\n        /// <summary>\r\n        /// Constructs " +
                     "Amazon");
             
-            #line 196 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 196 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -513,7 +513,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         /// <param name=""region"">The region to connect.</param>
         public Amazon");
             
-            #line 202 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 202 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -522,7 +522,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "RegionEndpoint region)\r\n            : this(awsAccessKeyId, awsSecretAccessKey, a" +
                     "wsSessionToken, new Amazon");
             
-            #line 203 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 203 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -530,14 +530,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config{RegionEndpoint = region})\r\n        {\r\n        }\r\n\r\n        /// <summary>\r\n" +
                     "        /// Constructs Amazon");
             
-            #line 208 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 208 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client with AWS Access Key ID, AWS Secret Key and an\r\n        /// Amazon");
             
-            #line 209 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 209 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -549,14 +549,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         /// <param name=""awsSessionToken"">AWS Session Token</param>
         /// <param name=""clientConfig"">The Amazon");
             
-            #line 214 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 214 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("Client Configuration Object</param>\r\n        public Amazon");
             
-            #line 215 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 215 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -564,7 +564,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Client(string awsAccessKeyId, string awsSecretAccessKey, string awsSessionToken, " +
                     "Amazon");
             
-            #line 215 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 215 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -572,7 +572,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config clientConfig)\r\n            : base(awsAccessKeyId, awsSecretAccessKey, awsS" +
                     "essionToken, clientConfig)\r\n        {\r\n        }\r\n\r\n        #endregion\r\n");
             
-            #line 221 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 221 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
     }
 
@@ -583,14 +583,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "ner for the service.\r\n        /// </summary>\r\n        protected override Abstrac" +
                     "tAWSSigner CreateSigner()\r\n        {\r\n            return new ");
             
-            #line 232 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 232 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(GeneratorHelpers.DetermineSigner(this.Config.ServiceModel.SignatureVersion, this.Config.ClassName)));
             
             #line default
             #line hidden
             this.Write("();\r\n        }    \r\n\r\n");
             
-            #line 235 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 235 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
  if(this.Config.ServiceModel.Customizations.PipelineOverride != null || this.Config.EndpointsRuleSet != null) { 
             
             #line default
@@ -599,7 +599,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "\r\n        /// <param name=\"pipeline\"></param>\r\n        protected override void C" +
                     "ustomizeRuntimePipeline(RuntimePipeline pipeline)\r\n        {\r\n");
             
-            #line 242 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 242 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
     var pipelineOverrides = this.Config.ServiceModel.Customizations.PipelineOverride;
     if (pipelineOverrides != null)
@@ -614,14 +614,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            if(");
             
-            #line 251 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 251 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(o.Condition));
             
             #line default
             #line hidden
             this.Write(")\r\n            {\r\n");
             
-            #line 253 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 253 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
                 if(o.OverrideMethod == "remove")
                 {
@@ -631,14 +631,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("                pipeline.");
             
-            #line 257 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 257 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(o.FormattedOverrideMethod));
             
             #line default
             #line hidden
             this.Write("();\r\n");
             
-            #line 258 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 258 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
                 }
                 else
@@ -649,28 +649,28 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("                pipeline.");
             
-            #line 263 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 263 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(o.FormattedOverrideMethod));
             
             #line default
             #line hidden
             this.Write("(new ");
             
-            #line 263 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 263 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(o.NewType));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 263 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 263 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(o.ConstructorInput));
             
             #line default
             #line hidden
             this.Write("));\r\n");
             
-            #line 264 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 264 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 				
                 }
 
@@ -679,7 +679,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            }\r\n");
             
-            #line 268 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 268 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
                 }
                 else if(o.OverrideMethod == "remove")
@@ -690,14 +690,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            pipeline.");
             
-            #line 273 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 273 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(o.FormattedOverrideMethod));
             
             #line default
             #line hidden
             this.Write("();\r\n");
             
-            #line 274 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 274 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
                 }
                 else
@@ -708,28 +708,28 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            pipeline.");
             
-            #line 279 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 279 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(o.FormattedOverrideMethod));
             
             #line default
             #line hidden
             this.Write("(new ");
             
-            #line 279 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 279 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(o.NewType));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 279 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 279 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(o.ConstructorInput));
             
             #line default
             #line hidden
             this.Write("));\r\n");
             
-            #line 280 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 280 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
             }
         }
@@ -739,7 +739,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line default
             #line hidden
             
-            #line 285 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 285 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
  if (this.Config.EndpointsRuleSet != null) { 
             
             #line default
@@ -748,21 +748,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "            pipeline.AddHandlerAfter<Amazon.Runtime.Internal.Marshaller>(new Ama" +
                     "zon");
             
-            #line 287 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 287 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("EndpointResolver());\r\n");
             
-            #line 288 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 288 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
  } 
             
             #line default
             #line hidden
             this.Write("        }\t\r\n");
             
-            #line 290 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 290 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         }
 
@@ -791,7 +791,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         {
 ");
             
-            #line 313 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 313 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         if(this.Config.ServiceId == "S3")
         {
@@ -804,7 +804,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "     {\r\n                clientConfig.S3ExpressCredentialProvider.Dispose();\r\n   " +
                     "         }\r\n");
             
-            #line 322 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 322 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         }
 
@@ -813,7 +813,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            base.Dispose(disposing);\r\n        }\r\n\r\n        #endregion\r\n\r\n");
             
-            #line 330 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 330 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         var endpointOperation = this.Config.ServiceModel.FindEndpointOperation();
         if(endpointOperation != null)
@@ -830,14 +830,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             {
 				var request = new ");
             
-            #line 341 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 341 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(endpointOperation.Name));
             
             #line default
             #line hidden
             this.Write("Request\r\n\t\t\t\t{\r\n");
             
-            #line 343 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 343 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         if(endpointOperation.RequestHasOperationEndpointOperationMember)
         {
@@ -847,7 +847,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t\t\t\tOperation = context.OperationName,\r\n");
             
-            #line 348 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 348 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         }
         if(endpointOperation.RequestHasIdentifiersEndpointOperationMember)
@@ -859,7 +859,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("\t\t\t\t\tIdentifiers = new Dictionary<string, string>(context.EndpointDiscoveryData.I" +
                     "dentifiers),\r\n");
             
-            #line 354 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 354 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         }
 
@@ -868,7 +868,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t\t\t};\r\n\t\t\t\t\r\n\t\t\t\tvar response = ");
             
-            #line 359 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 359 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(endpointOperation.Name));
             
             #line default
@@ -882,7 +882,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
 				var endpoints = new List<DiscoveryEndpointBase>();
 				foreach(var endpoint in response.Endpoints)
                 {
-                    endpoints.Add(new DiscoveryEndpoint(endpoint.Address, endpoint.CachePeriodInMinutes));
+                    endpoints.Add(new DiscoveryEndpoint(endpoint.Address, endpoint.CachePeriodInMinutes.GetValueOrDefault()));
                 }
             
 				return endpoints;
@@ -892,7 +892,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         #endregion
 ");
             
-            #line 376 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 376 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         }
 
@@ -904,14 +904,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\r\n        #region  ");
             
-            #line 383 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 383 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("\r\n\r\n");
             
-            #line 385 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 385 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         // Creates a version of the operation that takes no arguments and passes a request with no set members if specified in the customizations
         if (this.Config.ServiceModel.Customizations.CreateNoArgOverload(operation.Name))
@@ -921,7 +921,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line default
             #line hidden
             
-            #line 390 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 390 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         this.FormatOperationDocumentationSync(operation, false);
 		if(operation.IsDeprecated)
@@ -932,14 +932,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t[Obsolete(\"");
             
-            #line 395 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 395 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 396 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 396 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 		
 		}
 
@@ -948,35 +948,35 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        public virtual ");
             
-            #line 399 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 399 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response ");
             
-            #line 399 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 399 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("()\r\n        {\r\n            return ");
             
-            #line 401 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 401 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("(new ");
             
-            #line 401 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 401 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Request());\r\n        }\r\n\r\n");
             
-            #line 404 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 404 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         }
         // Adds any simple method forms specified in the customizations file
@@ -986,7 +986,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line default
             #line hidden
             
-            #line 409 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 409 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         this.FormatOperationDocumentationSync(operation, true);
 		if(operation.IsDeprecated)
@@ -997,14 +997,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t[Obsolete(\"");
             
-            #line 414 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 414 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 415 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 415 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 		
 		}
 
@@ -1013,28 +1013,28 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        ");
             
-            #line 418 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 418 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.IsInternal ? "internal" : "public"));
             
             #line default
             #line hidden
             this.Write(" virtual ");
             
-            #line 418 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 418 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response ");
             
-            #line 418 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 418 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 418 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 418 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1042,21 +1042,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Request request)\r\n        {\r\n            var options = new InvokeOptions();\r\n    " +
                     "        options.RequestMarshaller = ");
             
-            #line 421 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 421 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("RequestMarshaller.Instance;\r\n            options.ResponseUnmarshaller = ");
             
-            #line 422 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 422 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("ResponseUnmarshaller.Instance;\r\n");
             
-            #line 423 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 423 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
             if(!operation.IsEndpointOperation && operation.EndpointDiscoveryEnabled)
             {
@@ -1066,7 +1066,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            options.EndpointDiscoveryMarshaller = ");
             
-            #line 427 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 427 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1074,7 +1074,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("EndpointDiscoveryMarshaller.Instance;\r\n            options.EndpointOperation = En" +
                     "dpointOperation;\r\n");
             
-            #line 429 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 429 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
             }
 
@@ -1083,14 +1083,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\r\n            return Invoke<");
             
-            #line 433 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 433 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response>(request, options);\r\n        }\r\n\r\n");
             
-            #line 436 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 436 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         // Creates a version of the operation that takes no arguments and passes a request with no set members if specified in the customizations
         if (this.Config.ServiceModel.Customizations.CreateNoArgOverload(operation.Name))
@@ -1100,7 +1100,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line default
             #line hidden
             
-            #line 441 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 441 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         this.FormatOperationDocumentationAsync(operation, false);
 		if(operation.IsDeprecated)
@@ -1111,14 +1111,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t[Obsolete(\"");
             
-            #line 446 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 446 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 447 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 447 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 		
 		}
 
@@ -1127,14 +1127,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        public virtual Task<");
             
-            #line 450 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 450 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> ");
             
-            #line 450 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 450 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1142,21 +1142,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Async(System.Threading.CancellationToken cancellationToken = default(Cancellation" +
                     "Token))\r\n        {\r\n            return ");
             
-            #line 452 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 452 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Async(new ");
             
-            #line 452 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 452 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Request(), cancellationToken);\r\n        }\r\n");
             
-            #line 454 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 454 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         }
 
@@ -1172,14 +1172,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t[Obsolete(\"");
             
-            #line 464 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 464 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 465 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 465 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 		
 		}
 
@@ -1188,28 +1188,28 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        ");
             
-            #line 468 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 468 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.IsInternal ? "internal" : "public"));
             
             #line default
             #line hidden
             this.Write(" virtual Task<");
             
-            #line 468 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 468 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> ");
             
-            #line 468 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 468 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Async(");
             
-            #line 468 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 468 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1218,21 +1218,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "ancellationToken))\r\n        {\r\n            var options = new InvokeOptions();\r\n " +
                     "           options.RequestMarshaller = ");
             
-            #line 471 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 471 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("RequestMarshaller.Instance;\r\n            options.ResponseUnmarshaller = ");
             
-            #line 472 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 472 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("ResponseUnmarshaller.Instance;\r\n");
             
-            #line 473 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 473 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
             if(!operation.IsEndpointOperation && operation.EndpointDiscoveryEnabled)
             {
@@ -1242,7 +1242,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            options.EndpointDiscoveryMarshaller = ");
             
-            #line 477 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 477 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1250,7 +1250,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("EndpointDiscoveryMarshaller.Instance;\r\n            options.EndpointOperation = En" +
                     "dpointOperation;\r\n");
             
-            #line 479 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 479 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
             }
 
@@ -1259,7 +1259,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            \r\n            return InvokeAsync<");
             
-            #line 483 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 483 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1267,7 +1267,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Response>(request, options, cancellationToken);\r\n        }\r\n\r\n        #endregion\r" +
                     "\n        ");
             
-            #line 487 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 487 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
 
         }
         
@@ -1276,7 +1276,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\r\n");
             
-            #line 491 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 491 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
  if (this.Config.EndpointsRuleSet != null) { 
             
             #line default
@@ -1300,7 +1300,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             var executionContext = new Amazon.Runtime.Internal.ExecutionContext(requestContext, null);
             var resolver = new Amazon");
             
-            #line 509 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 509 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -1308,7 +1308,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("EndpointResolver();\r\n            return resolver.GetEndpoint(executionContext);\r\n" +
                     "        }\r\n\r\n        #endregion\r\n\r\n");
             
-            #line 515 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
+            #line 515 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetFramework.tt"
  } 
             
             #line default

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceClientsNetFramework.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceClientsNetFramework.tt
@@ -365,7 +365,7 @@ namespace <#=this.Config.Namespace#>
 				var endpoints = new List<DiscoveryEndpointBase>();
 				foreach(var endpoint in response.Endpoints)
                 {
-                    endpoints.Add(new DiscoveryEndpoint(endpoint.Address, endpoint.CachePeriodInMinutes));
+                    endpoints.Add(new DiscoveryEndpoint(endpoint.Address, endpoint.CachePeriodInMinutes.GetValueOrDefault()));
                 }
             
 				return endpoints;

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceClientsNetStandard.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceClientsNetStandard.cs
@@ -795,7 +795,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         {
 ");
             
-            #line 317 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 317 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         if(this.Config.ServiceId == "S3")
         {
@@ -808,7 +808,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "     {\r\n                clientConfig.S3ExpressCredentialProvider.Dispose();\r\n   " +
                     "         }\r\n");
             
-            #line 326 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 326 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         }
 
@@ -817,7 +817,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            base.Dispose(disposing);\r\n        }\r\n\r\n        #endregion\r\n\r\n");
             
-            #line 334 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 334 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         var endpointOperation = this.Config.ServiceModel.FindEndpointOperation();
         if(endpointOperation != null)
@@ -834,14 +834,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             {
 				var request = new ");
             
-            #line 345 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 345 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(endpointOperation.Name));
             
             #line default
             #line hidden
             this.Write("Request\r\n\t\t\t\t{\r\n");
             
-            #line 347 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 347 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         if(endpointOperation.RequestHasOperationEndpointOperationMember)
         {
@@ -851,7 +851,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t\t\t\tOperation = context.OperationName,\r\n");
             
-            #line 352 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 352 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         }
         if(endpointOperation.RequestHasIdentifiersEndpointOperationMember)
@@ -863,7 +863,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("\t\t\t\t\tIdentifiers = new Dictionary<string, string>(context.EndpointDiscoveryData.I" +
                     "dentifiers),\r\n");
             
-            #line 358 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 358 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         }
 
@@ -872,7 +872,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t\t\t};\r\n\t\t\t\t                \r\n\t\t\t\tvar response = ");
             
-            #line 363 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 363 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(endpointOperation.Name));
             
             #line default
@@ -886,7 +886,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
 				var endpoints = new List<DiscoveryEndpointBase>();
 				foreach(var endpoint in response.Endpoints)
                 {
-                    endpoints.Add(new DiscoveryEndpoint(endpoint.Address, endpoint.CachePeriodInMinutes));
+                    endpoints.Add(new DiscoveryEndpoint(endpoint.Address, endpoint.CachePeriodInMinutes.GetValueOrDefault()));
                 }
             
 				return endpoints;
@@ -896,7 +896,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         #endregion
 ");
             
-            #line 380 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 380 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         }
 
@@ -909,14 +909,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\r\n        #region  ");
             
-            #line 388 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 388 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("\r\n\r\n");
             
-            #line 390 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 390 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         if (this.Config.ServiceModel.Customizations.CreateNoArgOverload(operation.Name))
         {
@@ -928,14 +928,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t[Obsolete(\"");
             
-            #line 396 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 396 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 397 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 397 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 		
 		}
 
@@ -944,35 +944,35 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        internal virtual ");
             
-            #line 400 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 400 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response ");
             
-            #line 400 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 400 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("()\r\n        {\r\n            return ");
             
-            #line 402 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 402 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("(new ");
             
-            #line 402 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 402 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Request());\r\n        }\r\n");
             
-            #line 404 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 404 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         }
 		if(operation.IsDeprecated)
@@ -983,14 +983,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t[Obsolete(\"");
             
-            #line 409 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 409 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 410 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 410 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 		
 		}
 
@@ -999,21 +999,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        internal virtual ");
             
-            #line 413 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 413 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response ");
             
-            #line 413 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 413 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 413 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 413 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1021,21 +1021,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Request request)\r\n        {\r\n            var options = new InvokeOptions();\r\n    " +
                     "        options.RequestMarshaller = ");
             
-            #line 416 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 416 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("RequestMarshaller.Instance;\r\n            options.ResponseUnmarshaller = ");
             
-            #line 417 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 417 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("ResponseUnmarshaller.Instance;\r\n");
             
-            #line 418 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 418 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
             if(!operation.IsEndpointOperation && operation.EndpointDiscoveryEnabled)
             {
@@ -1045,7 +1045,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            options.EndpointDiscoveryMarshaller = ");
             
-            #line 422 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 422 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1053,7 +1053,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("EndpointDiscoveryMarshaller.Instance;\r\n            options.EndpointOperation = En" +
                     "dpointOperation;\r\n");
             
-            #line 424 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 424 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
             }
 
@@ -1062,14 +1062,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\r\n            return Invoke<");
             
-            #line 428 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 428 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response>(request, options);\r\n        }\r\n\r\n");
             
-            #line 431 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 431 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         // Creates a version of the operation that takes no arguments and passes a request with no set members if specified in the customizations
         if (this.Config.ServiceModel.Customizations.CreateNoArgOverload(operation.Name))
@@ -1079,7 +1079,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line default
             #line hidden
             
-            #line 436 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 436 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         this.FormatOperationDocumentationAsync(operation, false);
 		if(operation.IsDeprecated)
@@ -1090,14 +1090,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t[Obsolete(\"");
             
-            #line 441 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 441 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 442 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 442 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 		
 		}
 
@@ -1106,14 +1106,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        public virtual Task<");
             
-            #line 445 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 445 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> ");
             
-            #line 445 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 445 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1121,21 +1121,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Async(System.Threading.CancellationToken cancellationToken = default(Cancellation" +
                     "Token))\r\n        {\r\n            return ");
             
-            #line 447 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 447 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Async(new ");
             
-            #line 447 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 447 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Request(), cancellationToken);\r\n        }\r\n\r\n");
             
-            #line 450 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 450 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         }
 		// Add async simple methods
@@ -1146,7 +1146,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\r\n");
             
-            #line 456 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 456 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
 		this.FormatOperationDocumentationAsync(operation, true);
 		if(operation.IsDeprecated)
@@ -1157,14 +1157,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\t\t[Obsolete(\"");
             
-            #line 461 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 461 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 462 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 462 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 		
 		}
 
@@ -1173,28 +1173,28 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        ");
             
-            #line 465 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 465 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.IsInternal ? "internal" : "public"));
             
             #line default
             #line hidden
             this.Write(" virtual Task<");
             
-            #line 465 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 465 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> ");
             
-            #line 465 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 465 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("Async(");
             
-            #line 465 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 465 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1203,21 +1203,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "ancellationToken))\r\n        {\r\n            var options = new InvokeOptions();\r\n " +
                     "           options.RequestMarshaller = ");
             
-            #line 468 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 468 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("RequestMarshaller.Instance;\r\n            options.ResponseUnmarshaller = ");
             
-            #line 469 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 469 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
             #line hidden
             this.Write("ResponseUnmarshaller.Instance;\r\n");
             
-            #line 470 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 470 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
             if(!operation.IsEndpointOperation && operation.EndpointDiscoveryEnabled)
             {
@@ -1227,7 +1227,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            options.EndpointDiscoveryMarshaller = ");
             
-            #line 474 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 474 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1235,7 +1235,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("EndpointDiscoveryMarshaller.Instance;\r\n            options.EndpointOperation = En" +
                     "dpointOperation;\r\n");
             
-            #line 476 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 476 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
             }
 
@@ -1244,7 +1244,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\r\n            return InvokeAsync<");
             
-            #line 480 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 480 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(operation.Name));
             
             #line default
@@ -1252,7 +1252,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Response>(request, options, cancellationToken);\r\n        }\r\n\r\n        #endregion\r" +
                     "\n        ");
             
-            #line 484 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 484 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
 
         }
         
@@ -1261,7 +1261,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("\r\n");
             
-            #line 488 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 488 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
  if (this.Config.EndpointsRuleSet != null) { 
             
             #line default
@@ -1285,7 +1285,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             var executionContext = new Amazon.Runtime.Internal.ExecutionContext(requestContext, null);
             var resolver = new Amazon");
             
-            #line 506 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 506 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -1293,7 +1293,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("EndpointResolver();\r\n            return resolver.GetEndpoint(executionContext);\r\n" +
                     "        }\r\n\r\n        #endregion\r\n\r\n");
             
-            #line 512 "C:\Dev\Repos\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
+            #line 512 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceClientsNetStandard.tt"
  } 
             
             #line default

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceClientsNetStandard.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceClientsNetStandard.tt
@@ -369,7 +369,7 @@ namespace <#=this.Config.Namespace#>
 				var endpoints = new List<DiscoveryEndpointBase>();
 				foreach(var endpoint in response.Endpoints)
                 {
-                    endpoints.Add(new DiscoveryEndpoint(endpoint.Address, endpoint.CachePeriodInMinutes));
+                    endpoints.Add(new DiscoveryEndpoint(endpoint.Address, endpoint.CachePeriodInMinutes.GetValueOrDefault()));
                 }
             
 				return endpoints;

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/StructureGenerator.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/StructureGenerator.cs
@@ -18,7 +18,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class StructureGenerator : BaseGenerator
     {
@@ -30,7 +30,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         {
             this.Write("\r\n");
             
-            #line 7 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 7 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     AddLicenseHeader();
 
@@ -41,7 +41,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "\r\nusing System.Text;\r\nusing System.IO;\r\nusing System.Net;\r\n\r\nusing Amazon.Runtim" +
                     "e;\r\nusing Amazon.Runtime.Internal;\r\n");
             
-            #line 19 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 19 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 bool structureIsNotEventStream = this.Structure != null && !this.Structure.IsEventStream;
 bool structureIsEventStream = this.Structure != null && this.Structure.IsEventStream;
@@ -54,7 +54,7 @@ if(this.StructureType == StructureType.Request && this.Operation.AuthType.HasVal
             #line hidden
             this.Write("using Amazon.Runtime.Internal.Auth;\r\n");
             
-            #line 27 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 27 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 }
 
@@ -62,7 +62,7 @@ if(this.StructureType == StructureType.Request && this.Operation.AuthType.HasVal
             #line default
             #line hidden
             
-            #line 30 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 30 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 if(structureIsEvent || structureIsEventStream)
 {
@@ -73,7 +73,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("using Amazon.Runtime.EventStreams;\r\nusing Amazon.Runtime.EventStreams.Internal;\r\n" +
                     "using ");
             
-            #line 36 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 36 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
@@ -81,7 +81,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write(".Model.Internal.MarshallTransformations;\r\nusing Amazon.Runtime.EventStreams.Utils" +
                     ";\r\n");
             
-            #line 38 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 38 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 }
 
@@ -90,14 +90,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\nnamespace ");
             
-            #line 42 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 42 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
             #line hidden
             this.Write(".Model\r\n{\r\n");
             
-            #line 44 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 44 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
   
     if(this.StructureType == StructureType.Request)
         this.FormatOperationRequestDocumentation(this.Operation);
@@ -111,14 +111,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    /// <summary>\r\n    /// This is the response object from the ");
             
-            #line 53 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 53 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write(" operation.\r\n    /// </summary>\r\n");
             
-            #line 55 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 55 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     }
     else
@@ -128,7 +128,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 60 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 60 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
       
     if(this.Structure != null && this.Structure.IsDeprecated)
         {
@@ -138,14 +138,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    [Obsolete(\"");
             
-            #line 64 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 64 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 65 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
     if(this.Structure is ExceptionShape)
@@ -156,7 +156,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    #if !NETSTANDARD\r\n    [Serializable]\r\n    #endif\r\n");
             
-            #line 73 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 73 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
 
@@ -164,7 +164,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 76 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 76 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 
     if(this.Structure != null && this.Structure.IsEventStream)
@@ -181,14 +181,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    ");
             
-            #line 87 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 87 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(EventStreamOutput));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 88 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 88 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     }
 
@@ -196,7 +196,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 91 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 91 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     bool hasStreamingMember = this.Structure?.Members.Any(member => member.IsStreaming) ?? false;
         
@@ -214,20 +214,20 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    public partial class ");
             
-            #line 103 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 103 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.ClassName));
             
             #line default
             #line hidden
             
-            #line 103 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 103 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.BaseClassString));
             
             #line default
             #line hidden
             this.Write(", IDisposable\r\n    {\r\n");
             
-            #line 105 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 105 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
     else 
@@ -237,7 +237,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 110 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 110 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         if( (this.Structure == null) || (structureIsNotEventStream))
         {
@@ -247,20 +247,20 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    public partial class ");
             
-            #line 114 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 114 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.ClassName));
             
             #line default
             #line hidden
             
-            #line 114 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 114 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.BaseClassString));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 115 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 115 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
             if(structureIsEvent)
             {
@@ -270,7 +270,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        : IEventStreamEvent\r\n");
             
-            #line 120 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 120 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
             }
 
@@ -279,7 +279,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    {\r\n");
             
-            #line 124 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 124 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
 
@@ -287,7 +287,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 127 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 127 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     }
 
@@ -295,7 +295,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 130 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 130 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         if(structureIsNotEventStream)
         {
@@ -307,28 +307,28 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        private ");
             
-            #line 136 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 136 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
             #line hidden
             this.Write(" _response;\r\n\r\n        /// <summary>\r\n        /// Gets and sets the ");
             
-            #line 139 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 139 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
             #line hidden
             this.Write(" property.\r\n        /// </summary>\r\n        public ");
             
-            #line 141 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 141 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 141 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 141 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -336,7 +336,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("\r\n        {\r\n            get { return this._response; }\r\n            set { this._" +
                     "response = value; }\r\n        }\r\n");
             
-            #line 146 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 146 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
             }
             else
@@ -351,33 +351,27 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        private ");
             
-            #line 155 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 155 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
-            
-            #line default
-            #line hidden
-            
-            #line 155 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(member.IsNullable ? "?" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 155 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 155 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             
-            #line 155 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 155 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 156 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 156 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
 
@@ -386,7 +380,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\n");
             
-            #line 160 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 160 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 AddSimpleRequestConstructors(this.ClassName, this.Structure, this.Config.Namespace);
 
@@ -401,14 +395,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        private RetryableDetails _retryableDetails = new RetryableDetails(");
             
-            #line 169 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 169 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(exceptionShape.Throttling.ToString().ToLower()));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 170 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 170 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 
             
@@ -416,7 +410,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\n");
             
-            #line 173 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 173 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -425,7 +419,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        /// <summary>\r\n        /// Constructs a new ");
             
-            #line 2 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 2 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -434,7 +428,7 @@ if(structureIsEvent || structureIsEventStream)
                     "/// <param name=\"message\">\r\n        /// Describes the error encountered.\r\n      " +
                     "  /// </param>\r\n        public ");
             
-            #line 8 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 8 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -442,7 +436,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("(string message) \r\n            : base(message) {}\r\n\r\n        /// <summary>\r\n     " +
                     "   /// Construct instance of ");
             
-            #line 12 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 12 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -450,7 +444,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("\r\n        /// </summary>\r\n        /// <param name=\"message\"></param>\r\n        ///" +
                     " <param name=\"innerException\"></param>\r\n        public ");
             
-            #line 16 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -458,7 +452,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("(string message, Exception innerException) \r\n            : base(message, innerExc" +
                     "eption) {}\r\n\r\n        /// <summary>\r\n        /// Construct instance of ");
             
-            #line 20 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 20 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -466,7 +460,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("\r\n        /// </summary>\r\n        /// <param name=\"innerException\"></param>\r\n    " +
                     "    public ");
             
-            #line 23 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 23 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -474,7 +468,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("(Exception innerException) \r\n            : base(innerException) {}\r\n\r\n        ///" +
                     " <summary>\r\n        /// Construct instance of ");
             
-            #line 27 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 27 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -489,7 +483,7 @@ if(structureIsEvent || structureIsEventStream)
         /// <param name=""statusCode""></param>
         public ");
             
-            #line 35 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 35 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -500,7 +494,7 @@ if(structureIsEvent || structureIsEventStream)
         /// <summary>
         /// Construct instance of ");
             
-            #line 39 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 39 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -514,7 +508,7 @@ if(structureIsEvent || structureIsEventStream)
         /// <param name=""statusCode""></param>
         public ");
             
-            #line 46 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 46 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -526,7 +520,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("#if !NETSTANDARD\r\n        /// <summary>\r\n        /// Constructs a new instance of" +
                     " the ");
             
-            #line 3 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 3 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -539,7 +533,7 @@ if(structureIsEvent || structureIsEventStream)
         /// <exception cref=""T:System.Runtime.Serialization.SerializationException"">The class name is null or <see cref=""P:System.Exception.HResult"" /> is zero (0). </exception>
         protected ");
             
-            #line 9 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 9 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -547,7 +541,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serializatio" +
                     "n.StreamingContext context)\r\n            : base(info, context)\r\n        {\r\n");
             
-            #line 12 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 12 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
           
             foreach(var member in this.Structure.Members)
 			{
@@ -557,35 +551,35 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            this.");
             
-            #line 16 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = (");
             
-            #line 16 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             this.Write(")info.GetValue(\"");
             
-            #line 16 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("\", typeof(");
             
-            #line 16 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             this.Write("));\r\n");
             
-            #line 17 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 17 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
 
             }
 
@@ -609,7 +603,7 @@ if(structureIsEvent || structureIsEventStream)
             base.GetObjectData(info, context);
 ");
             
-            #line 35 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 35 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
 
             foreach(var member in this.Structure.Members)
 			{
@@ -619,21 +613,21 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            info.AddValue(\"");
             
-            #line 39 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 39 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("\", this.");
             
-            #line 39 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 39 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 40 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 40 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
 
             }
 
@@ -643,7 +637,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("        }\r\n#endif\r\n");
             this.Write("\r\n");
             
-            #line 178 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 178 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
                 foreach(var member in this.Structure.Members)
@@ -655,13 +649,13 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 185 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 185 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
  this.FormatPropertyDocumentation(member); 
             
             #line default
             #line hidden
             
-            #line 186 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 186 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
       
                     if(member.IsDeprecated)
                     {
@@ -671,14 +665,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        [Obsolete(\"");
             
-            #line 190 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 190 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 191 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 191 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -707,14 +701,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        [AWSProperty(");
             
-            #line 214 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 214 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(string.Join(", ", propertyAttributes)));
             
             #line default
             #line hidden
             this.Write(")]\r\n");
             
-            #line 215 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 215 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -723,92 +717,55 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        ");
             
-            #line 218 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.AccessModifier));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 218 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             
-            #line 218 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.UseNullable ? "?" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 218 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
-            this.Write("\r\n        {\r\n");
+            this.Write("\r\n        {\r\n            get { return this.");
             
-            #line 220 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
-
-                    if(member.IsNullable && !member.UseNullable)
-                    {
-
-            
-            #line default
-            #line hidden
-            this.Write("            get { return this.");
-            
-            #line 224 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 220 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
-            this.Write(".GetValueOrDefault(); }\r\n");
+            this.Write("; }\r\n            set { ");
             
-            #line 225 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
-
-                    }
-                    else
-                    {
-
-            
-            #line default
-            #line hidden
-            this.Write("            get { return this.");
-            
-            #line 230 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
-            
-            #line default
-            #line hidden
-            this.Write("; }\r\n");
-            
-            #line 231 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
-
-                    }
-
-            
-            #line default
-            #line hidden
-            this.Write("            set { ");
-            
-            #line 234 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 221 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.IsBackwardsCompatibleDateTimeProperty ? "this." + member.BackwardCompatibilityVariableName + " = " : ""));
             
             #line default
             #line hidden
             this.Write("this.");
             
-            #line 234 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 221 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(" = value; }\r\n        }\r\n\r\n");
             
-            #line 237 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 224 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     if (member.EmitIsSetProperties)
                     {
@@ -819,7 +776,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("        /// <summary>\r\n        /// This property is set to true if the property <" +
                     "seealso cref=\"");
             
-            #line 242 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 229 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
@@ -835,7 +792,7 @@ if(structureIsEvent || structureIsEventStream)
         /// </returns>
 ");
             
-            #line 251 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 238 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
       
                         if(member.IsDeprecated)
                         {
@@ -845,14 +802,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        [Obsolete(\"");
             
-            #line 255 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 242 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 256 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 243 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         }
 
@@ -861,7 +818,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        public bool Is");
             
-            #line 259 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 246 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
@@ -869,7 +826,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("Set\r\n        {\r\n            get\r\n            {\r\n                return Amazon.Uti" +
                     "l.Internal.InternalSDKUtils.GetIsSet(this.");
             
-            #line 263 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 250 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
@@ -877,14 +834,14 @@ if(structureIsEvent || structureIsEventStream)
             this.Write(");\r\n            }\r\n            set\r\n            {\r\n                Amazon.Util.In" +
                     "ternal.InternalSDKUtils.SetIsSet(value, ref this.");
             
-            #line 267 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 254 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 268 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 255 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         if(member.IsBackwardsCompatibleDateTimeProperty)
                         {
@@ -895,14 +852,14 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("  \r\n                Amazon.Util.Internal.InternalSDKUtils.SetIsSet(value, ref thi" +
                     "s.");
             
-            #line 272 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 259 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityVariableName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 273 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 260 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         }
 
@@ -911,7 +868,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            }\r\n        }\r\n\r\n");
             
-            #line 279 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 266 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -920,21 +877,21 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        // Check to see if ");
             
-            #line 282 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 269 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" property is set\r\n        internal bool IsSet");
             
-            #line 283 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 270 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("()\r\n        {\r\n");
             
-            #line 285 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 272 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     if (member.EmitIsSetProperties)
                     {
@@ -944,14 +901,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return this.Is");
             
-            #line 289 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 276 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("Set; \r\n");
             
-            #line 290 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 277 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                     else if (member.IsNullable)
@@ -962,14 +919,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return this.");
             
-            #line 295 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 282 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(".HasValue; \r\n");
             
-            #line 296 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 283 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                     else if (member.IsMap || member.IsList)
@@ -980,21 +937,21 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return this.");
             
-            #line 301 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 288 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(" != null && this.");
             
-            #line 301 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 288 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(".Count > 0; \r\n");
             
-            #line 302 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 289 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                     else if (member.IsDocument)
@@ -1005,14 +962,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return !this.");
             
-            #line 307 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 294 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(".IsNull();\r\n");
             
-            #line 308 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 295 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                     else
@@ -1023,14 +980,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return this.");
             
-            #line 313 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 300 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(" != null;\r\n");
             
-            #line 314 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 301 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -1039,7 +996,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        }\r\n\r\n");
             
-            #line 319 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 306 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
 
@@ -1053,7 +1010,7 @@ if(structureIsEvent || structureIsEventStream)
                     "   /// </summary>\r\n        /// <returns>A signer for this request.</returns>\r\n  " +
                     "      override protected AbstractAWSSigner CreateSigner()\r\n        {\r\n");
             
-            #line 331 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 318 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     switch (this.Operation.AuthType.Value)
                     {
@@ -1064,7 +1021,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return new NullSigner();\r\n");
             
-            #line 337 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 324 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         break;
                         case OperationAuthType.V4:
@@ -1074,7 +1031,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return new AWS4Signer();\r\n");
             
-            #line 342 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 329 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         break;
                         case OperationAuthType.V4UnsignedBody:
@@ -1084,7 +1041,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return new AWS4Signer(false);\r\n");
             
-            #line 347 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 334 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         break;
                         case OperationAuthType.Bearer:
@@ -1094,7 +1051,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return new BearerTokenSigner();\r\n");
             
-            #line 352 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 339 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         break;
                         default:
@@ -1106,7 +1063,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        }\r\n");
             
-            #line 359 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 346 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
                 // Flexible checksum overrides to allow response validation configuration on the request
@@ -1127,7 +1084,7 @@ if(structureIsEvent || structureIsEventStream)
             {
                 if (IsSet");
             
-            #line 373 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 360 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.ChecksumConfiguration.RequestValidationModeMember));
             
             #line default
@@ -1135,7 +1092,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("())\r\n                {\r\n                    return (CoreChecksumResponseBehavior)" +
                     "Enum.Parse(typeof(CoreChecksumResponseBehavior), this.");
             
-            #line 375 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 362 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.ChecksumConfiguration.RequestValidationModeMember));
             
             #line default
@@ -1145,7 +1102,7 @@ if(structureIsEvent || structureIsEventStream)
                     "ithm> _supportedChecksumAlgorithms = new List<CoreChecksumAlgorithm>\r\n        {\r" +
                     "\n            ");
             
-            #line 384 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 371 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(string.Join(", ", Operation.ChecksumConfiguration?.ResponseAlgorithms?.Select(s => $"CoreChecksumAlgorithm.{s}").ToArray())));
             
             #line default
@@ -1160,7 +1117,7 @@ if(structureIsEvent || structureIsEventStream)
 #endregion
 ");
             
-            #line 392 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 379 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
 
@@ -1172,7 +1129,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("#region Backwards compatible properties\r\n");
             
-            #line 399 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 386 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     foreach(var member in this.Structure.Members)
                     {
@@ -1184,33 +1141,27 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        private ");
             
-            #line 405 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 392 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
-            
-            #line default
-            #line hidden
-            
-            #line 405 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(member.IsNullable ? "?" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 405 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 392 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityVariableName));
             
             #line default
             #line hidden
             
-            #line 405 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 392 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 406 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 393 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -1219,7 +1170,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\n");
             
-            #line 410 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 397 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     foreach(var member in this.Structure.Members)
                     {
@@ -1230,7 +1181,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 416 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 403 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
  this.FormatPropertyDocumentation(member, "This property is deprecated. Setting this property results in non-UTC DateTimes " +
         "not being marshalled correctly. Use " + member.PropertyName + " instead. Setting either " + member.BackwardCompatibilityPropertyName +
         " or " + member.PropertyName + " results in both " + member.BackwardCompatibilityPropertyName + " and " + 
@@ -1243,35 +1194,35 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("        [Obsolete(\"Setting this property results in non-UTC DateTimes not being m" +
                     "arshalled correctly. \" +\r\n            \"Use ");
             
-            #line 423 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 410 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" instead. Setting either ");
             
-            #line 423 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 410 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write(" or ");
             
-            #line 423 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 410 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" results in both ");
             
-            #line 423 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 410 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write(" and \" +\r\n            \"");
             
-            #line 424 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 411 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
@@ -1279,7 +1230,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write(" being assigned, the latest assignment to either one of the two property is \" + \r" +
                     "\n            \"reflected in the value of both. ");
             
-            #line 425 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 412 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
@@ -1288,55 +1239,64 @@ if(structureIsEvent || structureIsEventStream)
                     "on-Utc DateTime to it results in the wrong timestamp being passed to the service" +
                     ".\", false)]\r\n        ");
             
-            #line 427 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 414 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.AccessModifier));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 427 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 414 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             
-            #line 427 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 414 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.UseNullable ? "?" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 427 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 414 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write("\r\n        {\r\n            get { return this.");
             
-            #line 429 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 416 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityVariableName));
             
             #line default
             #line hidden
             this.Write(".GetValueOrDefault(); }\r\n            set\r\n            {\r\n                this.");
             
-            #line 432 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 419 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityVariableName));
             
             #line default
             #line hidden
-            this.Write(" = value;\r\n                this.");
+            this.Write(" = value;\r\n                if (value != null)\r\n                {\r\n               " +
+                    "     this.");
             
-            #line 433 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 422 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
-            this.Write(" = new DateTime(value.Ticks, DateTimeKind.Utc);\r\n            }\r\n        }\r\n");
+            this.Write(" = new DateTime(value.Value.Ticks, DateTimeKind.Utc);\r\n                }\r\n       " +
+                    "         else\r\n                {\r\n                    this.");
             
-            #line 436 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 426 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
+            
+            #line default
+            #line hidden
+            this.Write(" = null;\r\n                }\r\n            }\r\n        }\r\n");
+            
+            #line 430 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         if (member.EmitIsSetProperties)
                         {
@@ -1347,7 +1307,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("        /// <summary>\r\n        /// This property is set to true if the property <" +
                     "seealso cref=\"");
             
-            #line 441 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 435 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
@@ -1363,42 +1323,42 @@ if(structureIsEvent || structureIsEventStream)
         /// </returns>
         [Obsolete(""Setting ");
             
-            #line 450 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 444 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write(" results in non-UTC DateTimes not being marshalled correctly. Use ");
             
-            #line 450 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 444 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" instead.\", false)]\r\n        public bool Is");
             
-            #line 451 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 445 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write("Set\r\n        {\r\n            get\r\n            {\r\n                return this.Is");
             
-            #line 455 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 449 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("Set;\r\n            }\r\n            set\r\n            {\r\n                this.Is");
             
-            #line 459 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 453 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("Set = value;;\r\n            }\r\n        }\r\n");
             
-            #line 462 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 456 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         }
                     }
@@ -1409,7 +1369,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("#endregion\r\n");
             
-            #line 468 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 462 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
                 if (this.Structure is ExceptionShape)
@@ -1434,7 +1394,7 @@ if(structureIsEvent || structureIsEventStream)
         }
 ");
             
-            #line 487 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 481 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                 }
@@ -1449,7 +1409,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\n");
             
-            #line 497 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 491 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
         if (this.StructureType == StructureType.Response && hasStreamingMember) 
@@ -1480,7 +1440,7 @@ if(structureIsEvent || structureIsEventStream)
             {
 ");
             
-            #line 522 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 516 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 if (this.Structure != null) 
                 {
@@ -1494,21 +1454,21 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("                this.");
             
-            #line 530 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 524 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write("?.Dispose();\r\n                this.");
             
-            #line 531 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 525 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(" = null;\r\n");
             
-            #line 532 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 526 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         }
                     }
@@ -1520,7 +1480,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("            }\r\n\r\n            this._disposed = true;\r\n         }\r\n\r\n         #endr" +
                     "egion\r\n");
             
-            #line 543 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 537 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
 
@@ -1531,7 +1491,7 @@ if(structureIsEvent || structureIsEventStream)
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 550 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+        #line 544 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     // Set to true when the service model specifies a shape that should be wrapped in a response. ElastiCache CreateCacheCluster is an example of this.
     public bool IsWrapped { get; set; }

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/StructureGenerator.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/StructureGenerator.tt
@@ -152,7 +152,7 @@ namespace <#=this.Config.Namespace#>.Model
                     if (member.IsExcluded)
                         continue;
 #>
-        private <#=member.DetermineType()#><#= member.IsNullable ? "?" : "" #> <#=member.VariableName#><#= member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"#>
+        private <#=member.DetermineType()#> <#=member.VariableName#><#= member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"#>
 <#
                 }
 #>
@@ -217,20 +217,7 @@ namespace <#=this.Config.Namespace#>.Model
 #>
         <#=member.AccessModifier#> <#=member.DetermineType()#><#=member.UseNullable ? "?" : ""#> <#=member.PropertyName#>
         {
-<#
-                    if(member.IsNullable && !member.UseNullable)
-                    {
-#>
-            get { return this.<#=member.VariableName#>.GetValueOrDefault(); }
-<#
-                    }
-                    else
-                    {
-#>
             get { return this.<#=member.VariableName#>; }
-<#
-                    }
-#>
             set { <#=member.IsBackwardsCompatibleDateTimeProperty ? "this." + member.BackwardCompatibilityVariableName + " = " : ""#>this.<#=member.VariableName#> = value; }
         }
 
@@ -402,7 +389,7 @@ namespace <#=this.Config.Namespace#>.Model
                         if (member.IsExcluded || !member.IsBackwardsCompatibleDateTimeProperty)
                             continue;
 #>
-        private <#=member.DetermineType()#><#= member.IsNullable ? "?" : "" #> <#=member.BackwardCompatibilityVariableName#><#= member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"#>
+        private <#=member.DetermineType()#> <#=member.BackwardCompatibilityVariableName#><#= member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"#>
 <#
                     }
 #>
@@ -430,7 +417,14 @@ namespace <#=this.Config.Namespace#>.Model
             set
             {
                 this.<#=member.BackwardCompatibilityVariableName#> = value;
-                this.<#=member.VariableName#> = new DateTime(value.Ticks, DateTimeKind.Utc);
+                if (value != null)
+                {
+                    this.<#=member.VariableName#> = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
+                else
+                {
+                    this.<#=member.VariableName#> = null;
+                }
             }
         }
 <#

--- a/generator/ServiceModels/budgets/budgets.customizations.json
+++ b/generator/ServiceModels/budgets/budgets.customizations.json
@@ -2,9 +2,9 @@
     "dataTypeSwap" : {
         "Spend" : {
             "Amount" : {
-                "Type" : "decimal",
+                "Type" : "decimal?",
                 "Marshaller" : "Amazon.Runtime.Internal.Util.StringUtils.FromDecimal",
-                "Unmarshaller" : "Amazon.Runtime.Internal.Transform.DecimalUnmarshaller"
+                "Unmarshaller" : "Amazon.Runtime.Internal.Transform.NullableDecimalUnmarshaller"
             }
         }
     }

--- a/generator/ServiceModels/ec2/ec2.customizations.json
+++ b/generator/ServiceModels/ec2/ec2.customizations.json
@@ -117,17 +117,17 @@
 	"dataTypeSwap" : {
         "SpotFleetRequestConfigData": {
             "ValidFrom": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.EC2.Internal.CustomMarshallTransformations.ConvertDateTimeISOWithoutMillisecondsUtc"
             },
             "ValidUntil": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.EC2.Internal.CustomMarshallTransformations.ConvertDateTimeISOWithoutMillisecondsUtc"
             }
         },
         "DescribeSpotFleetRequestHistoryRequest": {
             "StartTime": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.EC2.Internal.CustomMarshallTransformations.ConvertDateTimeISOWithoutMillisecondsUtc"
             }
         }

--- a/generator/ServiceModels/glacier/glacier.customizations.json
+++ b/generator/ServiceModels/glacier/glacier.customizations.json
@@ -22,85 +22,85 @@
 	"dataTypeSwap" : {
 		"DescribeVaultOutput" : {
             "CreationDate": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
-                "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
+                "Unmarshaller": "Amazon.Runtime.Internal.Transform.NullableDateTimeUnmarshaller"
             },
             "LastInventoryDate": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
                 "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
             }
 		},
 		"GlacierJobDescription" : {
             "CreationDate": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
-                "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
+                "Unmarshaller": "Amazon.Runtime.Internal.Transform.NullableDateTimeUnmarshaller"
             },
             "CompletionDate": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
-                "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
+                "Unmarshaller": "Amazon.Runtime.Internal.Transform.NullableDateTimeUnmarshaller"
             }
 		},
 	    "InitiateMultipartUploadInput" : {
 		  "partSize" : {
-		    "Type" : "long",
+		    "Type" : "long?",
 			"Marshaller" : "Amazon.Runtime.Internal.Util.StringUtils.FromLong",
-			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.LongUnmarshaller"
+			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.NullableLongUnmarshaller"
 		  }
 		},
 		"ListJobsInput" : {
 		  "limit" : {
-		    "Type" : "int",
+		    "Type" : "int?",
 			"Marshaller" : "Amazon.Runtime.Internal.Util.StringUtils.FromInt",
-			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.IntUnmarshaller"
+			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.NullableIntUnmarshaller"
 		  },
 		  "completed" : {
-		    "Type" : "bool",
+		    "Type" : "bool?",
 			"Marshaller" : "Amazon.Runtime.Internal.Util.StringUtils.FromBool",
-			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.BoolUnmarshaller"
+			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.NullableBoolUnmarshaller"
 		  }
 		},
 		"ListMultipartUploadsInput" : {
 		  "limit" : {
-		    "Type" : "int",
+		    "Type" : "int?",
 			"Marshaller" : "Amazon.Runtime.Internal.Util.StringUtils.FromInt",
-			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.IntUnmarshaller"
+			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.NullableIntUnmarshaller"
 		  }
 		},
 		"ListPartsInput" : {
 		  "limit" : {
-		    "Type" : "int",
+		    "Type" : "int?",
 			"Marshaller" : "Amazon.Runtime.Internal.Util.StringUtils.FromInt",
-			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.IntUnmarshaller"
+			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.NullableIntUnmarshaller"
 		  }
 		},
 		"ListPartsOutput" : {
             "CreationDate": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
-                "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
+                "Unmarshaller": "Amazon.Runtime.Internal.Transform.NullableDateTimeUnmarshaller"
             },
             "CompletionDate": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
-                "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
+                "Unmarshaller": "Amazon.Runtime.Internal.Transform.NullableDateTimeUnmarshaller"
             }
 		},
 		"ListVaultsInput" : {
 		  "limit" : {
-		    "Type" : "int",
+		    "Type" : "int?",
 			"Marshaller" : "Amazon.Runtime.Internal.Util.StringUtils.FromInt",
-			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.IntUnmarshaller"
+			"Unmarshaller" : "Amazon.Runtime.Internal.Transform.NullableIntUnmarshaller"
 		  }
 		},
 		"UploadListElement" : {
             "CreationDate": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
-                "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
+                "Unmarshaller": "Amazon.Runtime.Internal.Transform.NullableDateTimeUnmarshaller"
             }
 		}
 	},

--- a/generator/ServiceModels/logs/logs.customizations.json
+++ b/generator/ServiceModels/logs/logs.customizations.json
@@ -2,77 +2,72 @@
   "noArgOverloads": [
 	"DescribeLogGroups"
   ],
-  "useNullableType" : {
-    "LogGroup" : [
-	  "retentionInDays"
-	]
-  },
   "dataTypeSwap" : {
     "InputLogEvent" : {
 	  "timestamp" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  }
 	},
     "OutputLogEvent" : {
 	  "timestamp" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  },
 	  "ingestionTime" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  }	
 	},
     "GetLogEventsRequest" : {
 	  "startTime" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  },
 	  "endTime" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  }
 	},
     "LogGroup" : {
 	  "creationTime" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  }
 	},
     "LogStream" : {
 	  "creationTime" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  },
 	  "firstEventTimestamp" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  },
 	  "lastEventTimestamp" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  },
 	  "lastIngestionTime" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  }	  
 	},
     "MetricFilter" : {
 	  "creationTime" : {
-	    "Type" : "DateTime",
+	    "Type" : "DateTime?",
 		"Marshaller" : "Amazon.Runtime.Internal.Transform.CustomMarshallTransformations.ConvertDateTimeToEpochMilliseconds",
-		"Unmarshaller" : "DateTimeEpochLongMillisecondsUnmarshaller"
+		"Unmarshaller" : "NullableDateTimeEpochLongMillisecondsUnmarshaller"
 	  },
     }
   }

--- a/generator/ServiceModels/mobileanalytics/mobileanalytics.customizations.json
+++ b/generator/ServiceModels/mobileanalytics/mobileanalytics.customizations.json
@@ -2,21 +2,21 @@
     "dataTypeSwap": {
         "Session": {
             "startTimestamp": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
-                "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
+                "Unmarshaller": "Amazon.Runtime.Internal.Transform.NullableDateTimeUnmarshaller"
             },
             "stopTimestamp": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
-                "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
+                "Unmarshaller": "Amazon.Runtime.Internal.Transform.NullableDateTimeUnmarshaller"
             }
         },
         "Event": {
             "timestamp": {
-                "Type": "DateTime",
+                "Type": "DateTime?",
                 "Marshaller": "Amazon.Runtime.Internal.Util.StringUtils.FromDateTimeToISO8601",
-                "Unmarshaller": "Amazon.Runtime.Internal.Transform.DateTimeUnmarshaller"
+                "Unmarshaller": "Amazon.Runtime.Internal.Transform.NullableDateTimeUnmarshaller"
             }
         }
     },

--- a/generator/ServiceModels/scheduler/scheduler.customizations.json
+++ b/generator/ServiceModels/scheduler/scheduler.customizations.json
@@ -1,7 +1,3 @@
 {
-  "useNullableType": {
-    "FlexibleTimeWindow": [
-      "MaximumWindowInMinutes"
-    ]
-  }
+
 }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/SimpleTypeUnmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/SimpleTypeUnmarshaller.cs
@@ -81,7 +81,7 @@ namespace Amazon.Runtime.Internal.Transform
     /// This unmarshaller is not implemented for XML context, as XML responses
     /// will null elements (xsi:nil='true') will be skipped by the XML parser.
     /// </summary>
-    public class NullableIntUnmarshaller : IUnmarshaller<int?, JsonUnmarshallerContext>
+    public class NullableIntUnmarshaller : IUnmarshaller<int?, XmlUnmarshallerContext>, IUnmarshaller<int?, JsonUnmarshallerContext>
     {   
         private NullableIntUnmarshaller() { }
 
@@ -98,6 +98,18 @@ namespace Amazon.Runtime.Internal.Transform
         public static NullableIntUnmarshaller GetInstance()
         {
             return NullableIntUnmarshaller.Instance;
+        }
+
+        public int? Unmarshall(XmlUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+
+            if (text == null)
+            {
+                return null;
+            }
+            return int.Parse(text, CultureInfo.InvariantCulture);
         }
 
         public int? Unmarshall(JsonUnmarshallerContext context)
@@ -145,6 +157,45 @@ namespace Amazon.Runtime.Internal.Transform
         }
     }
 
+    public class NullableLongUnmarshaller : IUnmarshaller<long?, XmlUnmarshallerContext>, IUnmarshaller<long?, JsonUnmarshallerContext>
+    {
+        private NullableLongUnmarshaller() { }
+
+        private static NullableLongUnmarshaller _instance = new NullableLongUnmarshaller();
+
+        public static NullableLongUnmarshaller Instance
+        {
+            get
+            {
+                return _instance;
+            }
+        }
+
+        public long? Unmarshall(XmlUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+
+            if (text == null)
+            {
+                return null;
+            }
+            return long.Parse(text, CultureInfo.InvariantCulture);
+        }
+
+        public long? Unmarshall(JsonUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+
+            if (text == null)
+            {
+                return null;
+            }
+            return long.Parse(text, CultureInfo.InvariantCulture);
+        }
+    }
+
     /// <summary>
     /// Unmarshaller for float fields
     /// </summary>
@@ -175,6 +226,49 @@ namespace Amazon.Runtime.Internal.Transform
         {
             return SimpleTypeUnmarshaller<float>.Unmarshall(context);
         }
+    }
+
+    /// <summary>
+    /// Unmarshaller for float fields
+    /// </summary>
+    public class NullableFloatUnmarshaller : IUnmarshaller<float?, XmlUnmarshallerContext>, IUnmarshaller<float?, JsonUnmarshallerContext>
+    {
+        private NullableFloatUnmarshaller() { }
+
+        private static NullableFloatUnmarshaller _instance = new NullableFloatUnmarshaller();
+
+        public static NullableFloatUnmarshaller Instance
+        {
+            get
+            {
+                return _instance;
+            }
+        }
+
+        public float? Unmarshall(XmlUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+
+            if (text == null)
+            {
+                return null;
+            }
+            return float.Parse(text, CultureInfo.InvariantCulture);
+        }
+
+        public float? Unmarshall(JsonUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+
+            if (text == null)
+            {
+                return null;
+            }
+            return float.Parse(text, CultureInfo.InvariantCulture);
+        }
+
     }
 
     /// <summary>
@@ -211,6 +305,48 @@ namespace Amazon.Runtime.Internal.Transform
     }
 
     /// <summary>
+    /// Unmarshaller for double fields
+    /// </summary>
+    public class NullableDoubleUnmarshaller : IUnmarshaller<double?, XmlUnmarshallerContext>, IUnmarshaller<double?, JsonUnmarshallerContext>
+    {
+        private NullableDoubleUnmarshaller() { }
+
+        private static NullableDoubleUnmarshaller _instance = new NullableDoubleUnmarshaller();
+
+        public static NullableDoubleUnmarshaller Instance
+        {
+            get
+            {
+                return _instance;
+            }
+        }
+
+        public double? Unmarshall(XmlUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+
+            if (text == null)
+            {
+                return null;
+            }
+            return double.Parse(text, CultureInfo.InvariantCulture);
+        }
+
+        public double? Unmarshall(JsonUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+
+            if (text == null)
+            {
+                return null;
+            }
+            return double.Parse(text, CultureInfo.InvariantCulture);
+        }
+    }
+
+    /// <summary>
     /// Unmarshaller for decimal fields
     /// </summary>
     public class DecimalUnmarshaller : IUnmarshaller<decimal, XmlUnmarshallerContext>, IUnmarshaller<decimal, JsonUnmarshallerContext>
@@ -243,6 +379,48 @@ namespace Amazon.Runtime.Internal.Transform
     }
 
     /// <summary>
+    /// Unmarshaller for decimal fields
+    /// </summary>
+    public class NullableDecimalUnmarshaller : IUnmarshaller<decimal?, XmlUnmarshallerContext>, IUnmarshaller<decimal?, JsonUnmarshallerContext>
+    {
+        private NullableDecimalUnmarshaller() { }
+
+        private static NullableDecimalUnmarshaller _instance = new NullableDecimalUnmarshaller();
+
+        public static NullableDecimalUnmarshaller Instance
+        {
+            get
+            {
+                return _instance;
+            }
+        }
+
+        public decimal? Unmarshall(XmlUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+
+            if (text == null)
+            {
+                return null;
+            }
+            return decimal.Parse(text, CultureInfo.InvariantCulture);
+        }
+
+        public decimal? Unmarshall(JsonUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+
+            if (text == null)
+            {
+                return null;
+            }
+            return decimal.Parse(text, CultureInfo.InvariantCulture);
+        }
+    }
+
+    /// <summary>
     /// Unmarshaller for bool fields
     /// </summary>
     public class BoolUnmarshaller : IUnmarshaller<bool, XmlUnmarshallerContext>, IUnmarshaller<bool, JsonUnmarshallerContext>
@@ -271,6 +449,48 @@ namespace Amazon.Runtime.Internal.Transform
         public bool Unmarshall(JsonUnmarshallerContext context)
         {
             return SimpleTypeUnmarshaller<bool>.Unmarshall(context);
+        }
+    }
+
+    /// <summary>
+    /// Unmarshaller for bool fields
+    /// </summary>
+    public class NullableBoolUnmarshaller : IUnmarshaller<bool?, XmlUnmarshallerContext>, IUnmarshaller<bool?, JsonUnmarshallerContext>
+    {
+        private NullableBoolUnmarshaller() { }
+
+        private static NullableBoolUnmarshaller _instance = new NullableBoolUnmarshaller();
+
+        public static NullableBoolUnmarshaller Instance
+        {
+            get
+            {
+                return _instance;
+            }
+        }
+
+        public bool? Unmarshall(XmlUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+            if (string.IsNullOrEmpty(text))
+            {
+                return null;
+            }
+
+            return bool.Parse(text);
+        }
+
+        public bool? Unmarshall(JsonUnmarshallerContext context)
+        {
+            context.Read();
+            string text = context.ReadText();
+            if(string.IsNullOrEmpty(text))
+            {
+                return null;
+            }
+
+            return bool.Parse(text);
         }
     }
 
@@ -407,7 +627,7 @@ namespace Amazon.Runtime.Internal.Transform
     /// This unmarshaller is not implemented for XML context, as XML responses
     /// will null elements (xsi:nil='true') will be skipped by the XML parser.
     /// </summary>
-    public class NullableDateTimeUnmarshaller : IUnmarshaller<DateTime?, JsonUnmarshallerContext>
+    public class NullableDateTimeUnmarshaller : IUnmarshaller<DateTime?, XmlUnmarshallerContext>, IUnmarshaller<DateTime?, JsonUnmarshallerContext>
     {
         private NullableDateTimeUnmarshaller() { }
 
@@ -424,6 +644,12 @@ namespace Amazon.Runtime.Internal.Transform
         public static NullableDateTimeUnmarshaller GetInstance()
         {
             return NullableDateTimeUnmarshaller.Instance;
+        }
+
+        public DateTime? Unmarshall(XmlUnmarshallerContext context)
+        {
+            string text = context.ReadText();
+            return DateTimeUnmarshaller.UnmarshallInternal(text, treatAsNullable: true);
         }
 
         public DateTime? Unmarshall(JsonUnmarshallerContext context)
@@ -460,6 +686,47 @@ namespace Amazon.Runtime.Internal.Transform
         public DateTime Unmarshall(JsonUnmarshallerContext context)
         {
             long millseconds = LongUnmarshaller.Instance.Unmarshall(context);
+            var ret = Amazon.Util.AWSSDKUtils.EPOCH_START.AddMilliseconds(millseconds);
+            return ret;
+        }
+    }
+
+    public class NullableDateTimeEpochLongMillisecondsUnmarshaller : IUnmarshaller<DateTime?, XmlUnmarshallerContext>, IUnmarshaller<DateTime?, JsonUnmarshallerContext>
+    {
+        private NullableDateTimeEpochLongMillisecondsUnmarshaller() { }
+
+        private static NullableDateTimeEpochLongMillisecondsUnmarshaller _instance = new NullableDateTimeEpochLongMillisecondsUnmarshaller();
+
+        public static NullableDateTimeEpochLongMillisecondsUnmarshaller Instance
+        {
+            get
+            {
+                return _instance;
+            }
+        }
+
+        public DateTime? Unmarshall(XmlUnmarshallerContext context)
+        {
+            string text = context.ReadText();
+            if(text == null)
+            {
+                return null;
+            }
+
+            long millseconds = long.Parse(text, CultureInfo.InvariantCulture);
+            var ret = Amazon.Util.AWSSDKUtils.EPOCH_START.AddMilliseconds(millseconds);
+            return ret;
+        }
+
+        public DateTime? Unmarshall(JsonUnmarshallerContext context)
+        {
+            string text = context.ReadText();
+            if (text == null)
+            {
+                return null;
+            }
+
+            long millseconds = long.Parse(text, CultureInfo.InvariantCulture);
             var ret = Amazon.Util.AWSSDKUtils.EPOCH_START.AddMilliseconds(millseconds);
             return ret;
         }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/StringUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/StringUtils.cs
@@ -68,9 +68,22 @@ namespace Amazon.Runtime.Internal.Util
             return value.ToString(CultureInfo.InvariantCulture);
         }
 
+        public static string FromLong(long? value)
+        {
+            if (value != null)
+                return value.Value.ToString(CultureInfo.InvariantCulture);
+
+            return null;
+        }
+
         public static string FromFloat(float value)
         {
             return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public static string FromBool(bool? value)
+        {
+            return FromBool(value.GetValueOrDefault());
         }
 
         public static string FromBool(bool value)
@@ -91,6 +104,20 @@ namespace Amazon.Runtime.Internal.Util
         {
             return value.ToUniversalTime().ToString(AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture);
         }
+
+        /// <summary>
+        /// Converts a DateTime to ISO8601 formatted string.
+        /// </summary>
+        public static string FromDateTimeToISO8601(DateTime? value)
+        {
+            if (!value.HasValue)
+            {
+                return null;
+            }
+
+            return value.Value.ToUniversalTime().ToString(AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture);
+        }
+
         /// <summary>
         /// Converts a DateTime to ISO8601 formatted string.
         /// </summary>
@@ -120,9 +147,27 @@ namespace Amazon.Runtime.Internal.Util
             return value.ToString(CultureInfo.InvariantCulture);
         }
 
+        public static string FromDouble(double? value)
+        {
+            if (!value.HasValue)
+            {
+                return null;
+            }
+
+            return value.Value.ToString(CultureInfo.InvariantCulture);
+        }
+
         public static string FromDecimal(decimal value)
         {
             return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public static string FromDecimal(decimal? value)
+        {
+            if (value != null)
+                return value.Value.ToString(CultureInfo.InvariantCulture);
+
+            return null;
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/StringUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/StringUtils.cs
@@ -57,10 +57,12 @@ namespace Amazon.Runtime.Internal.Util
         
         public static string FromInt(int? value)
         {
-            if (value != null)
-                return value.Value.ToString(CultureInfo.InvariantCulture);
+            if (!value.HasValue)
+            {
+                return null;
+            }
 
-            return null;
+            return value.Value.ToString(CultureInfo.InvariantCulture);
         }
 
         public static string FromLong(long value)
@@ -70,10 +72,12 @@ namespace Amazon.Runtime.Internal.Util
 
         public static string FromLong(long? value)
         {
-            if (value != null)
-                return value.Value.ToString(CultureInfo.InvariantCulture);
+            if (!value.HasValue)
+            {
+                return null;
+            }
 
-            return null;
+            return value.Value.ToString(CultureInfo.InvariantCulture);
         }
 
         public static string FromFloat(float value)
@@ -164,10 +168,12 @@ namespace Amazon.Runtime.Internal.Util
 
         public static string FromDecimal(decimal? value)
         {
-            if (value != null)
-                return value.Value.ToString(CultureInfo.InvariantCulture);
+            if (!value.HasValue)
+            {
+                return null;
+            }
 
-            return null;
+            return value.Value.ToString(CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/sdk/src/Services/CognitoIdentity/Custom/CognitoAWSCredentials.cs
+++ b/sdk/src/Services/CognitoIdentity/Custom/CognitoAWSCredentials.cs
@@ -612,7 +612,7 @@ namespace Amazon.CognitoIdentity
             var credentials = (await sts.AssumeRoleWithWebIdentityAsync(assumeRequest).ConfigureAwait(false)).Credentials;
 
             // Return new refresh state (credentials and expiration)
-            credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration);
+            credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration.GetValueOrDefault());
             return credentialsState;
         }
 
@@ -653,7 +653,7 @@ namespace Amazon.CognitoIdentity
 
 
             var credentials = response.Credentials;
-            credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration);
+            credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration.GetValueOrDefault());
             return credentialsState;
         }
 
@@ -725,7 +725,7 @@ namespace Amazon.CognitoIdentity
             UpdateIdentity(response.IdentityId);
 
             var credentials = response.Credentials;
-            credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration);
+            credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration.GetValueOrDefault());
             return credentialsState;
         }
 
@@ -775,7 +775,7 @@ namespace Amazon.CognitoIdentity
             };
             var credentials = GetStsCredentials(assumeRequest);
 
-            credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration);
+            credentialsState = new CredentialsRefreshState(credentials.GetCredentials(), credentials.Expiration.GetValueOrDefault());
             return credentialsState;
         }
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
@@ -656,7 +656,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
             ddbBool = null;
             if (attributeValue.IsSetBOOL())
             {
-                ddbBool = new DynamoDBBool(attributeValue.BOOL);
+                ddbBool = new DynamoDBBool(attributeValue.BOOL.Value);
             }
             return (ddbBool != null);
         }

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
@@ -537,7 +537,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                             SourceTable.AddRequestHandler(scanReq, isAsync: false);
 
                             var scanResult = SourceTable.DDBClient.Scan(scanReq);
-                            count = Matches.Count + scanResult.Count;
+                            count = Matches.Count + scanResult.Count.GetValueOrDefault();
                             return count;
                         case SearchType.Query:
                             QueryRequest queryReq = new QueryRequest
@@ -562,7 +562,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                             SourceTable.AddRequestHandler(queryReq, isAsync: false);
 
                             var queryResult = SourceTable.DDBClient.Query(queryReq);
-                            count = Matches.Count + queryResult.Count;
+                            count = Matches.Count + queryResult.Count.GetValueOrDefault();
                             return count;
                         default:
                             throw new InvalidOperationException("Unknown Search Method");

--- a/sdk/src/Services/EC2/Custom/Internal/CustomMarshallTransformations.cs
+++ b/sdk/src/Services/EC2/Custom/Internal/CustomMarshallTransformations.cs
@@ -39,5 +39,20 @@ namespace Amazon.EC2.Internal
         {
             return dateTime.ToUniversalTime().ToString(AWSSDKUtils.ISO8601DateFormatNoMS, DateTimeFormatInfo.InvariantInfo);
         }
+
+        /// <summary>
+        /// Custom DateTime serializer for EC2.
+        /// </summary>
+        /// <param name="dateTime">The DateTime to serialize</param>
+        /// <returns>ISO formatted string with no miliseconds</returns>
+        public static String ConvertDateTimeISOWithoutMillisecondsUtc(DateTime? dateTime)
+        {
+            if (!dateTime.HasValue)
+            {
+                return null;
+            }
+
+            return dateTime.Value.ToUniversalTime().ToString(AWSSDKUtils.ISO8601DateFormatNoMS, DateTimeFormatInfo.InvariantInfo);
+        }
     }
 }

--- a/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
@@ -253,7 +253,7 @@ namespace Amazon.S3
             if (getPreSignedUrlRequest.IsSetUploadId())
                 request.AddSubResource("uploadId", S3Transforms.ToStringValue(getPreSignedUrlRequest.UploadId));
             if (getPreSignedUrlRequest.IsSetPartNumber())
-                request.AddSubResource("partNumber", S3Transforms.ToStringValue(getPreSignedUrlRequest.PartNumber));
+                request.AddSubResource("partNumber", S3Transforms.ToStringValue(getPreSignedUrlRequest.PartNumber.Value));
 
             var responseHeaderOverrides = getPreSignedUrlRequest.ResponseHeaderOverrides;
             if (!string.IsNullOrEmpty(responseHeaderOverrides.CacheControl))
@@ -433,7 +433,7 @@ namespace Amazon.S3
             {
                 baselineTime = config.CorrectedUtcNow;
             }
-            return Convert.ToInt64((request.Expires.ToUniversalTime() - baselineTime).TotalSeconds);
+            return Convert.ToInt64((request.Expires.GetValueOrDefault().ToUniversalTime() - baselineTime).TotalSeconds);
         }
         internal static void CleanupRequest(AmazonWebServiceRequest request)
         {

--- a/sdk/src/Services/S3/Custom/Encryption/Internal/SetupEncryptionHandler.cs
+++ b/sdk/src/Services/S3/Custom/Encryption/Internal/SetupEncryptionHandler.cs
@@ -222,7 +222,7 @@ namespace Amazon.S3.Encryption.Internal
                     throw new AmazonClientException("Upload Parts must in correct sequence");
 
                 request.InputStream = EncryptionUtils.EncryptUploadPartRequestUsingInstructions(request.InputStream, instructions);
-                contextForEncryption.PartNumber = request.PartNumber;
+                contextForEncryption.PartNumber = request.PartNumber.GetValueOrDefault();
             }
             else
             {

--- a/sdk/src/Services/S3/Custom/Internal/AmazonS3PostMarshallHandler.cs
+++ b/sdk/src/Services/S3/Custom/Internal/AmazonS3PostMarshallHandler.cs
@@ -121,7 +121,7 @@ namespace Amazon.S3.Internal
             if (uploadPartRequest.InputStream != null)
             {
                 // Wrap input stream in partial wrapper (to upload only part of the stream)
-                var partialStream = new PartialWrapperStream(uploadPartRequest.InputStream, uploadPartRequest.PartSize);
+                var partialStream = new PartialWrapperStream(uploadPartRequest.InputStream, uploadPartRequest.PartSize.GetValueOrDefault());
                 if (partialStream.Length > 0 && !(uploadPartRequest.DisablePayloadSigning ?? false))
                     request.UseChunkEncoding = uploadPartRequest.UseChunkEncoding;
                 if (!request.Headers.ContainsKey(HeaderKeys.ContentLengthHeader))

--- a/sdk/src/Services/S3/Custom/Internal/AmazonS3ResponseHandler.cs
+++ b/sdk/src/Services/S3/Custom/Internal/AmazonS3ResponseHandler.cs
@@ -129,7 +129,7 @@ namespace Amazon.S3.Internal
             var listObjectsResponse = response as ListObjectsResponse;
             if (listObjectsResponse != null)
             {
-                if (listObjectsResponse.IsTruncated &&
+                if (listObjectsResponse.IsTruncated.GetValueOrDefault() &&
                     string.IsNullOrEmpty(listObjectsResponse.NextMarker) &&
                     listObjectsResponse.S3Objects.Count > 0)
                 {

--- a/sdk/src/Services/S3/Custom/Internal/S3Express/DefaultS3ExpressCredentialProvider.cs
+++ b/sdk/src/Services/S3/Custom/Internal/S3Express/DefaultS3ExpressCredentialProvider.cs
@@ -41,7 +41,7 @@ namespace Amazon.S3.Internal.S3Express
             {
                 SessionCredentials = sessionCredentials;
                 CreatedAt = AWSSDKUtils.CorrectedUtcNow;
-                ExpirationDate = sessionCredentials.Expiration.ToUniversalTime();
+                ExpirationDate = sessionCredentials.Expiration.GetValueOrDefault().ToUniversalTime();
                 if (AWSConfigs.ManualClockCorrection.HasValue)
                     ExpirationDate = ExpirationDate + AWSConfigs.ManualClockCorrection.Value;
 
@@ -264,7 +264,7 @@ namespace Amazon.S3.Internal.S3Express
                     var credentialsLruItem = new SessionCredentialsLruItem(credentials.Credentials);
                     if (resetTime == DateTime.MinValue)
                     {
-                        resetTime = credentials.Credentials.Expiration.ToUniversalTime();
+                        resetTime = credentials.Credentials.Expiration.GetValueOrDefault().ToUniversalTime();
                     }
 
                     _cacheLock.Wait();

--- a/sdk/src/Services/S3/Custom/Model/CORSRule.cs
+++ b/sdk/src/Services/S3/Custom/Model/CORSRule.cs
@@ -105,9 +105,9 @@ namespace Amazon.S3.Model
         /// The time in seconds that your browser is to cache the preflight response for the specified resource.
         ///  
         /// </summary>
-        public int MaxAgeSeconds
+        public int? MaxAgeSeconds
         {
-            get { return this.maxAgeSeconds ?? default(int); }
+            get { return this.maxAgeSeconds; }
             set { this.maxAgeSeconds = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadResponse.cs
@@ -44,9 +44,9 @@ namespace Amazon.S3.Model
         /// with AWS KMS (SSE-KMS).
         /// </para>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
@@ -344,9 +344,9 @@ namespace Amazon.S3.Model
         /// S3 Bucket Key.
         /// </para>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 
@@ -386,13 +386,21 @@ namespace Amazon.S3.Model
             "ModifiedSinceDateUtc being assigned, the latest assignment to either one of the two property is " +
             "reflected in the value of both. ModifiedSinceDate is provided for backwards compatibility only and " +
             "assigning a non-Utc DateTime to it results in the wrong timestamp being passed to the service.", false)]
-        public DateTime ModifiedSinceDate
+        public DateTime? ModifiedSinceDate
         {
-            get { return this.modifiedSinceDate.GetValueOrDefault(); }
+            get { return this.modifiedSinceDate; }
             set
             {
-                this.modifiedSinceDate = value;
-                this.modifiedSinceDateUtc = new DateTime(value.Ticks, DateTimeKind.Utc);
+                if(value == null)
+                {
+                    this.modifiedSinceDate = null;
+                    this.modifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.modifiedSinceDate = value;
+                    this.modifiedSinceDateUtc = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
             }
         }
 
@@ -405,13 +413,21 @@ namespace Amazon.S3.Model
         /// Constraints: This property can be used with ETagToNotMatch,
         /// but cannot be used with other conditional copy properties.
         /// </remarks>
-        public DateTime ModifiedSinceDateUtc
+        public DateTime? ModifiedSinceDateUtc
         {
             get { return this.modifiedSinceDateUtc ?? default(DateTime); }
             set
             {
-                this.modifiedSinceDateUtc = value;
-                this.modifiedSinceDate = value;
+                if (value == null)
+                {
+                    this.modifiedSinceDate = null;
+                    this.modifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.modifiedSinceDateUtc = value;
+                    this.modifiedSinceDate = value;
+                }
             }
         }
 
@@ -446,13 +462,21 @@ namespace Amazon.S3.Model
             "UnmodifiedSinceDateUtc being assigned, the latest assignment to either one of the two property is " +
             "reflected in the value of both. UnmodifiedSinceDate is provided for backwards compatibility only and " +
             "assigning a non-Utc DateTime to it results in the wrong timestamp being passed to the service.", false)]
-        public DateTime UnmodifiedSinceDate
+        public DateTime? UnmodifiedSinceDate
         {
             get { return this.unmodifiedSinceDate ?? default(DateTime); }
             set
             {
-                this.unmodifiedSinceDate = value;
-                this.unmodifiedSinceDateUtc = new DateTime(value.Ticks, DateTimeKind.Utc);
+                if (value == null)
+                {
+                    this.unmodifiedSinceDate = null;
+                    this.unmodifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.unmodifiedSinceDate = value;
+                    this.unmodifiedSinceDateUtc = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
             }
         }
 
@@ -465,13 +489,21 @@ namespace Amazon.S3.Model
         /// Constraints: This property can be used with ETagToMatch,
         /// but cannot be used with other conditional copy properties.
         /// </remarks>
-        public DateTime UnmodifiedSinceDateUtc
+        public DateTime? UnmodifiedSinceDateUtc
         {
             get { return this.unmodifiedSinceDateUtc ?? default(DateTime); }
             set
             {
-                this.unmodifiedSinceDateUtc = value;
-                this.unmodifiedSinceDate = value;
+                if (value == null)
+                {
+                    this.unmodifiedSinceDate = null;
+                    this.unmodifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.unmodifiedSinceDateUtc = value;
+                    this.unmodifiedSinceDate = value;
+                }
             }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectResponse.cs
@@ -49,9 +49,9 @@ namespace Amazon.S3.Model
         /// with Amazon Web Services KMS (SSE-KMS).
         /// </para>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
@@ -349,9 +349,9 @@ namespace Amazon.S3.Model
         /// and determine the relative ordering within the destination object.  If a part already
         /// exists with the PartNumber it will be overwritten.
         /// </remarks>
-        public int PartNumber
+        public int? PartNumber
         {
-            get { return this.partNumber.GetValueOrDefault(); }
+            get { return this.partNumber; }
             set { this.partNumber = value; }
         }
 
@@ -371,9 +371,9 @@ namespace Amazon.S3.Model
         /// <remarks>
         /// The LastByte property must also be set or this value will be ignored.
         /// </remarks>
-        public long FirstByte
+        public long? FirstByte
         {
-            get { return this.firstByte.GetValueOrDefault(); }
+            get { return this.firstByte; }
             set { this.firstByte = value; }
         }
 
@@ -393,9 +393,9 @@ namespace Amazon.S3.Model
         /// <remarks>
         /// The FirstByte property must also be set or this value will be ignored.
         /// </remarks>
-        public long LastByte
+        public long? LastByte
         {
-            get { return this.lastByte.GetValueOrDefault(); }
+            get { return this.lastByte; }
             set { this.lastByte = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/CopyPartResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyPartResponse.cs
@@ -34,7 +34,7 @@ namespace Amazon.S3.Model
         private DateTime? lastModified;
         private string eTag;
         private string copySourceVersionId;
-        private int partNumber;
+        private int? partNumber;
         private ServerSideEncryptionMethod serverSideEncryption;
         private string serverSideEncryptionKeyManagementServiceKeyId;
         private bool? bucketKeyEnabled;
@@ -147,9 +147,9 @@ namespace Amazon.S3.Model
         /// Date and time at which the object was uploaded.
         ///  
         /// </summary>
-        public DateTime LastModified
+        public DateTime? LastModified
         {
-            get { return this.lastModified ?? default(DateTime); }
+            get { return this.lastModified; }
             set { this.lastModified = value; }
         }
 
@@ -182,7 +182,7 @@ namespace Amazon.S3.Model
         /// This is the part number in it's multi-part upload that will uniquely identify the part 
         /// and determine the relative ordering within the destination object.
         /// </summary>
-        public int PartNumber
+        public int? PartNumber
         {
             get { return this.partNumber; }
             set { this.partNumber = value; }

--- a/sdk/src/Services/S3/Custom/Model/DefaultRetention.cs
+++ b/sdk/src/Services/S3/Custom/Model/DefaultRetention.cs
@@ -43,9 +43,9 @@ namespace Amazon.S3.Model
         /// The number of days that you want to specify for the default retention period.
         /// </para>
         /// </summary>
-        public int Days
+        public int? Days
         {
-            get { return this._days.GetValueOrDefault(); }
+            get { return this._days; }
             set { this._days = value; }
         }
 
@@ -80,9 +80,9 @@ namespace Amazon.S3.Model
         /// The number of years that you want to specify for the default retention period.
         /// </para>
         /// </summary>
-        public int Years
+        public int? Years
         {
-            get { return this._years.GetValueOrDefault(); }
+            get { return this._years; }
             set { this._years = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectRequest.cs
@@ -209,9 +209,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool BypassGovernanceRetention
+        public bool? BypassGovernanceRetention
         {
-            get { return this.bypassGovernanceRetention.GetValueOrDefault(); }
+            get { return this.bypassGovernanceRetention; }
             set { this.bypassGovernanceRetention = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectsRequest.cs
@@ -230,9 +230,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool BypassGovernanceRetention
+        public bool? BypassGovernanceRetention
         {
-            get { return this.bypassGovernanceRetention.GetValueOrDefault(); }
+            get { return this.bypassGovernanceRetention; }
             set { this.bypassGovernanceRetention = value; }
         }
 
@@ -408,9 +408,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Gets and sets the property Quiet.
         /// </summary>
-        public bool Quiet
+        public bool? Quiet
         {
-            get { return this.quiet ?? default(bool); }
+            get { return this.quiet; }
             set { this.quiet = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/DeletedObject.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeletedObject.cs
@@ -48,9 +48,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool DeleteMarker
+        public bool? DeleteMarker
         {
-            get { return this.deleteMarker ?? default(bool); }
+            get { return this.deleteMarker; }
             set { this.deleteMarker = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/GetObjectAttributesPart.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectAttributesPart.cs
@@ -45,9 +45,9 @@ namespace Amazon.S3.Model
         /// the limit returned in the <code>MaxParts</code> element.
         /// </para>
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this._isTruncated.GetValueOrDefault(); }
+            get { return this._isTruncated; }
             set { this._isTruncated = value; }
         }
 
@@ -63,9 +63,9 @@ namespace Amazon.S3.Model
         /// The maximum number of parts allowed in the response.
         /// </para>
         /// </summary>
-        public int MaxParts
+        public int? MaxParts
         {
-            get { return this._maxParts.GetValueOrDefault(); }
+            get { return this._maxParts; }
             set { this._maxParts = value; }
         }
 
@@ -82,9 +82,9 @@ namespace Amazon.S3.Model
         /// as the value to use for the part-number-marker request parameter in a subsequent request.
         /// </para>
         /// </summary>
-        public int NextPartNumberMarker
+        public int? NextPartNumberMarker
         {
-            get { return this._nextPartNumberMarker.GetValueOrDefault(); }
+            get { return this._nextPartNumberMarker; }
             set { this._nextPartNumberMarker = value; }
         }
 
@@ -100,9 +100,9 @@ namespace Amazon.S3.Model
         /// The marker for the current part.
         /// </para>
         /// </summary>
-        public int PartNumberMarker
+        public int? PartNumberMarker
         {
-            get { return this._partNumberMarker.GetValueOrDefault(); }
+            get { return this._partNumberMarker; }
             set { this._partNumberMarker = value; }
         }
 
@@ -151,9 +151,9 @@ namespace Amazon.S3.Model
         /// The total number of parts.
         /// </para>
         /// </summary>
-        public int TotalPartsCount
+        public int? TotalPartsCount
         {
-            get { return this._totalPartsCount.GetValueOrDefault(); }
+            get { return this._totalPartsCount; }
             set { this._totalPartsCount = value; }
         }
 
@@ -162,6 +162,5 @@ namespace Amazon.S3.Model
         {
             return this._totalPartsCount.HasValue;
         }
-
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/GetObjectAttributesRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectAttributesRequest.cs
@@ -335,9 +335,9 @@ namespace Amazon.S3.Model
         /// Sets the maximum number of parts to return.
         /// </para>
         /// </summary>
-        public int MaxParts
+        public int? MaxParts
         {
-            get { return this._maxParts.GetValueOrDefault(); }
+            get { return this._maxParts; }
             set { this._maxParts = value; }
         }
 
@@ -373,9 +373,9 @@ namespace Amazon.S3.Model
         /// will be listed.
         /// </para>
         /// </summary>
-        public int PartNumberMarker
+        public int? PartNumberMarker
         {
-            get { return this._partNumberMarker.GetValueOrDefault(); }
+            get { return this._partNumberMarker; }
             set { this._partNumberMarker = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/GetObjectAttributesResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectAttributesResponse.cs
@@ -70,9 +70,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool DeleteMarker
+        public bool? DeleteMarker
         {
-            get { return this._deleteMarker.GetValueOrDefault(); }
+            get { return this._deleteMarker; }
             set { this._deleteMarker = value; }
         }
 
@@ -107,9 +107,9 @@ namespace Amazon.S3.Model
         /// Creation date of the object.
         /// </para>
         /// </summary>
-        public DateTime LastModified
+        public DateTime? LastModified
         {
-            get { return this._lastModified.GetValueOrDefault(); }
+            get { return this._lastModified; }
             set { this._lastModified = value; }
         }
 
@@ -143,9 +143,9 @@ namespace Amazon.S3.Model
         /// The size of the object in bytes.
         /// </para>
         /// </summary>
-        public long ObjectSize
+        public long? ObjectSize
         {
-            get { return this._objectSize.GetValueOrDefault(); }
+            get { return this._objectSize; }
             set { this._objectSize = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/GetObjectLockConfigurationRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectLockConfigurationRequest.cs
@@ -17,13 +17,7 @@
  * Do not modify this file. This file is generated from the s3-2006-03-01.normal.json service model.
  */
 using System;
-using System.Collections.Generic;
-using System.Xml.Serialization;
-using System.Text;
-using System.IO;
-
 using Amazon.Runtime;
-using Amazon.Runtime.Internal;
 
 namespace Amazon.S3.Model
 {

--- a/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
@@ -303,13 +303,21 @@ namespace Amazon.S3.Model
             "ModifiedSinceDateUtc being assigned, the latest assignment to either one of the two property is " +
             "reflected in the value of both. ModifiedSinceDate is provided for backwards compatibility only and " +
             "assigning a non-Utc DateTime to it results in the wrong timestamp being passed to the service.", false)]
-        public DateTime ModifiedSinceDate
+        public DateTime? ModifiedSinceDate
         {
-            get { return this.modifiedSinceDate.GetValueOrDefault(); }
+            get { return this.modifiedSinceDate; }
             set
             {
-                this.modifiedSinceDate = value;
-                this.modifiedSinceDateUtc = new DateTime(value.Ticks, DateTimeKind.Utc);
+                if (value == null)
+                {
+                    this.modifiedSinceDate = null;
+                    this.modifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.modifiedSinceDate = value;
+                    this.modifiedSinceDateUtc = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
             }
         }
 
@@ -317,13 +325,21 @@ namespace Amazon.S3.Model
         /// Returns the object only if it has been modified since the specified time, 
         /// otherwise returns a PreconditionFailed.
         /// </summary>
-        public DateTime ModifiedSinceDateUtc
+        public DateTime? ModifiedSinceDateUtc
         {
-            get { return this.modifiedSinceDateUtc.GetValueOrDefault(); }
+            get { return this.modifiedSinceDateUtc ?? default(DateTime); }
             set
             {
-                this.modifiedSinceDateUtc = value;
-                this.modifiedSinceDate = value;
+                if (value == null)
+                {
+                    this.modifiedSinceDate = null;
+                    this.modifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.modifiedSinceDateUtc = value;
+                    this.modifiedSinceDate = value;
+                }
             }
         }
 
@@ -366,13 +382,21 @@ namespace Amazon.S3.Model
             "UnmodifiedSinceDateUtc being assigned, the latest assignment to either one of the two property is " +
             "reflected in the value of both. UnmodifiedSinceDate is provided for backwards compatibility only and " +
             "assigning a non-Utc DateTime to it results in the wrong timestamp being passed to the service.", false)]
-        public DateTime UnmodifiedSinceDate
+        public DateTime? UnmodifiedSinceDate
         {
-            get { return this.unmodifiedSinceDate.GetValueOrDefault(); }
+            get { return this.unmodifiedSinceDate ?? default(DateTime); }
             set
             {
-                this.unmodifiedSinceDate = value;
-                this.unmodifiedSinceDateUtc = new DateTime(value.Ticks, DateTimeKind.Utc);
+                if (value == null)
+                {
+                    this.unmodifiedSinceDate = null;
+                    this.unmodifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.unmodifiedSinceDate = value;
+                    this.unmodifiedSinceDateUtc = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
             }
         }
 
@@ -380,13 +404,21 @@ namespace Amazon.S3.Model
         /// Returns the object only if it has not been modified since the specified time, 
         /// otherwise returns a PreconditionFailed.
         /// </summary>
-        public DateTime UnmodifiedSinceDateUtc
+        public DateTime? UnmodifiedSinceDateUtc
         {
             get { return this.unmodifiedSinceDateUtc ?? default(DateTime); }
             set
             {
-                this.unmodifiedSinceDateUtc = value;
-                this.unmodifiedSinceDate = value;
+                if (value == null)
+                {
+                    this.unmodifiedSinceDate = null;
+                    this.unmodifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.unmodifiedSinceDateUtc = value;
+                    this.unmodifiedSinceDate = value;
+                }
             }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/GetObjectMetadataResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectMetadataResponse.cs
@@ -33,7 +33,7 @@ namespace Amazon.S3.Model
         private string contentRange;
         private Expiration expiration;
         private DateTime? restoreExpiration;
-        private bool restoreInProgress;
+        private bool? restoreInProgress;
         private DateTime? lastModified;
         private string eTag;
         private int? missingMeta;
@@ -196,7 +196,7 @@ namespace Amazon.S3.Model
         /// Zone storage class is supported by directory buckets to store objects.
         /// </para>
         ///  </note>
-        public bool RestoreInProgress
+        public bool? RestoreInProgress
         {
             get { return this.restoreInProgress; }
             set { this.restoreInProgress = value; }
@@ -207,9 +207,9 @@ namespace Amazon.S3.Model
         /// Date and time when the object was last modified.
         /// </para>
         /// </summary>
-        public DateTime LastModified
+        public DateTime? LastModified
         {
-            get { return this.lastModified ?? default(DateTime); }
+            get { return this.lastModified; }
             set { this.lastModified = value; }
         }
 
@@ -249,9 +249,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public int MissingMeta
+        public int? MissingMeta
         {
-            get { return this.missingMeta ?? default(int); }
+            get { return this.missingMeta; }
             set { this.missingMeta = value; }
         }
 
@@ -288,17 +288,24 @@ namespace Amazon.S3.Model
         /// The date and time at which the object is no longer cacheable.
         ///  
         /// </summary>
-        public DateTime Expires
+        public DateTime? Expires
         {
             get
             {
                 if (this.isExpiresUnmarshalled)
                 {
-                    return this.expires.Value;
+                    return this.expires;
                 }
                 else
                 {
-                    this.expires = AmazonS3Util.ParseExpiresHeader(this.RawExpires, this.ResponseMetadata.RequestId);
+                    if (!string.IsNullOrEmpty(this.RawExpires))
+                    {
+                        this.expires = AmazonS3Util.ParseExpiresHeader(this.RawExpires, this.ResponseMetadata.RequestId);
+                    }
+                    else
+                    {
+                        this.expires = null;
+                    }
                     this.isExpiresUnmarshalled = true;
                     return this.expires.Value;
                 }
@@ -569,9 +576,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public DateTime ObjectLockRetainUntilDate
+        public DateTime? ObjectLockRetainUntilDate
         {
-            get { return this.objectLockRetainUntilDate.GetValueOrDefault(); }
+            get { return this.objectLockRetainUntilDate; }
             set { this.objectLockRetainUntilDate = value; }
         }
 
@@ -641,9 +648,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/GetObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectRequest.cs
@@ -330,13 +330,21 @@ namespace Amazon.S3.Model
             "ModifiedSinceDateUtc being assigned, the latest assignment to either one of the two property is " +
             "reflected in the value of both. ModifiedSinceDate is provided for backwards compatibility only and " +
             "assigning a non-Utc DateTime to it results in the wrong timestamp being passed to the service.", false)]
-        public DateTime ModifiedSinceDate
+        public DateTime? ModifiedSinceDate
         {
-            get { return this.modifiedSinceDate ?? default(DateTime); }
+            get { return this.modifiedSinceDate; }
             set
             {
-                this.modifiedSinceDate = value;
-                this.modifiedSinceDateUtc = new DateTime(value.Ticks, DateTimeKind.Utc);
+                if (value == null)
+                {
+                    this.modifiedSinceDate = null;
+                    this.modifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.modifiedSinceDate = value;
+                    this.modifiedSinceDateUtc = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
             }
         }
 
@@ -344,13 +352,21 @@ namespace Amazon.S3.Model
         /// Returns the object only if it has been modified since the specified time, 
         /// otherwise returns a PreconditionFailed.
         /// </summary>
-        public DateTime ModifiedSinceDateUtc
+        public DateTime? ModifiedSinceDateUtc
         {
-            get { return this.modifiedSinceDateUtc.GetValueOrDefault(); }
+            get { return this.modifiedSinceDateUtc ?? default(DateTime); }
             set
             {
-                this.modifiedSinceDateUtc = value;
-                this.modifiedSinceDate = value;
+                if (value == null)
+                {
+                    this.modifiedSinceDate = null;
+                    this.modifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.modifiedSinceDateUtc = value;
+                    this.modifiedSinceDate = value;
+                }
             }
         }
 
@@ -377,13 +393,21 @@ namespace Amazon.S3.Model
             "UnmodifiedSinceDateUtc being assigned, the latest assignment to either one of the two property is " +
             "reflected in the value of both. UnmodifiedSinceDate is provided for backwards compatibility only and " +
             "assigning a non-Utc DateTime to it results in the wrong timestamp being passed to the service.", false)]
-        public DateTime UnmodifiedSinceDate
+        public DateTime? UnmodifiedSinceDate
         {
-            get { return this.unmodifiedSinceDate.GetValueOrDefault(); }
+            get { return this.unmodifiedSinceDate ?? default(DateTime); }
             set
             {
-                this.unmodifiedSinceDate = value;
-                this.unmodifiedSinceDateUtc = new DateTime(value.Ticks, DateTimeKind.Utc);
+                if (value == null)
+                {
+                    this.unmodifiedSinceDate = null;
+                    this.unmodifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.unmodifiedSinceDate = value;
+                    this.unmodifiedSinceDateUtc = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
             }
         }
 
@@ -391,13 +415,21 @@ namespace Amazon.S3.Model
         /// Returns the object only if it has not been modified since the specified time, 
         /// otherwise returns a PreconditionFailed.
         /// </summary>
-        public DateTime UnmodifiedSinceDateUtc
+        public DateTime? UnmodifiedSinceDateUtc
         {
             get { return this.unmodifiedSinceDateUtc ?? default(DateTime); }
             set
             {
-                this.unmodifiedSinceDateUtc = value;
-                this.unmodifiedSinceDate = value;
+                if (value == null)
+                {
+                    this.unmodifiedSinceDate = null;
+                    this.unmodifiedSinceDateUtc = null;
+                }
+                else
+                {
+                    this.unmodifiedSinceDateUtc = value;
+                    this.unmodifiedSinceDate = value;
+                }
             }
         }
 
@@ -502,26 +534,42 @@ namespace Amazon.S3.Model
             "ResponseExpiresUtc being assigned, the latest assignment to either one of the two property is " +
             "reflected in the value of both. ResponseExpires is provided for backwards compatibility only and " +
             "assigning a non-Utc DateTime to it results in the wrong timestamp being passed to the service.", false)]
-        public DateTime ResponseExpires
+        public DateTime? ResponseExpires
         {
-            get { return this.responseExpires.GetValueOrDefault(); }
+            get { return this.responseExpires; }
             set
             {
-                this.responseExpires = value;
-                this.responseExpiresUtc = new DateTime(value.Ticks, DateTimeKind.Utc);
+                if (value == null)
+                {
+                    this.responseExpires = null;
+                    this.responseExpiresUtc = null;
+                }
+                else
+                {
+                    this.responseExpires = value;
+                    this.responseExpiresUtc = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
             }
         }
 
         /// <summary>
         /// Sets the Expires header of the response.
         /// </summary>
-        public DateTime ResponseExpiresUtc
+        public DateTime? ResponseExpiresUtc
         {
-            get { return this.responseExpiresUtc ?? default(DateTime); }
+            get { return this.responseExpiresUtc; }
             set
             {
-                this.responseExpiresUtc = value;
-                this.responseExpires = value;
+                if (value == null)
+                {
+                    this.responseExpires = null;
+                    this.responseExpiresUtc = null;
+                }
+                else
+                {
+                    this.responseExpiresUtc = value;
+                    this.responseExpires = value;
+                }
             }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/GetObjectResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectResponse.cs
@@ -38,7 +38,7 @@ namespace Amazon.S3.Model
         private string contentRange;
         private Expiration expiration;
         private DateTime? restoreExpiration;
-        private bool restoreInProgress;
+        private bool? restoreInProgress;
         private DateTime? lastModified;
         private string eTag;
         private int? missingMeta;
@@ -214,7 +214,7 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool RestoreInProgress
+        public bool? RestoreInProgress
         {
             get { return this.restoreInProgress; }
             set { this.restoreInProgress = value; }
@@ -226,9 +226,9 @@ namespace Amazon.S3.Model
         /// Date and time when the object was last modified.
         /// </para>
         /// </summary>
-        public DateTime LastModified
+        public DateTime? LastModified
         {
-            get { return this.lastModified ?? default(DateTime); }
+            get { return this.lastModified; }
             set { this.lastModified = value; }
         }
 
@@ -268,9 +268,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public int MissingMeta
+        public int? MissingMeta
         {
-            get { return this.missingMeta ?? default(int); }
+            get { return this.missingMeta; }
             set { this.missingMeta = value; }
         }
 
@@ -307,17 +307,24 @@ namespace Amazon.S3.Model
         /// The date and time at which the object is no longer cacheable.
         ///  
         /// </summary>
-        public DateTime Expires
+        public DateTime? Expires
         {
             get
             {
                 if (this.isExpiresUnmarshalled)
                 {
-                    return this.expires.Value;
+                    return this.expires;
                 }
                 else
                 {
-                    this.expires = AmazonS3Util.ParseExpiresHeader(this.RawExpires, this.ResponseMetadata.RequestId);
+                    if (!string.IsNullOrEmpty(this.RawExpires))
+                    {
+                        this.expires = AmazonS3Util.ParseExpiresHeader(this.RawExpires, this.ResponseMetadata.RequestId);
+                    }
+                    else
+                    {
+                        this.expires = null;
+                    }
                     this.isExpiresUnmarshalled = true;
                     return this.expires.Value;
                 }
@@ -389,9 +396,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public DateTime ObjectLockRetainUntilDate
+        public DateTime? ObjectLockRetainUntilDate
         {
-            get { return this.objectLockRetainUntilDate.GetValueOrDefault(); }
+            get { return this.objectLockRetainUntilDate; }
             set { this.objectLockRetainUntilDate = value; }
         }
 
@@ -630,9 +637,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/GetPreSignedUrlRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetPreSignedUrlRequest.cs
@@ -21,10 +21,8 @@
  */
 
 using System;
-using System.Xml.Serialization;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
-using Amazon.S3.Util;
 
 namespace Amazon.S3.Model
 {
@@ -145,9 +143,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// The expiry date and time for the pre-signed url.
         /// </summary>
-        public DateTime Expires
+        public DateTime? Expires
         {
-            get { return this.expires.GetValueOrDefault(); }
+            get { return this.expires; }
             set { this.expires = value; }
         }
 
@@ -250,9 +248,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// The part number for the multipart upload for which a pre-signed url should be created.
         /// </summary>
-        public int PartNumber
+        public int? PartNumber
         {
-            get { return this.partNumber ?? default(int); }
+            get { return this.partNumber; }
             set { this.partNumber = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/HeadBucketResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/HeadBucketResponse.cs
@@ -44,9 +44,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool AccessPointAlias
+        public bool? AccessPointAlias
         {
-            get { return this._accessPointAlias.GetValueOrDefault(); }
+            get { return this._accessPointAlias; }
             set { this._accessPointAlias = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
@@ -313,9 +313,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 
@@ -509,9 +509,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public DateTime ObjectLockRetainUntilDate
+        public DateTime? ObjectLockRetainUntilDate
         {
-            get { return this.objectLockRetainUntilDate.GetValueOrDefault(); }
+            get { return this.objectLockRetainUntilDate; }
             set { this.objectLockRetainUntilDate = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadResponse.cs
@@ -62,9 +62,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public DateTime AbortDate
+        public DateTime? AbortDate
         {
-            get { return this.abortDate.GetValueOrDefault(); }
+            get { return this.abortDate; }
             set { this.abortDate = value; }
         }
 
@@ -111,9 +111,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/LifecyclePredicateVisitor.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/LifecyclePredicateVisitor.cs
@@ -84,12 +84,12 @@ namespace Amazon.S3.Model.Internal
 
         public void Visit(LifecycleObjectSizeGreaterThanPredicate lifecycleGreaterThanPredicate)
         {
-            xmlWriter.WriteElementString("ObjectSizeGreaterThan", S3Transforms.ToXmlStringValue(lifecycleGreaterThanPredicate.ObjectSizeGreaterThan));
+            xmlWriter.WriteElementString("ObjectSizeGreaterThan", S3Transforms.ToXmlStringValue(lifecycleGreaterThanPredicate.ObjectSizeGreaterThan.Value));
         }
 
         public void Visit(LifecycleObjectSizeLessThanPredicate lifecycleGreaterLessThanPredicate)
         {
-            xmlWriter.WriteElementString("ObjectSizeLessThan", S3Transforms.ToXmlStringValue(lifecycleGreaterLessThanPredicate.ObjectSizeLessThan));
+            xmlWriter.WriteElementString("ObjectSizeLessThan", S3Transforms.ToXmlStringValue(lifecycleGreaterLessThanPredicate.ObjectSizeLessThan.Value));
         }
 
         public void Visit(LifecycleAndOperator lifecycleAndOperator)

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CompleteMultipartUploadRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CompleteMultipartUploadRequestMarshaller.cs
@@ -101,7 +101,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                         if (multipartUploadMultipartUploadpartsListValue.IsSetPartNumber())
                         {
                             xmlWriter.WriteElementString("PartNumber", 
-                                                         S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.PartNumber));
+                                                         S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.PartNumber.Value));
                         }
                         if (multipartUploadMultipartUploadpartsListValue.IsSetChecksumCRC32())
                         {

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
@@ -66,13 +66,13 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.Headers.Add(HeaderKeys.XAmzCopySourceIfMatchHeader, S3Transforms.ToStringValue(copyObjectRequest.ETagToMatch));
 
             if (copyObjectRequest.IsSetModifiedSinceDateUtc())
-                request.Headers.Add(HeaderKeys.XAmzCopySourceIfModifiedSinceHeader, S3Transforms.ToStringValue(copyObjectRequest.ModifiedSinceDateUtc));
+                request.Headers.Add(HeaderKeys.XAmzCopySourceIfModifiedSinceHeader, S3Transforms.ToStringValue(copyObjectRequest.ModifiedSinceDateUtc.Value));
 
             if (copyObjectRequest.IsSetETagToNotMatch())
                 request.Headers.Add(HeaderKeys.XAmzCopySourceIfNoneMatchHeader, S3Transforms.ToStringValue(copyObjectRequest.ETagToNotMatch));
 
             if (copyObjectRequest.IsSetUnmodifiedSinceDateUtc())
-                request.Headers.Add(HeaderKeys.XAmzCopySourceIfUnmodifiedSinceHeader, S3Transforms.ToStringValue(copyObjectRequest.UnmodifiedSinceDateUtc));
+                request.Headers.Add(HeaderKeys.XAmzCopySourceIfUnmodifiedSinceHeader, S3Transforms.ToStringValue(copyObjectRequest.UnmodifiedSinceDateUtc.Value));
 
             if (copyObjectRequest.IsSetTagSet())
             {
@@ -137,7 +137,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.Headers.Add(S3Constants.AmzHeaderExpectedSourceBucketOwner, S3Transforms.ToStringValue(copyObjectRequest.ExpectedSourceBucketOwner));
 
             if (copyObjectRequest.IsSetBucketKeyEnabled())
-                request.Headers.Add(S3Constants.AmzHeaderBucketKeyEnabled, S3Transforms.ToStringValue(copyObjectRequest.BucketKeyEnabled));
+                request.Headers.Add(S3Constants.AmzHeaderBucketKeyEnabled, S3Transforms.ToStringValue(copyObjectRequest.BucketKeyEnabled.Value));
 
             if (copyObjectRequest.IsSetChecksumAlgorithm())
                 request.Headers.Add(S3Constants.AmzHeaderChecksumAlgorithm ,S3Transforms.ToStringValue(copyObjectRequest.ChecksumAlgorithm));

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
@@ -90,7 +90,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             }
 
             if(copyPartRequest.IsSetFirstByte() && copyPartRequest.IsSetLastByte())
-            	request.Headers.Add(HeaderKeys.XAmzCopySourceRangeHeader, ConstructCopySourceRangeHeader(copyPartRequest.FirstByte, copyPartRequest.LastByte));
+            	request.Headers.Add(HeaderKeys.XAmzCopySourceRangeHeader, ConstructCopySourceRangeHeader(copyPartRequest.FirstByte.Value, copyPartRequest.LastByte.Value));
 
             if (copyPartRequest.IsSetExpectedBucketOwner())
                 request.Headers.Add(S3Constants.AmzHeaderExpectedBucketOwner, S3Transforms.ToStringValue(copyPartRequest.ExpectedBucketOwner));
@@ -110,7 +110,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             request.ResourcePath = string.Format(CultureInfo.InvariantCulture, "/{0}",
                                                  S3Transforms.ToStringValue(destinationKey));
 
-            request.AddSubResource("partNumber", S3Transforms.ToStringValue(copyPartRequest.PartNumber));
+            request.AddSubResource("partNumber", S3Transforms.ToStringValue(copyPartRequest.PartNumber.Value));
             request.AddSubResource("uploadId", S3Transforms.ToStringValue(copyPartRequest.UploadId));
 
             request.UseQueryString = true;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/DeleteObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/DeleteObjectRequestMarshaller.cs
@@ -40,8 +40,8 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             request.HttpMethod = "DELETE";
 
-			if (deleteObjectRequest.IsSetBypassGovernanceRetention())
-                request.Headers.Add("x-amz-bypass-governance-retention", S3Transforms.ToStringValue(deleteObjectRequest.BypassGovernanceRetention));
+            if (deleteObjectRequest.IsSetBypassGovernanceRetention())
+                request.Headers.Add("x-amz-bypass-governance-retention", S3Transforms.ToStringValue(deleteObjectRequest.BypassGovernanceRetention.Value));
             if (deleteObjectRequest.IsSetMfaCodes())
                 request.Headers.Add(HeaderKeys.XAmzMfaHeader, deleteObjectRequest.MfaCodes.FormattedMfaCodes);
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/DeleteObjectsRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/DeleteObjectsRequestMarshaller.cs
@@ -45,7 +45,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
 			if (deleteObjectsRequest.IsSetBypassGovernanceRetention())
-                request.Headers.Add("x-amz-bypass-governance-retention", S3Transforms.ToStringValue(deleteObjectsRequest.BypassGovernanceRetention));
+                request.Headers.Add("x-amz-bypass-governance-retention", S3Transforms.ToStringValue(deleteObjectsRequest.BypassGovernanceRetention.Value));
             if (deleteObjectsRequest.IsSetMfaCodes())
                 request.Headers.Add(HeaderKeys.XAmzMfaHeader, deleteObjectsRequest.MfaCodes.FormattedMfaCodes);
             if (deleteObjectsRequest.IsSetRequestPayer())
@@ -86,7 +86,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 }
                 if (deleteObjectsRequest.IsSetQuiet())
                 {
-                    xmlWriter.WriteElementString("Quiet", "", S3Transforms.ToXmlStringValue(deleteObjectsRequest.Quiet));
+                    xmlWriter.WriteElementString("Quiet", "", S3Transforms.ToXmlStringValue(deleteObjectsRequest.Quiet.Value));
                 }
                 xmlWriter.WriteEndElement();
             }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectMetadataRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectMetadataRequestMarshaller.cs
@@ -46,13 +46,13 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.Headers.Add(HeaderKeys.IfMatchHeader, S3Transforms.ToStringValue(headObjectRequest.EtagToMatch));
             
             if(headObjectRequest.IsSetModifiedSinceDateUtc())
-                request.Headers.Add(HeaderKeys.IfModifiedSinceHeader, S3Transforms.ToStringValue(headObjectRequest.ModifiedSinceDateUtc));
+                request.Headers.Add(HeaderKeys.IfModifiedSinceHeader, S3Transforms.ToStringValue(headObjectRequest.ModifiedSinceDateUtc.Value));
             
             if(headObjectRequest.IsSetEtagToNotMatch())
                 request.Headers.Add(HeaderKeys.IfNoneMatchHeader, S3Transforms.ToStringValue(headObjectRequest.EtagToNotMatch));
             
             if(headObjectRequest.IsSetUnmodifiedSinceDateUtc())
-                request.Headers.Add(HeaderKeys.IfUnmodifiedSinceHeader, S3Transforms.ToStringValue(headObjectRequest.UnmodifiedSinceDateUtc));
+                request.Headers.Add(HeaderKeys.IfUnmodifiedSinceHeader, S3Transforms.ToStringValue(headObjectRequest.UnmodifiedSinceDateUtc.Value));
 
             if (headObjectRequest.IsSetServerSideEncryptionCustomerMethod())
                 request.Headers.Add(HeaderKeys.XAmzSSECustomerAlgorithmHeader, headObjectRequest.ServerSideEncryptionCustomerMethod);

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectRequestMarshaller.cs
@@ -46,13 +46,13 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.Headers.Add(HeaderKeys.IfMatchHeader, S3Transforms.ToStringValue(getObjectRequest.EtagToMatch));
 
             if (getObjectRequest.IsSetModifiedSinceDateUtc())
-                request.Headers.Add(HeaderKeys.IfModifiedSinceHeader, S3Transforms.ToStringValue(getObjectRequest.ModifiedSinceDateUtc));
+                request.Headers.Add(HeaderKeys.IfModifiedSinceHeader, S3Transforms.ToStringValue(getObjectRequest.ModifiedSinceDateUtc.Value));
 
             if (getObjectRequest.IsSetEtagToNotMatch())
                 request.Headers.Add(HeaderKeys.IfNoneMatchHeader, S3Transforms.ToStringValue(getObjectRequest.EtagToNotMatch));
             
             if(getObjectRequest.IsSetUnmodifiedSinceDateUtc())
-                request.Headers.Add(HeaderKeys.IfUnmodifiedSinceHeader, S3Transforms.ToStringValue(getObjectRequest.UnmodifiedSinceDateUtc));
+                request.Headers.Add(HeaderKeys.IfUnmodifiedSinceHeader, S3Transforms.ToStringValue(getObjectRequest.UnmodifiedSinceDateUtc.Value));
             
             if(getObjectRequest.IsSetByteRange())
                 request.Headers.Add(HeaderKeys.RangeHeader, getObjectRequest.ByteRange.FormattedByteRange);
@@ -96,7 +96,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (headerOverrides.ContentType != null)
                 request.Parameters.Add("response-content-type", S3Transforms.ToStringValue(headerOverrides.ContentType));
             if (getObjectRequest.IsSetResponseExpiresUtc())
-                request.Parameters.Add("response-expires", S3Transforms.ToStringValue(getObjectRequest.ResponseExpiresUtc));
+                request.Parameters.Add("response-expires", S3Transforms.ToStringValue(getObjectRequest.ResponseExpiresUtc.Value));
             if (getObjectRequest.IsSetVersionId())
                 request.AddSubResource("versionId", S3Transforms.ToStringValue(getObjectRequest.VersionId));
             if (getObjectRequest.IsSetPartNumber())

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/InitiateMultipartUploadRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/InitiateMultipartUploadRequestMarshaller.cs
@@ -83,13 +83,13 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if(initiateMultipartUploadRequest.IsSetObjectLockMode())
                 request.Headers.Add("x-amz-object-lock-mode", S3Transforms.ToStringValue(initiateMultipartUploadRequest.ObjectLockMode));        
             if(initiateMultipartUploadRequest.IsSetObjectLockRetainUntilDate())
-                request.Headers.Add("x-amz-object-lock-retain-until-date", S3Transforms.ToStringValue(initiateMultipartUploadRequest.ObjectLockRetainUntilDate, AWSSDKUtils.ISO8601DateFormat));
+                request.Headers.Add("x-amz-object-lock-retain-until-date", S3Transforms.ToStringValue(initiateMultipartUploadRequest.ObjectLockRetainUntilDate.Value, AWSSDKUtils.ISO8601DateFormat));
 
             if (initiateMultipartUploadRequest.IsSetTagSet())
                 request.Headers.Add(S3Constants.AmzHeaderTagging, AmazonS3Util.TagSetToQueryString(initiateMultipartUploadRequest.TagSet));
 
             if (initiateMultipartUploadRequest.IsSetBucketKeyEnabled())
-                request.Headers.Add(S3Constants.AmzHeaderBucketKeyEnabled, S3Transforms.ToStringValue(initiateMultipartUploadRequest.BucketKeyEnabled));
+                request.Headers.Add(S3Constants.AmzHeaderBucketKeyEnabled, S3Transforms.ToStringValue(initiateMultipartUploadRequest.BucketKeyEnabled.Value));
 
             if (initiateMultipartUploadRequest.IsSetChecksumAlgorithm())
                 request.Headers.Add(S3Constants.AmzHeaderChecksumAlgorithm, S3Transforms.ToStringValue(initiateMultipartUploadRequest.ChecksumAlgorithm));

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListMultipartUploadsRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListMultipartUploadsRequestMarshaller.cs
@@ -55,7 +55,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (listMultipartUploadsRequest.IsSetKeyMarker())
                 request.Parameters.Add("key-marker", S3Transforms.ToStringValue(listMultipartUploadsRequest.KeyMarker));
             if (listMultipartUploadsRequest.IsSetMaxUploads())
-                request.Parameters.Add("max-uploads", S3Transforms.ToStringValue(listMultipartUploadsRequest.MaxUploads));
+                request.Parameters.Add("max-uploads", S3Transforms.ToStringValue(listMultipartUploadsRequest.MaxUploads.Value));
             if (listMultipartUploadsRequest.IsSetPrefix())
                 request.Parameters.Add("prefix", S3Transforms.ToStringValue(listMultipartUploadsRequest.Prefix));
             if (listMultipartUploadsRequest.IsSetUploadIdMarker())

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListObjectsRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListObjectsRequestMarshaller.cs
@@ -57,7 +57,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (listObjectsRequest.IsSetMarker())
                 request.Parameters.Add("marker", S3Transforms.ToStringValue(listObjectsRequest.Marker));
             if (listObjectsRequest.IsSetMaxKeys())
-                request.Parameters.Add("max-keys", S3Transforms.ToStringValue(listObjectsRequest.MaxKeys));
+                request.Parameters.Add("max-keys", S3Transforms.ToStringValue(listObjectsRequest.MaxKeys.Value));
             if (listObjectsRequest.IsSetPrefix())
                 request.Parameters.Add("prefix", S3Transforms.ToStringValue(listObjectsRequest.Prefix));
             if (listObjectsRequest.IsSetEncoding())

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListObjectsV2RequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListObjectsV2RequestMarshaller.cs
@@ -55,13 +55,13 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (listObjectsRequest.IsSetEncoding())
                 request.Parameters.Add("encoding-type", S3Transforms.ToStringValue(listObjectsRequest.Encoding));
             if (listObjectsRequest.IsSetMaxKeys())
-                request.Parameters.Add("max-keys", S3Transforms.ToStringValue(listObjectsRequest.MaxKeys));
+                request.Parameters.Add("max-keys", S3Transforms.ToStringValue(listObjectsRequest.MaxKeys.Value));
             if (listObjectsRequest.IsSetPrefix())
                 request.Parameters.Add("prefix", S3Transforms.ToStringValue(listObjectsRequest.Prefix));
             if (listObjectsRequest.IsSetContinuationToken())
                 request.Parameters.Add("continuation-token", S3Transforms.ToStringValue(listObjectsRequest.ContinuationToken));
             if (listObjectsRequest.IsSetFetchOwner())
-                request.Parameters.Add("fetch-owner", S3Transforms.ToStringValue(listObjectsRequest.FetchOwner));
+                request.Parameters.Add("fetch-owner", S3Transforms.ToStringValue(listObjectsRequest.FetchOwner.Value));
             if (listObjectsRequest.IsSetStartAfter())
                 request.Parameters.Add("start-after", S3Transforms.ToStringValue(listObjectsRequest.StartAfter));
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListPartsRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListPartsRequestMarshaller.cs
@@ -56,7 +56,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.AddSubResource("uploadId", S3Transforms.ToStringValue(listPartsRequest.UploadId));
 
             if (listPartsRequest.IsSetMaxParts())
-                request.Parameters.Add("max-parts", S3Transforms.ToStringValue(listPartsRequest.MaxParts));
+                request.Parameters.Add("max-parts", S3Transforms.ToStringValue(listPartsRequest.MaxParts.Value));
             if (listPartsRequest.IsSetPartNumberMarker())
                 request.Parameters.Add("part-number-marker", S3Transforms.ToStringValue(listPartsRequest.PartNumberMarker));
             if (listPartsRequest.IsSetEncoding())

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListVersionsRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListVersionsRequestMarshaller.cs
@@ -57,7 +57,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (listVersionsRequest.IsSetKeyMarker())
                 request.Parameters.Add("key-marker", S3Transforms.ToStringValue(listVersionsRequest.KeyMarker));
             if (listVersionsRequest.IsSetMaxKeys())
-                request.Parameters.Add("max-keys", S3Transforms.ToStringValue(listVersionsRequest.MaxKeys));
+                request.Parameters.Add("max-keys", S3Transforms.ToStringValue(listVersionsRequest.MaxKeys.Value));
             if (listVersionsRequest.IsSetPrefix())
                 request.Parameters.Add("prefix", S3Transforms.ToStringValue(listVersionsRequest.Prefix));
             if (listVersionsRequest.IsSetVersionIdMarker())

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketEncryptionRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketEncryptionRequestMarshaller.cs
@@ -88,7 +88,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
                                 if (serverSideEncryptionRule.IsSetBucketKeyEnabled())
                                 {
-                                    xmlWriter.WriteElementString("BucketKeyEnabled", S3Transforms.ToXmlStringValue(serverSideEncryptionRule.BucketKeyEnabled));
+                                    xmlWriter.WriteElementString("BucketKeyEnabled", S3Transforms.ToXmlStringValue(serverSideEncryptionRule.BucketKeyEnabled.Value));
                                 }
                             }
                             xmlWriter.WriteEndElement();

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketIntelligentTieringConfigurationRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketIntelligentTieringConfigurationRequestMarshaller.cs
@@ -101,7 +101,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 								if (tiering != null)
 								{
 									xmlWriter.WriteStartElement("Tiering");
-									xmlWriter.WriteElementString("Days", S3Transforms.ToXmlStringValue(tiering.Days));
+									xmlWriter.WriteElementString("Days", S3Transforms.ToXmlStringValue(tiering.Days.Value));
 									xmlWriter.WriteElementString("AccessTier", S3Transforms.ToXmlStringValue(tiering.AccessTier));
 									xmlWriter.WriteEndElement();
 								}

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketInventoryConfigurationRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketInventoryConfigurationRequestMarshaller.cs
@@ -117,7 +117,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                             xmlWriter.WriteEndElement();
                         }
 
-                        xmlWriter.WriteElementString("IsEnabled", S3Transforms.ToXmlStringValue(inventoryConfiguration.IsEnabled));
+                        xmlWriter.WriteElementString("IsEnabled", S3Transforms.ToXmlStringValue(inventoryConfiguration.IsEnabled.GetValueOrDefault()));
 
                         if (inventoryConfiguration.IsSetInventoryFilter())
                         {

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketPolicyRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketPolicyRequestMarshaller.cs
@@ -48,7 +48,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (!request.Headers.ContainsKey(HeaderKeys.ContentTypeHeader))
                 request.Headers.Add(HeaderKeys.ContentTypeHeader, "text/plain");
             if (putBucketPolicyRequest.IsSetConfirmRemoveSelfBucketAccess())
-                request.Headers.Add(HeaderKeys.ConfirmSelfBucketAccess, S3Transforms.ToStringValue(putBucketPolicyRequest.ConfirmRemoveSelfBucketAccess));
+                request.Headers.Add(HeaderKeys.ConfirmSelfBucketAccess, S3Transforms.ToStringValue(putBucketPolicyRequest.ConfirmRemoveSelfBucketAccess.Value));
             if (putBucketPolicyRequest.IsSetExpectedBucketOwner())
                 request.Headers.Add(S3Constants.AmzHeaderExpectedBucketOwner, S3Transforms.ToStringValue(putBucketPolicyRequest.ExpectedBucketOwner));
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketReplicationRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketReplicationRequestMarshaller.cs
@@ -201,7 +201,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                         xmlWriter.WriteStartElement("EventThreshold");
                                         if (rule.Destination.Metrics.EventThreshold.IsSetMinutes())
                                         {
-                                            xmlWriter.WriteElementString("Minutes", S3Transforms.ToXmlStringValue(rule.Destination.Metrics.EventThreshold.Minutes));
+                                            xmlWriter.WriteElementString("Minutes", S3Transforms.ToXmlStringValue(rule.Destination.Metrics.EventThreshold.Minutes.Value));
                                         }
                                         xmlWriter.WriteEndElement();
                                     }
@@ -219,7 +219,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                         xmlWriter.WriteStartElement("Time");
                                         if (rule.Destination.ReplicationTime.Time.IsSetMinutes())
                                         {
-                                            xmlWriter.WriteElementString("Minutes", S3Transforms.ToXmlStringValue(rule.Destination.ReplicationTime.Time.Minutes));
+                                            xmlWriter.WriteElementString("Minutes", S3Transforms.ToXmlStringValue(rule.Destination.ReplicationTime.Time.Minutes.Value));
                                         }
                                         xmlWriter.WriteEndElement();
                                     }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketRequestMarshaller.cs
@@ -51,7 +51,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 ConvertPutWithACLRequest(putBucketRequest, request);
 
             if(putBucketRequest.IsSetObjectLockEnabledForBucket())
-                request.Headers.Add("x-amz-bucket-object-lock-enabled", S3Transforms.ToStringValue(putBucketRequest.ObjectLockEnabledForBucket));
+                request.Headers.Add("x-amz-bucket-object-lock-enabled", S3Transforms.ToStringValue(putBucketRequest.ObjectLockEnabledForBucket.Value));
 
             if (putBucketRequest.IsSetObjectOwnership())
                 request.Headers["x-amz-object-ownership"] = putBucketRequest.ObjectOwnership;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketVersioningRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketVersioningRequestMarshaller.cs
@@ -69,7 +69,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
                     if (versioningConfigurationVersioningConfiguration.IsSetEnableMfaDelete())
                     {
-                        xmlWriter.WriteElementString("MfaDelete", versioningConfigurationVersioningConfiguration.EnableMfaDelete ? "Enabled" : "Disabled");
+                        xmlWriter.WriteElementString("MfaDelete", versioningConfigurationVersioningConfiguration.EnableMfaDelete.Value ? "Enabled" : "Disabled");
                     }
                     if (versioningConfigurationVersioningConfiguration.IsSetStatus())
                     {

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutCORSConfigurationRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutCORSConfigurationRequestMarshaller.cs
@@ -131,7 +131,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
                                 if (cORSConfigurationCORSConfigurationcORSRulesListValue.IsSetMaxAgeSeconds())
                                 {
-                                    xmlWriter.WriteElementString("MaxAgeSeconds", S3Transforms.ToXmlStringValue(cORSConfigurationCORSConfigurationcORSRulesListValue.MaxAgeSeconds));
+                                    xmlWriter.WriteElementString("MaxAgeSeconds", S3Transforms.ToXmlStringValue(cORSConfigurationCORSConfigurationcORSRulesListValue.MaxAgeSeconds.Value));
                                 }
 
                                 if (cORSConfigurationCORSConfigurationcORSRulesListValue.IsSetId())

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutLifecycleConfigurationRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutLifecycleConfigurationRequestMarshaller.cs
@@ -80,15 +80,15 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                         xmlWriter.WriteStartElement("Expiration");
                                         if (expiration.IsSetDateUtc())
                                         {
-                                            xmlWriter.WriteElementString("Date", S3Transforms.ToXmlStringValue(expiration.DateUtc));
+                                            xmlWriter.WriteElementString("Date", S3Transforms.ToXmlStringValue(expiration.DateUtc.Value));
                                         }
                                         if (expiration.IsSetDays())
                                         {
-                                            xmlWriter.WriteElementString("Days", S3Transforms.ToXmlStringValue(expiration.Days));
+                                            xmlWriter.WriteElementString("Days", S3Transforms.ToXmlStringValue(expiration.Days.Value));
                                         }
                                         if (expiration.IsSetExpiredObjectDeleteMarker())
                                         {
-                                            xmlWriter.WriteElementString("ExpiredObjectDeleteMarker", S3Transforms.ToXmlStringValue(expiration.ExpiredObjectDeleteMarker));
+                                            xmlWriter.WriteElementString("ExpiredObjectDeleteMarker", S3Transforms.ToXmlStringValue(expiration.ExpiredObjectDeleteMarker.Value));
                                         }
                                         xmlWriter.WriteEndElement();
                                     }
@@ -103,11 +103,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                                 xmlWriter.WriteStartElement("Transition");
                                                 if (transition.IsSetDateUtc())
                                                 {
-                                                    xmlWriter.WriteElementString("Date", S3Transforms.ToXmlStringValue(transition.DateUtc));
+                                                    xmlWriter.WriteElementString("Date", S3Transforms.ToXmlStringValue(transition.DateUtc.Value));
                                                 }
                                                 if (transition.IsSetDays())
                                                 {
-                                                    xmlWriter.WriteElementString("Days", S3Transforms.ToXmlStringValue(transition.Days));
+                                                    xmlWriter.WriteElementString("Days", S3Transforms.ToXmlStringValue(transition.Days.Value));
                                                 }
                                                 if (transition.IsSetStorageClass())
                                                 {
@@ -124,7 +124,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                         xmlWriter.WriteStartElement("NoncurrentVersionExpiration");
                                         if (noncurrentVersionExpiration.IsSetNoncurrentDays())
                                         {
-                                            xmlWriter.WriteElementString("NoncurrentDays", S3Transforms.ToXmlStringValue(noncurrentVersionExpiration.NoncurrentDays));
+                                            xmlWriter.WriteElementString("NoncurrentDays", S3Transforms.ToXmlStringValue(noncurrentVersionExpiration.NoncurrentDays.Value));
                                         }
                                         xmlWriter.WriteEndElement();
                                     }
@@ -139,7 +139,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                                 xmlWriter.WriteStartElement("NoncurrentVersionTransition");
                                                 if (noncurrentVersionTransition.IsSetNoncurrentDays())
                                                 {
-                                                    xmlWriter.WriteElementString("NoncurrentDays", S3Transforms.ToXmlStringValue(noncurrentVersionTransition.NoncurrentDays));
+                                                    xmlWriter.WriteElementString("NoncurrentDays", S3Transforms.ToXmlStringValue(noncurrentVersionTransition.NoncurrentDays.Value));
                                                 }
                                                 if (noncurrentVersionTransition.IsSetStorageClass())
                                                 {
@@ -156,7 +156,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                         xmlWriter.WriteStartElement("AbortIncompleteMultipartUpload");
                                         if (abortIncompleteMultipartUpload.IsSetDaysAfterInitiation())
                                         {
-                                            xmlWriter.WriteElementString("DaysAfterInitiation", S3Transforms.ToXmlStringValue(abortIncompleteMultipartUpload.DaysAfterInitiation));
+                                            xmlWriter.WriteElementString("DaysAfterInitiation", S3Transforms.ToXmlStringValue(abortIncompleteMultipartUpload.DaysAfterInitiation.Value));
                                         }
                                         xmlWriter.WriteEndElement();
                                     }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutObjectRequestMarshaller.cs
@@ -88,7 +88,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.Headers.Add("x-amz-object-lock-mode", S3Transforms.ToStringValue(putObjectRequest.ObjectLockMode));
 
             if (putObjectRequest.IsSetObjectLockRetainUntilDate())
-                request.Headers.Add("x-amz-object-lock-retain-until-date", S3Transforms.ToStringValue(putObjectRequest.ObjectLockRetainUntilDate, AWSSDKUtils.ISO8601DateFormat));
+                request.Headers.Add("x-amz-object-lock-retain-until-date", S3Transforms.ToStringValue(putObjectRequest.ObjectLockRetainUntilDate.Value, AWSSDKUtils.ISO8601DateFormat));
 
             if (putObjectRequest.IsSetRequestPayer())
                 request.Headers.Add(S3Constants.AmzHeaderRequestPayer, S3Transforms.ToStringValue(putObjectRequest.RequestPayer.ToString()));
@@ -100,7 +100,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.Headers.Add(S3Constants.AmzHeaderExpectedBucketOwner, S3Transforms.ToStringValue(putObjectRequest.ExpectedBucketOwner));
 
             if (putObjectRequest.IsSetBucketKeyEnabled())
-                request.Headers.Add(S3Constants.AmzHeaderBucketKeyEnabled, S3Transforms.ToStringValue(putObjectRequest.BucketKeyEnabled));
+                request.Headers.Add(S3Constants.AmzHeaderBucketKeyEnabled, S3Transforms.ToStringValue(putObjectRequest.BucketKeyEnabled.Value));
 
             if (putObjectRequest.IsSetChecksumAlgorithm())
                 request.Headers.Add(S3Constants.AmzHeaderSdkChecksumAlgorithm, S3Transforms.ToStringValue(putObjectRequest.ChecksumAlgorithm));

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutObjectRetentionRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutObjectRetentionRequestMarshaller.cs
@@ -62,7 +62,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             request.AddSubResource("retention");
         
             if (publicRequest.IsSetBypassGovernanceRetention())
-                request.Headers.Add("x-amz-bypass-governance-retention", S3Transforms.ToStringValue(publicRequest.BypassGovernanceRetention));
+                request.Headers.Add("x-amz-bypass-governance-retention", S3Transforms.ToStringValue(publicRequest.BypassGovernanceRetention.Value));
             if (publicRequest.IsSetChecksumAlgorithm())
                 request.Headers.Add(S3Constants.AmzHeaderSdkChecksumAlgorithm, S3Transforms.ToStringValue(publicRequest.ChecksumAlgorithm));
             if (publicRequest.IsSetContentMD5())
@@ -88,10 +88,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     xmlWriter.WriteStartElement("Retention", S3Constants.S3RequestXmlNamespace);
                     if(publicRequest.Retention.IsSetMode())
-                        xmlWriter.WriteElementString("Mode", StringUtils.FromString(publicRequest.Retention.Mode));                    
+                        xmlWriter.WriteElementString("Mode", StringUtils.FromString(publicRequest.Retention.Mode));
     
                     if(publicRequest.Retention.IsSetRetainUntilDate())
-                        xmlWriter.WriteElementString("RetainUntilDate", StringUtils.FromDateTimeToISO8601(publicRequest.Retention.RetainUntilDate));                    
+                        xmlWriter.WriteElementString("RetainUntilDate", StringUtils.FromDateTimeToISO8601(publicRequest.Retention.RetainUntilDate.Value));
     
     
                     xmlWriter.WriteEndElement();

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutPublicAccessBlockRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutPublicAccessBlockRequestMarshaller.cs
@@ -66,19 +66,19 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     xmlWriter.WriteStartElement("PublicAccessBlockConfiguration", S3Constants.S3RequestXmlNamespace);                    
                     if (publicAccessBlockConfiguration.IsSetBlockPublicAcls())
                     {
-                        xmlWriter.WriteElementString("BlockPublicAcls", S3Transforms.ToXmlStringValue(publicAccessBlockConfiguration.BlockPublicAcls));
+                        xmlWriter.WriteElementString("BlockPublicAcls", S3Transforms.ToXmlStringValue(publicAccessBlockConfiguration.BlockPublicAcls.Value));
                     }
                     if (publicAccessBlockConfiguration.IsSetIgnorePublicAcls())
                     {
-                        xmlWriter.WriteElementString("IgnorePublicAcls", S3Transforms.ToXmlStringValue(publicAccessBlockConfiguration.IgnorePublicAcls));
+                        xmlWriter.WriteElementString("IgnorePublicAcls", S3Transforms.ToXmlStringValue(publicAccessBlockConfiguration.IgnorePublicAcls.Value));
                     }
                     if (publicAccessBlockConfiguration.IsSetBlockPublicPolicy())
                     {
-                        xmlWriter.WriteElementString("BlockPublicPolicy", S3Transforms.ToXmlStringValue(publicAccessBlockConfiguration.BlockPublicPolicy));
+                        xmlWriter.WriteElementString("BlockPublicPolicy", S3Transforms.ToXmlStringValue(publicAccessBlockConfiguration.BlockPublicPolicy.Value));
                     }
                     if (publicAccessBlockConfiguration.IsSetRestrictPublicBuckets())
                     {
-                        xmlWriter.WriteElementString("RestrictPublicBuckets", S3Transforms.ToXmlStringValue(publicAccessBlockConfiguration.RestrictPublicBuckets));
+                        xmlWriter.WriteElementString("RestrictPublicBuckets", S3Transforms.ToXmlStringValue(publicAccessBlockConfiguration.RestrictPublicBuckets.Value));
                     }
                     xmlWriter.WriteEndElement();
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/UploadPartRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/UploadPartRequestMarshaller.cs
@@ -85,7 +85,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                                  S3Transforms.ToStringValue(uploadPartRequest.Key));
 
             if (uploadPartRequest.IsSetPartNumber())
-                request.AddSubResource("partNumber", S3Transforms.ToStringValue(uploadPartRequest.PartNumber));
+                request.AddSubResource("partNumber", S3Transforms.ToStringValue(uploadPartRequest.PartNumber.Value));
             if (uploadPartRequest.IsSetUploadId())
                 request.AddSubResource("uploadId", S3Transforms.ToStringValue(uploadPartRequest.UploadId));
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/WriteGetObjectResponseRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/WriteGetObjectResponseRequestMarshaller.cs
@@ -94,19 +94,19 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.Headers["x-amz-fwd-header-Content-Type"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.ContentType);
 
             if (writeGetObjectResponseRequest.IsSetDeleteMarker())
-                request.Headers["x-amz-fwd-header-x-amz-delete-marker"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.DeleteMarker);
+                request.Headers["x-amz-fwd-header-x-amz-delete-marker"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.DeleteMarker.Value);
 
             if (writeGetObjectResponseRequest.IsSetETag())
                 request.Headers["x-amz-fwd-header-ETag"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.ETag);
 
             if (writeGetObjectResponseRequest.IsSetExpires())
-                request.Headers["x-amz-fwd-header-Expires"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.Expires);
+                request.Headers["x-amz-fwd-header-Expires"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.Expires.Value);
 
             if (writeGetObjectResponseRequest.IsSetExpiration())
                 request.Headers["x-amz-fwd-header-x-amz-expiration"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.Expiration);
 
             if (writeGetObjectResponseRequest.IsSetLastModified())
-                request.Headers["x-amz-fwd-header-Last-Modified"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.LastModified);
+                request.Headers["x-amz-fwd-header-Last-Modified"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.LastModified.Value);
 
             if (writeGetObjectResponseRequest.IsSetMissingMeta())
                 request.Headers["x-amz-fwd-header-x-amz-missing-meta"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.MissingMeta.Value);
@@ -120,7 +120,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.Headers["x-amz-fwd-header-x-amz-object-lock-legal-hold"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.ObjectLockLegalHoldStatus);
 
             if (writeGetObjectResponseRequest.IsSetObjectLockRetainUntilDate())
-                request.Headers["x-amz-fwd-header-x-amz-object-lock-retain-until-date"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.ObjectLockRetainUntilDate);
+                request.Headers["x-amz-fwd-header-x-amz-object-lock-retain-until-date"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.ObjectLockRetainUntilDate.Value);
 
             if (writeGetObjectResponseRequest.IsSetPartsCount())
                 request.Headers["x-amz-fwd-header-x-amz-mp-parts-count"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.PartsCount.Value);
@@ -156,7 +156,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 request.Headers["x-amz-fwd-header-x-amz-version-id"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.VersionId);
 
             if (writeGetObjectResponseRequest.IsSetBucketKeyEnabled())
-                request.Headers["x-amz-fwd-header-x-amz-server-side-encryption-bucket-key-enabled"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.BucketKeyEnabled);
+                request.Headers["x-amz-fwd-header-x-amz-server-side-encryption-bucket-key-enabled"] = S3Transforms.ToStringValue(writeGetObjectResponseRequest.BucketKeyEnabled.Value);
 
             var stream = writeGetObjectResponseRequest.Body ?? new MemoryStream();
             request.ContentStream = stream;

--- a/sdk/src/Services/S3/Custom/Model/InventoryConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/InventoryConfiguration.cs
@@ -31,7 +31,7 @@ namespace Amazon.S3.Model
         private InventoryDestination inventoryDestination;
         private InventoryFilter inventoryFilter;
         private string inventoryId;
-        private bool isEnabled;
+        private bool? isEnabled;
         private InventoryIncludedObjectVersions inventoryIncludedObjectVersions;
         private List<InventoryOptionalField> inventoryOptionalFields = new List<InventoryOptionalField>();
         private InventorySchedule inventorySchedule;
@@ -113,7 +113,7 @@ namespace Amazon.S3.Model
         /// generated.
         /// </para>
         /// </summary>
-        public bool IsEnabled
+        public bool? IsEnabled
         {
             get { return this.isEnabled; }
             set { this.isEnabled = value; }

--- a/sdk/src/Services/S3/Custom/Model/LifecycleFilter.cs
+++ b/sdk/src/Services/S3/Custom/Model/LifecycleFilter.cs
@@ -154,9 +154,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Gets and sets the property ObjectSizeGreaterThan.
         /// </summary>
-        public long ObjectSizeGreaterThan
+        public long? ObjectSizeGreaterThan
         {
-            get { return this._objectSizeGreaterThan.GetValueOrDefault(); }
+            get { return this._objectSizeGreaterThan; }
             set { this._objectSizeGreaterThan = value; }
         }
 
@@ -186,9 +186,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Gets and sets the property ObjectSizeLessThan.
         /// </summary>
-        public long ObjectSizeLessThan
+        public long? ObjectSizeLessThan
         {
-            get { return this._objectSizeLessThan.GetValueOrDefault(); }
+            get { return this._objectSizeLessThan; }
             set { this._objectSizeLessThan = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/LifecycleRuleAbortIncompleteMultipartUpload.cs
+++ b/sdk/src/Services/S3/Custom/Model/LifecycleRuleAbortIncompleteMultipartUpload.cs
@@ -32,9 +32,9 @@ namespace Amazon.S3.Model
         /// Indicates the number of days that must pass since initiation for Lifecycle
         /// to abort an Incomplete Multipart Upload.
         /// </summary>
-        public int DaysAfterInitiation
+        public int? DaysAfterInitiation
         {
-            get { return this.daysAfterInitiation ?? default(int); }
+            get { return this.daysAfterInitiation; }
             set { this.daysAfterInitiation = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/LifecycleRuleExpiration.cs
+++ b/sdk/src/Services/S3/Custom/Model/LifecycleRuleExpiration.cs
@@ -37,13 +37,21 @@ namespace Amazon.S3.Model
         private bool? expiredObjectDeleteMarker;
 
         [Obsolete("Setting this property results in non-UTC DateTimes not being marshalled correctly. Use DateUtc instead.", false)]
-        public DateTime Date
+        public DateTime? Date
         {
-            get { return this.date ?? default(DateTime); }
+            get { return this.date; }
             set
             {
                 this.date = value;
-                this.dateUtc = new DateTime(value.Ticks, DateTimeKind.Utc);
+
+                if (value.HasValue)
+                {
+                    this.dateUtc = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
+                else
+                {
+                    this.dateUtc = null;
+                }
             }
         }
 
@@ -51,9 +59,9 @@ namespace Amazon.S3.Model
         /// Indicates at what date the object is to be moved or deleted. The date value must conform
         /// to the ISO 8601 format. The time is always midnight UTC.
         /// </summary>
-        public DateTime DateUtc
+        public DateTime? DateUtc
         {
-            get { return this.dateUtc ?? default(DateTime); }
+            get { return this.dateUtc; }
             set { this.dateUtc = this.date = value; }
         }
 
@@ -67,9 +75,9 @@ namespace Amazon.S3.Model
         /// Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer.
         ///  
         /// </summary>
-        public int Days
+        public int? Days
         {
-            get { return this.days ?? default(int); }
+            get { return this.days; }
             set { this.days = value; }
         }
 
@@ -84,9 +92,9 @@ namespace Amazon.S3.Model
         /// Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set to true, the delete marker will be expired; if set to false the policy takes no action. This cannot be specified with Days or Date in a Lifecycle Expiration Policy.
         ///  
         /// </summary>
-        public bool ExpiredObjectDeleteMarker
+        public bool? ExpiredObjectDeleteMarker
         {
-            get { return this.expiredObjectDeleteMarker.GetValueOrDefault(); }
+            get { return this.expiredObjectDeleteMarker; }
             set { this.expiredObjectDeleteMarker = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/LifecycleRuleNoncurrentVersionExpiration.cs
+++ b/sdk/src/Services/S3/Custom/Model/LifecycleRuleNoncurrentVersionExpiration.cs
@@ -38,9 +38,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Gets and sets the property NewerNoncurrentVersions.
         /// </summary>
-        public int NewerNoncurrentVersions
+        public int? NewerNoncurrentVersions
         {
-            get { return this._newerNoncurrentVersions.GetValueOrDefault(); }
+            get { return this._newerNoncurrentVersions; }
             set { this._newerNoncurrentVersions = value; }
         }
 
@@ -60,9 +60,9 @@ namespace Amazon.S3.Model
         /// Guide</i>.
         /// </para>
         /// </summary>
-        public int NoncurrentDays
+        public int? NoncurrentDays
         {
-            get { return this._noncurrentDays.GetValueOrDefault(); }
+            get { return this._noncurrentDays; }
             set { this._noncurrentDays = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/LifecycleRuleNoncurrentVersionTransition.cs
+++ b/sdk/src/Services/S3/Custom/Model/LifecycleRuleNoncurrentVersionTransition.cs
@@ -32,9 +32,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Gets and sets the property NewerNoncurrentVersions.
         /// </summary>
-        public int NewerNoncurrentVersions
+        public int? NewerNoncurrentVersions
         {
-            get { return this._newerNoncurrentVersions.GetValueOrDefault(); }
+            get { return this._newerNoncurrentVersions; }
             set { this._newerNoncurrentVersions = value; }
         }
 
@@ -50,9 +50,9 @@ namespace Amazon.S3.Model
         /// <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html">How Amazon S3 Calculates When an Object Became Noncurrent</a> 
         /// in the Amazon Simple Storage Service Developer Guide.
         /// </summary>
-        public int NoncurrentDays
+        public int? NoncurrentDays
         {
-            get { return this.noncurrentDays ?? default(int); }
+            get { return this.noncurrentDays; }
             set { this.noncurrentDays = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/LifecycleTransition.cs
+++ b/sdk/src/Services/S3/Custom/Model/LifecycleTransition.cs
@@ -32,13 +32,20 @@ namespace Amazon.S3.Model
         private S3StorageClass storageClass;
 
         [Obsolete("Setting this property results in non-UTC DateTimes not being marshalled correctly. Use DateUtc instead.", false)]
-        public DateTime Date
+        public DateTime? Date
         {
-            get { return this.date ?? default(DateTime); }
+            get { return this.date; }
             set
             {
                 this.date = value;
-                this.dateUtc = new DateTime(value.Ticks, DateTimeKind.Utc);
+                if (value != null)
+                {
+                    this.dateUtc = new DateTime(value.Value.Ticks, DateTimeKind.Utc);
+                }
+                else
+                {
+                    this.dateUtc = null;
+                }
             }
         }
 
@@ -46,9 +53,9 @@ namespace Amazon.S3.Model
         /// Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.
         ///  
         /// </summary>
-        public DateTime DateUtc
+        public DateTime? DateUtc
         {
-            get { return this.dateUtc ?? default(DateTime); }
+            get { return this.dateUtc; }
             set { this.dateUtc = this.date = value; }
         }
 
@@ -62,9 +69,9 @@ namespace Amazon.S3.Model
         /// Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer.
         ///  
         /// </summary>
-        public int Days
+        public int? Days
         {
-            get { return this.days ?? default(int); }
+            get { return this.days; }
             set { this.days = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListBucketAnalyticsConfigurationsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListBucketAnalyticsConfigurationsResponse.cs
@@ -65,9 +65,9 @@ namespace Amazon.S3.Model
         /// Indicates whether the returned list of analytics configurations is complete. 
         /// A value of true indicates that the list is not complete and the NextContinuationToken will be provided for a subsequent request.
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this.isTruncated ?? default(bool); }
+            get { return this.isTruncated; }
             set { this.isTruncated = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListBucketIntelligentTieringConfigurationsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListBucketIntelligentTieringConfigurationsResponse.cs
@@ -64,9 +64,9 @@ namespace Amazon.S3.Model
         /// A value of true indicates that the list is not complete and the 
         /// NextContinuationToken will be provided for a subsequent request.</para>
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this.isTruncated ?? default(bool); }
+            get { return this.isTruncated; }
             set { this.isTruncated = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListBucketInventoryConfigurationsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListBucketInventoryConfigurationsResponse.cs
@@ -64,9 +64,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Indicates whether the returned list of inventory configurations is truncated in this response. A value of true indicates that the list is truncated.
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this.isTruncated ?? default(bool); }
+            get { return this.isTruncated; }
             set { this.isTruncated = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListBucketMetricsConfigurationsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListBucketMetricsConfigurationsResponse.cs
@@ -72,9 +72,9 @@ namespace Amazon.S3.Model
         /// a subsequent request.
         /// </para>
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this.isTruncated ?? default(bool); }
+            get { return this.isTruncated; }
             set { this.isTruncated = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListDirectoryBucketsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListDirectoryBucketsRequest.cs
@@ -90,9 +90,9 @@ namespace Amazon.S3.Model
         /// </para>
         /// </summary>
         [AWSProperty(Min = 0, Max = 1000)]
-        public int MaxDirectoryBuckets
+        public int? MaxDirectoryBuckets
         {
-            get { return this._maxDirectoryBuckets.GetValueOrDefault(); }
+            get { return this._maxDirectoryBuckets; }
             set { this._maxDirectoryBuckets = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListMultipartUploadsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListMultipartUploadsRequest.cs
@@ -346,9 +346,9 @@ namespace Amazon.S3.Model
         /// body. 1,000 is the maximum number of uploads that can be returned in a response.
         /// </para>
         /// </summary>
-        public int MaxUploads
+        public int? MaxUploads
         {
-            get { return this.maxUploads ?? default(int); }
+            get { return this.maxUploads; }
             set { this.maxUploads = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListMultipartUploadsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListMultipartUploadsResponse.cs
@@ -142,9 +142,9 @@ namespace Amazon.S3.Model
         /// Maximum number of multipart uploads that could have been included in the response.
         ///  
         /// </summary>
-        public int MaxUploads
+        public int? MaxUploads
         {
-            get { return this.maxUploads ?? default(int); }
+            get { return this.maxUploads; }
             set { this.maxUploads = value; }
         }
 
@@ -159,9 +159,9 @@ namespace Amazon.S3.Model
         /// be truncated if the number of multipart uploads exceeds the limit allowed or specified by max uploads.
         ///  
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this.isTruncated ?? default(bool); }
+            get { return this.isTruncated; }
             set { this.isTruncated = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListObjectsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListObjectsRequest.cs
@@ -223,9 +223,9 @@ namespace Amazon.S3.Model
         /// more. 
         /// </para>
         /// </summary>
-        public int MaxKeys
+        public int? MaxKeys
         {
-            get { return this.maxKeys ?? default(int); }
+            get { return this.maxKeys; }
             set { this.maxKeys = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListObjectsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListObjectsResponse.cs
@@ -40,9 +40,9 @@ namespace Amazon.S3.Model
         /// A flag that indicates whether or not Amazon S3 returned all of the results that satisfied 
         /// the search criteria.
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this.isTruncated ?? default(bool); }
+            get { return this.isTruncated; }
             set { this.isTruncated = value; }
         }
 
@@ -150,9 +150,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Gets and sets the MaxKeys property. This is max number of object keys returned by the list operation.
         /// </summary>
-        public int MaxKeys
+        public int? MaxKeys
         {
-            get { return this.maxKeys ?? default(int); }
+            get { return this.maxKeys; }
             set { this.maxKeys = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListObjectsV2Request.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListObjectsV2Request.cs
@@ -279,9 +279,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool FetchOwner
+        public bool? FetchOwner
         {
-            get { return this.fetchOwner.GetValueOrDefault(); }
+            get { return this.fetchOwner; }
             set { this.fetchOwner = value; }
         }
 
@@ -299,9 +299,9 @@ namespace Amazon.S3.Model
         /// more.
         /// </para>
         /// </summary>
-        public int MaxKeys
+        public int? MaxKeys
         {
-            get { return this.maxKeys ?? default(int); }
+            get { return this.maxKeys; }
             set { this.maxKeys = value; }
         }
         

--- a/sdk/src/Services/S3/Custom/Model/ListObjectsV2Response.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListObjectsV2Response.cs
@@ -187,9 +187,9 @@ namespace Amazon.S3.Model
         /// results might not be returned.
         /// </para>
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this.isTruncated ?? default(bool); }
+            get { return this.isTruncated; }
             set { this.isTruncated = value; }
         }
 
@@ -207,9 +207,9 @@ namespace Amazon.S3.Model
         /// result will include 50 keys or fewer.
         /// </para>
         /// </summary>
-        public int KeyCount
+        public int? KeyCount
         {
-            get { return this.keyCount ?? default(int); }
+            get { return this.keyCount; }
             set { this.keyCount = value; }
         }
 
@@ -227,9 +227,9 @@ namespace Amazon.S3.Model
         /// more.
         /// </para>
         /// </summary>
-        public int MaxKeys
+        public int? MaxKeys
         {
-            get { return this.maxKeys ?? default(int); }
+            get { return this.maxKeys; }
             set { this.maxKeys = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListPartsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListPartsRequest.cs
@@ -271,9 +271,9 @@ namespace Amazon.S3.Model
         /// Sets the maximum number of parts to return.
         /// </para>
         /// </summary>
-        public int MaxParts
+        public int? MaxParts
         {
-            get { return this.maxParts ?? default(int); }
+            get { return this.maxParts; }
             set { this.maxParts = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListPartsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListPartsResponse.cs
@@ -115,9 +115,9 @@ namespace Amazon.S3.Model
         /// Part number after which listing begins.
         ///  
         /// </summary>
-        public int PartNumberMarker
+        public int? PartNumberMarker
         {
-            get { return this.partNumberMarker ?? default(int); }
+            get { return this.partNumberMarker; }
             set { this.partNumberMarker = value; }
         }
 
@@ -136,9 +136,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  
         /// </summary>
-        public int NextPartNumberMarker
+        public int? NextPartNumberMarker
         {
-            get { return this.nextPartNumberMarker ?? default(int); }
+            get { return this.nextPartNumberMarker; }
             set { this.nextPartNumberMarker = value; }
         }
 
@@ -152,9 +152,9 @@ namespace Amazon.S3.Model
         /// Maximum number of parts that were allowed in the response.
         ///  
         /// </summary>
-        public int MaxParts
+        public int? MaxParts
         {
-            get { return this.maxParts ?? default(int); }
+            get { return this.maxParts; }
             set { this.maxParts = value; }
         }
 
@@ -168,9 +168,9 @@ namespace Amazon.S3.Model
         /// Indicates whether the returned list of parts is truncated.
         ///  
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this.isTruncated ?? default(bool); }
+            get { return this.isTruncated; }
             set { this.isTruncated = value; }
         }
 
@@ -290,9 +290,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public DateTime AbortDate
+        public DateTime? AbortDate
         {
-            get { return this.abortDate.GetValueOrDefault(); }
+            get { return this.abortDate; }
             set { this.abortDate = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ListVersionsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListVersionsRequest.cs
@@ -154,7 +154,7 @@ namespace Amazon.S3.Model
         /// To return the additional keys, see <code>key-marker</code> and <code>version-id-marker</code>.
         /// </para>
         /// </summary>
-        public int MaxKeys
+        public int? MaxKeys
         {
             get { return this.maxKeys ?? default(int); }
             set { this.maxKeys = value; }

--- a/sdk/src/Services/S3/Custom/Model/ListVersionsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListVersionsResponse.cs
@@ -50,9 +50,9 @@ namespace Amazon.S3.Model
         /// results.
         /// </para>
         /// </summary>
-        public bool IsTruncated
+        public bool? IsTruncated
         {
-            get { return this.isTruncated ?? default(bool); }
+            get { return this.isTruncated; }
             set { this.isTruncated = value; }
         }
 
@@ -198,9 +198,9 @@ namespace Amazon.S3.Model
         /// This is the maximum number of keys in the S3ObjectVersions collection.
         /// The value is derived from the MaxKeys parameter to ListVersionsRequest.
         /// </summary>
-        public int MaxKeys
+        public int? MaxKeys
         {
-            get { return this.maxKeys ?? default(int); }
+            get { return this.maxKeys; }
             set { this.maxKeys = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/MultipartUpload.cs
+++ b/sdk/src/Services/S3/Custom/Model/MultipartUpload.cs
@@ -55,9 +55,9 @@ namespace Amazon.S3.Model
         /// Date and time at which the multipart upload was initiated.
         ///  
         /// </summary>
-        public DateTime Initiated
+        public DateTime? Initiated
         {
-            get { return this.initiated ?? default(DateTime); }
+            get { return this.initiated; }
             set { this.initiated = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ObjectLockRetention.cs
+++ b/sdk/src/Services/S3/Custom/Model/ObjectLockRetention.cs
@@ -17,13 +17,6 @@
  * Do not modify this file. This file is generated from the s3-2006-03-01.normal.json service model.
  */
 using System;
-using System.Collections.Generic;
-using System.Xml.Serialization;
-using System.Text;
-using System.IO;
-
-using Amazon.Runtime;
-using Amazon.Runtime.Internal;
 
 namespace Amazon.S3.Model
 {
@@ -56,9 +49,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Gets and sets the property RetainUntilDate.
         /// </summary>
-        public DateTime RetainUntilDate
+        public DateTime? RetainUntilDate
         {
-            get { return this._retainUntilDate.GetValueOrDefault(); }
+            get { return this._retainUntilDate; }
             set { this._retainUntilDate = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ObjectPart.cs
+++ b/sdk/src/Services/S3/Custom/Model/ObjectPart.cs
@@ -118,9 +118,9 @@ namespace Amazon.S3.Model
         /// Part number identifying the part. This is a positive integer between 1 and 10,000.
         /// </para>
         /// </summary>
-        public int PartNumber
+        public int? PartNumber
         {
-            get { return this._partNumber.GetValueOrDefault(); }
+            get { return this._partNumber; }
             set { this._partNumber = value; }
         }
 
@@ -136,9 +136,9 @@ namespace Amazon.S3.Model
         /// The size of the uploaded part in bytes.
         /// </para>
         /// </summary>
-        public long Size
+        public long? Size
         {
-            get { return this._size.GetValueOrDefault(); }
+            get { return this._size; }
             set { this._size = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/PartDetail.cs
+++ b/sdk/src/Services/S3/Custom/Model/PartDetail.cs
@@ -52,9 +52,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// The size of the uploaded part data.
         /// </summary>
-        public long Size
+        public long? Size
         {
-            get { return this.size.GetValueOrDefault(); }
+            get { return this.size; }
             set { this.size = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/PartEtag.cs
+++ b/sdk/src/Services/S3/Custom/Model/PartEtag.cs
@@ -101,7 +101,7 @@ namespace Amazon.S3.Model
         /// </returns>
         public int CompareTo(PartETag other)
         {
-            return this.PartNumber.CompareTo(other.PartNumber);
+            return this.PartNumber.GetValueOrDefault().CompareTo(other.PartNumber.GetValueOrDefault());
         }
 
         #region PartNumber
@@ -109,9 +109,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// The part number identifying the part.
         /// </summary>
-        public int PartNumber
+        public int? PartNumber
         {
-            get { return this.partNumber.GetValueOrDefault(); }
+            get { return this.partNumber; }
             set { this.partNumber = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/PolicyStatus.cs
+++ b/sdk/src/Services/S3/Custom/Model/PolicyStatus.cs
@@ -35,9 +35,9 @@ namespace Amazon.S3.Model
         /// is public. <code>FALSE</code> indicates that the bucket is not public.
         /// </para>
         /// </summary>
-        public bool IsPublic
+        public bool? IsPublic
         {
-            get { return this.isPublic ?? default(bool); }
+            get { return this.isPublic; }
             set { this.isPublic = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/PublicAccessBlockConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/PublicAccessBlockConfiguration.cs
@@ -112,9 +112,9 @@ namespace Amazon.S3.Model
         /// Note that enabling this setting doesn't affect existing policies or ACLs.
         /// </para>
         /// </summary>
-        public bool BlockPublicAcls
+        public bool? BlockPublicAcls
         {
-            get { return this.blockPublicAcls ?? default(bool); }
+            get { return this.blockPublicAcls; }
             set { this.blockPublicAcls = value; }
         }
 
@@ -137,9 +137,9 @@ namespace Amazon.S3.Model
         /// and doesn't prevent new public ACLs from being set.
         /// </para>
         /// </summary>
-        public bool IgnorePublicAcls
+        public bool? IgnorePublicAcls
         {
-            get { return this.ignorePublicAcls ?? default(bool); }
+            get { return this.ignorePublicAcls; }
             set { this.ignorePublicAcls = value; }
         }
 
@@ -161,9 +161,9 @@ namespace Amazon.S3.Model
         /// Note that enabling this setting doesn't affect existing bucket policies.
         /// </para>
         /// </summary>
-        public bool BlockPublicPolicy
+        public bool? BlockPublicPolicy
         {
-            get { return this.blockPublicPolicy ?? default(bool); }
+            get { return this.blockPublicPolicy; }
             set { this.blockPublicPolicy = value; }
         }
 
@@ -188,9 +188,9 @@ namespace Amazon.S3.Model
         /// delegation to specific accounts, is blocked.
         /// </para>
         /// </summary>
-        public bool RestrictPublicBuckets
+        public bool? RestrictPublicBuckets
         {
-            get { return this.restrictPublicBuckets ?? default(bool); }
+            get { return this.restrictPublicBuckets; }
             set { this.restrictPublicBuckets = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/PutBucketNotificationRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutBucketNotificationRequest.cs
@@ -207,9 +207,9 @@ namespace Amazon.S3.Model
         /// Skips validation of Amazon SQS, Amazon SNS, and Lambda destinations
         /// </para>
         /// </summary>
-        public bool SkipDestinationValidation
+        public bool? SkipDestinationValidation
         {
-            get { return this._skipDestinationValidation.GetValueOrDefault(); }
+            get { return this._skipDestinationValidation; }
             set { this._skipDestinationValidation = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/PutBucketPolicyRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutBucketPolicyRequest.cs
@@ -253,11 +253,11 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool ConfirmRemoveSelfBucketAccess
+        public bool? ConfirmRemoveSelfBucketAccess
         {
             get
             {
-                return this.confirmRemoveSelfBucketAccess.GetValueOrDefault();
+                return this.confirmRemoveSelfBucketAccess;
             }
             set
             {

--- a/sdk/src/Services/S3/Custom/Model/PutBucketRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutBucketRequest.cs
@@ -303,9 +303,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool ObjectLockEnabledForBucket
+        public bool? ObjectLockEnabledForBucket
         {
-            get { return this._objectLockEnabledForBucket.GetValueOrDefault(); }
+            get { return this._objectLockEnabledForBucket; }
             set { this._objectLockEnabledForBucket = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
@@ -275,9 +275,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 
@@ -498,9 +498,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public DateTime ObjectLockRetainUntilDate
+        public DateTime? ObjectLockRetainUntilDate
         {
-            get { return this.objectLockRetainUntilDate.GetValueOrDefault(); }
+            get { return this.objectLockRetainUntilDate; }
             set { this.objectLockRetainUntilDate = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/PutObjectResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectResponse.cs
@@ -259,9 +259,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/PutObjectRetentionRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectRetentionRequest.cs
@@ -94,9 +94,9 @@ namespace Amazon.S3.Model
         /// Indicates whether this action should bypass Governance-mode restrictions.
         /// </para>
         /// </summary>
-        public bool BypassGovernanceRetention
+        public bool? BypassGovernanceRetention
         {
-            get { return this._bypassGovernanceRetention.GetValueOrDefault(); }
+            get { return this._bypassGovernanceRetention; }
             set { this._bypassGovernanceRetention = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/ReplicationTimeValue.cs
+++ b/sdk/src/Services/S3/Custom/Model/ReplicationTimeValue.cs
@@ -22,9 +22,9 @@ namespace Amazon.S3.Model
         ///  Valid value: 15
         /// </para>
         /// </summary>
-        public int Minutes
+        public int? Minutes
         {
-            get { return this.minutes ?? default(int); }
+            get { return this.minutes; }
             set { this.minutes = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/RestoreObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/RestoreObjectRequest.cs
@@ -400,9 +400,9 @@ namespace Amazon.S3.Model
         /// <para>The Days element is required for regular restores, and must not be provided for 
         /// select requests.</para>
         /// </summary>
-        public int Days
+        public int? Days
         {
-            get { return this.days ?? default(int); }
+            get { return this.days; }
             set { this.days = value; }
         }
 
@@ -567,7 +567,7 @@ namespace Amazon.S3.Model
                 }
 
                 if (IsSetDays())
-                    xmlWriter.WriteElementString("Days", S3Transforms.ToXmlStringValue(Days));
+                    xmlWriter.WriteElementString("Days", S3Transforms.ToXmlStringValue(Days.Value));
                 if (IsSetType())
                     xmlWriter.WriteElementString("Type", S3Transforms.ToXmlStringValue(RestoreRequestType.Value));
                 if (IsSetDescription())

--- a/sdk/src/Services/S3/Custom/Model/RestoreStatus.cs
+++ b/sdk/src/Services/S3/Custom/Model/RestoreStatus.cs
@@ -49,9 +49,9 @@ namespace Amazon.S3.Model
         /// If the object hasn't been restored, there is no header response.
         /// </para>
         /// </summary>
-        public bool IsRestoreInProgress
+        public bool? IsRestoreInProgress
         {
-            get { return this._isRestoreInProgress.GetValueOrDefault(); }
+            get { return this._isRestoreInProgress; }
             set { this._isRestoreInProgress = value; }
         }
 
@@ -73,9 +73,9 @@ namespace Amazon.S3.Model
         /// 
         /// </para>
         /// </summary>
-        public DateTime RestoreExpiryDate
+        public DateTime? RestoreExpiryDate
         {
-            get { return this._restoreExpiryDate.GetValueOrDefault(); }
+            get { return this._restoreExpiryDate; }
             set { this._restoreExpiryDate = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/S3Bucket.cs
+++ b/sdk/src/Services/S3/Custom/Model/S3Bucket.cs
@@ -33,9 +33,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// <para>Date the bucket was created. This date can change when making changes to your bucket, such as editing its bucket policy.</para>
         /// </summary>
-        public DateTime CreationDate
+        public DateTime? CreationDate
         {
-            get { return this.creationDate ?? default(DateTime); }
+            get { return this.creationDate; }
             set { this.creationDate = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/S3BucketVersioningConfig.cs
+++ b/sdk/src/Services/S3/Custom/Model/S3BucketVersioningConfig.cs
@@ -54,9 +54,9 @@ namespace Amazon.S3.Model
         /// PutBucketVersioningRequest's MfaCodes property is set with 
         /// the Serial of and Token on the MFA device.
         /// </remarks>
-        public bool EnableMfaDelete
+        public bool? EnableMfaDelete
         {
-            get { return this.enableMfaDelete.GetValueOrDefault(); }
+            get { return this.enableMfaDelete; }
             set { this.enableMfaDelete = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/S3Object.cs
+++ b/sdk/src/Services/S3/Custom/Model/S3Object.cs
@@ -135,9 +135,9 @@ namespace Amazon.S3.Model
         /// The date retrieved from S3 is in ISO8601 format. A GMT formatted date is passed back to the user.
         /// </remarks>
         /// </summary>
-        public DateTime LastModified
+        public DateTime? LastModified
         {
-            get { return this.lastModified ?? default(DateTime); }
+            get { return this.lastModified; }
             set { this.lastModified = value; }
         }
 
@@ -185,9 +185,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// The size of the object.
         /// </summary>
-        public long Size
+        public long? Size
         {
-            get { return this.size ?? default(long); }
+            get { return this.size; }
             set { this.size = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/S3ObjectVersion.cs
+++ b/sdk/src/Services/S3/Custom/Model/S3ObjectVersion.cs
@@ -30,14 +30,14 @@ namespace Amazon.S3.Model
 
         private bool? isLatest;
         private string versionId;
-        private bool isDeleteMarker;
+        private bool? isDeleteMarker;
         private RestoreStatus _restoreStatus;
         /// <summary>
         /// Specifies whether the object is (true) or is not (false) the latest version of an object.
         /// </summary>
-        public bool IsLatest
+        public bool? IsLatest
         {
-            get { return this.isLatest ?? default(bool); }
+            get { return this.isLatest; }
             set { this.isLatest = value; }
         }
 
@@ -53,7 +53,7 @@ namespace Amazon.S3.Model
         /// <summary>
         /// If true, the object is a delete marker for a deleted object.
         /// </summary>
-        public bool IsDeleteMarker
+        public bool? IsDeleteMarker
         {
             get { return this.isDeleteMarker; }
             set { this.isDeleteMarker = value; }

--- a/sdk/src/Services/S3/Custom/Model/ScanRange.cs
+++ b/sdk/src/Services/S3/Custom/Model/ScanRange.cs
@@ -29,9 +29,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Specifies the start of the byte range. This parameter is optional. Valid values: non-negative integers. The default value is 0.
         /// </summary>
-        public long Start
+        public long? Start
         {
-            get { return this.start.GetValueOrDefault(); }
+            get { return this.start; }
             set { this.start = value; }
         }
 
@@ -43,9 +43,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// Specifies the end of the byte range. This parameter is optional. Valid values: non-negative integers. The default value is one less than the size of the object being queried.
         /// </summary>
-        public long End
+        public long? End
         {
-            get { return this.end.GetValueOrDefault(); }
+            get { return this.end; }
             set { this.end = value; }
         }
 
@@ -59,9 +59,9 @@ namespace Amazon.S3.Model
             xmlWriter.WriteStartElement(memberName);
             {
                 if (IsSetStart())
-                    xmlWriter.WriteElementString("Start", S3Transforms.ToXmlStringValue(Start));
+                    xmlWriter.WriteElementString("Start", S3Transforms.ToXmlStringValue(Start.Value));
                 if (IsSetEnd())
-                    xmlWriter.WriteElementString("End", S3Transforms.ToXmlStringValue(End));
+                    xmlWriter.WriteElementString("End", S3Transforms.ToXmlStringValue(End.Value));
             }
             xmlWriter.WriteEndElement();
 

--- a/sdk/src/Services/S3/Custom/Model/ServerSideEncryptionRule.cs
+++ b/sdk/src/Services/S3/Custom/Model/ServerSideEncryptionRule.cs
@@ -55,9 +55,9 @@ namespace Amazon.S3.Model
         /// see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html\">Bucket key</a> in 
         /// the <i>Amazon Simple Storage Service Developer Guide</i>.</para>",
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/SessionCredentials.cs
+++ b/sdk/src/Services/S3/Custom/Model/SessionCredentials.cs
@@ -67,9 +67,9 @@ namespace Amazon.S3.Model
         /// </para>
         /// </summary>
         [AWSProperty(Required = true)]
-        public DateTime Expiration
+        public DateTime? Expiration
         {
-            get { return this._expiration.GetValueOrDefault(); }
+            get { return this._expiration; }
             set { this._expiration = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/Tiering.cs
+++ b/sdk/src/Services/S3/Custom/Model/Tiering.cs
@@ -34,9 +34,9 @@ namespace Amazon.S3.Model
 		/// days specified for Archive Access tier must be at least 90 days and Deep Archive Access tier 
 		/// must be at least 180 days. The maximum can be up to 2 years (730 days).</para>
 		/// </summary>
-		public int Days
+		public int? Days
 		{
-			get { return this.days.GetValueOrDefault(); }
+			get { return this.days; }
 			set { this.days = value; }
 		}
 

--- a/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/UploadPartRequest.cs
@@ -482,9 +482,9 @@ namespace Amazon.S3.Model
         /// Part number of part being uploaded. This is a positive integer between 1 and 10,000.
         /// </para>
         /// </summary>
-        public int PartNumber
+        public int? PartNumber
         {
-            get { return this.partNumber.GetValueOrDefault(); }
+            get { return this.partNumber; }
             set { this.partNumber = value; }
         }
 
@@ -679,9 +679,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// The size of the part to be uploaded.
         /// </summary>
-        public long PartSize
+        public long? PartSize
         {
-            get { return this.partSize.GetValueOrDefault(); }
+            get { return this.partSize; }
             set { this.partSize = value; }
         }
 
@@ -721,9 +721,9 @@ namespace Amazon.S3.Model
         /// Position in the file specified by FilePath from which to retrieve the content of the part. 
         /// This field is required when a file path is specified. It is ignored when using the InputStream property.
         /// </summary>
-        public long FilePosition
+        public long? FilePosition
         {
-            get { return this.filePosition.GetValueOrDefault(); }
+            get { return this.filePosition; }
             set { this.filePosition = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/UploadPartResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/UploadPartResponse.cs
@@ -28,7 +28,7 @@ namespace Amazon.S3.Model
     {
         private ServerSideEncryptionMethod serverSideEncryption;
         private string eTag;
-        private int partNumber;
+        private int? partNumber;
         private RequestCharged requestCharged;
         private bool? bucketKeyEnabled;
         private string _checksumCRC32;
@@ -75,7 +75,7 @@ namespace Amazon.S3.Model
         /// Gets and sets the part number specified for the part upload.  This is needed when
         /// completing the multipart upload.
         /// </summary>
-        public int PartNumber
+        public int? PartNumber
         {
             get { return this.partNumber; }
             set { this.partNumber = value; }
@@ -111,9 +111,9 @@ namespace Amazon.S3.Model
         /// </para>
         ///  </note>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/WriteGetObjectResponseRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/WriteGetObjectResponseRequest.cs
@@ -403,9 +403,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// <para>Specifies whether an object stored in Amazon S3 is (<code>true</code>) or is not (<code>false</code>) a delete marker.</para>
         /// </summary>
-        public bool DeleteMarker
+        public bool? DeleteMarker
         {
-            get { return this.deleteMarker.GetValueOrDefault(); }
+            get { return this.deleteMarker; }
             set { this.deleteMarker = value; }
         }
 
@@ -431,9 +431,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// <para>The date and time at which the object is no longer cacheable.</para>
         /// </summary>
-        public DateTime Expires
+        public DateTime? Expires
         {
-            get { return this.expires.GetValueOrDefault(); }
+            get { return this.expires; }
             set { this.expires = value; }
         }
 
@@ -459,9 +459,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// <para>Date and time the object was last modified.</para>
         /// </summary>
-        public DateTime LastModified
+        public DateTime? LastModified
         {
-            get { return this.lastModified.GetValueOrDefault(); }
+            get { return this.lastModified; }
             set { this.lastModified = value; }
         }
 
@@ -528,9 +528,9 @@ namespace Amazon.S3.Model
         /// <summary>
         /// <para>Date and time when Object Lock is configured to expire.</para>
         /// </summary>
-        public DateTime ObjectLockRetainUntilDate
+        public DateTime? ObjectLockRetainUntilDate
         {
-            get { return this.objectLockRetainUntilDate.GetValueOrDefault(); }
+            get { return this.objectLockRetainUntilDate; }
             set { this.objectLockRetainUntilDate = value; }
         }
 
@@ -708,9 +708,9 @@ namespace Amazon.S3.Model
         /// encryption with Amazon Web Services KMS (SSE-KMS).
         /// </para>
         /// </summary>
-        public bool BucketKeyEnabled
+        public bool? BucketKeyEnabled
         {
-            get { return this.bucketKeyEnabled.GetValueOrDefault(); }
+            get { return this.bucketKeyEnabled; }
             set { this.bucketKeyEnabled = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListMultipartUploadsPaginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListMultipartUploadsPaginator.cs
@@ -75,7 +75,7 @@ namespace Amazon.S3.Model
                 uploadIdMarker = response.NextUploadIdMarker;
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
 #if AWS_ASYNC_ENUMERABLES_API
@@ -99,7 +99,7 @@ namespace Amazon.S3.Model
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
     }

--- a/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListObjectsPaginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListObjectsPaginator.cs
@@ -71,7 +71,7 @@ namespace Amazon.S3.Model
                 marker = response.NextMarker;
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
 #if AWS_ASYNC_ENUMERABLES_API
@@ -92,7 +92,7 @@ namespace Amazon.S3.Model
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
     }

--- a/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListObjectsV2Paginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListObjectsV2Paginator.cs
@@ -71,7 +71,7 @@ namespace Amazon.S3.Model
                 continuationToken = response.NextContinuationToken;
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
 #if AWS_ASYNC_ENUMERABLES_API
@@ -92,7 +92,7 @@ namespace Amazon.S3.Model
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
     }

--- a/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListPartsPaginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListPartsPaginator.cs
@@ -65,7 +65,7 @@ namespace Amazon.S3.Model
                 partNumberMarker = response.NextPartNumberMarker.ToString();
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
 #if AWS_ASYNC_ENUMERABLES_API
@@ -86,7 +86,7 @@ namespace Amazon.S3.Model
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
     }

--- a/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListVersionsPaginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl+netstandard/ListVersionsPaginator.cs
@@ -74,7 +74,7 @@ namespace Amazon.S3.Model
                 versionIdMarker = response.NextVersionIdMarker;
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
 #if AWS_ASYNC_ENUMERABLES_API
@@ -98,7 +98,7 @@ namespace Amazon.S3.Model
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return response;
             }
-            while (response.IsTruncated);
+            while (response.IsTruncated.GetValueOrDefault());
         }
 #endif
     }

--- a/sdk/src/Services/S3/Custom/Model/_bcl/UploadPartRequest.bcl.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl/UploadPartRequest.bcl.cs
@@ -84,7 +84,7 @@ namespace Amazon.S3.Model
         internal void SetupForFilePath()
         {
             var fileStream = new FileStream(this.FilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            fileStream.Position = this.FilePosition;
+            fileStream.Position = this.FilePosition.GetValueOrDefault();
             this.InputStream = fileStream;
         }
     }

--- a/sdk/src/Services/S3/Custom/Model/_netstandard/UploadPartRequest.netstandard.cs
+++ b/sdk/src/Services/S3/Custom/Model/_netstandard/UploadPartRequest.netstandard.cs
@@ -41,7 +41,7 @@ namespace Amazon.S3.Model
         internal void SetupForFilePath()
         {
             var fileStream = new FileStream(this.FilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            fileStream.Position = this.FilePosition;
+            fileStream.Position = this.FilePosition.GetValueOrDefault();
             this.InputStream = fileStream;
         }
     }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
@@ -192,10 +192,10 @@ namespace Amazon.S3.Transfer.Internal
         private bool ShouldDownload(S3Object s3o)
         {
             // skip objects based on ModifiedSinceDateUtc
-            if (this._request.IsSetModifiedSinceDateUtc() && s3o.LastModified.ToUniversalTime() <= this._request.ModifiedSinceDateUtc.ToUniversalTime())
+            if (this._request.IsSetModifiedSinceDateUtc() && s3o.LastModified.GetValueOrDefault().ToUniversalTime() <= this._request.ModifiedSinceDateUtc.ToUniversalTime())
                 return false;
             // skip objects based on UnmodifiedSinceDateUtc
-            if (this._request.IsSetUnmodifiedSinceDateUtc() && s3o.LastModified.ToUniversalTime() > this._request.UnmodifiedSinceDateUtc.ToUniversalTime())
+            if (this._request.IsSetUnmodifiedSinceDateUtc() && s3o.LastModified.GetValueOrDefault().ToUniversalTime() > this._request.UnmodifiedSinceDateUtc.ToUniversalTime())
                 return false;
 #pragma warning disable CS0618 //A class member was marked with the Obsolete attribute
             // skip objects based on ModifiedSinceDate

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/AbortMultipartUploadsCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/AbortMultipartUploadsCommand.async.cs
@@ -81,7 +81,7 @@ namespace Amazon.S3.Transfer.Internal
                         }
                     }
                 }
-                while (listResponse.IsTruncated);
+                while (listResponse.IsTruncated.GetValueOrDefault());
 
                 await WhenAllOrFirstExceptionAsync(pendingTasks,cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
@@ -131,7 +131,7 @@ namespace Amazon.S3.Transfer.Internal
                 {
                     if (ShouldDownload(s3o))
                     {
-                        this._totalBytes += s3o.Size;
+                        this._totalBytes += s3o.Size.GetValueOrDefault();
                         objs.Add(s3o);
                     }
                 }
@@ -151,7 +151,7 @@ namespace Amazon.S3.Transfer.Internal
                 {
                     if (ShouldDownload(s3o))
                     {
-                        this._totalBytes += s3o.Size;
+                        this._totalBytes += s3o.Size.GetValueOrDefault();
                         objs.Add(s3o);
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Util/_async/AmazonS3Util.Operations.cs
+++ b/sdk/src/Services/S3/Custom/Util/_async/AmazonS3Util.Operations.cs
@@ -302,12 +302,12 @@ namespace Amazon.S3.Util
                 {
                     listVersionsRequest.KeyMarker = listVersionsResponse.NextKeyMarker;
                     listVersionsRequest.VersionIdMarker = listVersionsResponse.NextVersionIdMarker;
-                    isTruncated = listVersionsResponse.IsTruncated;
+                    isTruncated = listVersionsResponse.IsTruncated.GetValueOrDefault();
                 }
                 if(listObjectsV2Response != null)
                 {
                     listObjectsV2Request.ContinuationToken = listObjectsV2Response.NextContinuationToken;
-                    isTruncated = listObjectsV2Response.IsTruncated;
+                    isTruncated = listObjectsV2Response.IsTruncated.GetValueOrDefault();
                 }
 
             }

--- a/sdk/src/Services/S3/Custom/_bcl/IO/S3DirectoryInfo.cs
+++ b/sdk/src/Services/S3/Custom/_bcl/IO/S3DirectoryInfo.cs
@@ -281,7 +281,7 @@ namespace Amazon.S3.IO
                                     .FirstOrDefault();
                         if (lastWrittenObject != null)
                         {
-                            ret = lastWrittenObject.LastModified;
+                            ret = lastWrittenObject.LastModified.GetValueOrDefault();
                         }
                     }
                 }
@@ -501,7 +501,7 @@ namespace Amazon.S3.IO
                         listRequest.Marker = s3o.Key;
                     }
                     
-                } while (listResponse.IsTruncated);
+                } while (listResponse.IsTruncated.GetValueOrDefault());
 
                 if (deleteRequest.Objects.Count > 0)
                 {

--- a/sdk/src/Services/S3/Custom/_bcl/IO/S3FileInfo.cs
+++ b/sdk/src/Services/S3/Custom/_bcl/IO/S3FileInfo.cs
@@ -196,7 +196,7 @@ namespace Amazon.S3.IO
                     };
                     ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)request).AddBeforeRequestHandler(S3Helper.FileIORequestEventHandler);
                     var response = s3Client.GetObjectMetadata(request);
-                    ret = response.LastModified.ToLocalTime();
+                    ret = response.LastModified.GetValueOrDefault().ToLocalTime();
                 }
                 return ret;
             }
@@ -227,7 +227,7 @@ namespace Amazon.S3.IO
                     };
                     ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)request).AddBeforeRequestHandler(S3Helper.FileIORequestEventHandler);
                     var response = s3Client.GetObjectMetadata(request);
-                    ret = response.LastModified;
+                    ret = response.LastModified.GetValueOrDefault();
                 }
                 return ret;
             }

--- a/sdk/src/Services/SSO/Custom/Internal/_bcl+netstandard/CoreAmazonSSO.cs
+++ b/sdk/src/Services/SSO/Custom/Internal/_bcl+netstandard/CoreAmazonSSO.cs
@@ -42,7 +42,7 @@ namespace Amazon.SSO.Internal
             var response = client.GetRoleCredentials(request);
 
             DateTime credentialsExpiration =
-                AWSSDKUtils.ConvertFromUnixEpochMilliseconds(response.RoleCredentials.Expiration);
+                AWSSDKUtils.ConvertFromUnixEpochMilliseconds(response.RoleCredentials.Expiration.GetValueOrDefault());
 
             return new SSOImmutableCredentials(
                 response.RoleCredentials.AccessKeyId,
@@ -73,7 +73,7 @@ namespace Amazon.SSO.Internal
             var response = await client.GetRoleCredentialsAsync(request).ConfigureAwait(false);
 
             DateTime credentialsExpiration =
-                AWSSDKUtils.ConvertFromUnixEpochMilliseconds(response.RoleCredentials.Expiration);
+                AWSSDKUtils.ConvertFromUnixEpochMilliseconds(response.RoleCredentials.Expiration.GetValueOrDefault());
 
             return new SSOImmutableCredentials(
                 response.RoleCredentials.AccessKeyId,

--- a/sdk/src/Services/SSOOIDC/Custom/Internal/_bcl+netstandard/CoreAmazonSSOOIDC.cs
+++ b/sdk/src/Services/SSOOIDC/Custom/Internal/_bcl+netstandard/CoreAmazonSSOOIDC.cs
@@ -78,7 +78,7 @@ namespace Amazon.SSOOIDC.Internal
 
             // Spec: The expiration time must be calculated by adding the number of seconds 
             // returned by StartDeviceAuthorization (ExpiresIn) to the current time.
-            DateTime deviceCodeExpiration = DateTime.UtcNow.AddSeconds(startDeviceAuthorizationResponse.ExpiresIn);
+            DateTime deviceCodeExpiration = DateTime.UtcNow.AddSeconds(startDeviceAuthorizationResponse.ExpiresIn.GetValueOrDefault());
 
             request.SsoVerificationCallback(new SsoVerificationArguments
             {
@@ -99,7 +99,7 @@ namespace Amazon.SSOOIDC.Internal
 
             var ssoToken = PollForSsoToken(client,
                 createTokenRequest,
-                startDeviceAuthorizationResponse.Interval,
+                startDeviceAuthorizationResponse.Interval.GetValueOrDefault(),
                 deviceCodeExpiration,
                 context);
             var clientSecretExpiresAtString = XmlConvert.ToString(AWSSDKUtils.ConvertFromUnixEpochSeconds((int)registerClientResponse.ClientSecretExpiresAt), XmlDateTimeSerializationMode.Utc);
@@ -111,7 +111,7 @@ namespace Amazon.SSOOIDC.Internal
                 ClientSecret = registerClientResponse.ClientSecret,
                 RegistrationExpiresAt = clientSecretExpiresAtString,
                 RefreshToken = ssoToken.RefreshToken,
-                ExpiresAt = DateTime.UtcNow.AddSeconds(ssoToken.ExpiresIn),
+                ExpiresAt = DateTime.UtcNow.AddSeconds(ssoToken.ExpiresIn.GetValueOrDefault()),
                 StartUrl = request.StartUrl
             };
         }
@@ -162,7 +162,7 @@ namespace Amazon.SSOOIDC.Internal
 
             // Spec: The expiration time must be calculated by adding the number of seconds 
             // returned by StartDeviceAuthorization (ExpiresIn) to the current time.
-            DateTime deviceCodeExpiration = DateTime.UtcNow.AddSeconds(startDeviceAuthorizationResponse.ExpiresIn);
+            DateTime deviceCodeExpiration = DateTime.UtcNow.AddSeconds(startDeviceAuthorizationResponse.ExpiresIn.GetValueOrDefault());
 
             request.SsoVerificationCallback(new SsoVerificationArguments
             {
@@ -183,7 +183,7 @@ namespace Amazon.SSOOIDC.Internal
             var ssoToken = await PollForSsoTokenAsync(
                 client,
                 createTokenRequest,
-                startDeviceAuthorizationResponse.Interval,
+                startDeviceAuthorizationResponse.Interval.GetValueOrDefault(),
                 deviceCodeExpiration,
                 context,
                 cancellationToken
@@ -198,7 +198,7 @@ namespace Amazon.SSOOIDC.Internal
                 ClientSecret = registerClientResponse.ClientSecret,
                 RegistrationExpiresAt = clientSecretExpiresAtString,
                 RefreshToken = ssoToken.RefreshToken,
-                ExpiresAt = DateTime.UtcNow.AddSeconds(ssoToken.ExpiresIn),
+                ExpiresAt = DateTime.UtcNow.AddSeconds(ssoToken.ExpiresIn.GetValueOrDefault()),
                 StartUrl = request.StartUrl
             };
         }
@@ -219,7 +219,7 @@ namespace Amazon.SSOOIDC.Internal
             return new GetSsoTokenResponse
             {
                 AccessToken = ssoToken.AccessToken,
-                ExpiresAt = AWSSDKUtils.CorrectedUtcNow.AddSeconds(ssoToken.ExpiresIn),
+                ExpiresAt = AWSSDKUtils.CorrectedUtcNow.AddSeconds(ssoToken.ExpiresIn.GetValueOrDefault()),
                 RefreshToken = ssoToken.RefreshToken,
                 Region = previousResponse.Region,
                 RegistrationExpiresAt = previousResponse.RegistrationExpiresAt,
@@ -245,7 +245,7 @@ namespace Amazon.SSOOIDC.Internal
             return new GetSsoTokenResponse
             {
                 AccessToken = ssoToken.AccessToken,
-                ExpiresAt = AWSSDKUtils.CorrectedUtcNow.AddSeconds(ssoToken.ExpiresIn),
+                ExpiresAt = AWSSDKUtils.CorrectedUtcNow.AddSeconds(ssoToken.ExpiresIn.GetValueOrDefault()),
                 RefreshToken = ssoToken.RefreshToken,
                 Region = previousResponse.Region,
                 RegistrationExpiresAt = previousResponse.RegistrationExpiresAt,

--- a/sdk/src/Services/SecurityToken/Custom/AmazonSecurityTokenServiceClient.Extension.cs
+++ b/sdk/src/Services/SecurityToken/Custom/AmazonSecurityTokenServiceClient.Extension.cs
@@ -115,7 +115,7 @@ namespace Amazon.SecurityToken
             {
                 var response = AssumeRoleWithWebIdentity(request);
                 return new AssumeRoleImmutableCredentials(response.Credentials.AccessKeyId, response.Credentials.SecretAccessKey,
-                    response.Credentials.SessionToken, response.Credentials.Expiration);
+                    response.Credentials.SessionToken, response.Credentials.Expiration.GetValueOrDefault());
             }
             catch (Exception e)
             {
@@ -143,7 +143,7 @@ namespace Amazon.SecurityToken
             {
                 var response = await AssumeRoleWithWebIdentityAsync(request).ConfigureAwait(false);
                 return new AssumeRoleImmutableCredentials(response.Credentials.AccessKeyId, response.Credentials.SecretAccessKey,
-                    response.Credentials.SessionToken, response.Credentials.Expiration);
+                    response.Credentials.SessionToken, response.Credentials.Expiration.GetValueOrDefault());
             }
             catch (Exception e)
             {
@@ -188,7 +188,7 @@ namespace Amazon.SecurityToken
 
                 var response = AssumeRole(request);
                 return new AssumeRoleImmutableCredentials(response.Credentials.AccessKeyId, response.Credentials.SecretAccessKey,
-                    response.Credentials.SessionToken, response.Credentials.Expiration);
+                    response.Credentials.SessionToken, response.Credentials.Expiration.GetValueOrDefault());
             }
             catch (Exception e)
             {

--- a/sdk/src/Services/SecurityToken/Custom/AssumeRoleAWSCredentials.cs
+++ b/sdk/src/Services/SecurityToken/Custom/AssumeRoleAWSCredentials.cs
@@ -61,7 +61,7 @@ namespace Amazon.SecurityToken
             Credentials credentials = GetServiceCredentials();
             return new CredentialsRefreshState
             {
-                Expiration = credentials.Expiration,
+                Expiration = credentials.Expiration.GetValueOrDefault(),
                 Credentials = credentials.GetCredentials()
             };
         }

--- a/sdk/src/Services/SecurityToken/Custom/SAML/SAMLAssertion.cs
+++ b/sdk/src/Services/SecurityToken/Custom/SAML/SAMLAssertion.cs
@@ -117,7 +117,7 @@ namespace Amazon.SecurityToken.SAML
 #endif
 
             return new SAMLImmutableCredentials(response.Credentials.GetCredentials(), 
-                                                response.Credentials.Expiration.ToUniversalTime(),
+                                                response.Credentials.Expiration.GetValueOrDefault().ToUniversalTime(),
                                                 response.Subject);
         }
 

--- a/sdk/test/NetStandard/IntegrationTests/Framework/UtilityMethods.cs
+++ b/sdk/test/NetStandard/IntegrationTests/Framework/UtilityMethods.cs
@@ -238,7 +238,7 @@ namespace Amazon.DNXCore.IntegrationTests
 
             }
             // Continue listing objects and deleting them until the bucket is empty.
-            while (listVersionsResponse.IsTruncated);
+            while (listVersionsResponse.IsTruncated.GetValueOrDefault());
 
             const int maxRetries = 10;
             for (int retries = 1; retries <= maxRetries; retries++)

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/CloudWatchLogs.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/CloudWatchLogs.cs
@@ -120,10 +120,10 @@ namespace Amazon.DNXCore.IntegrationTests
 
                     Assert.Equal(2, getResponse.Events.Count);
                     Assert.Equal("First Data", getResponse.Events[0].Message);
-                    Assert.Equal(DateTime.UtcNow.Date, getResponse.Events[0].Timestamp.Date);
+                    Assert.Equal(DateTime.UtcNow.Date, getResponse.Events[0].Timestamp.Value.Date);
 
                     Assert.Equal("Second Data", getResponse.Events[1].Message);
-                    Assert.Equal(DateTime.UtcNow.Date, getResponse.Events[1].Timestamp.Date);
+                    Assert.Equal(DateTime.UtcNow.Date, getResponse.Events[1].Timestamp.Value.Date);
 
                     Assert.True(getResponse.Events[0].Timestamp < getResponse.Events[1].Timestamp);
                 }

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/EC2/EC2TestHelper.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/EC2/EC2TestHelper.cs
@@ -164,7 +164,7 @@ namespace Amazon.DNXCore.IntegrationTests.IntegrationTests.EC2
 
             foreach (var acl in describeResponse.NetworkAcls)
             {
-                if (!acl.IsDefault)
+                if (!acl.IsDefault.GetValueOrDefault())
                 {
                     await _ec2Client.DeleteNetworkAclAsync(new DeleteNetworkAclRequest { NetworkAclId = acl.NetworkAclId });
                 }
@@ -214,7 +214,7 @@ namespace Amazon.DNXCore.IntegrationTests.IntegrationTests.EC2
             bool isMain = false;
             foreach (var association in table.Associations)
             {
-                if (!association.Main)
+                if (!association.Main.GetValueOrDefault())
                 {
                    await _ec2Client.DisassociateRouteTableAsync(new DisassociateRouteTableRequest { AssociationId = association.RouteTableAssociationId });
                 }

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/IAM/AccessKeyTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/IAM/AccessKeyTests.cs
@@ -30,7 +30,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.IAM
                     CreateAccessKeyResponse response =
                         await Client.CreateAccessKeyAsync(new CreateAccessKeyRequest() { UserName = username });
                     keyId = response.AccessKey.AccessKeyId;
-                    Assert.True(response.AccessKey.CreateDate.Date.CompareTo(DateTime.Now.Date) == 0);
+                    Assert.True(response.AccessKey.CreateDate.Value.Date.CompareTo(DateTime.Now.Date) == 0);
                 }
                 finally
                 {

--- a/sdk/test/Services/CloudDirectory/IntegrationTests/CloudDirectory.cs
+++ b/sdk/test/Services/CloudDirectory/IntegrationTests/CloudDirectory.cs
@@ -44,7 +44,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                     Assert.IsNotNull(value);
 
                     Assert.IsNull(value.BinaryValue);
-                    Assert.IsFalse(value.BooleanValue);
+                    Assert.IsFalse(value.BooleanValue.Value);
                     Assert.AreEqual(default(DateTime), value.DatetimeValue);
                     Assert.IsNull(value.NumberValue);
                     Assert.AreEqual("bob", value.StringValue);

--- a/sdk/test/Services/CloudSearch/IntegrationTests/CloudSearch.cs
+++ b/sdk/test/Services/CloudSearch/IntegrationTests/CloudSearch.cs
@@ -74,18 +74,16 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                 Client.DefineIndexField(new DefineIndexFieldRequest { DomainName = domainName, IndexField = indexField });
 
                 var status = Client.DescribeDomains(new DescribeDomainsRequest { DomainNames = { domainName } }).DomainStatusList[0].RequiresIndexDocuments;
-                Assert.IsTrue(status);
+                Assert.IsTrue(status.Value);
 
                 Client.IndexDocuments(new IndexDocumentsRequest { DomainName = domainName });
 
                 var req = new DescribeDomainsRequest { DomainNames = { domainName } };
 
-                Assert.IsTrue(Client.DescribeDomains(req).DomainStatusList[0].Processing);
-
+                Assert.IsTrue(Client.DescribeDomains(req).DomainStatusList[0].Processing.Value);
             }
             finally
             {
-
                 Client.DeleteDomain(new DeleteDomainRequest { DomainName = domainName });
             }
         }

--- a/sdk/test/Services/CloudWatch/IntegrationTests/CloudWatch.cs
+++ b/sdk/test/Services/CloudWatch/IntegrationTests/CloudWatch.cs
@@ -189,7 +189,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                     AlarmNames = new List<string> { alarmName }
                 });
                 alarm = describeResponse.MetricAlarms[0];
-                Assert.IsTrue(alarm.ActionsEnabled);
+                Assert.IsTrue(alarm.ActionsEnabled.Value);
 
                 Client.DisableAlarmActions(new DisableAlarmActionsRequest()
                 {
@@ -201,7 +201,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                     AlarmNames = new List<string> { alarmName }
                 });
                 alarm = describeResponse.MetricAlarms[0];
-                Assert.IsFalse(alarm.ActionsEnabled);
+                Assert.IsFalse(alarm.ActionsEnabled.Value);
 
                 var describeMetricResponse = Client.DescribeAlarmsForMetric(new DescribeAlarmsForMetricRequest()
                 {
@@ -409,7 +409,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             foreach (MetricAlarm alarm in describeResult.MetricAlarms)
             {
                 Assert.IsTrue(rq1.AlarmName.Equals(alarm.AlarmName) || rq2.AlarmName.Equals(alarm.AlarmName));
-                Assert.IsFalse(alarm.ActionsEnabled);
+                Assert.IsFalse(alarm.ActionsEnabled.Value);
             }
 
             /*
@@ -433,7 +433,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             {
                 Assert.IsTrue(rq1.AlarmName.Equals(alarm.AlarmName)
                         || rq2.AlarmName.Equals(alarm.AlarmName));
-                Assert.IsTrue(alarm.ActionsEnabled);
+                Assert.IsTrue(alarm.ActionsEnabled.Value);
             }
         }
 
@@ -465,7 +465,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             foreach (MetricAlarm alarm in describeResult.MetricAlarms)
             {
                 Assert.IsTrue(rq1.AlarmName.Equals(alarm.AlarmName) || rq2.AlarmName.Equals(alarm.AlarmName));
-                Assert.IsTrue(alarm.ActionsEnabled);
+                Assert.IsTrue(alarm.ActionsEnabled.Value);
             }
         }
 

--- a/sdk/test/Services/CloudWatchLogs/IntegrationTests/CloudWatchLogs.cs
+++ b/sdk/test/Services/CloudWatchLogs/IntegrationTests/CloudWatchLogs.cs
@@ -125,12 +125,12 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
 
                     Assert.AreEqual(2, getResponse.Events.Count);
                     Assert.AreEqual("First Data", getResponse.Events[0].Message);
-                    Assert.AreEqual(DateTime.UtcNow.Date, getResponse.Events[0].Timestamp.Date);
+                    Assert.AreEqual(DateTime.UtcNow.Date, getResponse.Events[0].Timestamp.Value.Date);
 
                     Assert.AreEqual("Second Data", getResponse.Events[1].Message);
-                    Assert.AreEqual(DateTime.UtcNow.Date, getResponse.Events[1].Timestamp.Date);
+                    Assert.AreEqual(DateTime.UtcNow.Date, getResponse.Events[1].Timestamp.Value.Date);
 
-                    Assert.IsTrue(getResponse.Events[0].Timestamp < getResponse.Events[1].Timestamp);
+                    Assert.IsTrue(getResponse.Events[0].Timestamp.Value < getResponse.Events[1].Timestamp.Value);
 
 
                     Client.DeleteLogStream(new DeleteLogStreamRequest

--- a/sdk/test/Services/DataPipeline/IntegrationTests/DataPipeline.cs
+++ b/sdk/test/Services/DataPipeline/IntegrationTests/DataPipeline.cs
@@ -66,7 +66,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                         PipelineId = createdPipelineId,
                         PipelineObjects = new List<PipelineObject> { pipelineObject }
                     });
-                Assert.IsFalse(putPipelineDefinitionResult.Errored);
+                Assert.IsFalse(putPipelineDefinitionResult.Errored.Value);
 
                 var tags = new List<Tag>
                 {

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/ServiceTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/ServiceTests.cs
@@ -246,7 +246,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.IsTrue(item["EmptyMap"].IsMSet);
             Assert.IsFalse(item["EmptyMap"].IsLSet);
             Assert.IsTrue(item["BoolFalse"].IsBOOLSet);
-            Assert.IsFalse(item["BoolFalse"].BOOL);
+            Assert.IsFalse(item["BoolFalse"].BOOL.Value);
             Assert.IsTrue(item["NonEmptyList"].IsLSet);
             Assert.AreEqual(nonEmptyListAV.L.Count, item["NonEmptyList"].L.Count);
 

--- a/sdk/test/Services/EC2/UnitTests/Custom/UnmarshallTests.cs
+++ b/sdk/test/Services/EC2/UnitTests/Custom/UnmarshallTests.cs
@@ -81,10 +81,10 @@ namespace AWSSDK_DotNet.UnitTests.EC2
             Assert.AreEqual("snap-1a2b3c4d", image.BlockDeviceMappings[0].Ebs.SnapshotId);
             Assert.AreEqual(15, image.BlockDeviceMappings[0].Ebs.VolumeSize);
             Assert.AreEqual(VolumeType.Standard, image.BlockDeviceMappings[0].Ebs.VolumeType);
-            Assert.IsFalse(image.BlockDeviceMappings[0].Ebs.DeleteOnTermination);
+            Assert.IsFalse(image.BlockDeviceMappings[0].Ebs.DeleteOnTermination.Value);
 
             Assert.AreEqual(VolumeType.Gp2, image.BlockDeviceMappings[1].Ebs.VolumeType);
-            Assert.IsTrue(image.BlockDeviceMappings[1].Ebs.DeleteOnTermination);
+            Assert.IsTrue(image.BlockDeviceMappings[1].Ebs.DeleteOnTermination.Value);
 
         }
 
@@ -222,7 +222,7 @@ namespace AWSSDK_DotNet.UnitTests.EC2
             Assert.AreEqual(1, vol.Attachments.Count);
             Assert.AreEqual("vol-1a2b3c4d", vol.Attachments[0].VolumeId);
             Assert.AreEqual("i-1a2b3c4d", vol.Attachments[0].InstanceId);
-            Assert.IsFalse(vol.Attachments[0].DeleteOnTermination);
+            Assert.IsFalse(vol.Attachments[0].DeleteOnTermination.Value);
 
         }
 
@@ -362,7 +362,7 @@ namespace AWSSDK_DotNet.UnitTests.EC2
             Assert.IsTrue(string.IsNullOrEmpty(instance.Placement.GroupName));
 
             Assert.AreEqual(MonitoringState.Disabled, instance.Monitoring.State);
-            Assert.IsTrue(instance.SourceDestCheck);
+            Assert.IsTrue(instance.SourceDestCheck.Value);
 
             Assert.AreEqual(1, instance.SecurityGroups.Count);
             Assert.AreEqual("sg-188d9f74", instance.SecurityGroups[0].GroupId);
@@ -376,20 +376,20 @@ namespace AWSSDK_DotNet.UnitTests.EC2
 
             Assert.AreEqual("eni-ffc37f96", netInt.NetworkInterfaceId);
             Assert.AreEqual("10.0.2.106", netInt.PrivateIpAddress);
-            Assert.IsTrue(netInt.SourceDestCheck);
+            Assert.IsTrue(netInt.SourceDestCheck.Value);
             Assert.AreEqual(1, netInt.Groups.Count);
             Assert.AreEqual("sg-188d9f74", netInt.Groups[0].GroupId);
             Assert.AreEqual("default", netInt.Groups[0].GroupName);
 
             Assert.AreEqual("eni-attach-d1d917b8", netInt.Attachment.AttachmentId);
-            Assert.IsTrue(netInt.Attachment.DeleteOnTermination);
+            Assert.IsTrue(netInt.Attachment.DeleteOnTermination.Value);
 
             Assert.AreEqual(3, instance.NetworkInterfaces[0].PrivateIpAddresses.Count);
             Assert.AreEqual("10.0.2.106", netInt.PrivateIpAddresses[0].PrivateIpAddress);
-            Assert.IsTrue(netInt.PrivateIpAddresses[0].Primary);
+            Assert.IsTrue(netInt.PrivateIpAddresses[0].Primary.Value);
 
             Assert.AreEqual("10.0.2.108", netInt.PrivateIpAddresses[2].PrivateIpAddress);
-            Assert.IsFalse(netInt.PrivateIpAddresses[2].Primary);
+            Assert.IsFalse(netInt.PrivateIpAddresses[2].Primary.Value);
         }
 
         [TestMethod]
@@ -501,7 +501,7 @@ namespace AWSSDK_DotNet.UnitTests.EC2
 
             Assert.AreEqual(NetworkInterfaceStatus.Attaching, result.NetworkInterface.Status);
             Assert.AreEqual("02:74:b0:78:bf:ab", result.NetworkInterface.MacAddress);
-            Assert.IsTrue(result.NetworkInterface.SourceDestCheck);
+            Assert.IsTrue(result.NetworkInterface.SourceDestCheck.Value);
 
             Assert.AreEqual(1, result.NetworkInterface.Groups.Count);
             Assert.AreEqual("sg-1a2b3c4d", result.NetworkInterface.Groups[0].GroupId);
@@ -511,10 +511,10 @@ namespace AWSSDK_DotNet.UnitTests.EC2
 
             Assert.AreEqual(3, result.NetworkInterface.PrivateIpAddresses.Count);
             Assert.AreEqual("10.0.2.130", result.NetworkInterface.PrivateIpAddresses[0].PrivateIpAddress);
-            Assert.IsTrue(result.NetworkInterface.PrivateIpAddresses[0].Primary);
+            Assert.IsTrue(result.NetworkInterface.PrivateIpAddresses[0].Primary.Value);
 
             Assert.AreEqual("10.0.2.132", result.NetworkInterface.PrivateIpAddresses[2].PrivateIpAddress);
-            Assert.IsFalse(result.NetworkInterface.PrivateIpAddresses[2].Primary);
+            Assert.IsFalse(result.NetworkInterface.PrivateIpAddresses[2].Primary.Value);
         }
 
         [TestMethod]
@@ -537,7 +537,7 @@ namespace AWSSDK_DotNet.UnitTests.EC2
 
             Assert.AreEqual("1", result.ResponseMetadata.RequestId);
             Assert.AreEqual("123456", result.VolumeId);
-            Assert.IsTrue(result.AutoEnableIO);
+            Assert.IsTrue(result.AutoEnableIO.Value);
         }
 
         [TestMethod]

--- a/sdk/test/Services/ElasticBeanstalk/IntegrationTests/Beanstalk.cs
+++ b/sdk/test/Services/ElasticBeanstalk/IntegrationTests/Beanstalk.cs
@@ -42,7 +42,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             };
 
             CheckDNSAvailabilityResponse response = Client.CheckDNSAvailability(request);
-            Assert.IsTrue(response.Available);
+            Assert.IsTrue(response.Available.Value);
             Assert.IsNotNull(response.FullyQualifiedCNAME);
         }
 

--- a/sdk/test/Services/IdentityManagement/IntegrationTests/AccessKeyTests.cs
+++ b/sdk/test/Services/IdentityManagement/IntegrationTests/AccessKeyTests.cs
@@ -62,7 +62,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.IAM
                 CreateAccessKeyResponse response =
                     Client.CreateAccessKey(new CreateAccessKeyRequest() { UserName = username });
                 keyId = response.AccessKey.AccessKeyId;
-                Assert.IsTrue(response.AccessKey.CreateDate.Date.CompareTo(DateTime.Now.Date) == 0);
+                Assert.IsTrue(response.AccessKey.CreateDate.Value.Date.CompareTo(DateTime.Now.Date) == 0);
             }
             finally
             {

--- a/sdk/test/Services/IdentityManagement/IntegrationTests/LoginProfileTests.cs
+++ b/sdk/test/Services/IdentityManagement/IntegrationTests/LoginProfileTests.cs
@@ -79,7 +79,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.IAM
 
                 var login = getRes.LoginProfile;
                 Assert.AreEqual(username, login.UserName);
-                Assert.IsTrue(login.PasswordResetRequired);
+                Assert.IsTrue(login.PasswordResetRequired.Value);
 
 
                 Client.UpdateLoginProfile(new UpdateLoginProfileRequest
@@ -96,7 +96,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.IAM
 
                 login = getRes.LoginProfile;
                 Assert.AreEqual(username, login.UserName);
-                Assert.IsFalse(login.PasswordResetRequired);
+                Assert.IsFalse(login.PasswordResetRequired.Value);
             }
             finally
             {

--- a/sdk/test/Services/IdentityManagement/IntegrationTests/PasswordPolicyTests.cs
+++ b/sdk/test/Services/IdentityManagement/IntegrationTests/PasswordPolicyTests.cs
@@ -59,8 +59,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.IAM
                 Client.UpdateAccountPasswordPolicy();
 
                 policy = Client.GetAccountPasswordPolicy().PasswordPolicy;
-                Assert.IsFalse(policy.RequireNumbers);
-                Assert.IsFalse(policy.RequireSymbols);
+                Assert.IsFalse(policy.RequireNumbers.Value);
+                Assert.IsFalse(policy.RequireSymbols.Value);
             }
             finally
             {

--- a/sdk/test/Services/IdentityManagement/IntegrationTests/PolicyTests.cs
+++ b/sdk/test/Services/IdentityManagement/IntegrationTests/PolicyTests.cs
@@ -829,7 +829,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.IAM
                     yield return p;
 
                 request.Marker = response.Marker;
-            } while (response.IsTruncated);
+            } while (response.IsTruncated.Value);
         }
 
         [Ignore("Excluding tests that need IAM Write/Permissions management.")]

--- a/sdk/test/Services/ImportExport/IntegrationTests/ImportExport.cs
+++ b/sdk/test/Services/ImportExport/IntegrationTests/ImportExport.cs
@@ -121,10 +121,10 @@ returnAddress:
             Job job = FindJob(createdJobId, listJobsResponse.Jobs);
             Assert.IsNotNull(job);
             Assert.IsTrue(job.CreationDate > DateTime.MinValue);
-            Assert.IsFalse(job.IsCanceled);
+            Assert.IsFalse(job.IsCanceled.Value);
             Assert.AreEqual(createdJobId, job.JobId);
             Assert.AreEqual(JobType.Export, job.JobType);
-            Assert.IsFalse(job.IsCanceled);
+            Assert.IsFalse(job.IsCanceled.Value);
 
 
             // GetStatus
@@ -164,7 +164,7 @@ returnAddress:
         private void AssertJobIsCancelled(string jobId)
         {
             Job job = FindJob(jobId, Client.ListJobs(new ListJobsRequest()).Jobs);
-            Assert.IsTrue(job.IsCanceled);
+            Assert.IsTrue(job.IsCanceled.Value);
         }
 
 

--- a/sdk/test/Services/KeyManagementService/IntegrationTests/KeyManagementService.cs
+++ b/sdk/test/Services/KeyManagementService/IntegrationTests/KeyManagementService.cs
@@ -230,15 +230,15 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
 
         private void TestRotation(string keyId)
         {
-            var rotationEnabled = Client.GetKeyRotationStatus(keyId).KeyRotationEnabled;
+            var rotationEnabled = Client.GetKeyRotationStatus(keyId).KeyRotationEnabled.Value;
             Assert.IsFalse(rotationEnabled);
 
             Client.EnableKeyRotation(keyId);
-            rotationEnabled = Client.GetKeyRotationStatus(keyId).KeyRotationEnabled;
+            rotationEnabled = Client.GetKeyRotationStatus(keyId).KeyRotationEnabled.Value;
             Assert.IsTrue(rotationEnabled);
 
             Client.DisableKeyRotation(keyId);
-            rotationEnabled = Client.GetKeyRotationStatus(keyId).KeyRotationEnabled;
+            rotationEnabled = Client.GetKeyRotationStatus(keyId).KeyRotationEnabled.Value;
             Assert.IsFalse(rotationEnabled);
         }
 

--- a/sdk/test/Services/Route53/IntegrationTests/Route53.cs
+++ b/sdk/test/Services/Route53/IntegrationTests/Route53.cs
@@ -284,7 +284,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                 Id = createdZoneId
             });
             Assert.IsNotNull(hostedZoneInfo.VPCs);
-            Assert.IsFalse(hostedZoneInfo.HostedZone.Config.PrivateZone);
+            Assert.IsFalse(hostedZoneInfo.HostedZone.Config.PrivateZone.Value);
             Assert.AreEqual(delegationSet.Id, hostedZoneInfo.DelegationSet.Id);
 
             var hostedZones = Client.ListHostedZones(new ListHostedZonesRequest
@@ -360,7 +360,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                 });
                 Assert.IsNotNull(hostedZoneInfo.VPCs);
                 Assert.AreEqual(1, hostedZoneInfo.VPCs.Count);
-                Assert.IsTrue(hostedZoneInfo.HostedZone.Config.PrivateZone);
+                Assert.IsTrue(hostedZoneInfo.HostedZone.Config.PrivateZone.Value);
 
                 var changeInfo = Client.AssociateVPCWithHostedZone(new AssociateVPCWithHostedZoneRequest
                 {

--- a/sdk/test/Services/S3/IntegrationTests/BucketRegionTestRunner.cs
+++ b/sdk/test/Services/S3/IntegrationTests/BucketRegionTestRunner.cs
@@ -113,7 +113,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                     BucketName = bucketName,
                 });
             }
-            else if (TestBucket.CreationDate.AddHours(TemporaryRedirectMaxExpirationHours) < DateTime.Now)
+            else if (TestBucket.CreationDate.Value.AddHours(TemporaryRedirectMaxExpirationHours) < DateTime.Now)
             {
                 BucketRegionDetector.BucketRegionCache.Clear();
                 TestBucketIsReady = true;

--- a/sdk/test/Services/S3/IntegrationTests/KMSTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/KMSTests.cs
@@ -515,7 +515,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                     BucketName = bucketName,
                     Key = srcKey
                 });
-                srcTimeStamp = gomr.LastModified;
+                srcTimeStamp = gomr.LastModified.Value;
                 srcVersionID = gomr.VersionId;
                 srcETag = gomr.ETag;
 

--- a/sdk/test/Services/S3/IntegrationTests/ListObjectsTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/ListObjectsTests.cs
@@ -90,7 +90,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 StartAfter = keys[0],
                 FetchOwner = true
             });
-            Assert.IsFalse(response.IsTruncated);
+            Assert.IsFalse(response.IsTruncated.Value);
             Assert.AreEqual(keys.Count - 1, response.KeyCount);
             Assert.AreEqual(keys.Count - 1, response.S3Objects.Count);
             Assert.IsNull(response.ContinuationToken);
@@ -106,7 +106,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 StartAfter = keys[0],
                 FetchOwner = true
             });
-            Assert.IsTrue(response.IsTruncated);
+            Assert.IsTrue(response.IsTruncated.Value);
             Assert.AreEqual(1, response.KeyCount);
             Assert.AreEqual(1, response.MaxKeys);
             Assert.AreEqual(1, response.S3Objects.Count);
@@ -122,7 +122,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 FetchOwner = true,
                 ContinuationToken = response.NextContinuationToken
             });
-            Assert.IsTrue(response.IsTruncated);
+            Assert.IsTrue(response.IsTruncated.Value);
             Assert.AreEqual(1, response.KeyCount);
             Assert.AreEqual(1, response.MaxKeys);
             Assert.IsNotNull(response.ContinuationToken);
@@ -136,7 +136,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 BucketName = bucketName,
                 MaxKeys = 1,
             });
-            Assert.IsTrue(response.IsTruncated);
+            Assert.IsTrue(response.IsTruncated.Value);
             Assert.AreEqual(1, response.KeyCount);
             Assert.AreEqual(1, response.MaxKeys);
             Assert.AreEqual(1, response.S3Objects.Count);
@@ -151,7 +151,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 MaxKeys = 1,
                 ContinuationToken = response.NextContinuationToken
             });
-            Assert.IsTrue(response.IsTruncated);
+            Assert.IsTrue(response.IsTruncated.Value);
             Assert.AreEqual(1, response.KeyCount);
             Assert.AreEqual(1, response.MaxKeys);
             Assert.IsNotNull(response.ContinuationToken);

--- a/sdk/test/Services/S3/IntegrationTests/ObjectLockConfigurationTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/ObjectLockConfigurationTests.cs
@@ -377,7 +377,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 
             }
             // Continue listing objects and deleting them until the bucket is empty.
-            while (listVersionsResponse.IsTruncated);
+            while (listVersionsResponse.IsTruncated.Value);
         }
     }
 }

--- a/sdk/test/Services/S3/IntegrationTests/PutObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/PutObjectTests.cs
@@ -366,7 +366,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 
             using (var getResponse = Client.GetObject(new GetObjectRequest { BucketName = bucketName, Key = key }))
             {
-                Assert.IsTrue(expires.ApproximatelyEqual(getResponse.Expires));
+                Assert.IsTrue(expires.ApproximatelyEqual(getResponse.Expires.Value));
             }
         }
 

--- a/sdk/test/Services/S3/IntegrationTests/S3TestUtils.cs
+++ b/sdk/test/Services/S3/IntegrationTests/S3TestUtils.cs
@@ -295,7 +295,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 listVersionsRequest.VersionIdMarker = listVersionsResponse.NextVersionIdMarker;
             }
             // Continue listing objects and deleting them until the bucket is empty.
-            while (listVersionsResponse.IsTruncated);
+            while (listVersionsResponse.IsTruncated.GetValueOrDefault());
         }
 
         public static T WaitForConsistency<T>(Func<T> loadFunction)

--- a/sdk/test/Services/S3/IntegrationTests/StorageInsightsInventoryTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/StorageInsightsInventoryTests.cs
@@ -135,7 +135,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         private static void GetBucketInventoryAndValidate(InventoryConfiguration getInventoryConfiguration, InventoryConfiguration putInventoryConfiguration)
         {
             Assert.AreEqual(getInventoryConfiguration.InventoryId, putInventoryConfiguration.InventoryId);
-            Assert.IsTrue(getInventoryConfiguration.IsEnabled);
+            Assert.IsTrue(getInventoryConfiguration.IsEnabled.Value);
             Assert.AreEqual(getInventoryConfiguration.Schedule.Frequency, putInventoryConfiguration.Schedule.Frequency);
             Assert.AreEqual(((InventoryPrefixPredicate)getInventoryConfiguration.InventoryFilter.InventoryFilterPredicate).Prefix, "string");
             Assert.AreEqual(getInventoryConfiguration.IncludedObjectVersions, putInventoryConfiguration.IncludedObjectVersions);

--- a/sdk/test/Services/S3/IntegrationTests/TransferUtilityObjectLockMD5Tests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/TransferUtilityObjectLockMD5Tests.cs
@@ -420,7 +420,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 Assert.AreEqual(content, getBody);
                 Assert.AreEqual(desiredObjectLockLegalHoldStatus, getResponse.ObjectLockLegalHoldStatus);
                 Assert.AreEqual(desiredObjectLockMode, getResponse.ObjectLockMode);
-                Assert.AreEqual(desiredObjectLockRetainUntilDate.Date, getResponse.ObjectLockRetainUntilDate.ToUniversalTime().Date);
+                Assert.AreEqual(desiredObjectLockRetainUntilDate.Date, getResponse.ObjectLockRetainUntilDate.Value.ToUniversalTime().Date);
             }
         }
 
@@ -477,7 +477,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                     Assert.AreEqual(new string('a', file.Value), getBody);
                     Assert.AreEqual(desiredObjectLockLegalHoldStatus, getResponse.ObjectLockLegalHoldStatus);
                     Assert.AreEqual(desiredObjectLockMode, getResponse.ObjectLockMode);
-                    Assert.AreEqual(desiredObjectLockRetainUntilDate.Date, getResponse.ObjectLockRetainUntilDate.ToUniversalTime().Date);
+                    Assert.AreEqual(desiredObjectLockRetainUntilDate.Date, getResponse.ObjectLockRetainUntilDate.Value.ToUniversalTime().Date);
                 }
             }
         }
@@ -522,7 +522,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 Assert.AreEqual(content, getBody);
                 Assert.AreEqual(desiredObjectLockLegalHoldStatus, getResponse.ObjectLockLegalHoldStatus);
                 Assert.AreEqual(desiredObjectLockMode, getResponse.ObjectLockMode);
-                Assert.AreEqual(desiredObjectLockRetainUntilDate.Date, getResponse.ObjectLockRetainUntilDate.ToUniversalTime().Date);
+                Assert.AreEqual(desiredObjectLockRetainUntilDate.Date, getResponse.ObjectLockRetainUntilDate.Value.ToUniversalTime().Date);
             }
         }
 
@@ -605,7 +605,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 
             }
             // Continue listing objects and deleting them until the bucket is empty.
-            while (listVersionsResponse.IsTruncated);
+            while (listVersionsResponse.IsTruncated.Value);
         }
     }
 }

--- a/sdk/test/Services/S3Control/IntegrationTests/PublicAccessBlockTests.cs
+++ b/sdk/test/Services/S3Control/IntegrationTests/PublicAccessBlockTests.cs
@@ -48,7 +48,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3Control
                 AccountId = accountId
             });
             Assert.IsTrue(response.ResponseMetadata.Metadata.ContainsKey(HeaderKeys.XAmzId2Header));
-            Assert.IsFalse(response.PublicAccessBlockConfiguration.BlockPublicPolicy);
+            Assert.IsFalse(response.PublicAccessBlockConfiguration.BlockPublicPolicy.Value);
             client.DeletePublicAccessBlock(new DeletePublicAccessBlockRequest()
             {
                 AccountId = accountId

--- a/sdk/test/Services/SSOOIDC/UnitTests/Custom/_bcl+netstandard/CoreAmazonSSOOIDCTest.cs
+++ b/sdk/test/Services/SSOOIDC/UnitTests/Custom/_bcl+netstandard/CoreAmazonSSOOIDCTest.cs
@@ -43,7 +43,7 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         public void GetSsoToken()
         {
-            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn);
+            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn.Value);
             var response = CoreAmazonSSOOIDC.GetSsoToken(_testFixture.OidcClient.Object,
                 _testFixture.GetSsoTokenRequest, _testFixture.GetSsoTokenContext.Object);
 
@@ -58,7 +58,7 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         public async Task GetSsoTokenAsync()
         {
-            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn);
+            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn.Value);
             var response = await CoreAmazonSSOOIDC.GetSsoTokenAsync(_testFixture.OidcClient.Object,
                 _testFixture.GetSsoTokenRequest, _testFixture.GetSsoTokenContext.Object);
 
@@ -73,7 +73,7 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         public void GetSsoToken_Poll_AuthorizationPendingException()
         {
-            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn);
+            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn.Value);
             _testFixture.WithCreateTokenExceptionThenSuccess(new AuthorizationPendingException("simulation"));
 
             var response = CoreAmazonSSOOIDC.GetSsoToken(_testFixture.OidcClient.Object,
@@ -87,7 +87,7 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         public async Task GetSsoTokenAsync_Poll_AuthorizationPendingException()
         {
-            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn);
+            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn.Value);
             _testFixture.WithCreateTokenExceptionThenSuccess(new AuthorizationPendingException("simulation"));
 
             var response = await CoreAmazonSSOOIDC.GetSsoTokenAsync(_testFixture.OidcClient.Object,
@@ -101,7 +101,7 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         public void GetSsoToken_Poll_SlowDownException()
         {
-            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn);
+            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn.Value);
             _testFixture.WithCreateTokenExceptionThenSuccess(new SlowDownException("simulation"));
 
             var response = CoreAmazonSSOOIDC.GetSsoToken(_testFixture.OidcClient.Object,
@@ -115,7 +115,7 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         public async Task GetSsoTokenAsync_Poll_SlowDownException()
         {
-            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn);
+            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn.Value);
             _testFixture.WithCreateTokenExceptionThenSuccess(new SlowDownException("simulation"));
 
             var response = await CoreAmazonSSOOIDC.GetSsoTokenAsync(_testFixture.OidcClient.Object,
@@ -129,7 +129,7 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         public void GetSsoToken_Poll_TimeoutException()
         {
-            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn);
+            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn.Value);
 
             _testFixture.WithCreateTokenExceptionThenSuccess(new TimeoutException("simulation"));
 
@@ -145,7 +145,7 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         public async Task GetSsoTokenAsync_Poll_TimeoutException()
         {
-            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn);
+            var minExpectedExpiresAt = DateTime.Now.AddSeconds(_testFixture.CreateTokenResponse.ExpiresIn.Value);
 
             _testFixture.WithCreateTokenExceptionThenSuccess(new TimeoutException("simulation"));
 

--- a/sdk/test/Services/SimpleDB/IntegrationTests/SimpleDB.cs
+++ b/sdk/test/Services/SimpleDB/IntegrationTests/SimpleDB.cs
@@ -203,9 +203,9 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                 expectedAttributeValueCount += item.Attributes.Count;
             }
 
-            Assert.AreEqual<int>(expectedItemCount, domainMetadataResult.ItemCount);
-            Assert.AreEqual<int>(expectedAttributeNameCount, domainMetadataResult.AttributeNameCount);
-            Assert.AreEqual<int>(expectedAttributeValueCount, domainMetadataResult.AttributeValueCount);
+            Assert.AreEqual<int>(expectedItemCount, domainMetadataResult.ItemCount.Value);
+            Assert.AreEqual<int>(expectedAttributeNameCount, domainMetadataResult.AttributeNameCount.Value);
+            Assert.AreEqual<int>(expectedAttributeValueCount, domainMetadataResult.AttributeValueCount.Value);
             Assert.IsNotNull(domainMetadataResult.Timestamp);
         }
 


### PR DESCRIPTION
## Description
Update the value types for the generated model types and manually written S3 model types to use nullables for value types.

When updating code that was affected by the change I would use the `Value` property if there was a check like `IsSet<name>` before accessing the property. In the SDK code itself I used `GetValueOrDefault` if there was no check. In the tests I generally used `Value` because the tests were written with the expectation there was a value and if there wasn't a value that would be a bug that shouldn't be hidden by the `GetValueOrDefault`.

I removed some of the customizations for nullablity but more exists that are tied to collections. I'll remove the rest that make sense to remove as part of that story.

## Motivation and Context
This is part of V4 effort to better model behavior and allow users to understand if a value is not set in a service or not.

## Testing
Confirmed both the .NET Framework and .NET Solution uber solution files compile. Running all of the tests is delayed till we setup the new CI system for V4.

The PR is kind of large because I wanted the PR to compile which involved pretty much making all of the changes. I broke up the changes into component commits that might make it easier to review.

I did not change collections to use nullables. So we would still use types like `List<int>` instead of `List<int?>`. I think the experience if using nullables for all collections would be a pretty bad user experience. I'm going to create a separate story to figure out how to special case the theoretical use case of having collections that could possibly have nullable value types. 
