### PR TITLE
Update changelog for Iot RoboRunner removal

### DIFF
--- a/changelogs/SDK.CHANGELOG.2024.md
+++ b/changelogs/SDK.CHANGELOG.2024.md
@@ -7,6 +7,8 @@
 	* This release allows you to configure HTTP client keep-alive duration for communication between clients and Application Load Balancers.
 * FIS (3.7.302.0)
 	* This release adds support for previewing target resources before running a FIS experiment. It also adds resource ARNs for actions, experiments, and experiment templates to API responses.
+* IoTRoboRunner (Removed)
+	* AWS IoT RoboRunner has been removed from the SDK because it has been discontinued.
 * RDS (3.7.309.4)
 	* Updates Amazon RDS documentation for EBCDIC collation for RDS for Db2.
 * SecretsManager (3.7.302.32)

--- a/changelogs/SDK.CHANGELOG.ALL.md
+++ b/changelogs/SDK.CHANGELOG.ALL.md
@@ -7,6 +7,8 @@
 	* This release allows you to configure HTTP client keep-alive duration for communication between clients and Application Load Balancers.
 * FIS (3.7.302.0)
 	* This release adds support for previewing target resources before running a FIS experiment. It also adds resource ARNs for actions, experiments, and experiment templates to API responses.
+* IoTRoboRunner (Removed)
+	* AWS IoT RoboRunner has been removed from the SDK because it has been discontinued.
 * RDS (3.7.309.4)
 	* Updates Amazon RDS documentation for EBCDIC collation for RDS for Db2.
 * SecretsManager (3.7.302.32)


### PR DESCRIPTION
## Description
Update changelogs to indicate IoTRoboRunner has been removed from the SDK.

## Types of changes
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license