### PR TITLE
Add ability to initialize collections to null instead of empty

### DIFF
--- a/generator/.DevConfigs/32BCF48A-645E-4BE0-9B3A-8E81D989EE98.json
+++ b/generator/.DevConfigs/32BCF48A-645E-4BE0-9B3A-8E81D989EE98.json
@@ -1,7 +1,8 @@
 {
     "core": {
         "changeLogMessages": [
-            "Add InitializeCollections property to AWSConfigs. If true types used for request and responses for service calls initializes collection properties to empty collection. If false the collections will be initialized to null. The default value is true."
+            "Add InitializeCollections property to AWSConfigs. If true types used for request and responses for service calls initializes collection properties to empty collection. If false the collections will be initialized to null. The default value is true.",
+			"Fixed issue overriding OS configured proxy for .NET Framework targets."
         ],
         "type": "minor",
         "updateMinimum": true

--- a/generator/.DevConfigs/32BCF48A-645E-4BE0-9B3A-8E81D989EE98.json
+++ b/generator/.DevConfigs/32BCF48A-645E-4BE0-9B3A-8E81D989EE98.json
@@ -1,0 +1,10 @@
+@@ -0,0 +1,9 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Add InitializeCollections property to AWSConfigs. If true types used for request and responses for service calls initializes collection properties to empty collection. If false the collections will be initialized to null. The default value is true."
+        ],
+        "type": "minor",
+        "updateMinimum": true
+    }
+}

--- a/generator/.DevConfigs/32BCF48A-645E-4BE0-9B3A-8E81D989EE98.json
+++ b/generator/.DevConfigs/32BCF48A-645E-4BE0-9B3A-8E81D989EE98.json
@@ -1,4 +1,3 @@
-@@ -0,0 +1,9 @@
 {
     "core": {
         "changeLogMessages": [

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryEC2ResponseUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryEC2ResponseUnmarshaller.cs
@@ -180,17 +180,38 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("                        var item = unmarshaller.Unmarshall(context);\r\n           " +
-                    "             response.");
+            this.Write("                        if (response.");
             
-            #line 76 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 75 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
+            
+            #line default
+            #line hidden
+            this.Write(" == null)\r\n                        {\r\n                            response.");
+            
+            #line 77 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
+            
+            #line default
+            #line hidden
+            this.Write(" = new ");
+            
+            #line 77 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
+            
+            #line default
+            #line hidden
+            this.Write("();\r\n                        }\r\n                        var item = unmarshaller.U" +
+                    "nmarshall(context);\r\n                        response.");
+            
+            #line 80 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
             
             #line default
             #line hidden
             this.Write(".Add(item);\r\n");
             
-            #line 77 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 81 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
 
 					}
 					else
@@ -201,14 +222,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                        response.");
             
-            #line 82 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 86 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
             
             #line default
             #line hidden
             this.Write(" = unmarshaller.Unmarshall(context);\r\n");
             
-            #line 83 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 87 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
 
 	                }
 
@@ -217,7 +238,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                        continue;\r\n                    }\r\n");
             
-            #line 88 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 92 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
 
 				}
 			}
@@ -228,7 +249,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                } \r\n            }\r\n");
             
-            #line 95 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 99 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
 
 	}
 
@@ -251,7 +272,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             ErrorResponse errorResponse = ErrorResponseUnmarshaller.GetInstance().Unmarshall(context);
 ");
             
-            #line 112 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 116 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
 
     foreach (var exception in this.Operation.Exceptions)
     {
@@ -261,14 +282,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("            if (errorResponse.Code != null && errorResponse.Code.Equals(\"");
             
-            #line 116 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 120 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(exception.Code));
             
             #line default
             #line hidden
             this.Write("\"))\r\n            {\r\n                return new ");
             
-            #line 118 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 122 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(exception.Name));
             
             #line default
@@ -276,7 +297,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write("(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, e" +
                     "rrorResponse.RequestId, statusCode);\r\n            }\r\n");
             
-            #line 120 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 124 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
 
     }
 
@@ -285,7 +306,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("            return new ");
             
-            #line 123 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 127 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.BaseException));
             
             #line default
@@ -293,7 +314,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write("(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, e" +
                     "rrorResponse.RequestId, statusCode);\r\n        }\r\n");
             
-            #line 125 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+            #line 129 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
 
 	    this.AddResponseSingletonMethod();
 
@@ -304,7 +325,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 130 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
+        #line 134 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryEC2ResponseUnmarshaller.tt"
 
 // if the result fields have been wrapped in a subordinate structure, wire the accessor
 // to use it when addressing a member

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryEC2ResponseUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryEC2ResponseUnmarshaller.tt
@@ -72,6 +72,10 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
 					if (member.IsList)
 					{
 #>
+                        if (response.<#=MemberAccessorFor(member.PropertyName)#> == null)
+                        {
+                            response.<#=MemberAccessorFor(member.PropertyName)#> = new <#=member.DetermineType()#>();
+                        }
                         var item = unmarshaller.Unmarshall(context);
                         response.<#=MemberAccessorFor(member.PropertyName)#>.Add(item);
 <#

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryExceptionUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryExceptionUnmarshaller.cs
@@ -153,23 +153,44 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("                        var item = ");
+            this.Write("                        if (response.");
             
             #line 62 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
+            
+            #line default
+            #line hidden
+            this.Write(" == null)\r\n                        {\r\n                            response.");
+            
+            #line 64 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
+            
+            #line default
+            #line hidden
+            this.Write(" = new ");
+            
+            #line 64 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
+            
+            #line default
+            #line hidden
+            this.Write("();\r\n                        }\r\n                        var item = ");
+            
+            #line 66 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
             this.Write(".Unmarshall(context);\r\n                        response.");
             
-            #line 63 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            #line 67 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
             
             #line default
             #line hidden
             this.Write(".Add(item);\r\n");
             
-            #line 64 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            #line 68 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
 
             }
             else
@@ -180,21 +201,21 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                        response.");
             
-            #line 69 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            #line 73 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
             
             #line default
             #line hidden
             this.Write(" = ");
             
-            #line 69 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            #line 73 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
             this.Write(".Unmarshall(context);\r\n");
             
-            #line 70 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            #line 74 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
 
             }
 
@@ -203,7 +224,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                    }\r\n");
             
-            #line 74 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            #line 78 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
 
         }
     }
@@ -213,7 +234,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                }\r\n            }\r\n            return response;\r\n        }\r\n\r\n");
             
-            #line 83 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+            #line 87 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
 
     this.AddStructureSingletonMethod();
 
@@ -224,7 +245,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 88 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
+        #line 92 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryExceptionUnmarshaller.tt"
 
 // if the result fields have been wrapped in a subordinate structure, wire the accessor
 // to use it when addressing a member

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryExceptionUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryExceptionUnmarshaller.tt
@@ -59,6 +59,10 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
             if (member.IsMap || member.IsList)
             {
 #>
+                        if (response.<#=MemberAccessorFor(member.PropertyName)#> == null)
+                        {
+                            response.<#=MemberAccessorFor(member.PropertyName)#> = new <#=member.DetermineType()#>();
+                        }
                         var item = <#= member.DetermineTypeUnmarshallerInstantiate() #>.Unmarshall(context);
                         response.<#=MemberAccessorFor(member.PropertyName)#>.Add(item);
 <#

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryResponseUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryResponseUnmarshaller.cs
@@ -228,17 +228,38 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("                        var item = unmarshaller.Unmarshall(context);\r\n           " +
-                    "             response.");
+            this.Write("                        if (response.");
             
-            #line 98 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 97 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
+            
+            #line default
+            #line hidden
+            this.Write(" == null)\r\n                        {\r\n                            response.");
+            
+            #line 99 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
+            
+            #line default
+            #line hidden
+            this.Write(" = new ");
+            
+            #line 99 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
+            
+            #line default
+            #line hidden
+            this.Write("();\r\n                        }\r\n                        var item = unmarshaller.U" +
+                    "nmarshall(context);\r\n                        response.");
+            
+            #line 102 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
             
             #line default
             #line hidden
             this.Write(".Add(item);\r\n");
             
-            #line 99 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 103 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
 
                 }
                 else
@@ -249,14 +270,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                        response.");
             
-            #line 104 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 108 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(MemberAccessorFor(member.PropertyName)));
             
             #line default
             #line hidden
             this.Write(" = unmarshaller.Unmarshall(context);\r\n");
             
-            #line 105 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 109 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
 
                 }
 
@@ -265,7 +286,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                        continue;\r\n                    }\r\n");
             
-            #line 110 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 114 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
 
             }
         }
@@ -301,7 +322,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             {
 ");
             
-            #line 140 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 144 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
 
     foreach (var exception in this.Operation.Exceptions)
     {
@@ -311,14 +332,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                if (errorResponse.Code != null && errorResponse.Code.Equals(\"");
             
-            #line 144 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 148 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(exception.Code));
             
             #line default
             #line hidden
             this.Write("\"))\r\n                {\r\n                    return ");
             
-            #line 146 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 150 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(exception.Name));
             
             #line default
@@ -326,7 +347,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write("Unmarshaller.Instance.Unmarshall(contextCopy, errorResponse);\r\n                }\r" +
                     "\n");
             
-            #line 148 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 152 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
 
     }
 
@@ -335,7 +356,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("            }\r\n            return new ");
             
-            #line 152 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 156 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.BaseException));
             
             #line default
@@ -343,7 +364,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write("(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, e" +
                     "rrorResponse.RequestId, statusCode);\r\n        }\r\n");
             
-            #line 154 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+            #line 158 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
 
 	    this.AddResponseSingletonMethod();
 
@@ -354,7 +375,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 159 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
+        #line 163 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryResponseUnmarshaller.tt"
 
 // if the result fields have been wrapped in a subordinate structure, wire the accessor
 // to use it when addressing a member

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryResponseUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryResponseUnmarshaller.tt
@@ -94,6 +94,10 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
                 if (member.IsMap || member.IsList)
                 {
 #>
+                        if (response.<#=MemberAccessorFor(member.PropertyName)#> == null)
+                        {
+                            response.<#=MemberAccessorFor(member.PropertyName)#> = new <#=member.DetermineType()#>();
+                        }
                         var item = unmarshaller.Unmarshall(context);
                         response.<#=MemberAccessorFor(member.PropertyName)#>.Add(item);
 <#

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryStructureUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryStructureUnmarshaller.cs
@@ -147,17 +147,39 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("                        var item = unmarshaller.Unmarshall(context);\r\n           " +
-                    "             unmarshalledObject.");
+            this.Write("                        if (unmarshalledObject.");
             
-            #line 51 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            #line 50 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(" == null)\r\n                        {\r\n                            unmarshalledObj" +
+                    "ect.");
+            
+            #line 52 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(" = new ");
+            
+            #line 52 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
+            
+            #line default
+            #line hidden
+            this.Write("();\r\n                        }\r\n                        var item = unmarshaller.U" +
+                    "nmarshall(context);\r\n                        unmarshalledObject.");
+            
+            #line 55 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(".Add(item);\r\n");
             
-            #line 52 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            #line 56 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
 
             }
             else
@@ -168,14 +190,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                        unmarshalledObject.");
             
-            #line 57 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            #line 61 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = unmarshaller.Unmarshall(context);\r\n");
             
-            #line 58 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            #line 62 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
 
             }
 
@@ -184,7 +206,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                        continue;\r\n                    }\r\n");
             
-            #line 63 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            #line 67 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
 
         }
     }
@@ -209,7 +231,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
         /// <returns></returns>
         public ");
             
-            #line 82 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            #line 86 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
@@ -217,7 +239,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write(" Unmarshall(JsonUnmarshallerContext context)\r\n        {\r\n            return null;" +
                     "\r\n        }\r\n\r\n\r\n");
             
-            #line 88 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
+            #line 92 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\AWSQueryStructureUnmarshaller.tt"
 
     this.AddStructureSingletonMethod();
 

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryStructureUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/AWSQueryStructureUnmarshaller.tt
@@ -47,6 +47,10 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
             if (member.IsMap || member.IsList)
             {
 #>
+                        if (unmarshalledObject.<#=member.PropertyName#> == null)
+                        {
+                            unmarshalledObject.<#=member.PropertyName#> = new <#=member.DetermineType()#>();
+                        }
                         var item = unmarshaller.Unmarshall(context);
                         unmarshalledObject.<#=member.PropertyName#>.Add(item);
 <#

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlExceptionUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlExceptionUnmarshaller.cs
@@ -151,16 +151,37 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write(";\r\n                        response.");
+            this.Write(";\r\n                        if (response.");
             
             #line 54 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
-            this.Write(".Add(unmarshaller.Unmarshall(context));\r\n                    }\r\n");
+            this.Write(" == null)\r\n                        {\r\n                            response.");
             
             #line 56 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(" = new ");
+            
+            #line 56 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
+            
+            #line default
+            #line hidden
+            this.Write("();\r\n                        }\r\n                        response.");
+            
+            #line 58 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(".Add(unmarshaller.Unmarshall(context));\r\n                    }\r\n");
+            
+            #line 60 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
 
         }
         else
@@ -171,28 +192,28 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                    if (context.TestExpression(\"");
             
-            #line 61 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
+            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.MarshallName));
             
             #line default
             #line hidden
             this.Write("\"))\r\n                    {\r\n                        var unmarshaller = ");
             
-            #line 63 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
+            #line 67 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
             this.Write(";\r\n                        response.");
             
-            #line 64 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
+            #line 68 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = unmarshaller.Unmarshall(context);\r\n                    }\r\n");
             
-            #line 66 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
+            #line 70 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
 
         }
     }
@@ -202,7 +223,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                }\r\n            }\r\n            return response;\r\n        }\r\n\r\n");
             
-            #line 75 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
+            #line 79 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlExceptionUnmarshaller.tt"
 
     this.AddStructureSingletonMethod();
 

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlExceptionUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlExceptionUnmarshaller.tt
@@ -51,6 +51,10 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
                     if (context.TestExpression("<#=member.MarshallName#>/<#=listMarshallName#>"))
                     {
                         var unmarshaller = <#= member.DetermineTypeUnmarshallerInstantiate() #>;
+                        if (response.<#=member.PropertyName#> == null)
+                        {
+                            response.<#=member.PropertyName#> = new <#=member.DetermineType()#>();
+                        }
                         response.<#=member.PropertyName#>.Add(unmarshaller.Unmarshall(context));
                     }
 <#

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlRequestMarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlRequestMarshaller.cs
@@ -1058,7 +1058,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(listVariable));
         #line hidden
         
         #line 232 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlRequestMarshaller.tt"
-this.Write(" != null && ");
+this.Write(" != null && (");
 
         
         #line default
@@ -1072,7 +1072,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(listVariable));
         #line hidden
         
         #line 232 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlRequestMarshaller.tt"
-this.Write(".Count > 0) \r\n");
+this.Write(".Count > 0 || !AWSConfigs.InitializeCollections)) \r\n");
 
         
         #line default

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlRequestMarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlRequestMarshaller.tt
@@ -229,7 +229,7 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
 				var listItemVariable = (variableName + member.PropertyName).Replace(".",string.Empty) + "Value";
 #>
 <#=new string(' ', level * 4)#>				var <#=listVariable#> = <#=variableName#>.<#=member.PropertyName#>;
-<#=new string(' ', level * 4)#>				if (<#=listVariable#> != null && <#=listVariable#>.Count > 0) 
+<#=new string(' ', level * 4)#>				if (<#=listVariable#> != null && (<#=listVariable#>.Count > 0 || !AWSConfigs.InitializeCollections)) 
 <#=new string(' ', level * 4)#>				{						
 <#=new string(' ', level * 4)#>					xmlWriter.WriteStartElement("<#=member.MarshallName#>", "<#=xmlNamespace#>");
 <#=new string(' ', level * 4)#>					foreach (var <#=listItemVariable#> in <#=listVariable#>) 

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlResponseUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlResponseUnmarshaller.cs
@@ -287,23 +287,44 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("\", targetDepth))\r\n\t\t\t\t\t{\r\n\t\t\t\t\t\tvar unmarshaller = ");
+            this.Write("\", targetDepth))\r\n\t\t\t\t\t{\r\n                        if (response.");
             
             #line 136 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(" == null)\r\n                        {\r\n                            response.");
+            
+            #line 138 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(" = new ");
+            
+            #line 138 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
+            
+            #line default
+            #line hidden
+            this.Write("();\r\n                        }\r\n\t\t\t\t\t\tvar unmarshaller = ");
+            
+            #line 140 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
             this.Write(";\r\n\t\t\t\t\t\tresponse.");
             
-            #line 137 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 141 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(".Add(unmarshaller.Unmarshall(context));\r\n\t\t\t\t\t\tcontinue;\r\n\t\t\t\t\t}\r\n");
             
-            #line 140 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 144 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
               
                 }
 
@@ -316,35 +337,56 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("\t\t\t\t    if (context.TestExpression(\"");
             
-            #line 147 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 151 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.MarshallName));
             
             #line default
             #line hidden
             this.Write("/");
             
-            #line 147 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 151 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(listMarshallName));
             
             #line default
             #line hidden
-            this.Write("\", targetDepth))\r\n\t\t\t\t    {\r\n\t\t\t\t\t    var unmarshaller = ");
+            this.Write("\", targetDepth))\r\n\t\t\t\t    {\r\n                        if (response.");
             
-            #line 149 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 153 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(" == null)\r\n                        {\r\n                            response.");
+            
+            #line 155 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(" = new ");
+            
+            #line 155 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
+            
+            #line default
+            #line hidden
+            this.Write("();\r\n                        }\r\n\t\t\t\t\t    var unmarshaller = ");
+            
+            #line 157 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
             this.Write(";\r\n\t\t\t\t\t    response.");
             
-            #line 150 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 158 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(".Add(unmarshaller.Unmarshall(context));\r\n\t\t\t\t\t    continue;\r\n\t\t\t\t    }\r\n");
             
-            #line 153 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 161 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
 
 			    }
             }
@@ -356,28 +398,28 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("\t\t\t\t\tif (context.TestExpression(\"");
             
-            #line 159 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 167 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.MarshallName));
             
             #line default
             #line hidden
             this.Write("\", targetDepth))\r\n\t\t\t\t\t{\r\n\t\t\t\t\t\tvar unmarshaller = ");
             
-            #line 161 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 169 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
             this.Write(";\r\n\t\t\t\t\t\tresponse.");
             
-            #line 162 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 170 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = unmarshaller.Unmarshall(context);\r\n\t\t\t\t\t\tcontinue;\r\n\t\t\t\t\t}\r\n");
             
-            #line 165 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 173 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
 
 			}
         }
@@ -390,28 +432,28 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("\t\t\t\t\tif (context.TestExpression(\"");
             
-            #line 172 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 180 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(payload.MarshallName));
             
             #line default
             #line hidden
             this.Write("\", targetDepth))\r\n\t\t\t\t\t{\r\n\t\t\t\t\t\tvar unmarshaller = ");
             
-            #line 174 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 182 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(payload.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
             this.Write(";\r\n\t\t\t\t\t\tresponse.");
             
-            #line 175 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 183 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(payload.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = unmarshaller.Unmarshall(context);\r\n\t\t\t\t\t\tcontinue;\r\n\t\t\t\t\t}\r\n");
             
-            #line 178 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 186 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
 
         }
 
@@ -422,7 +464,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
                     "\r\n                {\r\n                    return;\r\n                }\r\n           " +
                     " }\r\n          \r\n            return;\r\n        }\r\n");
             
-            #line 190 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 198 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
 
     }
 
@@ -451,7 +493,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             {
 ");
             
-            #line 212 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 220 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
 
     foreach (var exception in this.Operation.Exceptions)
     {
@@ -461,14 +503,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("                if (errorResponse.Code != null && errorResponse.Code.Equals(\"");
             
-            #line 216 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 224 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(exception.Code));
             
             #line default
             #line hidden
             this.Write("\"))\r\n                {\r\n                    return ");
             
-            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 226 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(exception.Name));
             
             #line default
@@ -476,7 +518,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write("Unmarshaller.Instance.Unmarshall(contextCopy, errorResponse);\r\n                }\r" +
                     "\n");
             
-            #line 220 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 228 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
 
     }
 
@@ -485,7 +527,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("            }\r\n            return new ");
             
-            #line 224 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 232 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.BaseException));
             
             #line default
@@ -493,7 +535,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write("(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, e" +
                     "rrorResponse.RequestId, statusCode);\r\n        }\r\n\r\n");
             
-            #line 227 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
+            #line 235 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlResponseUnmarshaller.tt"
 
     this.AddResponseSingletonMethod();
 

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlResponseUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlResponseUnmarshaller.tt
@@ -133,6 +133,10 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
 #>
 					if (context.TestExpression("<#=listMarshallName#>", targetDepth))
 					{
+                        if (response.<#=member.PropertyName#> == null)
+                        {
+                            response.<#=member.PropertyName#> = new <#=member.DetermineType()#>();
+                        }
 						var unmarshaller = <#= member.DetermineTypeUnmarshallerInstantiate() #>;
 						response.<#=member.PropertyName#>.Add(unmarshaller.Unmarshall(context));
 						continue;
@@ -146,6 +150,10 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
 #>
 				    if (context.TestExpression("<#=member.MarshallName#>/<#=listMarshallName#>", targetDepth))
 				    {
+                        if (response.<#=member.PropertyName#> == null)
+                        {
+                            response.<#=member.PropertyName#> = new <#=member.DetermineType()#>();
+                        }
 					    var unmarshaller = <#= member.DetermineTypeUnmarshallerInstantiate() #>;
 					    response.<#=member.PropertyName#>.Add(unmarshaller.Unmarshall(context));
 					    continue;

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlStructureUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlStructureUnmarshaller.cs
@@ -18,7 +18,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class RestXmlStructureUnmarshaller : BaseResponseUnmarshaller
     {
@@ -29,7 +29,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
         public override string TransformText()
         {
             
-            #line 6 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 6 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
     AddLicenseHeader();
 
@@ -40,7 +40,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("\r\nnamespace ");
             
-            #line 12 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 12 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
@@ -48,21 +48,21 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write(".Model.Internal.MarshallTransformations\r\n{\r\n    /// <summary>\r\n    /// Response U" +
                     "nmarshaller for ");
             
-            #line 15 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 15 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
             #line hidden
             this.Write(" Object\r\n    /// </summary>  \r\n    public class ");
             
-            #line 17 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 17 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
             #line hidden
             this.Write("Unmarshaller : IUnmarshaller<");
             
-            #line 17 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 17 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
@@ -72,28 +72,28 @@ namespace ServiceClientGenerator.Generators.Marshallers
                     "\n        /// <param name=\"context\"></param>\r\n        /// <returns></returns>\r\n  " +
                     "      public ");
             
-            #line 24 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
             #line hidden
             this.Write(" Unmarshall(XmlUnmarshallerContext context)\r\n        {\r\n            ");
             
-            #line 26 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 26 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
             #line hidden
             this.Write(" unmarshalledObject = new ");
             
-            #line 26 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 26 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
             #line hidden
             this.Write("();\r\n");
             
-            #line 27 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 27 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
     if(this.Structure != null && this.Structure.IsEvent && !this.Structure.HasImplicitEventPayloadMembers())
     {
@@ -107,14 +107,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write("            using (var sr = new StreamReader(context.Stream))\r\n            {\r\n   " +
                     "             unmarshalledObject.");
             
-            #line 36 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 36 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(eventPayloadMember.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = sr.ReadToEnd();\r\n            }\r\n");
             
-            #line 38 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 38 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
         }
         else
@@ -125,14 +125,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("            unmarshalledObject.");
             
-            #line 43 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(eventPayloadMember.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = context.Stream as MemoryStream;\r\n");
             
-            #line 44 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 44 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
         }
     }
@@ -141,7 +141,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line default
             #line hidden
             
-            #line 48 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
      //HasImplicitEventPayloadMembers means that the structure does not have a member with the EventPayload trait
      if(this.Structure != null && (this.Structure.HasImplicitEventPayloadMembers() || !this.Structure.IsEvent))
@@ -162,7 +162,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
                 {
 ");
             
-            #line 63 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 63 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
     }
 
@@ -170,7 +170,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line default
             #line hidden
             
-            #line 66 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 66 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
     if(this.Structure != null && (!this.Structure.IsEvent ||  this.Structure.HasImplicitEventPayloadMembers()))
     {
@@ -186,35 +186,57 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("\t\t\t\t\tif (context.TestExpression(\"");
             
-            #line 76 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 76 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.MarshallName));
             
             #line default
             #line hidden
             this.Write("/");
             
-            #line 76 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 76 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(listMarshallName));
             
             #line default
             #line hidden
-            this.Write("\", targetDepth))\r\n\t\t\t\t\t{\r\n\t\t\t\t\t\tvar unmarshaller = ");
+            this.Write("\", targetDepth))\r\n\t\t\t\t\t{\r\n                        if (unmarshalledObject.");
             
-            #line 78 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 78 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(" == null)\r\n                        {\r\n                            unmarshalledObj" +
+                    "ect.");
+            
+            #line 80 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(" = new ");
+            
+            #line 80 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
+            
+            #line default
+            #line hidden
+            this.Write("();\r\n                        }\r\n\t\t\t\t\t\tvar unmarshaller = ");
+            
+            #line 82 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
             this.Write(";\r\n\t\t\t\t\t\tunmarshalledObject.");
             
-            #line 79 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 83 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(".Add(unmarshaller.Unmarshall(context));\r\n\t\t\t\t\t\tcontinue;\r\n\t\t\t\t\t}\r\n");
             
-            #line 82 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 86 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
 			}
 			else
@@ -225,28 +247,28 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("\t\t\t\t\tif (context.TestExpression(\"");
             
-            #line 87 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 91 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.MarshallName));
             
             #line default
             #line hidden
             this.Write("\", targetDepth))\r\n\t\t\t\t\t{\r\n\t\t\t\t\t\tvar unmarshaller = ");
             
-            #line 89 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 93 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
             this.Write(";\r\n\t\t\t\t\t\tunmarshalledObject.");
             
-            #line 90 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 94 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = unmarshaller.Unmarshall(context);\r\n\t\t\t\t\t\tcontinue;\r\n\t\t\t\t\t}\r\n");
             
-            #line 93 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 97 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
 			}
         }
@@ -266,7 +288,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
 
 ");
             
-            #line 107 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
+            #line 111 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Marshallers\RestXmlStructureUnmarshaller.tt"
 
     this.AddStructureSingletonMethod();
 

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlStructureUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/RestXmlStructureUnmarshaller.tt
@@ -75,6 +75,10 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
 #>
 					if (context.TestExpression("<#=member.MarshallName#>/<#=listMarshallName#>", targetDepth))
 					{
+                        if (unmarshalledObject.<#=member.PropertyName#> == null)
+                        {
+                            unmarshalledObject.<#=member.PropertyName#> = new <#=member.DetermineType()#>();
+                        }
 						var unmarshaller = <#= member.DetermineTypeUnmarshallerInstantiate() #>;
 						unmarshalledObject.<#=member.PropertyName#>.Add(unmarshaller.Unmarshall(context));
 						continue;

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.cs
@@ -155,7 +155,14 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
             
             #line default
             #line hidden
-            this.Write(");\r\n");
+            this.Write(" ?? new ");
+            
+            #line 42 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.Member.DetermineType()));
+            
+            #line default
+            #line hidden
+            this.Write("());\r\n");
             
             #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.tt
@@ -39,7 +39,7 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
         /// Enumerable containing all of the <#=resultKey.Member.PropertyName#>
         /// </summary>
         public IPaginatedEnumerable<<#=resultKey.ListItemType#>> <#=resultKey.Member.PropertyName#> => 
-            new PaginatedResultKeyResponse<<#=this.Operation.Name#>Response, <#=resultKey.ListItemType#>>(this, (i) => i.<#=resultKey.PropertyName#>);
+            new PaginatedResultKeyResponse<<#=this.Operation.Name#>Response, <#=resultKey.ListItemType#>>(this, (i) => i.<#=resultKey.PropertyName#> ?? new <#=resultKey.Member.DetermineType()#>());
 <#
 }
 #>

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/StructureGenerator.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/StructureGenerator.cs
@@ -18,7 +18,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class StructureGenerator : BaseGenerator
     {
@@ -30,7 +30,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         {
             this.Write("\r\n");
             
-            #line 7 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 7 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     AddLicenseHeader();
 
@@ -41,7 +41,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "\r\nusing System.Text;\r\nusing System.IO;\r\nusing System.Net;\r\n\r\nusing Amazon.Runtim" +
                     "e;\r\nusing Amazon.Runtime.Internal;\r\n");
             
-            #line 19 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 19 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 bool structureIsNotEventStream = this.Structure != null && !this.Structure.IsEventStream;
 bool structureIsEventStream = this.Structure != null && this.Structure.IsEventStream;
@@ -54,7 +54,7 @@ if(this.StructureType == StructureType.Request && this.Operation.AuthType.HasVal
             #line hidden
             this.Write("using Amazon.Runtime.Internal.Auth;\r\n");
             
-            #line 27 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 27 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 }
 
@@ -62,7 +62,7 @@ if(this.StructureType == StructureType.Request && this.Operation.AuthType.HasVal
             #line default
             #line hidden
             
-            #line 30 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 30 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 if(structureIsEvent || structureIsEventStream)
 {
@@ -73,7 +73,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("using Amazon.Runtime.EventStreams;\r\nusing Amazon.Runtime.EventStreams.Internal;\r\n" +
                     "using ");
             
-            #line 36 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 36 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
@@ -81,7 +81,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write(".Model.Internal.MarshallTransformations;\r\nusing Amazon.Runtime.EventStreams.Utils" +
                     ";\r\n");
             
-            #line 38 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 38 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 }
 
@@ -90,14 +90,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\nnamespace ");
             
-            #line 42 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 42 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
             #line hidden
             this.Write(".Model\r\n{\r\n");
             
-            #line 44 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 44 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
   
     if(this.StructureType == StructureType.Request)
         this.FormatOperationRequestDocumentation(this.Operation);
@@ -111,14 +111,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    /// <summary>\r\n    /// This is the response object from the ");
             
-            #line 53 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 53 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write(" operation.\r\n    /// </summary>\r\n");
             
-            #line 55 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 55 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     }
     else
@@ -128,7 +128,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 60 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 60 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
       
     if(this.Structure != null && this.Structure.IsDeprecated)
         {
@@ -138,14 +138,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    [Obsolete(\"");
             
-            #line 64 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 64 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 65 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
     if(this.Structure is ExceptionShape)
@@ -156,7 +156,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    #if !NETSTANDARD\r\n    [Serializable]\r\n    #endif\r\n");
             
-            #line 73 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 73 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
 
@@ -164,7 +164,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 76 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 76 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 
     if(this.Structure != null && this.Structure.IsEventStream)
@@ -181,14 +181,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    ");
             
-            #line 87 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 87 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(EventStreamOutput));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 88 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 88 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     }
 
@@ -196,7 +196,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 91 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 91 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     bool hasStreamingMember = this.Structure?.Members.Any(member => member.IsStreaming) ?? false;
         
@@ -214,20 +214,20 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    public partial class ");
             
-            #line 103 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 103 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.ClassName));
             
             #line default
             #line hidden
             
-            #line 103 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 103 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.BaseClassString));
             
             #line default
             #line hidden
             this.Write(", IDisposable\r\n    {\r\n");
             
-            #line 105 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 105 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
     else 
@@ -237,7 +237,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 110 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 110 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         if( (this.Structure == null) || (structureIsNotEventStream))
         {
@@ -247,20 +247,20 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    public partial class ");
             
-            #line 114 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 114 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.ClassName));
             
             #line default
             #line hidden
             
-            #line 114 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 114 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.BaseClassString));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 115 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 115 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
             if(structureIsEvent)
             {
@@ -270,7 +270,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        : IEventStreamEvent\r\n");
             
-            #line 120 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 120 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
             }
 
@@ -279,7 +279,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("    {\r\n");
             
-            #line 124 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 124 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
 
@@ -287,7 +287,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 127 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 127 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     }
 
@@ -295,7 +295,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 130 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 130 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         if(structureIsNotEventStream)
         {
@@ -307,28 +307,28 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        private ");
             
-            #line 136 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 136 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
             #line hidden
             this.Write(" _response;\r\n\r\n        /// <summary>\r\n        /// Gets and sets the ");
             
-            #line 139 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 139 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
             #line hidden
             this.Write(" property.\r\n        /// </summary>\r\n        public ");
             
-            #line 141 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 141 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 141 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 141 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -336,7 +336,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("\r\n        {\r\n            get { return this._response; }\r\n            set { this._" +
                     "response = value; }\r\n        }\r\n");
             
-            #line 146 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 146 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
             }
             else
@@ -351,33 +351,33 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        private ");
             
-            #line 155 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 155 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             
-            #line 155 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 155 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.IsNullable ? "?" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 155 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 155 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             
-            #line 155 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"));
+            #line 155 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.IsCollection ? string.Format(" = AWSConfigs.InitializeCollections ? new {0}() : null;", member.DetermineType()) : ";"));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 156 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 156 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
 
@@ -386,7 +386,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\n");
             
-            #line 160 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 160 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 AddSimpleRequestConstructors(this.ClassName, this.Structure, this.Config.Namespace);
 
@@ -401,14 +401,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        private RetryableDetails _retryableDetails = new RetryableDetails(");
             
-            #line 169 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 169 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(exceptionShape.Throttling.ToString().ToLower()));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 170 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 170 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
 
             
@@ -416,7 +416,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\n");
             
-            #line 173 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 173 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -425,7 +425,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        /// <summary>\r\n        /// Constructs a new ");
             
-            #line 2 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 2 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -434,7 +434,7 @@ if(structureIsEvent || structureIsEventStream)
                     "/// <param name=\"message\">\r\n        /// Describes the error encountered.\r\n      " +
                     "  /// </param>\r\n        public ");
             
-            #line 8 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 8 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -442,7 +442,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("(string message) \r\n            : base(message) {}\r\n\r\n        /// <summary>\r\n     " +
                     "   /// Construct instance of ");
             
-            #line 12 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 12 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -450,7 +450,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("\r\n        /// </summary>\r\n        /// <param name=\"message\"></param>\r\n        ///" +
                     " <param name=\"innerException\"></param>\r\n        public ");
             
-            #line 16 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -458,7 +458,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("(string message, Exception innerException) \r\n            : base(message, innerExc" +
                     "eption) {}\r\n\r\n        /// <summary>\r\n        /// Construct instance of ");
             
-            #line 20 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 20 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -466,7 +466,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("\r\n        /// </summary>\r\n        /// <param name=\"innerException\"></param>\r\n    " +
                     "    public ");
             
-            #line 23 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 23 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -474,7 +474,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("(Exception innerException) \r\n            : base(innerException) {}\r\n\r\n        ///" +
                     " <summary>\r\n        /// Construct instance of ");
             
-            #line 27 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 27 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -489,7 +489,7 @@ if(structureIsEvent || structureIsEventStream)
         /// <param name=""statusCode""></param>
         public ");
             
-            #line 35 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 35 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -500,7 +500,7 @@ if(structureIsEvent || structureIsEventStream)
         /// <summary>
         /// Construct instance of ");
             
-            #line 39 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 39 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -514,7 +514,7 @@ if(structureIsEvent || structureIsEventStream)
         /// <param name=""statusCode""></param>
         public ");
             
-            #line 46 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
+            #line 46 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionConstructors.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -526,7 +526,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("#if !NETSTANDARD\r\n        /// <summary>\r\n        /// Constructs a new instance of" +
                     " the ");
             
-            #line 3 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 3 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -539,7 +539,7 @@ if(structureIsEvent || structureIsEventStream)
         /// <exception cref=""T:System.Runtime.Serialization.SerializationException"">The class name is null or <see cref=""P:System.Exception.HResult"" /> is zero (0). </exception>
         protected ");
             
-            #line 9 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 9 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Structure.Name));
             
             #line default
@@ -547,7 +547,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serializatio" +
                     "n.StreamingContext context)\r\n            : base(info, context)\r\n        {\r\n");
             
-            #line 12 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 12 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
           
             foreach(var member in this.Structure.Members)
 			{
@@ -557,35 +557,35 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            this.");
             
-            #line 16 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = (");
             
-            #line 16 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             this.Write(")info.GetValue(\"");
             
-            #line 16 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("\", typeof(");
             
-            #line 16 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             this.Write("));\r\n");
             
-            #line 17 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 17 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
 
             }
 
@@ -613,7 +613,7 @@ if(structureIsEvent || structureIsEventStream)
                     "ystem.Runtime.Serialization.StreamingContext context)\r\n        {\r\n            ba" +
                     "se.GetObjectData(info, context);\r\n");
             
-            #line 40 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 40 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
 
             foreach(var member in this.Structure.Members)
 			{
@@ -623,21 +623,21 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            info.AddValue(\"");
             
-            #line 44 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 44 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("\", this.");
             
-            #line 44 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 44 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 45 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
+            #line 45 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\.\Exceptions\ExceptionSerialization.t4"
 
             }
 
@@ -647,7 +647,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("        }\r\n#endif\r\n");
             this.Write("\r\n");
             
-            #line 178 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 178 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
                 foreach(var member in this.Structure.Members)
@@ -659,13 +659,13 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 185 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 185 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
  this.FormatPropertyDocumentation(member); 
             
             #line default
             #line hidden
             
-            #line 186 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 186 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
       
                     if(member.IsDeprecated)
                     {
@@ -675,14 +675,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        [Obsolete(\"");
             
-            #line 190 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 190 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 191 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 191 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -711,14 +711,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        [AWSProperty(");
             
-            #line 214 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 214 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(string.Join(", ", propertyAttributes)));
             
             #line default
             #line hidden
             this.Write(")]\r\n");
             
-            #line 215 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 215 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -727,34 +727,34 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        ");
             
-            #line 218 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.AccessModifier));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 218 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             
-            #line 218 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.UseNullable ? "?" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 218 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 218 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("\r\n        {\r\n");
             
-            #line 220 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 220 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     if(member.IsNullable && !member.UseNullable)
                     {
@@ -764,14 +764,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            get { return this.");
             
-            #line 224 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 224 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(".GetValueOrDefault(); }\r\n");
             
-            #line 225 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 225 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                     else
@@ -782,14 +782,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            get { return this.");
             
-            #line 230 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 230 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write("; }\r\n");
             
-            #line 231 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 231 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -798,21 +798,21 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            set { ");
             
-            #line 234 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 234 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.IsBackwardsCompatibleDateTimeProperty ? "this." + member.BackwardCompatibilityVariableName + " = " : ""));
             
             #line default
             #line hidden
             this.Write("this.");
             
-            #line 234 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 234 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(" = value; }\r\n        }\r\n\r\n");
             
-            #line 237 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 237 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     if (member.EmitIsSetProperties)
                     {
@@ -823,7 +823,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("        /// <summary>\r\n        /// This property is set to true if the property <" +
                     "seealso cref=\"");
             
-            #line 242 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 242 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
@@ -839,7 +839,7 @@ if(structureIsEvent || structureIsEventStream)
         /// </returns>
 ");
             
-            #line 251 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 251 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
       
                         if(member.IsDeprecated)
                         {
@@ -849,14 +849,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        [Obsolete(\"");
             
-            #line 255 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 255 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DeprecationMessage));
             
             #line default
             #line hidden
             this.Write("\")]\r\n");
             
-            #line 256 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 256 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         }
 
@@ -865,7 +865,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        public bool Is");
             
-            #line 259 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 259 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
@@ -873,7 +873,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("Set\r\n        {\r\n            get\r\n            {\r\n                return Amazon.Uti" +
                     "l.Internal.InternalSDKUtils.GetIsSet(this.");
             
-            #line 263 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 263 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
@@ -881,14 +881,14 @@ if(structureIsEvent || structureIsEventStream)
             this.Write(");\r\n            }\r\n            set\r\n            {\r\n                Amazon.Util.In" +
                     "ternal.InternalSDKUtils.SetIsSet(value, ref this.");
             
-            #line 267 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 267 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 268 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 268 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         if(member.IsBackwardsCompatibleDateTimeProperty)
                         {
@@ -899,14 +899,14 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("  \r\n                Amazon.Util.Internal.InternalSDKUtils.SetIsSet(value, ref thi" +
                     "s.");
             
-            #line 272 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 272 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityVariableName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 273 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 273 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         }
 
@@ -915,7 +915,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            }\r\n        }\r\n\r\n");
             
-            #line 279 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 279 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -924,21 +924,21 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        // Check to see if ");
             
-            #line 282 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 282 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" property is set\r\n        internal bool IsSet");
             
-            #line 283 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 283 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("()\r\n        {\r\n");
             
-            #line 285 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 285 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     if (member.EmitIsSetProperties)
                     {
@@ -948,14 +948,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return this.Is");
             
-            #line 289 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 289 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("Set; \r\n");
             
-            #line 290 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 290 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                     else if (member.IsNullable)
@@ -966,14 +966,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return this.");
             
-            #line 295 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 295 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(".HasValue; \r\n");
             
-            #line 296 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 296 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                     else if (member.IsMap || member.IsList)
@@ -984,21 +984,21 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return this.");
             
-            #line 301 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 301 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
-            this.Write(" != null && this.");
+            this.Write(" != null && (this.");
             
-            #line 301 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 301 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
-            this.Write(".Count > 0; \r\n");
+            this.Write(".Count > 0 || !AWSConfigs.InitializeCollections); \r\n");
             
-            #line 302 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 302 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                     else if (member.IsDocument)
@@ -1009,14 +1009,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return !this.");
             
-            #line 307 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 307 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(".IsNull();\r\n");
             
-            #line 308 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 308 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                     else
@@ -1027,14 +1027,14 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return this.");
             
-            #line 313 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 313 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(" != null;\r\n");
             
-            #line 314 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 314 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -1043,7 +1043,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        }\r\n\r\n");
             
-            #line 319 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 319 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
 
@@ -1057,7 +1057,7 @@ if(structureIsEvent || structureIsEventStream)
                     "   /// </summary>\r\n        /// <returns>A signer for this request.</returns>\r\n  " +
                     "      override protected AbstractAWSSigner CreateSigner()\r\n        {\r\n");
             
-            #line 331 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 331 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     switch (this.Operation.AuthType.Value)
                     {
@@ -1068,7 +1068,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return new NullSigner();\r\n");
             
-            #line 337 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 337 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         break;
                         case OperationAuthType.V4:
@@ -1078,7 +1078,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return new AWS4Signer();\r\n");
             
-            #line 342 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 342 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         break;
                         case OperationAuthType.V4UnsignedBody:
@@ -1088,7 +1088,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return new AWS4Signer(false);\r\n");
             
-            #line 347 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 347 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         break;
                         case OperationAuthType.Bearer:
@@ -1098,7 +1098,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("            return new BearerTokenSigner();\r\n");
             
-            #line 352 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 352 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         break;
                         default:
@@ -1110,7 +1110,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        }\r\n");
             
-            #line 359 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 359 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
                 // Flexible checksum overrides to allow response validation configuration on the request
@@ -1131,7 +1131,7 @@ if(structureIsEvent || structureIsEventStream)
             {
                 if (IsSet");
             
-            #line 373 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 373 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.ChecksumConfiguration.RequestValidationModeMember));
             
             #line default
@@ -1139,7 +1139,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("())\r\n                {\r\n                    return (CoreChecksumResponseBehavior)" +
                     "Enum.Parse(typeof(CoreChecksumResponseBehavior), this.");
             
-            #line 375 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 375 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.ChecksumConfiguration.RequestValidationModeMember));
             
             #line default
@@ -1149,7 +1149,7 @@ if(structureIsEvent || structureIsEventStream)
                     "ithm> _supportedChecksumAlgorithms = new List<CoreChecksumAlgorithm>\r\n        {\r" +
                     "\n            ");
             
-            #line 384 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 384 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(string.Join(", ", Operation.ChecksumConfiguration?.ResponseAlgorithms?.Select(s => $"CoreChecksumAlgorithm.{s}").ToArray())));
             
             #line default
@@ -1164,7 +1164,7 @@ if(structureIsEvent || structureIsEventStream)
 #endregion
 ");
             
-            #line 392 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 392 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
 
@@ -1176,7 +1176,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("#region Backwards compatible properties\r\n");
             
-            #line 399 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 399 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     foreach(var member in this.Structure.Members)
                     {
@@ -1188,33 +1188,33 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("        private ");
             
-            #line 405 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 405 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             
-            #line 405 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 405 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.IsNullable ? "?" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 405 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 405 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityVariableName));
             
             #line default
             #line hidden
             
-            #line 405 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"));
+            #line 405 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.IsCollection ? string.Format(" = AWSConfigs.InitializeCollections ? new {0}() : null;", member.DetermineType()) : ";"));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 406 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 406 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
 
@@ -1223,7 +1223,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\n");
             
-            #line 410 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 410 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     foreach(var member in this.Structure.Members)
                     {
@@ -1234,7 +1234,7 @@ if(structureIsEvent || structureIsEventStream)
             #line default
             #line hidden
             
-            #line 416 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 416 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
  this.FormatPropertyDocumentation(member, "This property is deprecated. Setting this property results in non-UTC DateTimes " +
         "not being marshalled correctly. Use " + member.PropertyName + " instead. Setting either " + member.BackwardCompatibilityPropertyName +
         " or " + member.PropertyName + " results in both " + member.BackwardCompatibilityPropertyName + " and " + 
@@ -1247,35 +1247,35 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("        [Obsolete(\"Setting this property results in non-UTC DateTimes not being m" +
                     "arshalled correctly. \" +\r\n            \"Use ");
             
-            #line 423 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 423 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" instead. Setting either ");
             
-            #line 423 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 423 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write(" or ");
             
-            #line 423 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 423 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" results in both ");
             
-            #line 423 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 423 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write(" and \" +\r\n            \"");
             
-            #line 424 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 424 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
@@ -1283,7 +1283,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write(" being assigned, the latest assignment to either one of the two property is \" + \r" +
                     "\n            \"reflected in the value of both. ");
             
-            #line 425 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 425 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
@@ -1292,55 +1292,55 @@ if(structureIsEvent || structureIsEventStream)
                     "on-Utc DateTime to it results in the wrong timestamp being passed to the service" +
                     ".\", false)]\r\n        ");
             
-            #line 427 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 427 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.AccessModifier));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 427 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 427 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineType()));
             
             #line default
             #line hidden
             
-            #line 427 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 427 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.UseNullable ? "?" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 427 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 427 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write("\r\n        {\r\n            get { return this.");
             
-            #line 429 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 429 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityVariableName));
             
             #line default
             #line hidden
             this.Write(".GetValueOrDefault(); }\r\n            set\r\n            {\r\n                this.");
             
-            #line 432 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 432 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityVariableName));
             
             #line default
             #line hidden
             this.Write(" = value;\r\n                this.");
             
-            #line 433 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 433 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(" = new DateTime(value.Ticks, DateTimeKind.Utc);\r\n            }\r\n        }\r\n");
             
-            #line 436 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 436 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         if (member.EmitIsSetProperties)
                         {
@@ -1351,7 +1351,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("        /// <summary>\r\n        /// This property is set to true if the property <" +
                     "seealso cref=\"");
             
-            #line 441 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 441 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
@@ -1367,42 +1367,42 @@ if(structureIsEvent || structureIsEventStream)
         /// </returns>
         [Obsolete(""Setting ");
             
-            #line 450 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 450 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write(" results in non-UTC DateTimes not being marshalled correctly. Use ");
             
-            #line 450 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 450 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" instead.\", false)]\r\n        public bool Is");
             
-            #line 451 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 451 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.BackwardCompatibilityPropertyName));
             
             #line default
             #line hidden
             this.Write("Set\r\n        {\r\n            get\r\n            {\r\n                return this.Is");
             
-            #line 455 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 455 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("Set;\r\n            }\r\n            set\r\n            {\r\n                this.Is");
             
-            #line 459 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 459 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
             this.Write("Set = value;;\r\n            }\r\n        }\r\n");
             
-            #line 462 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 462 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         }
                     }
@@ -1413,7 +1413,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("#endregion\r\n");
             
-            #line 468 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 468 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 }
                 if (this.Structure is ExceptionShape)
@@ -1438,7 +1438,7 @@ if(structureIsEvent || structureIsEventStream)
         }
 ");
             
-            #line 487 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 487 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                     }
                 }
@@ -1453,7 +1453,7 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("\r\n");
             
-            #line 497 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 497 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
         if (this.StructureType == StructureType.Response && hasStreamingMember) 
@@ -1484,7 +1484,7 @@ if(structureIsEvent || structureIsEventStream)
             {
 ");
             
-            #line 522 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 522 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                 if (this.Structure != null) 
                 {
@@ -1498,21 +1498,21 @@ if(structureIsEvent || structureIsEventStream)
             #line hidden
             this.Write("                this.");
             
-            #line 530 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 530 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write("?.Dispose();\r\n                this.");
             
-            #line 531 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 531 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.VariableName));
             
             #line default
             #line hidden
             this.Write(" = null;\r\n");
             
-            #line 532 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 532 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
                         }
                     }
@@ -1524,7 +1524,7 @@ if(structureIsEvent || structureIsEventStream)
             this.Write("            }\r\n\r\n            this._disposed = true;\r\n         }\r\n\r\n         #endr" +
                     "egion\r\n");
             
-            #line 543 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+            #line 543 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
         }
 
@@ -1535,7 +1535,7 @@ if(structureIsEvent || structureIsEventStream)
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 550 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
+        #line 550 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\StructureGenerator.tt"
 
     // Set to true when the service model specifies a shape that should be wrapped in a response. ElastiCache CreateCacheCluster is an example of this.
     public bool IsWrapped { get; set; }

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/StructureGenerator.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/StructureGenerator.tt
@@ -152,7 +152,7 @@ namespace <#=this.Config.Namespace#>.Model
                     if (member.IsExcluded)
                         continue;
 #>
-        private <#=member.DetermineType()#><#= member.IsNullable ? "?" : "" #> <#=member.VariableName#><#= member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"#>
+        private <#=member.DetermineType()#><#= member.IsNullable ? "?" : "" #> <#=member.VariableName#><#= member.IsCollection ? string.Format(" = AWSConfigs.InitializeCollections ? new {0}() : null;", member.DetermineType()) : ";"#>
 <#
                 }
 #>
@@ -298,7 +298,7 @@ namespace <#=this.Config.Namespace#>.Model
                     else if (member.IsMap || member.IsList)
                     {
 #>
-            return this.<#=member.VariableName#> != null && this.<#=member.VariableName#>.Count > 0; 
+            return this.<#=member.VariableName#> != null && (this.<#=member.VariableName#>.Count > 0 || !AWSConfigs.InitializeCollections); 
 <#
                     }
                     else if (member.IsDocument)
@@ -402,7 +402,7 @@ namespace <#=this.Config.Namespace#>.Model
                         if (member.IsExcluded || !member.IsBackwardsCompatibleDateTimeProperty)
                             continue;
 #>
-        private <#=member.DetermineType()#><#= member.IsNullable ? "?" : "" #> <#=member.BackwardCompatibilityVariableName#><#= member.ShouldInstantiate ? string.Format(" = new {0}();", member.DetermineType()) : ";"#>
+        private <#=member.DetermineType()#><#= member.IsNullable ? "?" : "" #> <#=member.BackwardCompatibilityVariableName#><#= member.IsCollection ? string.Format(" = AWSConfigs.InitializeCollections ? new {0}() : null;", member.DetermineType()) : ";"#>
 <#
                     }
 #>

--- a/generator/ServiceClientGeneratorLib/Member.cs
+++ b/generator/ServiceClientGeneratorLib/Member.cs
@@ -964,7 +964,7 @@ namespace ServiceClientGenerator
         /// <summary>
         /// Determines if the member is a type that needs to be instantiated, such as a list or map
         /// </summary>
-        public bool ShouldInstantiate
+        public bool IsCollection
         {
             get { return this.IsMap || this.IsList; }
         }

--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -86,7 +86,7 @@ namespace Amazon
         internal static string _awsProfileName = GetConfig(AWSProfileNameKey);
         internal static string _awsAccountsLocation = GetConfig(AWSProfilesLocationKey);
         internal static bool _useSdkCache = GetConfigBool(UseSdkCacheKey, defaultValue: true);
-        internal static bool _initializeCollections = GetConfigBool(InitializeCollectionsKey, defaultValue: false);
+        internal static bool _initializeCollections = GetConfigBool(InitializeCollectionsKey, defaultValue: true);
         // for reading from awsconfigs.xml
         private static object _lock = new object();
         private static List<string> standardConfigs = new List<string>() { "region", "logging", "correctForClockSkew" };

--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -86,6 +86,7 @@ namespace Amazon
         internal static string _awsProfileName = GetConfig(AWSProfileNameKey);
         internal static string _awsAccountsLocation = GetConfig(AWSProfilesLocationKey);
         internal static bool _useSdkCache = GetConfigBool(UseSdkCacheKey, defaultValue: true);
+        internal static bool _initializeCollections = GetConfigBool(InitializeCollectionsKey, defaultValue: true);
         // for reading from awsconfigs.xml
         private static object _lock = new object();
         private static List<string> standardConfigs = new List<string>() { "region", "logging", "correctForClockSkew" };
@@ -395,6 +396,34 @@ namespace Amazon
             set { _rootConfig.UseSdkCache = value; }
         }
 
+        #endregion
+
+        #region Initialize Collections
+        /// <summary>
+        /// Key for the InitializeCollections property.
+        /// <seealso cref="Amazon.AWSConfigs.InitializeCollections"/>
+        /// </summary>
+        public const string InitializeCollectionsKey = "AWSInitializeCollections";
+
+        /// <summary>
+        /// When true the collections used on the service API request and response objects are initialized
+        /// to an empty collection. The collections are sent as part of requests when a collection is non-empty.
+        /// 
+        /// Setting InitializeCollections to false means all collections used on the service API request and 
+        /// response objects are initialized to null. The collections are sent as part of requests when
+        /// the collection non-null including an empty collection.
+        /// 
+        /// The default value is true. In the next major version of the SDK the default will change to false.
+        /// This will improve performance not creating unnecessary collection instances and provide more
+        /// control when the collection is sent to the service.
+        /// 
+        /// Setting this property is not thread safe and should only be set at application startup.
+        /// </summary>
+        public static bool InitializeCollections
+        {
+            get { return _rootConfig.InitializeCollections; }
+            set { _rootConfig.InitializeCollections = value; }
+        }
         #endregion
 
         #region AWS Config Sections

--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -86,7 +86,7 @@ namespace Amazon
         internal static string _awsProfileName = GetConfig(AWSProfileNameKey);
         internal static string _awsAccountsLocation = GetConfig(AWSProfilesLocationKey);
         internal static bool _useSdkCache = GetConfigBool(UseSdkCacheKey, defaultValue: true);
-        internal static bool _initializeCollections = GetConfigBool(InitializeCollectionsKey, defaultValue: true);
+        internal static bool _initializeCollections = GetConfigBool(InitializeCollectionsKey, defaultValue: false);
         // for reading from awsconfigs.xml
         private static object _lock = new object();
         private static List<string> standardConfigs = new List<string>() { "region", "logging", "correctForClockSkew" };

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
@@ -135,6 +135,8 @@ namespace Amazon.Runtime.Internal
             var userAgentAddition = requestContext.OriginalRequest.UserAgentAddition;
             sb.AppendFormat(" {0}", userAgentAddition);
 
+            sb.AppendFormat(" cfg/init-coll#{0}", AWSConfigs.InitializeCollections ? "1" : "0");
+
             var userAgent = sb.ToString();
 
             userAgent = InternalSDKUtils.ReplaceInvalidUserAgentCharacters(userAgent);

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
@@ -132,10 +132,13 @@ namespace Amazon.Runtime.Internal
 
             sb.AppendFormat(" md/{0}", requestContext.IsAsync ? "ClientAsync" : "ClientSync");
 
-            var userAgentAddition = requestContext.OriginalRequest.UserAgentAddition;
-            sb.AppendFormat(" {0}", userAgentAddition);
-
             sb.AppendFormat(" cfg/init-coll#{0}", AWSConfigs.InitializeCollections ? "1" : "0");
+
+            var userAgentAddition = requestContext.OriginalRequest.UserAgentAddition;
+            if (!string.IsNullOrEmpty(userAgentAddition))
+            {
+                sb.AppendFormat(" {0}", userAgentAddition);
+            }
 
             var userAgent = sb.ToString();
 

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_bcl/HttpWebRequestFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_bcl/HttpWebRequestFactory.cs
@@ -479,11 +479,18 @@ namespace Amazon.Runtime.Internal
             {
                 if (_request.RequestUri.Scheme == Uri.UriSchemeHttp)
                 {
-                    _request.Proxy = requestContext.ClientConfig.GetHttpProxy();
+                    proxy = requestContext.ClientConfig.GetHttpProxy();
                 }
                 else if (_request.RequestUri.Scheme == Uri.UriSchemeHttps)
                 {
-                    _request.Proxy = requestContext.ClientConfig.GetHttpsProxy();
+                    proxy = requestContext.ClientConfig.GetHttpsProxy();
+                }
+
+                // Only set the HttpWebRequest Proxy property if we have a value so
+                // that we don't override any OS level proxy settings.
+                if (proxy != null)
+                {
+                    _request.Proxy = proxy;
                 }
             }
 

--- a/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
@@ -271,13 +271,16 @@ namespace Amazon.Util.Internal
             IDictionary<TKey, TValue> dictionary, TValue value, IEqualityComparer<TValue> valueComparer,
             out TKey key)
         {
-            foreach (var kvp in dictionary)
+            if (dictionary != null)
             {
-                var candidateValue = kvp.Value;
-                if (valueComparer.Equals(value, candidateValue))
+                foreach (var kvp in dictionary)
                 {
-                    key = kvp.Key;
-                    return true;
+                    var candidateValue = kvp.Value;
+                    if (valueComparer.Equals(value, candidateValue))
+                    {
+                        key = kvp.Key;
+                        return true;
+                    }
                 }
             }
 

--- a/sdk/src/Core/Amazon.Util/Internal/RootConfig.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/RootConfig.cs
@@ -37,6 +37,8 @@ namespace Amazon.Util.Internal
         }
         public bool UseSdkCache { get; set; }
 
+        public bool InitializeCollections { get; set; }
+
         public bool CorrectForClockSkew { get; set; }
 
         public bool UseAlternateUserAgentHeader { get; set; }
@@ -59,6 +61,7 @@ namespace Amazon.Util.Internal
             ProfileName = AWSConfigs._awsProfileName;
             ProfilesLocation = AWSConfigs._awsAccountsLocation;
             UseSdkCache = AWSConfigs._useSdkCache;
+            InitializeCollections = AWSConfigs._initializeCollections;
             CorrectForClockSkew = true;
 
 #if !NETSTANDARD

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentBatchWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentBatchWrite.cs
@@ -432,6 +432,11 @@ namespace Amazon.DynamoDBv2.DocumentModel
                             tableDocumentMap.Add(key, item.Document);
                         }
                     }
+
+                    if (request.RequestItems == null)
+                    {
+                        request.RequestItems = new Dictionary<string, List<WriteRequest>>();
+                    }
                     request.RequestItems[tableName] = requestList;
                 }
             }

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpectedState.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpectedState.cs
@@ -113,6 +113,11 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 eav.ComparisonOperator = EnumMapper.Convert(comparison);
                 foreach (var val in values)
                 {
+                    if (eav.AttributeValueList == null)
+                    {
+                        eav.AttributeValueList = new List<AttributeValue>();
+                    }
+
                     var attributeConversionConfig = new DynamoDBEntry.AttributeConversionConfig(conversion, isEmptyStringValueEnabled);
                     eav.AttributeValueList.Add(val.ConvertToAttributeValue(attributeConversionConfig));
                 }

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
@@ -89,29 +89,45 @@ namespace Amazon.DynamoDBv2.DocumentModel
         internal void ApplyExpression(ScanRequest request, Table table)
         {
             request.FilterExpression = this.ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
             request.ExpressionAttributeValues = ConvertToAttributeValues(this.ExpressionAttributeValues, table);
+
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
         internal void ApplyExpression(DeleteItemRequest request, Table table)
         {
             request.ConditionExpression = this.ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
             request.ExpressionAttributeValues = ConvertToAttributeValues(this.ExpressionAttributeValues, table);
+
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
         internal void ApplyExpression(PutItemRequest request, Table table)
         {
             request.ConditionExpression = this.ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
             request.ExpressionAttributeValues = ConvertToAttributeValues(this.ExpressionAttributeValues, table);
+        
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
         internal void ApplyExpression(UpdateItemRequest request, Table table)
         {
             request.ConditionExpression = this.ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string,string>(this.ExpressionAttributeNames);
             request.ExpressionAttributeValues = ConvertToAttributeValues(this.ExpressionAttributeValues, table);
+
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
         internal void ApplyExpression(Get request, Table table)
@@ -123,29 +139,45 @@ namespace Amazon.DynamoDBv2.DocumentModel
         internal void ApplyExpression(Put request, Table table)
         {
             request.ConditionExpression = ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string,string>(ExpressionAttributeNames);
             request.ExpressionAttributeValues = ConvertToAttributeValues(ExpressionAttributeValues, table);
+
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
         internal void ApplyExpression(Update request, Table table)
         {
             request.ConditionExpression = ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string,string>(ExpressionAttributeNames);
             request.ExpressionAttributeValues = ConvertToAttributeValues(ExpressionAttributeValues, table);
+
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
         internal void ApplyExpression(Delete request, Table table)
         {
             request.ConditionExpression = ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string,string>(ExpressionAttributeNames);
             request.ExpressionAttributeValues = ConvertToAttributeValues(ExpressionAttributeValues, table);
+
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
         internal void ApplyExpression(ConditionCheck request, Table table)
         {
             request.ConditionExpression = ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string,string>(ExpressionAttributeNames);
             request.ExpressionAttributeValues = ConvertToAttributeValues(ExpressionAttributeValues, table);
+
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
 
@@ -168,12 +200,22 @@ namespace Amazon.DynamoDBv2.DocumentModel
             var kean = keyExpression.ExpressionAttributeNames;
             var fean = filterExpression.ExpressionAttributeNames;
             var combinedEan = Common.Combine(kean, fean, StringComparer.Ordinal);
-            request.ExpressionAttributeNames = combinedEan;
+
+            if(combinedEan?.Count > 0)
+            {
+                request.ExpressionAttributeNames = combinedEan;
+            }
 
             var keav = new Document(keyExpression.ExpressionAttributeValues).ForceConversion(table.Conversion);
             var feav = new Document(filterExpression.ExpressionAttributeValues).ForceConversion(table.Conversion);
             var combinedEav = Common.Combine(keav, feav, null);
-            request.ExpressionAttributeValues = ConvertToAttributeValues(combinedEav, table);
+
+            var attributeValues = ConvertToAttributeValues(combinedEav, table);
+
+            if (attributeValues?.Count > 0)
+            {
+                request.ExpressionAttributeValues = attributeValues;
+            }
         }
 
         internal static Dictionary<string, AttributeValue> ConvertToAttributeValues(

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
@@ -343,10 +343,14 @@ namespace Amazon.DynamoDBv2.DocumentModel
                             Limit = Limit,
                             TableName = TableName,
                             AttributesToGet = AttributesToGet,
-                            ScanFilter = Filter.ToConditions(SourceTable),
                             Select = EnumMapper.Convert(Select),
                             ConsistentRead = IsConsistentRead
                         };
+
+                        var scanFilter = Filter.ToConditions(SourceTable);
+                        if (scanFilter?.Count > 0)
+                            scanReq.ScanFilter = scanFilter;
+
                         if (!string.IsNullOrEmpty(this.IndexName))
                             scanReq.IndexName = this.IndexName;
                         if (this.FilterExpression != null && this.FilterExpression.IsSet)
@@ -396,8 +400,8 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
                         Dictionary<string, Condition> keyConditions, filterConditions;
                         SplitQueryFilter(Filter, SourceTable, queryReq.IndexName, out keyConditions, out filterConditions);
-                        queryReq.KeyConditions = keyConditions;
-                        queryReq.QueryFilter = filterConditions;
+                        queryReq.KeyConditions = keyConditions.Count > 0 ? keyConditions : null;
+                        queryReq.QueryFilter = filterConditions.Count > 0 ? filterConditions : null;
                         Common.ConvertAttributesToGetToProjectionExpression(queryReq);
 
                         if (queryReq.QueryFilter != null && queryReq.QueryFilter.Count > 1)

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
@@ -223,16 +223,26 @@ namespace Amazon.DynamoDBv2.DocumentModel
                             Limit = Limit,
                             TableName = TableName,
                             AttributesToGet = AttributesToGet,
-                            ScanFilter = Filter.ToConditions(SourceTable),
                             Select = EnumMapper.Convert(Select),
                             ConsistentRead = IsConsistentRead
                         };
+
                         if (!string.IsNullOrEmpty(this.IndexName))
                             scanReq.IndexName = this.IndexName;
                         if (this.FilterExpression != null && this.FilterExpression.IsSet)
                             this.FilterExpression.ApplyExpression(scanReq, SourceTable);
-                        if (scanReq.ScanFilter != null && scanReq.ScanFilter.Count > 1)
-                            scanReq.ConditionalOperator = EnumMapper.Convert(ConditionalOperator);
+
+
+                        var scanFilter = Filter.ToConditions(SourceTable);
+                        if (scanFilter != null && scanFilter.Count > 0)
+                        {
+                            scanReq.ScanFilter = scanFilter;
+
+                            if (scanFilter.Count > 1)
+                            {
+                                scanReq.ConditionalOperator = EnumMapper.Convert(ConditionalOperator);
+                            }
+                        }
                         Common.ConvertAttributesToGetToProjectionExpression(scanReq);
 
                         if (this.TotalSegments != 0)
@@ -276,8 +286,16 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
                         Dictionary<string, Condition> keyConditions, filterConditions;
                         SplitQueryFilter(Filter, SourceTable, queryReq.IndexName, out keyConditions, out filterConditions);
-                        queryReq.KeyConditions = keyConditions;
-                        queryReq.QueryFilter = filterConditions;
+                        
+                        if (keyConditions?.Count > 0)
+                        {
+                            queryReq.KeyConditions = keyConditions;
+                        }
+
+                        if (filterConditions?.Count > 0)
+                        {
+                            queryReq.QueryFilter = filterConditions;
+                        }
                         Common.ConvertAttributesToGetToProjectionExpression(queryReq);
 
                         if (queryReq.QueryFilter != null && queryReq.QueryFilter.Count > 1)

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
@@ -400,8 +400,8 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
                         Dictionary<string, Condition> keyConditions, filterConditions;
                         SplitQueryFilter(Filter, SourceTable, queryReq.IndexName, out keyConditions, out filterConditions);
-                        queryReq.KeyConditions = keyConditions.Count > 0 ? keyConditions : null;
-                        queryReq.QueryFilter = filterConditions.Count > 0 ? filterConditions : null;
+                        queryReq.KeyConditions = keyConditions?.Count > 0 ? keyConditions : null;
+                        queryReq.QueryFilter = filterConditions?.Count > 0 ? filterConditions : null;
                         Common.ConvertAttributesToGetToProjectionExpression(queryReq);
 
                         if (queryReq.QueryFilter != null && queryReq.QueryFilter.Count > 1)

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
@@ -169,22 +169,25 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 logger.InfoFormat("Description for table [{0}] loaded from SDK Cache", TableName);
             }
 
-            foreach (var key in table.KeySchema)
+            if (table.KeySchema != null)
             {
-                string keyName = key.AttributeName;
-                AttributeDefinition attributeDefinition = table.AttributeDefinitions
-                    .FirstOrDefault(a => string.Equals(a.AttributeName, keyName, StringComparison.Ordinal));
-                if (attributeDefinition == null) throw new InvalidOperationException("No attribute definition found for key " + key.AttributeName);
-                KeyDescription keyDescription = new KeyDescription
+                foreach (var key in table.KeySchema)
                 {
-                    IsHash = string.Equals(key.KeyType, "HASH", StringComparison.OrdinalIgnoreCase),
-                    Type = GetType(attributeDefinition.AttributeType)
-                };
-                if (keyDescription.IsHash)
-                    HashKeys.Add(keyName);
-                else
-                    RangeKeys.Add(keyName);
-                Keys[keyName] = keyDescription;
+                    string keyName = key.AttributeName;
+                    AttributeDefinition attributeDefinition = table.AttributeDefinitions
+                        .FirstOrDefault(a => string.Equals(a.AttributeName, keyName, StringComparison.Ordinal));
+                    if (attributeDefinition == null) throw new InvalidOperationException("No attribute definition found for key " + key.AttributeName);
+                    KeyDescription keyDescription = new KeyDescription
+                    {
+                        IsHash = string.Equals(key.KeyType, "HASH", StringComparison.OrdinalIgnoreCase),
+                        Type = GetType(attributeDefinition.AttributeType)
+                    };
+                    if (keyDescription.IsHash)
+                        HashKeys.Add(keyName);
+                    else
+                        RangeKeys.Add(keyName);
+                    Keys[keyName] = keyDescription;
+                }
             }
 
             if (table.LocalSecondaryIndexes != null)
@@ -205,9 +208,12 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 }
             }
 
-            foreach (var attribute in table.AttributeDefinitions)
+            if (table.AttributeDefinitions != null)
             {
-                Attributes.Add(attribute);
+                foreach (var attribute in table.AttributeDefinitions)
+                {
+                    Attributes.Add(attribute);
+                }
             }
         }
 
@@ -577,6 +583,11 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 {
                     IndexName = gsiIndexName
                 };
+
+                if (indexDescription.KeySchema == null)
+                {
+                    indexDescription.KeySchema = new List<KeySchemaElement>();
+                }
 
                 var hashKeyProperty = itemStorageConfig.GetPropertyStorage(gsi.HashKeyPropertyName);
                 indexDescription.KeySchema.Add(new KeySchemaElement()

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Util.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Util.cs
@@ -391,6 +391,11 @@ namespace Amazon.DynamoDBv2.DocumentModel
             if (request.IsSetAttributesToGet() &&
                 (request.IsSetExpressionAttributeNames() || request.IsSetExpressionAttributeValues() || request.IsSetFilterExpression()))
             {
+                if (request.ExpressionAttributeNames == null)
+                {
+                    request.ExpressionAttributeNames = new Dictionary<string, string>();
+                }
+
                 var attributesToGet = request.AttributesToGet;
                 var attributeNames = request.ExpressionAttributeNames;
 
@@ -403,6 +408,11 @@ namespace Amazon.DynamoDBv2.DocumentModel
             if (request.IsSetAttributesToGet() &&
                 (request.IsSetExpressionAttributeNames() || request.IsSetExpressionAttributeValues() || request.IsSetFilterExpression()))
             {
+                if (request.ExpressionAttributeNames == null)
+                {
+                    request.ExpressionAttributeNames = new Dictionary<string, string>();
+                }
+
                 var attributesToGet = request.AttributesToGet;
                 var attributeNames = request.ExpressionAttributeNames;
 
@@ -413,7 +423,10 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         private static string AttributesToGetAsProjectionExpression(List<string> attributesToGet, Dictionary<string, string> attributeNames)
         {
-            int attributeCount = attributeNames.Count;
+            if (attributesToGet == null || attributesToGet.Count == 0)
+                return null;
+
+            int attributeCount = attributeNames != null ? attributeNames.Count : 0;
             var referencesToGet = new List<string>();
             foreach (var attribute in attributesToGet)
             {

--- a/sdk/src/Services/EC2/Custom/Internal/AmazonEC2PreMarshallHandler.cs
+++ b/sdk/src/Services/EC2/Custom/Internal/AmazonEC2PreMarshallHandler.cs
@@ -234,6 +234,9 @@ namespace Amazon.EC2.Internal
         /// <param name="IpPermissions"></param>
         private static void SelectModifiedIpRange(List<IpPermission> IpPermissions)
         {
+            if (IpPermissions == null)
+                return;
+
             foreach (var ipPermission in IpPermissions)
             {
                 switch (ipPermission.CanModify())
@@ -241,7 +244,9 @@ namespace Amazon.EC2.Internal
                     case IpRangeValue.Invalid:
                         throw new ArgumentException("Cannot set values for both Ipv4Ranges and IpRanges properties on the IpPermission type which is part of the request. Consider using only Ipv4Ranges as IpRanges has been marked obsolete.");
                     case IpRangeValue.IpRanges:
+#pragma warning disable CS0618
                         ipPermission.SelectIpRangeForMarshalling(ipPermission.IpRanges);
+#pragma warning restore CS0618
                         break;
                     case IpRangeValue.Ipv4Ranges:
                         ipPermission.SelectIpV4RangeForMarshalling(ipPermission.Ipv4Ranges);

--- a/sdk/src/Services/EC2/Custom/Model/IpPermission.cs
+++ b/sdk/src/Services/EC2/Custom/Model/IpPermission.cs
@@ -74,7 +74,15 @@ namespace Amazon.EC2.Model
         /// <returns></returns>
         internal IpRangeValue CanModify()
         {
-            List<string> ipv4Ranges = this._ipv4Ranges.Select(p => p.CidrIp).ToList();
+#pragma warning disable CS0618
+            if (this._ipv4Ranges != null && this.IpRanges == null)
+                return IpRangeValue.Ipv4Ranges;
+            else if (this.IpRanges != null && this._ipv4Ranges == null)
+                return IpRangeValue.IpRanges;
+            else if (this._ipv4Ranges == null && this.IpRanges == null)
+                return IpRangeValue.Ipv4Ranges; // This is the no IP case so defaulting to the non obsolete property.
+
+            List<string> ipv4Ranges = this._ipv4Ranges?.Select(p => p.CidrIp).ToList() ?? new List<string>();
             var equallyModified = !(ipv4Ranges.Except(this.IpRanges).ToList().Any() || this.IpRanges.Except(ipv4Ranges).ToList().Any());
 
             if (equallyModified)
@@ -91,6 +99,7 @@ namespace Amazon.EC2.Model
                 return IpRangeValue.IpRanges;
             else
                 return IpRangeValue.Ipv4Ranges;
+#pragma warning restore CS0618
         }
 
         /// <summary>

--- a/sdk/src/Services/EC2/Custom/Model/IpPermission.cs
+++ b/sdk/src/Services/EC2/Custom/Model/IpPermission.cs
@@ -69,7 +69,8 @@ namespace Amazon.EC2.Model
         /// This method decides which of IpRanges/Ipv4Ranges property values will be used to make the request.
         /// If both IpRanges and Ipv4Ranges are set with the same Cidr values, Ipv4Range property is selected. 
         /// If no modifications have been made on either of IpRanges Ipv4ranges properties, Ipv4Ranges property is selected.
-        /// If both IpRanges and Ipv4Ranges are set differently, an ArgumentException is thrown.
+        /// If both IpRanges and Ipv4Ranges are set with different CIDRs the method returns IpRangeValue.Invalid. The AmazonEC2PreMarshallHandler 
+        /// is main caller of this method which throws an ArgumentException exception if IpRangeValue.Invalid is returned.
         /// </summary>
         /// <returns></returns>
         internal IpRangeValue CanModify()

--- a/sdk/src/Services/S3/Custom/Internal/AmazonS3ResponseHandler.cs
+++ b/sdk/src/Services/S3/Custom/Internal/AmazonS3ResponseHandler.cs
@@ -149,9 +149,9 @@ namespace Amazon.S3.Internal
             {
                 if (listObjectsResponse.IsTruncated &&
                     string.IsNullOrEmpty(listObjectsResponse.NextMarker) &&
-                    listObjectsResponse.S3Objects.Count > 0)
+                    listObjectsResponse.S3Objects?.Count > 0)
                 {
-                    listObjectsResponse.NextMarker = listObjectsResponse.S3Objects.Last().Key;
+                    listObjectsResponse.NextMarker = listObjectsResponse.S3Objects?.Last().Key;
                 }
             }
 

--- a/sdk/src/Services/S3/Custom/Model/CORSConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/CORSConfiguration.cs
@@ -26,7 +26,7 @@ namespace Amazon.S3.Model
     public class CORSConfiguration
     {
         
-        private List<CORSRule> rules = new List<CORSRule>();
+        private List<CORSRule> rules = AWSConfigs.InitializeCollections ? new List<CORSRule>() : null;
 
         /// <summary>
         /// The collection of rules in this configuration.
@@ -40,7 +40,7 @@ namespace Amazon.S3.Model
         // Check to see if Rules property is set
         internal bool IsSetRules()
         {
-            return this.rules.Count > 0;
+            return this.rules != null && (this.rules.Count > 0 || !AWSConfigs.InitializeCollections);
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/CORSRule.cs
+++ b/sdk/src/Services/S3/Custom/Model/CORSRule.cs
@@ -25,10 +25,10 @@ namespace Amazon.S3.Model
     public class CORSRule
     {
         private string id;
-        private List<string> allowedMethods = new List<string>();
-        private List<string> allowedOrigins = new List<string>();
-        private List<string> exposeHeaders = new List<string>();
-        private List<string> allowedHeaders = new List<string>();
+        private List<string> allowedMethods = AWSConfigs.InitializeCollections ? new List<string>() : null;
+        private List<string> allowedOrigins = AWSConfigs.InitializeCollections ? new List<string>() : null;
+        private List<string> exposeHeaders = AWSConfigs.InitializeCollections ? new List<string>() : null;
+        private List<string> allowedHeaders = AWSConfigs.InitializeCollections ? new List<string>() : null;
         private int? maxAgeSeconds;
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Amazon.S3.Model
         // Check to see if AllowedMethods property is set
         internal bool IsSetAllowedMethods()
         {
-            return this.allowedMethods.Count > 0;
+            return this.allowedMethods != null && (this.allowedMethods.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Amazon.S3.Model
         // Check to see if AllowedOrigins property is set
         internal bool IsSetAllowedOrigins()
         {
-            return this.allowedOrigins.Count > 0;
+            return this.allowedOrigins != null && (this.allowedOrigins.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace Amazon.S3.Model
         // Check to see if ExposeHeaders property is set
         internal bool IsSetExposeHeaders()
         {
-            return this.exposeHeaders.Count > 0;
+            return this.exposeHeaders != null && (this.exposeHeaders.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Amazon.S3.Model
         /// <returns>true if AllowedHeaders property is set.</returns>
         internal bool IsSetAllowedHeaders()
         {
-            return (this.AllowedHeaders.Count > 0);
+            return this.allowedHeaders != null && (this.allowedHeaders.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
 

--- a/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
@@ -200,7 +200,7 @@ namespace Amazon.S3.Model
         private string _checksumSHA1;
         private string _checksumSHA256;
         private string key;
-        private List<PartETag> partETags = new List<PartETag>();
+        private List<PartETag> partETags = AWSConfigs.InitializeCollections ? new List<PartETag>() : null;
         private string uploadId;
         private RequestPayer requestPayer;
         private string _sseCustomerAlgorithm;
@@ -403,15 +403,7 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<PartETag> PartETags
         {
-            get
-            {
-                if (this.partETags == null)
-                {
-                    this.partETags = new List<PartETag>();
-                }
-
-                return this.partETags;
-            }
+            get { return this.partETags; }
             set { this.partETags = value; }
         }
 
@@ -421,9 +413,12 @@ namespace Amazon.S3.Model
         /// <param name="partETags">PartETags that will added to this request.</param>
         public void AddPartETags(params PartETag[] partETags)
         {
-            foreach (PartETag part in partETags)
+            if (partETags != null)
             {
-                this.PartETags.Add(part);
+                foreach (PartETag part in partETags)
+                {
+                    this.PartETags.Add(part);
+                }
             }
         }
 
@@ -433,6 +428,10 @@ namespace Amazon.S3.Model
         /// <param name="partETags">PartETags that will added to this request.</param>
         public void AddPartETags(IEnumerable<PartETag> partETags)
         {
+            if (partETags == null)
+            {
+                partETags = new List<PartETag>();
+            }
             foreach (PartETag part in partETags)
             {
                 this.PartETags.Add(part);
@@ -445,6 +444,11 @@ namespace Amazon.S3.Model
         /// <param name="responses">The list of response objects return from UploadParts.</param>
         public void AddPartETags(params UploadPartResponse[] responses)
         {
+            if (PartETags == null)
+            {
+                PartETags = new List<PartETag>();
+            }
+
             foreach (UploadPartResponse response in responses)
             {
                 this.PartETags.Add(new PartETag(response));
@@ -457,6 +461,11 @@ namespace Amazon.S3.Model
         /// <param name="responses">The list of response objects return from UploadParts.</param>
         public void AddPartETags(IEnumerable<UploadPartResponse> responses)
         {
+            if (PartETags == null)
+            {
+                PartETags = new List<PartETag>();
+            }
+
             foreach (UploadPartResponse response in responses)
             {
                 this.PartETags.Add(new PartETag(response));
@@ -469,6 +478,11 @@ namespace Amazon.S3.Model
         /// <param name="responses">The list of response objects return from CopyParts.</param>
         public void AddPartETags(params CopyPartResponse[] responses)
         {
+            if (PartETags == null)
+            {
+                PartETags = new List<PartETag>();
+            }
+
             foreach (CopyPartResponse response in responses)
             {
                 this.PartETags.Add(new PartETag(response));
@@ -481,6 +495,11 @@ namespace Amazon.S3.Model
         /// <param name="responses">The list of response objects return from CopyParts.</param>
         public void AddPartETags(IEnumerable<CopyPartResponse> responses)
         {
+            if (PartETags == null)
+            {
+                PartETags = new List<PartETag>();
+            }
+
             foreach (CopyPartResponse response in responses)
             {
                 this.PartETags.Add(new PartETag(response));

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
@@ -222,7 +222,7 @@ namespace Amazon.S3.Model
         private DateTime? modifiedSinceDateUtc;
         private DateTime? unmodifiedSinceDateUtc;
 
-        private List<Tag> tagset = new List<Tag>();
+        private List<Tag> tagset = AWSConfigs.InitializeCollections ? new List<Tag>() : null;
 
         private S3MetadataDirective metadataDirective;
         private S3StorageClass storageClass;
@@ -942,7 +942,7 @@ namespace Amazon.S3.Model
         /// <returns>true if Tagging is set.</returns>
         internal bool IsSetTagSet()
         {
-            return (this.tagset != null) && (this.tagset.Count > 0);
+            return (this.tagset != null) && (this.tagset.Count > 0 || !AWSConfigs.InitializeCollections);
         }
         
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
@@ -223,8 +223,8 @@ namespace Amazon.S3.Model
         private string dstBucket;
         private string dstKey;
         private string uploadId;
-        private List<string> etagsToMatch;
-        private List<string> etagsToNotMatch;
+        private List<string> etagsToMatch = AWSConfigs.InitializeCollections ? new List<string>() : null;
+        private List<string> etagsToNotMatch = AWSConfigs.InitializeCollections ? new List<string>() : null;
         private DateTime? modifiedSinceDate;
         private DateTime? unmodifiedSinceDate;
         private int? partNumber;
@@ -444,14 +444,7 @@ namespace Amazon.S3.Model
         /// </remarks>
         public List<string> ETagToMatch
         {
-            get
-            {
-                if (this.etagsToMatch == null)
-                {
-                    this.etagsToMatch = new List<String>();
-                }
-                return this.etagsToMatch;
-            }
+            get{ return this.etagsToMatch;}
             set { this.etagsToMatch = value; }
         }
 
@@ -477,14 +470,7 @@ namespace Amazon.S3.Model
         /// </remarks>
         public List<string> ETagsToNotMatch
         {
-            get
-            {
-                if (this.etagsToNotMatch == null)
-                {
-                    this.etagsToNotMatch = new List<String>();
-                }
-                return this.etagsToNotMatch;
-            }
+            get { return this.etagsToNotMatch; }
             set { this.etagsToNotMatch = value; }
         }
 

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectsRequest.cs
@@ -158,7 +158,7 @@ namespace Amazon.S3.Model
         private string bucketName;
         private bool? bypassGovernanceRetention;
         private ChecksumAlgorithm _checksumAlgorithm;
-        private List<KeyVersion> objects = new List<KeyVersion>();
+        private List<KeyVersion> objects = AWSConfigs.InitializeCollections ? new List<KeyVersion>() : null;
         private bool? quiet;
         private MfaCodes mfaCodes;
         private RequestPayer requestPayer;
@@ -328,20 +328,14 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<KeyVersion> Objects
         {
-            get
-            {
-                if (this.objects == null)
-                    this.objects = new List<KeyVersion>();
-
-                return this.objects;
-            }
+            get { return this.objects; }
             set { this.objects = value; }
         }
 
         // Check to see if Objects property is set
         internal bool IsSetObjects()
         {
-            return this.objects.Count > 0;
+            return this.objects != null && (this.objects.Count > 0 || !AWSConfigs.InitializeCollections);
         }
         /// <summary>
         /// Gets and sets the property MFA. 

--- a/sdk/src/Services/S3/Custom/Model/DeleteObjectsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteObjectsResponse.cs
@@ -31,8 +31,8 @@ namespace Amazon.S3.Model
 #endif
 
     {
-        private List<DeletedObject> deleted = new List<DeletedObject>();
-        private List<DeleteError> errors = new List<DeleteError>();
+        private List<DeletedObject> deleted = AWSConfigs.InitializeCollections ? new List<DeletedObject>() : null;
+        private List<DeleteError> errors = AWSConfigs.InitializeCollections ? new List<DeleteError>() : null;
         private RequestCharged requestCharged;
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Amazon.S3.Model
         // Check to see if Deleted property is set
         internal bool IsSetDeletedObjects()
         {
-            return this.deleted.Count > 0;
+            return this.deleted != null && (this.deleted.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Amazon.S3.Model
         // Check to see if DeleteErrors property is set
         internal bool IsSetDeleteErrors()
         {
-            return this.errors.Count > 0;
+            return this.errors != null && (this.errors.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/GetBucketNotificationResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetBucketNotificationResponse.cs
@@ -26,48 +26,30 @@ namespace Amazon.S3.Model
     /// </summary>
     public class GetBucketNotificationResponse : AmazonWebServiceResponse
     {
-        List<TopicConfiguration> _topicConfigurations;
+        List<TopicConfiguration> _topicConfigurations = AWSConfigs.InitializeCollections ? new List<TopicConfiguration>() : null;
         /// <summary>
         /// Gets and sets the TopicConfigurations property. TopicConfigurations are configuration 
         /// for Amazon S3 events to be sent to Amazon SNS topics.
         /// </summary>
         public List<TopicConfiguration> TopicConfigurations 
         {
-            get
-            {
-                if (this._topicConfigurations == null)
-                    this._topicConfigurations = new List<TopicConfiguration>();
-
-                return this._topicConfigurations;
-            }
-            set
-            {
-                this._topicConfigurations = value;
-            }
+            get { return _topicConfigurations; }
+            set {  _topicConfigurations = value; }
         }
 
-        List<QueueConfiguration> _queueConfigurations;
+        List<QueueConfiguration> _queueConfigurations = AWSConfigs.InitializeCollections ? new List<QueueConfiguration>() : null;
         /// <summary>
         /// Gets and sets the QueueConfigurations property. QueueConfigurations are configuration 
         /// for Amazon S3 events to be sent to Amazon SQS queues.
         /// </summary>
         public List<QueueConfiguration> QueueConfigurations
         {
-            get
-            {
-                if (this._queueConfigurations == null)
-                    this._queueConfigurations = new List<QueueConfiguration>();
-
-                return this._queueConfigurations;
-            }
-            set
-            {
-                this._queueConfigurations = value;
-            }
+            get { return _queueConfigurations; }
+            set { _queueConfigurations = value; }
         }
 
 
-        List<LambdaFunctionConfiguration> _lambdaFunctionConfigurations;
+        List<LambdaFunctionConfiguration> _lambdaFunctionConfigurations = AWSConfigs.InitializeCollections ? new List<LambdaFunctionConfiguration>() : null;
         /// <summary>
         /// Gets and sets the property LambdaFunctionConfigurations. 
         /// <para>
@@ -76,17 +58,8 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<LambdaFunctionConfiguration> LambdaFunctionConfigurations
         {
-            get
-            {
-                if (this._lambdaFunctionConfigurations == null)
-                    this._lambdaFunctionConfigurations = new List<LambdaFunctionConfiguration>();
-
-                return this._lambdaFunctionConfigurations;
-            }
-            set
-            {
-                this._lambdaFunctionConfigurations = value;
-            }
+            get { return _lambdaFunctionConfigurations; }
+            set { _lambdaFunctionConfigurations = value; }
         }
 
         private EventBridgeConfiguration _eventBridgeConfiguration;

--- a/sdk/src/Services/S3/Custom/Model/GetBucketTaggingResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetBucketTaggingResponse.cs
@@ -26,7 +26,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public class GetBucketTaggingResponse : AmazonWebServiceResponse
     {
-        private List<Tag> tagSet = new List<Tag>();
+        private List<Tag> tagSet = AWSConfigs.InitializeCollections ? new List<Tag>() : null;
 
         /// <summary>
         /// The collection of tags.
@@ -40,7 +40,7 @@ namespace Amazon.S3.Model
         // Check to see if TagSet property is set
         internal bool IsSetTagSet()
         {
-            return this.tagSet.Count > 0;
+            return this.tagSet != null && (this.tagSet.Count > 0 || !AWSConfigs.InitializeCollections);
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/GetObjectAttributesPart.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectAttributesPart.cs
@@ -34,7 +34,7 @@ namespace Amazon.S3.Model
         private int? _maxParts;
         private int? _nextPartNumberMarker;
         private int? _partNumberMarker;
-        private List<ObjectPart> _parts = new List<ObjectPart>();
+        private List<ObjectPart> _parts = AWSConfigs.InitializeCollections ? new List<ObjectPart>() : null;
         private int? _totalPartsCount;
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Amazon.S3.Model
         // Check to see if Parts property is set
         internal bool IsSetParts()
         {
-            return this._parts != null && this._parts.Count > 0;
+            return this._parts != null && (this._parts.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/GetObjectAttributesRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectAttributesRequest.cs
@@ -228,7 +228,7 @@ namespace Amazon.S3.Model
         private string _expectedBucketOwner;
         private string _key;
         private int? _maxParts;
-        private List<ObjectAttributes> _objectAttributes = new List<ObjectAttributes>();
+        private List<ObjectAttributes> _objectAttributes = AWSConfigs.InitializeCollections ? new List<ObjectAttributes>() : null;
         private int? _partNumberMarker;
         private RequestPayer _requestPayer;
         private string _sseCustomerAlgorithm;
@@ -362,7 +362,7 @@ namespace Amazon.S3.Model
         // Check to see if ObjectAttributes property is set
         internal bool IsSetObjectAttributes()
         {
-            return this._objectAttributes != null && this._objectAttributes.Count > 0;
+            return this._objectAttributes != null && (this._objectAttributes.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/GetObjectTaggingResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectTaggingResponse.cs
@@ -24,7 +24,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public partial class GetObjectTaggingResponse : AmazonWebServiceResponse
     {
-        private List<Tag> tagging = new List<Tag>();
+        private List<Tag> tagging = AWSConfigs.InitializeCollections ? new List<Tag>() : null;
 
         /// <summary>
         /// Gets or sets tag-set for a given object

--- a/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/InitiateMultipartUploadRequest.cs
@@ -265,7 +265,7 @@ namespace Amazon.S3.Model
         private string serverSideEncryptionKeyManagementServiceKeyId;
         private string serverSideEncryptionKeyManagementServiceEncryptionContext;
         private S3StorageClass storageClass;
-        private List<Tag> tagset = new List<Tag>();
+        private List<Tag> tagset = AWSConfigs.InitializeCollections ? new List<Tag>() : null;
         private string websiteRedirectLocation;
         private ChecksumAlgorithm _checksumAlgorithm;
 
@@ -763,7 +763,7 @@ namespace Amazon.S3.Model
         /// <returns>true if Tagging is set.</returns>
         internal bool IsSetTagSet()
         {
-            return (this.tagset != null) && (this.tagset.Count > 0);
+            return this.tagset != null && (this.tagset.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/IntelligentTieringConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/IntelligentTieringConfiguration.cs
@@ -27,7 +27,7 @@ namespace Amazon.S3.Model
 		private string intelligentTieringId;
 		private IntelligentTieringFilter intelligentTieringFilter;
 		private IntelligentTieringStatus status;
-		private List<Tiering> tierings = new List<Tiering>();
+		private List<Tiering> tierings = AWSConfigs.InitializeCollections ? new List<Tiering>() : null;
 
 		/// <summary>
 		/// <para>The ID used to identify the S3 Intelligent-Tiering configuration.</para>
@@ -87,7 +87,7 @@ namespace Amazon.S3.Model
 		// Check if the tieringList property is set
 		internal bool IsSetTieringList()
 		{
-			return this.tierings.Count > 0;
-		}
+            return this.tierings != null && (this.tierings.Count > 0 || !AWSConfigs.InitializeCollections);
+        }
 	}
 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CORSRuleUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CORSRuleUnmarshaller.cs
@@ -39,26 +39,42 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("AllowedMethod", targetDepth))
                     {
+                        if (cORSRule.AllowedMethods == null)
+                        {
+                            cORSRule.AllowedMethods = new List<string>();
+                        }
+
                         cORSRule.AllowedMethods.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
-                            
                         continue;
                     }
                     if (context.TestExpression("AllowedOrigin", targetDepth))
                     {
+                        if (cORSRule.AllowedOrigins == null)
+                        {
+                            cORSRule.AllowedOrigins = new List<string>();
+                        }
+
                         cORSRule.AllowedOrigins.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
-                            
                         continue;
                     }
                     if (context.TestExpression("ExposeHeader", targetDepth))
                     {
+                        if (cORSRule.ExposeHeaders == null)
+                        {
+                            cORSRule.ExposeHeaders = new List<string>();
+                        }
+
                         cORSRule.ExposeHeaders.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
-                            
                         continue;
                     }
                     if (context.TestExpression("AllowedHeader", targetDepth))
                     {
-                        cORSRule.AllowedHeaders.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
+                        if (cORSRule.AllowedHeaders == null)
+                        {
+                            cORSRule.AllowedHeaders = new List<string>();
+                        }
 
+                        cORSRule.AllowedHeaders.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
                         continue;
                     }
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CloudFunctionConfigurationUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CloudFunctionConfigurationUnmarshaller.cs
@@ -44,6 +44,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Event", targetDepth))
                     {
+                        if (cloudFunctionConfiguration.Events == null)
+                        {
+                            cloudFunctionConfiguration.Events = new List<EventType>();
+                        }
+
                         cloudFunctionConfiguration.Events.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
 
                         continue;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CompleteMultipartUploadRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CompleteMultipartUploadRequestMarshaller.cs
@@ -86,48 +86,52 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             {
                 xmlWriter.WriteStartElement("CompleteMultipartUpload", S3Constants.S3RequestXmlNamespace);
                 var multipartUploadMultipartUploadpartsList = completeMultipartUploadRequest.PartETags;
-                multipartUploadMultipartUploadpartsList.Sort();
-
-                if (multipartUploadMultipartUploadpartsList != null && multipartUploadMultipartUploadpartsList.Count > 0)
+                if (multipartUploadMultipartUploadpartsList != null)
                 {
-                    foreach (var multipartUploadMultipartUploadpartsListValue in multipartUploadMultipartUploadpartsList)
+                    multipartUploadMultipartUploadpartsList.Sort();
+
+                    if (multipartUploadMultipartUploadpartsList != null && multipartUploadMultipartUploadpartsList.Count > 0)
                     {
-                        xmlWriter.WriteStartElement("Part");
-                        if (multipartUploadMultipartUploadpartsListValue.IsSetETag())
+                        foreach (var multipartUploadMultipartUploadpartsListValue in multipartUploadMultipartUploadpartsList)
                         {
-                            xmlWriter.WriteElementString("ETag", 
-                                                         S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ETag));
-                        }
-                        if (multipartUploadMultipartUploadpartsListValue.IsSetPartNumber())
-                        {
-                            xmlWriter.WriteElementString("PartNumber", 
-                                                         S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.PartNumber));
-                        }
-                        if (multipartUploadMultipartUploadpartsListValue.IsSetChecksumCRC32())
-                        {
-                            xmlWriter.WriteElementString("ChecksumCRC32", 
-                                S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ChecksumCRC32));
-                        }
-                        if (multipartUploadMultipartUploadpartsListValue.IsSetChecksumCRC32C())
-                        {
-                            xmlWriter.WriteElementString("ChecksumCRC32C", 
-                                S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ChecksumCRC32C));
-                        }
+                            xmlWriter.WriteStartElement("Part");
+                            if (multipartUploadMultipartUploadpartsListValue.IsSetETag())
+                            {
+                                xmlWriter.WriteElementString("ETag",
+                                                             S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ETag));
+                            }
+                            if (multipartUploadMultipartUploadpartsListValue.IsSetPartNumber())
+                            {
+                                xmlWriter.WriteElementString("PartNumber",
+                                                             S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.PartNumber));
+                            }
+                            if (multipartUploadMultipartUploadpartsListValue.IsSetChecksumCRC32())
+                            {
+                                xmlWriter.WriteElementString("ChecksumCRC32",
+                                    S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ChecksumCRC32));
+                            }
+                            if (multipartUploadMultipartUploadpartsListValue.IsSetChecksumCRC32C())
+                            {
+                                xmlWriter.WriteElementString("ChecksumCRC32C",
+                                    S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ChecksumCRC32C));
+                            }
 
-                        if (multipartUploadMultipartUploadpartsListValue.IsSetChecksumSHA1())
-                        {
-                            xmlWriter.WriteElementString("ChecksumSHA1", 
-                                S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ChecksumSHA1));
-                        }
+                            if (multipartUploadMultipartUploadpartsListValue.IsSetChecksumSHA1())
+                            {
+                                xmlWriter.WriteElementString("ChecksumSHA1",
+                                    S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ChecksumSHA1));
+                            }
 
-                        if (multipartUploadMultipartUploadpartsListValue.IsSetChecksumSHA256())
-                        {
-                            xmlWriter.WriteElementString("ChecksumSHA256", 
-                                S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ChecksumSHA256));
+                            if (multipartUploadMultipartUploadpartsListValue.IsSetChecksumSHA256())
+                            {
+                                xmlWriter.WriteElementString("ChecksumSHA256",
+                                    S3Transforms.ToXmlStringValue(multipartUploadMultipartUploadpartsListValue.ChecksumSHA256));
+                            }
+                            xmlWriter.WriteEndElement();
                         }
-                        xmlWriter.WriteEndElement();
                     }
                 }
+
                 xmlWriter.WriteEndElement();
             }
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ContentsItemUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ContentsItemUnmarshaller.cs
@@ -39,6 +39,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("ChecksumAlgorithm", targetDepth))
                     {
+                        if (contentsItem.ChecksumAlgorithm == null)
+                        {
+                            contentsItem.ChecksumAlgorithm = new List<string>();
+                        }
                         contentsItem.ChecksumAlgorithm.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
                         continue;
                     }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/DeleteObjectsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/DeleteObjectsResponseUnmarshaller.cs
@@ -63,14 +63,22 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("Deleted", targetDepth))
                     {
+                        if (response.DeletedObjects == null)
+                        {
+                            response.DeletedObjects = new List<DeletedObject>();
+                        }
+
                         response.DeletedObjects.Add(DeletedObjectUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                     if (context.TestExpression("Error", targetDepth))
                     {
+                        if (response.DeleteErrors == null)
+                        {
+                            response.DeleteErrors = new List<DeleteError>();
+                        }
+
                         response.DeleteErrors.Add(ErrorsItemUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetACLResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetACLResponseUnmarshaller.cs
@@ -68,9 +68,15 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     if (context.TestExpression("Grant", targetDepth + 1))
                     {
                         if (null == response.AccessControlList)
+                        {
                             response.AccessControlList = new S3AccessControlList();
+                        }
+                        if (null == response.AccessControlList.Grants)
+                        {
+                            response.AccessControlList.Grants = new List<S3Grant>();
+                        }
+
                         response.AccessControlList.Grants.Add(GrantUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketEncryptionResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketEncryptionResponseUnmarshaller.cs
@@ -56,8 +56,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("Rule", targetDepth))
                     {
+                        if (response.ServerSideEncryptionConfiguration.ServerSideEncryptionRules == null)
+                        {
+                            response.ServerSideEncryptionConfiguration.ServerSideEncryptionRules = new List<ServerSideEncryptionRule>();
+                        }
                         response.ServerSideEncryptionConfiguration.ServerSideEncryptionRules.Add(ServerSideEncryptionRuleUnmarshaller.Instance.Unmarshall(context));
-
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketIntelligentTieringConfigurationResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketIntelligentTieringConfigurationResponseUnmarshaller.cs
@@ -80,6 +80,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
                     if (context.TestExpression("Tiering", targetDepth))
                     {
+                        if (response.IntelligentTieringConfiguration.Tierings == null)
+                        {
+                            response.IntelligentTieringConfiguration.Tierings = new List<Tiering>();
+                        }
                         response.IntelligentTieringConfiguration.Tierings.Add(TieringUnmarshaller.Instance.Unmarshall(context));
                         continue;
                     }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketInventoryConfigurationResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketInventoryConfigurationResponseUnmarshaller.cs
@@ -91,8 +91,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Field", targetDepth + 1))
                     {
+                        if (response.InventoryConfiguration.InventoryOptionalFields == null)
+                        {
+                            response.InventoryConfiguration.InventoryOptionalFields = new List<InventoryOptionalField>();
+                        }
                         response.InventoryConfiguration.InventoryOptionalFields.Add(StringUnmarshaller.Instance.Unmarshall(context));
-
                         continue;
                     }
                     if (context.TestExpression("Schedule", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketNotificationResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketNotificationResponseUnmarshaller.cs
@@ -36,8 +36,8 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             while (context.Read())
             {
                 if (context.IsStartElement)
-                {                    
-                    UnmarshallResult(context,response);                        
+                {
+                    UnmarshallResult(context,response);
                     continue;
                 }
             }
@@ -60,16 +60,28 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("TopicConfiguration", targetDepth))
                     {
+                        if (response.TopicConfigurations == null)
+                        {
+                            response.TopicConfigurations = new List<TopicConfiguration>();
+                        }
                         response.TopicConfigurations.Add(TopicConfigurationUnmarshaller.Instance.Unmarshall(context));
                         continue;
                     }
                     if (context.TestExpression("QueueConfiguration", targetDepth))
                     {
+                        if (response.QueueConfigurations == null)
+                        {
+                            response.QueueConfigurations = new List<QueueConfiguration>();
+                        }
                         response.QueueConfigurations.Add(QueueConfigurationUnmarshaller.Instance.Unmarshall(context));
                         continue;
                     }
                     if (context.TestExpression("CloudFunctionConfiguration", targetDepth))
                     {
+                        if (response.LambdaFunctionConfigurations == null)
+                        {
+                            response.LambdaFunctionConfigurations = new List<LambdaFunctionConfiguration>();
+                        }
                         response.LambdaFunctionConfigurations.Add(LambdaFunctionConfigurationUnmarshaller.Instance.Unmarshall(context));
                         continue;
                     }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketOwnershipControlsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketOwnershipControlsResponseUnmarshaller.cs
@@ -51,6 +51,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("Rule", targetDepth))
                     {
+                        if (response.OwnershipControls.Rules == null)
+                        {
+                            response.OwnershipControls.Rules = new List<OwnershipControlsRule>();
+                        }
                         response.OwnershipControls.Rules.Add(OwnershipControlsRuleUnmarshaller.Instance.Unmarshall(context));
 
                         continue;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketReplicationResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketReplicationResponseUnmarshaller.cs
@@ -63,6 +63,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
                     if (context.TestExpression("Rule", targetDepth))
                     {
+                        if (response.Configuration.Rules == null)
+                        {
+                            response.Configuration.Rules = new List<ReplicationRule>();
+                        }
                         response.Configuration.Rules.Add(ReplicationRuleUnmarshaller.Instance.Unmarshall(context));
 
                         continue;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketTaggingResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketTaggingResponseUnmarshaller.cs
@@ -59,8 +59,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("Tag", targetDepth + 1))
                     {
+                        if (response.TagSet == null)
+                        {
+                            response.TagSet = new List<Tag>();
+                        }
                         response.TagSet.Add(TagUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketWebsiteResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetBucketWebsiteResponseUnmarshaller.cs
@@ -79,8 +79,12 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("RoutingRule", targetDepth + 1))
                     {
+                        if (response.WebsiteConfiguration.RoutingRules == null)
+                        {
+                            response.WebsiteConfiguration.RoutingRules = new List<RoutingRule>();
+                        }
+
                         response.WebsiteConfiguration.RoutingRules.Add(RoutingRuleUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetCORSConfigurationResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetCORSConfigurationResponseUnmarshaller.cs
@@ -61,6 +61,8 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     {
                         if (response.Configuration == null)
                             response.Configuration = new CORSConfiguration();
+                        if (response.Configuration.Rules == null)
+                            response.Configuration.Rules = new List<CORSRule>();
 
                         response.Configuration.Rules.Add(CORSRuleUnmarshaller.Instance.Unmarshall(context));
                             

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetLifecycleConfigurationResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetLifecycleConfigurationResponseUnmarshaller.cs
@@ -59,8 +59,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("Rule", targetDepth))
                     {
+                        if (response.Configuration.Rules == null)
+                        {
+                            response.Configuration.Rules = new List<LifecycleRule>();
+                        }
                         response.Configuration.Rules.Add(RulesItemUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectAttributesPartsUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectAttributesPartsUnmarshaller.cs
@@ -78,6 +78,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Part", targetDepth))
                     {
+                        if (unmarshalledObject.Parts == null)
+                        {
+                            unmarshalledObject.Parts = new List<ObjectPart>();
+                        }
                         var unmarshaller = ObjectPartUnmarshaller.Instance;
                         unmarshalledObject.Parts.Add(unmarshaller.Unmarshall(context));
                         continue;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectTaggingResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectTaggingResponseUnmarshaller.cs
@@ -14,6 +14,7 @@
  */
 using Amazon.Runtime;
 using Amazon.Runtime.Internal.Transform;
+using System.Collections.Generic;
 
 namespace Amazon.S3.Model.Internal.MarshallTransformations
 {
@@ -51,8 +52,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("Tag", targetDepth))
                     {
+                        if (response.Tagging == null)
+                        {
+                            response.Tagging = new List<Tag>();
+                        }
                         response.Tagging.Add(TagUnmarshaller.Instance.Unmarshall(context));
-
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/HeaderACLRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/HeaderACLRequestMarshaller.cs
@@ -27,22 +27,28 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         public static void Marshall(IRequest request, PutWithACLRequest aclRequest)
         {
             var protoHeaders = new Dictionary<S3Permission, string>();
-            foreach (var grant in aclRequest.Grants)
+            if( aclRequest != null )
             {
-                string grantee = null;
-                if (grant.Grantee.CanonicalUser != null && !string.IsNullOrEmpty(grant.Grantee.CanonicalUser))
-                    grantee = string.Format(CultureInfo.InvariantCulture, "id=\"{0}\"", grant.Grantee.CanonicalUser);
-                else if (grant.Grantee.IsSetEmailAddress())
-                    grantee = string.Format(CultureInfo.InvariantCulture, "emailAddress=\"{0}\"", grant.Grantee.EmailAddress);
-                else if (grant.Grantee.IsSetURI())
-                    grantee = string.Format(CultureInfo.InvariantCulture, "uri=\"{0}\"", grant.Grantee.URI);
-                else continue;
+                if (aclRequest.Grants != null)
+                {
+                    foreach (var grant in aclRequest.Grants)
+                    {
+                        string grantee = null;
+                        if (grant.Grantee.CanonicalUser != null && !string.IsNullOrEmpty(grant.Grantee.CanonicalUser))
+                            grantee = string.Format(CultureInfo.InvariantCulture, "id=\"{0}\"", grant.Grantee.CanonicalUser);
+                        else if (grant.Grantee.IsSetEmailAddress())
+                            grantee = string.Format(CultureInfo.InvariantCulture, "emailAddress=\"{0}\"", grant.Grantee.EmailAddress);
+                        else if (grant.Grantee.IsSetURI())
+                            grantee = string.Format(CultureInfo.InvariantCulture, "uri=\"{0}\"", grant.Grantee.URI);
+                        else continue;
 
-                string glist = null;
-                if (protoHeaders.TryGetValue(grant.Permission, out glist))
-                    protoHeaders[grant.Permission] = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", glist, grantee);
-                else
-                    protoHeaders.Add(grant.Permission, grantee);
+                        string glist = null;
+                        if (protoHeaders.TryGetValue(grant.Permission, out glist))
+                            protoHeaders[grant.Permission] = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", glist, grantee);
+                        else
+                            protoHeaders.Add(grant.Permission, grantee);
+                    }
+                }
             }
 
             foreach (var permission in protoHeaders.Keys)

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/IntelligentTieringConfigurationUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/IntelligentTieringConfigurationUnmarshaller.cs
@@ -59,6 +59,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
                     if (context.TestExpression("Tiering", targetDepth))
                     {
+                        if (response.Tierings == null)
+                        {
+                            response.Tierings = new List<Tiering>();
+                        }
                         response.Tierings.Add(TieringUnmarshaller.Instance.Unmarshall(context));
                         continue;
                     }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/InventoryConfigurationUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/InventoryConfigurationUnmarshaller.cs
@@ -69,8 +69,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Field", targetDepth + 1))
                     {
+                        if (response.InventoryOptionalFields == null)
+                        {
+                            response.InventoryOptionalFields = new List<InventoryOptionalField>();
+                        }
                         response.InventoryOptionalFields.Add(InventoryOptionalField.FindValue(StringUnmarshaller.Instance.Unmarshall(context)));
-
                         continue;
                     }
                     if (context.TestExpression("Schedule", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketAnalyticsConfigurationsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketAnalyticsConfigurationsResponseUnmarshaller.cs
@@ -68,8 +68,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
                     if (context.TestExpression("AnalyticsConfiguration", targetDepth))
                     {
+                        if (response.AnalyticsConfigurationList == null)
+                        {
+                            response.AnalyticsConfigurationList = new List<AnalyticsConfiguration>();
+                        }
                         response.AnalyticsConfigurationList.Add(AnalyticsConfigurationUnmarshaller.Instance.Unmarshall(context));
-
                         continue;
                     }
                     if (context.TestExpression("IsTruncated", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketIntelligentTieringConfigurationsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketIntelligentTieringConfigurationsResponseUnmarshaller.cs
@@ -63,8 +63,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("IntelligentTieringConfiguration", targetDepth))
                     {
+                        if (response.IntelligentTieringConfigurationList == null)
+                        {
+                            response.IntelligentTieringConfigurationList = new List<IntelligentTieringConfiguration>();
+                        }
                         response.IntelligentTieringConfigurationList.Add(IntelligentTieringConfigurationUnmarshaller.Instance.Unmarshall(context));
-
                         continue;
                     }
                     if (context.TestExpression("IsTruncated", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketInventoryConfigurationsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketInventoryConfigurationsResponseUnmarshaller.cs
@@ -69,8 +69,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
                     if (context.TestExpression("InventoryConfiguration", targetDepth))
                     {
+                        if (response.InventoryConfigurationList == null)
+                        {
+                            response.InventoryConfigurationList = new List<InventoryConfiguration>();
+                        }
                         response.InventoryConfigurationList.Add(InventoryConfigurationUnmarshaller.Instance.Unmarshall(context));
-
                         continue;
                     }
                     if (context.TestExpression("IsTruncated", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketMetricsConfigurationsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketMetricsConfigurationsResponseUnmarshaller.cs
@@ -67,8 +67,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("MetricsConfiguration", targetDepth))
                     {
+                        if (response.MetricsConfigurationList == null)
+                        {
+                            response.MetricsConfigurationList = new List<MetricsConfiguration>();
+                        }
                         response.MetricsConfigurationList.Add(MetricsConfigurationUnmarshaller.Instance.Unmarshall(context));
-
                         continue;
                     }
                     if (context.TestExpression("IsTruncated", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListBucketsResponseUnmarshaller.cs
@@ -61,8 +61,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("Bucket", targetDepth + 1))
                     {
+                        if (response.Buckets == null)
+                        {
+                            response.Buckets = new List<S3Bucket>();
+                        }
                         response.Buckets.Add(BucketUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                     if (context.TestExpression("Owner", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListDirectoryBucketsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListDirectoryBucketsResponseUnmarshaller.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 
@@ -53,6 +54,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("Buckets/Bucket", targetDepth))
                     {
+                        if (response.Buckets == null)
+                        {
+                            response.Buckets = new List<S3Bucket>();
+                        }
                         var unmarshaller = BucketUnmarshaller.Instance;
                         response.Buckets.Add(unmarshaller.Unmarshall(context));
                         continue;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListMultipartUploadsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListMultipartUploadsResponseUnmarshaller.cs
@@ -105,8 +105,12 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Upload", targetDepth))
                     {
+                        if (response.MultipartUploads == null)
+                        {
+                            response.MultipartUploads = new List<MultipartUpload>();
+                        }
+
                         response.MultipartUploads.Add(MultipartUploadUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                     if (context.TestExpression("Delimiter", targetDepth))
@@ -126,7 +130,13 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                         var prefix = CommonPrefixesItemUnmarshaller.Instance.Unmarshall(context);
 
                         if (prefix != null)
+                        {
+                            if (response.CommonPrefixes == null)
+                            {
+                                response.CommonPrefixes = new List<string>();
+                            }
                             response.CommonPrefixes.Add(prefix);
+                        }
 
                         continue;
                     }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListObjectsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListObjectsResponseUnmarshaller.cs
@@ -75,12 +75,16 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Contents", targetDepth))
                     {
+                        if (response.S3Objects == null)
+                        {
+                            response.S3Objects = new List<S3Object>();
+                        }
+
                         // adding the bucket name into the S3Object instance enables
                         // a better pipelining experience in PowerShell
                         var s3Object = ContentsItemUnmarshaller.Instance.Unmarshall(context);
                         s3Object.BucketName = response.Name;
                         response.S3Objects.Add(s3Object);
-                            
                         continue;
                     }
                     if (context.TestExpression("Name", targetDepth))
@@ -112,8 +116,14 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                         var prefix = CommonPrefixesItemUnmarshaller.Instance.Unmarshall(context);
 
                         if(prefix != null)
+                        {
+                            if (response.CommonPrefixes == null)
+                            {
+                                response.CommonPrefixes = new List<string>();
+                            }
                             response.CommonPrefixes.Add(prefix);
-                            
+                        }
+
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListObjectsV2ResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListObjectsV2ResponseUnmarshaller.cs
@@ -69,12 +69,16 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Contents", targetDepth))
                     {
+                        if (response.S3Objects == null)
+                        {
+                            response.S3Objects = new List<S3Object>();
+                        }
+
                         // adding the bucket name into the S3Object instance enables
                         // a better pipelining experience in PowerShell
                         var s3Object = ContentsItemUnmarshaller.Instance.Unmarshall(context);
                         s3Object.BucketName = response.Name;
                         response.S3Objects.Add(s3Object);
-
                         continue;
                     }
                     if (context.TestExpression("Name", targetDepth))
@@ -106,8 +110,14 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                         var prefix = CommonPrefixesItemUnmarshaller.Instance.Unmarshall(context);
 
                         if(prefix != null)
+                        {
+                            if (response.CommonPrefixes == null)
+                            {
+                                response.CommonPrefixes = new List<string>();
+                            }
                             response.CommonPrefixes.Add(prefix);
-                            
+                        }
+
                         continue;
                     }
                     if (context.TestExpression("EncodingType", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListPartsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListPartsResponseUnmarshaller.cs
@@ -103,8 +103,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Part", targetDepth))
                     {
+                        if (response.Parts == null)
+                        {
+                            response.Parts = new List<PartDetail>();
+                        }
                         response.Parts.Add(PartDetailUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                     if (context.TestExpression("Initiator", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListVersionsResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ListVersionsResponseUnmarshaller.cs
@@ -99,19 +99,27 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Version", targetDepth))
                     {
+                        if (response.Versions == null)
+                        {
+                            response.Versions = new List<S3ObjectVersion>();
+                        }
+
                         var version = VersionsItemUnmarshaller.Instance.Unmarshall(context);
                         version.BucketName = response.Name;
                         response.Versions.Add(version);
-                            
                         continue;
                     }
                     if (context.TestExpression("DeleteMarker", targetDepth))
                     {
+                        if (response.Versions == null)
+                        {
+                            response.Versions = new List<S3ObjectVersion>();
+                        }
+
                         var version = VersionsItemUnmarshaller.Instance.Unmarshall(context);
                         version.BucketName = response.Name;
                         version.IsDeleteMarker = true;
                         response.Versions.Add(version);
-                            
                         continue;
                     }
                     if (context.TestExpression("Name", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/LoggingEnabledUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/LoggingEnabledUnmarshaller.cs
@@ -45,8 +45,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Grant", targetDepth + 1))
                     {
+                        if (loggingEnabled.Grants == null)
+                        {
+                            loggingEnabled.Grants = new List<S3Grant>();
+                        }
                         loggingEnabled.Grants.Add(GrantUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                     if (context.TestExpression("TargetObjectKeyFormat", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketEncryptionRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketEncryptionRequestMarshaller.cs
@@ -66,32 +66,35 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     xmlWriter.WriteStartElement("ServerSideEncryptionConfiguration", S3Constants.S3RequestXmlNamespace);
                     if (sseConfiguration != null)
                     {
-                        foreach(var serverSideEncryptionRule in sseConfiguration.ServerSideEncryptionRules)
+                        if (sseConfiguration.ServerSideEncryptionRules != null)
                         {
-                            xmlWriter.WriteStartElement("Rule");
-                            if (serverSideEncryptionRule != null)
+                            foreach (var serverSideEncryptionRule in sseConfiguration.ServerSideEncryptionRules)
                             {
-                                if (serverSideEncryptionRule.IsSetServerSideEncryptionByDefault())
+                                xmlWriter.WriteStartElement("Rule");
+                                if (serverSideEncryptionRule != null)
                                 {
-                                    xmlWriter.WriteStartElement("ApplyServerSideEncryptionByDefault");
-                                    var sseDefault = serverSideEncryptionRule.ServerSideEncryptionByDefault;
-                                    if(sseDefault.IsSetServerSideEncryptionAlgorithm())
+                                    if (serverSideEncryptionRule.IsSetServerSideEncryptionByDefault())
                                     {
-                                        xmlWriter.WriteElementString("SSEAlgorithm", S3Transforms.ToXmlStringValue(sseDefault.ServerSideEncryptionAlgorithm));
+                                        xmlWriter.WriteStartElement("ApplyServerSideEncryptionByDefault");
+                                        var sseDefault = serverSideEncryptionRule.ServerSideEncryptionByDefault;
+                                        if (sseDefault.IsSetServerSideEncryptionAlgorithm())
+                                        {
+                                            xmlWriter.WriteElementString("SSEAlgorithm", S3Transforms.ToXmlStringValue(sseDefault.ServerSideEncryptionAlgorithm));
+                                        }
+                                        if (sseDefault.IsSetServerSideEncryptionKeyManagementServiceKeyId())
+                                        {
+                                            xmlWriter.WriteElementString("KMSMasterKeyID", S3Transforms.ToXmlStringValue(sseDefault.ServerSideEncryptionKeyManagementServiceKeyId));
+                                        }
+                                        xmlWriter.WriteEndElement();
                                     }
-                                    if (sseDefault.IsSetServerSideEncryptionKeyManagementServiceKeyId())
-                                    {
-                                        xmlWriter.WriteElementString("KMSMasterKeyID", S3Transforms.ToXmlStringValue(sseDefault.ServerSideEncryptionKeyManagementServiceKeyId));
-                                    }
-                                    xmlWriter.WriteEndElement();
-                                }
 
-                                if (serverSideEncryptionRule.IsSetBucketKeyEnabled())
-                                {
-                                    xmlWriter.WriteElementString("BucketKeyEnabled", S3Transforms.ToXmlStringValue(serverSideEncryptionRule.BucketKeyEnabled));
+                                    if (serverSideEncryptionRule.IsSetBucketKeyEnabled())
+                                    {
+                                        xmlWriter.WriteElementString("BucketKeyEnabled", S3Transforms.ToXmlStringValue(serverSideEncryptionRule.BucketKeyEnabled));
+                                    }
                                 }
+                                xmlWriter.WriteEndElement();
                             }
-                            xmlWriter.WriteEndElement();
                         }
                     }
                     xmlWriter.WriteEndElement();

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutBucketRequestMarshaller.cs
@@ -140,22 +140,25 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         protected internal static void ConvertPutWithACLRequest(PutWithACLRequest request, IRequest irequest)
         {
             Dictionary<S3Permission, string> protoHeaders = new Dictionary<S3Permission, string>();
-            foreach (var grant in request.Grants)
+            if (request.Grants != null)
             {
-                string grantee = null;
-                if (grant.Grantee.CanonicalUser != null && !string.IsNullOrEmpty(grant.Grantee.CanonicalUser))
-                    grantee = string.Format(CultureInfo.InvariantCulture, "id=\"{0}\"", grant.Grantee.CanonicalUser);
-                else if (grant.Grantee.IsSetEmailAddress())
-                    grantee = string.Format(CultureInfo.InvariantCulture, "emailAddress=\"{0}\"", grant.Grantee.EmailAddress);
-                else if (grant.Grantee.IsSetURI())
-                    grantee = string.Format(CultureInfo.InvariantCulture, "uri=\"{0}\"", grant.Grantee.URI);
-                else continue;
+                foreach (var grant in request.Grants)
+                {
+                    string grantee = null;
+                    if (grant.Grantee.CanonicalUser != null && !string.IsNullOrEmpty(grant.Grantee.CanonicalUser))
+                        grantee = string.Format(CultureInfo.InvariantCulture, "id=\"{0}\"", grant.Grantee.CanonicalUser);
+                    else if (grant.Grantee.IsSetEmailAddress())
+                        grantee = string.Format(CultureInfo.InvariantCulture, "emailAddress=\"{0}\"", grant.Grantee.EmailAddress);
+                    else if (grant.Grantee.IsSetURI())
+                        grantee = string.Format(CultureInfo.InvariantCulture, "uri=\"{0}\"", grant.Grantee.URI);
+                    else continue;
 
-                string glist = null;
-                if (protoHeaders.TryGetValue(grant.Permission, out glist))
-                    protoHeaders[grant.Permission] = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", glist, grantee);
-                else
-                    protoHeaders.Add(grant.Permission, grantee);
+                    string glist = null;
+                    if (protoHeaders.TryGetValue(grant.Permission, out glist))
+                        protoHeaders[grant.Permission] = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", glist, grantee);
+                    else
+                        protoHeaders.Add(grant.Permission, grantee);
+                }
             }
 
             foreach (var permission in protoHeaders.Keys)

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/QueueConfigurationUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/QueueConfigurationUnmarshaller.cs
@@ -44,6 +44,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Event", targetDepth))
                     {
+                        if (queueConfiguration.Events == null)
+                        {
+                            queueConfiguration.Events = new List<EventType>();
+                        }
+
                         queueConfiguration.Events.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
 
                         continue;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ReplicationRuleAndOperatorUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/ReplicationRuleAndOperatorUnmarshaller.cs
@@ -42,8 +42,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Tag", targetDepth))
                     {
+                        if (ruleAndOperator.Tags == null)
+                        {
+                            ruleAndOperator.Tags = new List<Tag>();
+                        }
                         ruleAndOperator.Tags.Add(TagUnmarshaller.Instance.Unmarshall(context));
-
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/RulesItemUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/RulesItemUnmarshaller.cs
@@ -83,14 +83,20 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Transition", targetDepth))
                     {
+                        if (rulesItem.Transitions == null)
+                        {
+                            rulesItem.Transitions = new List<LifecycleTransition>();
+                        }
                         rulesItem.Transitions.Add(TransitionUnmarshaller.Instance.Unmarshall(context));
-                            
                         continue;
                     }
                     if (context.TestExpression("NoncurrentVersionTransition", targetDepth))
                     {
+                        if (rulesItem.NoncurrentVersionTransitions == null)
+                        {
+                            rulesItem.NoncurrentVersionTransitions = new List<LifecycleRuleNoncurrentVersionTransition>();
+                        }
                         rulesItem.NoncurrentVersionTransitions.Add(LifecycleRuleNoncurrentVersionTransitionUnmarshaller.Instance.Unmarshall(context));
-
                         continue;
                     }
                     if (context.TestExpression("NoncurrentVersionExpiration", targetDepth))

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/S3KeyFilterUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/S3KeyFilterUnmarshaller.cs
@@ -39,7 +39,12 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("FilterRule", targetDepth))
                     {
-                        s3KeyFilter.FilterRules.Add(FilterRuleUnmarshaller.Instance.Unmarshall(context));                            
+                        if (s3KeyFilter.FilterRules == null)
+                        {
+                            s3KeyFilter.FilterRules = new List<FilterRule>();
+                        }
+
+                        s3KeyFilter.FilterRules.Add(FilterRuleUnmarshaller.Instance.Unmarshall(context));
                         continue;
                     }
                 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/TopicConfigurationUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/TopicConfigurationUnmarshaller.cs
@@ -45,6 +45,11 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Event", targetDepth))
                     {
+                        if (topicConfiguration.Events == null)
+                        {
+                            topicConfiguration.Events = new List<EventType>();
+                        }
+
                         topicConfiguration.Events.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
                             
                         continue;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/VersionsItemUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/VersionsItemUnmarshaller.cs
@@ -39,6 +39,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 {
                     if (context.TestExpression("ChecksumAlgorithm", targetDepth))
                     {
+                        if (versionsItem.ChecksumAlgorithm == null)
+                        {
+                            versionsItem.ChecksumAlgorithm = new List<string>();
+                        }
                         versionsItem.ChecksumAlgorithm.Add(StringUnmarshaller.GetInstance().Unmarshall(context));
                         continue;
                     }

--- a/sdk/src/Services/S3/Custom/Model/InventoryConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/InventoryConfiguration.cs
@@ -33,7 +33,7 @@ namespace Amazon.S3.Model
         private string inventoryId;
         private bool isEnabled;
         private InventoryIncludedObjectVersions inventoryIncludedObjectVersions;
-        private List<InventoryOptionalField> inventoryOptionalFields = new List<InventoryOptionalField>();
+        private List<InventoryOptionalField> inventoryOptionalFields = AWSConfigs.InitializeCollections ? new List<InventoryOptionalField>() : null;
         private InventorySchedule inventorySchedule;
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Amazon.S3.Model
         // Check to see if InventoryOptionalFields property is set
         internal bool IsSetInventoryOptionalFields()
         {
-            return this.inventoryOptionalFields.Count > 0;
+            return this.inventoryOptionalFields != null && (this.inventoryOptionalFields.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/LifecycleConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/LifecycleConfiguration.cs
@@ -32,7 +32,7 @@ namespace Amazon.S3.Model
     public class LifecycleConfiguration
     {
         
-        private List<LifecycleRule> rules = new List<LifecycleRule>();
+        private List<LifecycleRule> rules = AWSConfigs.InitializeCollections ? new List<LifecycleRule>() : null;
 
         /// <summary>
         /// Gets and sets the Rules property. These rules defined the lifecycle configuration.
@@ -46,7 +46,7 @@ namespace Amazon.S3.Model
         // Check to see if Rules property is set
         internal bool IsSetRules()
         {
-            return this.rules.Count > 0;
+            return this.rules != null && (this.rules.Count > 0 || !AWSConfigs.InitializeCollections);
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/LifecycleRule.cs
+++ b/sdk/src/Services/S3/Custom/Model/LifecycleRule.cs
@@ -32,10 +32,10 @@ namespace Amazon.S3.Model
         private LifecycleRuleExpiration expiration;
         private string id;
         private LifecycleRuleNoncurrentVersionExpiration noncurrentVersionExpiration;
-        private List<LifecycleRuleNoncurrentVersionTransition> noncurrentVersionTransitions;
+        private List<LifecycleRuleNoncurrentVersionTransition> noncurrentVersionTransitions = AWSConfigs.InitializeCollections ? new List<LifecycleRuleNoncurrentVersionTransition>() : null;
         private string prefix;
         private LifecycleRuleStatus status = LifecycleRuleStatus.Disabled;
-        private List<LifecycleTransition> transitions;
+        private List<LifecycleTransition> transitions = AWSConfigs.InitializeCollections ? new List<LifecycleTransition>() : null;
 
         private LifecycleFilter filter;
 
@@ -184,17 +184,20 @@ namespace Amazon.S3.Model
             }
             set
             {
-                if (this.NoncurrentVersionTransitions.Count == 0)
-                    this.NoncurrentVersionTransitions.Add(value);
-                else
-                    this.NoncurrentVersionTransitions[0] = value;
-            }
-        }
+                if (this.NoncurrentVersionTransition == null)
+                {
+                    this.NoncurrentVersionTransition = new LifecycleRuleNoncurrentVersionTransition();
+                }
 
-        // Check to see if Transition property is set
-        internal bool IsSetNoncurrentVersionTransition()
-        {
-            return this.NoncurrentVersionTransitions != null && this.NoncurrentVersionTransitions.Count > 0 && this.NoncurrentVersionTransitions[0] != null;
+                if (this.NoncurrentVersionTransitions.Count == 0)
+                {
+                    this.NoncurrentVersionTransitions.Add(value);
+                }
+                else
+                {
+                    this.NoncurrentVersionTransitions[0] = value;
+                }
+            }
         }
 
         /// <summary>
@@ -203,20 +206,14 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<LifecycleRuleNoncurrentVersionTransition> NoncurrentVersionTransitions
         {
-            get
-            {
-                if (this.noncurrentVersionTransitions == null)
-                    this.noncurrentVersionTransitions = new List<LifecycleRuleNoncurrentVersionTransition>();
-
-                return this.noncurrentVersionTransitions;
-            }
+            get { return this.noncurrentVersionTransitions; }
             set { this.noncurrentVersionTransitions = value; }
         }
 
         // Check to see if Transitions property is set
         internal bool IsSetNoncurrentVersionTransitions()
         {
-            return this.noncurrentVersionTransitions != null && this.noncurrentVersionTransitions.Count > 0;
+            return this.noncurrentVersionTransitions != null && (this.noncurrentVersionTransitions.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>
@@ -241,21 +238,14 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<LifecycleTransition> Transitions
         {
-            get
-            {
-                if (this.transitions == null)
-                    this.transitions = new List<LifecycleTransition>();
-
-                return this.transitions;
-            }
+            get { return this.transitions; }
             set { this.transitions = value; }
         }
 
         // Check to see if Transitions property is set
         internal bool IsSetTransitions()
         {
-            return this.transitions != null && this.transitions.Count > 0;
+            return this.transitions != null && (this.transitions.Count > 0 || !AWSConfigs.InitializeCollections);
         }
-
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/LifecycleRule.cs
+++ b/sdk/src/Services/S3/Custom/Model/LifecycleRule.cs
@@ -150,6 +150,11 @@ namespace Amazon.S3.Model
             }
             set
             {
+                if (this.Transitions == null)
+                {
+                    this.Transitions = new List<LifecycleTransition>();
+                }
+
                 if (this.Transitions.Count == 0)
                     this.Transitions.Add(value);
                 else
@@ -184,9 +189,9 @@ namespace Amazon.S3.Model
             }
             set
             {
-                if (this.NoncurrentVersionTransition == null)
+                if (this.NoncurrentVersionTransitions == null)
                 {
-                    this.NoncurrentVersionTransition = new LifecycleRuleNoncurrentVersionTransition();
+                    this.NoncurrentVersionTransitions = new List<LifecycleRuleNoncurrentVersionTransition>();
                 }
 
                 if (this.NoncurrentVersionTransitions.Count == 0)

--- a/sdk/src/Services/S3/Custom/Model/ListBucketAnalyticsConfigurationsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListBucketAnalyticsConfigurationsResponse.cs
@@ -27,7 +27,7 @@ namespace Amazon.S3.Model
     public partial class ListBucketAnalyticsConfigurationsResponse : AmazonWebServiceResponse
     {
         private string token;
-        private List<AnalyticsConfiguration> analyticsConfigurationList = new List<AnalyticsConfiguration>();
+        private List<AnalyticsConfiguration> analyticsConfigurationList = AWSConfigs.InitializeCollections ? new List<AnalyticsConfiguration>() : null;
         private bool? isTruncated;
         private string nextToken;
 
@@ -58,7 +58,7 @@ namespace Amazon.S3.Model
         // Check to see if AnalyticsConfigurationList property is set
         public bool IsSetAnalyticsConfigurationList()
         {
-            return this.analyticsConfigurationList.Count > 0;
+            return this.analyticsConfigurationList != null && (this.analyticsConfigurationList.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListBucketIntelligentTieringConfigurationsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListBucketIntelligentTieringConfigurationsResponse.cs
@@ -23,8 +23,8 @@ namespace Amazon.S3.Model
 	public partial class ListBucketIntelligentTieringConfigurationsResponse : AmazonWebServiceResponse
 	{
 		private string continuationToken;
-		private List<IntelligentTieringConfiguration> intelligentTieringConfigurationList = new List<IntelligentTieringConfiguration>();
-		private bool? isTruncated;
+		private List<IntelligentTieringConfiguration> intelligentTieringConfigurationList = AWSConfigs.InitializeCollections ? new List<IntelligentTieringConfiguration>() : null;
+        private bool? isTruncated;
 		private string nextContinuationToken;
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Amazon.S3.Model
         /// </summary>
         public bool IsSetIntelligentTieringConfigurationList()
         {
-            return this.intelligentTieringConfigurationList.Count > 0;
+            return this.intelligentTieringConfigurationList != null && (this.intelligentTieringConfigurationList.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListBucketInventoryConfigurationsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListBucketInventoryConfigurationsResponse.cs
@@ -27,7 +27,7 @@ namespace Amazon.S3.Model
     public partial class ListBucketInventoryConfigurationsResponse : AmazonWebServiceResponse
     {
         private string token;
-        private List<InventoryConfiguration> inventoryConfigurationList = new List<InventoryConfiguration>();
+        private List<InventoryConfiguration> inventoryConfigurationList = AWSConfigs.InitializeCollections ? new List<InventoryConfiguration>() : null;
         private bool? isTruncated;
         private string nextToken;
 
@@ -58,7 +58,7 @@ namespace Amazon.S3.Model
         // Check to see if InventoryConfigurationList property is set
         public bool IsSetInventoryConfigurationList()
         {
-            return this.inventoryConfigurationList.Count > 0;
+            return this.inventoryConfigurationList != null && (this.inventoryConfigurationList.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListBucketMetricsConfigurationsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListBucketMetricsConfigurationsResponse.cs
@@ -27,7 +27,7 @@ namespace Amazon.S3.Model
     public partial class ListBucketMetricsConfigurationsResponse : AmazonWebServiceResponse
     {
         private string token;
-        private List<MetricsConfiguration> metricsConfigurationList = new List<MetricsConfiguration>();
+        private List<MetricsConfiguration> metricsConfigurationList = AWSConfigs.InitializeCollections ? new List<MetricsConfiguration>() : null;
         private bool? isTruncated;
         private string nextToken;
 
@@ -62,7 +62,7 @@ namespace Amazon.S3.Model
         // Check to see if MetricsConfigurationList property is set
         public bool IsSetMetricsConfigurationList()
         {
-            return this.metricsConfigurationList.Count > 0;
+            return this.metricsConfigurationList != null && (this.metricsConfigurationList.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListBucketsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListBucketsResponse.cs
@@ -26,7 +26,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public class ListBucketsResponse : AmazonWebServiceResponse
     {
-        private List<S3Bucket> buckets = new List<S3Bucket>();
+        private List<S3Bucket> buckets = AWSConfigs.InitializeCollections ? new List<S3Bucket>() : null;
         private Owner owner;
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Amazon.S3.Model
         // Check to see if Buckets property is set
         internal bool IsSetBuckets()
         {
-            return this.buckets.Count > 0;
+            return this.buckets != null && (this.buckets.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListDirectoryBucketsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListDirectoryBucketsResponse.cs
@@ -27,7 +27,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public partial class ListDirectoryBucketsResponse : AmazonWebServiceResponse
     {
-        private List<S3Bucket> _buckets = new List<S3Bucket>();
+        private List<S3Bucket> _buckets = AWSConfigs.InitializeCollections ? new List<S3Bucket>() : null;
         private string _continuationToken;
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Amazon.S3.Model
         // Check to see if Buckets property is set
         internal bool IsSetBuckets()
         {
-            return this._buckets != null && this._buckets.Count > 0;
+            return this._buckets != null && (this._buckets.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListMultipartUploadsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListMultipartUploadsResponse.cs
@@ -35,9 +35,9 @@ namespace Amazon.S3.Model
         private RequestCharged _requestCharged;
         private bool? isTruncated;
 
-        private List<MultipartUpload> multipartUploads;
+        private List<MultipartUpload> multipartUploads = AWSConfigs.InitializeCollections ? new List<MultipartUpload>() : null;
         private string delimiter;
-        private List<string> commonPrefixes;
+        private List<string> commonPrefixes = AWSConfigs.InitializeCollections ? new List<string>() : null;
         private string prefix;
 
         /// <summary>
@@ -184,13 +184,7 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<MultipartUpload> MultipartUploads
         {
-            get 
-            {
-                if (this.multipartUploads == null)
-                    this.multipartUploads = new List<MultipartUpload>();
-
-                return this.multipartUploads; 
-            }
+            get { return this.multipartUploads; }
             set { this.multipartUploads = value; }
         }
 
@@ -263,14 +257,8 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<string> CommonPrefixes
         {
-            get
-            {
-                if (this.commonPrefixes == null)
-                {
-                    this.commonPrefixes = new List<string>();
-                }
-                return this.commonPrefixes;
-            }
+            get { return this.commonPrefixes; }
+            set { this.commonPrefixes = value; }
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/ListObjectsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListObjectsRequest.cs
@@ -81,7 +81,7 @@ namespace Amazon.S3.Model
         private string expectedBucketOwner;
         private string marker;
         private int? maxKeys;
-        private List<string> _optionalObjectAttributes = new List<string>();
+        private List<string> _optionalObjectAttributes = AWSConfigs.InitializeCollections ? new List<string>() : null;
         private string prefix;
         private RequestPayer requestPayer;
 
@@ -251,7 +251,7 @@ namespace Amazon.S3.Model
         // Check to see if OptionalObjectAttributes property is set
         internal bool IsSetOptionalObjectAttributes()
         {
-            return this._optionalObjectAttributes != null && this._optionalObjectAttributes.Count > 0;
+            return this._optionalObjectAttributes != null && (this._optionalObjectAttributes.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListObjectsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListObjectsResponse.cs
@@ -28,11 +28,11 @@ namespace Amazon.S3.Model
     {
         private bool? isTruncated;
         private string nextMarker;
-        private List<S3Object> contents = new List<S3Object>();
+        private List<S3Object> contents = AWSConfigs.InitializeCollections ? new List<S3Object>() : null;
         private string name;
         private string prefix;
         private int? maxKeys;
-        private List<string> commonPrefixes = new List<string>();
+        private List<string> commonPrefixes = AWSConfigs.InitializeCollections ? new List<string>() : null;
         private string delimiter;
         private RequestCharged _requestCharged;
 
@@ -69,7 +69,7 @@ namespace Amazon.S3.Model
                 // last returned Key as the default value.
                 if (System.String.IsNullOrEmpty(nextMarker) &&
                     isTruncated.GetValueOrDefault() &&
-                    (this.S3Objects.Count > 0))
+                    (this.S3Objects?.Count > 0))
                 {
                     int lastObjIdx = this.S3Objects.Count - 1;
                     nextMarker = this.S3Objects[lastObjIdx].Key;
@@ -99,7 +99,7 @@ namespace Amazon.S3.Model
         // Check to see if Contents property is set
         internal bool IsSetContents()
         {
-            return this.contents.Count > 0;
+            return this.contents != null && (this.contents.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>
@@ -180,7 +180,7 @@ namespace Amazon.S3.Model
         // Check to see if CommonPrefixes property is set
         internal bool IsSetCommonPrefixes()
         {
-            return this.commonPrefixes.Count > 0;
+            return this.commonPrefixes != null && (this.commonPrefixes.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListObjectsV2Request.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListObjectsV2Request.cs
@@ -115,7 +115,7 @@ namespace Amazon.S3.Model
         private string expectedBucketOwner;
         private bool? fetchOwner;
         private int? maxKeys;
-        private List<string> _optionalObjectAttributes = new List<string>();
+        private List<string> _optionalObjectAttributes = AWSConfigs.InitializeCollections ? new List<string>() : null;
         private string prefix;
         private RequestPayer requestPayer;
         private string startAfter;
@@ -332,7 +332,7 @@ namespace Amazon.S3.Model
         // Check to see if OptionalObjectAttributes property is set
         internal bool IsSetOptionalObjectAttributes()
         {
-            return this._optionalObjectAttributes != null && this._optionalObjectAttributes.Count > 0;
+            return this._optionalObjectAttributes != null && (this._optionalObjectAttributes.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListObjectsV2Response.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListObjectsV2Response.cs
@@ -26,8 +26,8 @@ namespace Amazon.S3.Model
     /// </summary>
     public class ListObjectsV2Response : AmazonWebServiceResponse
     {
-        private List<string> commonPrefixes = new List<string>();
-        private List<S3Object> contents = new List<S3Object>();
+        private List<string> commonPrefixes = AWSConfigs.InitializeCollections ? new List<string>() : null;
+        private List<S3Object> contents = AWSConfigs.InitializeCollections ? new List<S3Object>() : null;
         private string continuationToken;
         private string delimiter;
         private EncodingType encoding;
@@ -92,7 +92,7 @@ namespace Amazon.S3.Model
         // Check to see if CommonPrefixes property is set
         internal bool IsSetCommonPrefixes()
         {
-            return this.commonPrefixes.Count > 0;
+            return this.commonPrefixes != null && (this.commonPrefixes.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace Amazon.S3.Model
         // Check to see if Contents property is set
         internal bool IsSetContents()
         {
-            return this.contents.Count > 0;
+            return this.contents != null && (this.contents.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListPartsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListPartsResponse.cs
@@ -37,7 +37,7 @@ namespace Amazon.S3.Model
         private int? nextPartNumberMarker;
         private int? maxParts;
         private bool? isTruncated;
-        private List<PartDetail> parts = new List<PartDetail>();
+        private List<PartDetail> parts = AWSConfigs.InitializeCollections ? new List<PartDetail>() : null;
         private DateTime? abortDate;
         private string abortRuleId;
         private RequestCharged requestCharged;
@@ -199,7 +199,7 @@ namespace Amazon.S3.Model
         // Check to see if Parts property is set
         internal bool IsSetParts()
         {
-            return this.parts.Count > 0;
+            return this.parts != null && (this.parts.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListVersionsRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListVersionsRequest.cs
@@ -83,7 +83,7 @@ namespace Amazon.S3.Model
         private string keyMarker;
         private int? maxKeys;
         private string prefix;
-        private List<string> _optionalObjectAttributes = new List<string>();
+        private List<string> _optionalObjectAttributes = AWSConfigs.InitializeCollections ? new List<string>() : null;
         private RequestPayer _requestPayer;
         private string versionIdMarker;
         private EncodingType encoding;
@@ -182,7 +182,7 @@ namespace Amazon.S3.Model
         // Check to see if OptionalObjectAttributes property is set
         internal bool IsSetOptionalObjectAttributes()
         {
-            return this._optionalObjectAttributes != null && this._optionalObjectAttributes.Count > 0;
+            return this._optionalObjectAttributes != null && (this._optionalObjectAttributes.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ListVersionsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/ListVersionsResponse.cs
@@ -32,11 +32,11 @@ namespace Amazon.S3.Model
         private string versionIdMarker;
         private string nextKeyMarker;
         private string nextVersionIdMarker;
-        private List<S3ObjectVersion> versions = new List<S3ObjectVersion>();
+        private List<S3ObjectVersion> versions = AWSConfigs.InitializeCollections ? new List<S3ObjectVersion>() : null;
         private string name;
         private string prefix;
         private int? maxKeys;
-        private List<string> commonPrefixes = new List<string>();
+        private List<string> commonPrefixes = AWSConfigs.InitializeCollections ? new List<string>() : null;
         private string delimiter;
         private RequestCharged _requestCharged;
 
@@ -144,7 +144,7 @@ namespace Amazon.S3.Model
         // Check to see if Versions property is set
         internal bool IsSetVersions()
         {
-            return this.versions.Count > 0;
+            return this.versions != null && (this.versions.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace Amazon.S3.Model
         // Check to see if CommonPrefixes property is set
         internal bool IsSetCommonPrefixes()
         {
-            return this.commonPrefixes.Count > 0;
+            return this.commonPrefixes != null && (this.commonPrefixes.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/NotificationConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/NotificationConfiguration.cs
@@ -25,26 +25,20 @@ namespace Amazon.S3.Model
     /// </summary>
     public abstract class NotificationConfiguration
     {
-        List<EventType> _events;
+        List<EventType> _events = AWSConfigs.InitializeCollections ? new List<EventType>() : null;
         /// <summary>
         /// Gets and sets the Events property. These are the events the configuration will listen to.
         /// </summary>
         public List<EventType> Events
         {
-            get
-            {
-                if (this._events == null)
-                    this._events = new List<EventType>();
-
-                return this._events;
-            }
+            get { return this._events; }
             set { this._events = value; }
         }
 
         // Check to see if Event property is set
         internal bool IsSetEvents()
         {
-            return this._events != null && this._events.Count > 0;
+            return this._events != null && (this._events.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
 

--- a/sdk/src/Services/S3/Custom/Model/OwnershipControls.cs
+++ b/sdk/src/Services/S3/Custom/Model/OwnershipControls.cs
@@ -24,7 +24,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public class OwnershipControls
     {
-        private List<OwnershipControlsRule> rules = new List<OwnershipControlsRule>();
+        private List<OwnershipControlsRule> rules = AWSConfigs.InitializeCollections ? new List<OwnershipControlsRule>() : null;
 
         /// <summary>
         /// A bucket's ownership control rules

--- a/sdk/src/Services/S3/Custom/Model/PutBucketTaggingRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutBucketTaggingRequest.cs
@@ -105,7 +105,7 @@ namespace Amazon.S3.Model
     {
         private string bucketName;
         private ChecksumAlgorithm _checksumAlgorithm;
-        private List<Tag> tagSet = new List<Tag>();
+        private List<Tag> tagSet = AWSConfigs.InitializeCollections ? new List<Tag>() : null;
         private string expectedBucketOwner;
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace Amazon.S3.Model
         // Check to see if TagSet property is set
         internal bool IsSetTagSet()
         {
-            return this.tagSet.Count > 0;
+            return this.tagSet != null && (this.tagSet.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutObjectRequest.cs
@@ -176,7 +176,7 @@ namespace Amazon.S3.Model
         private string serverSideEncryptionKeyManagementServiceKeyId;
         private string serverSideEncryptionKeyManagementServiceEncryptionContext;
         private S3StorageClass storageClass;
-        private List<Tag> tagset = new List<Tag>();
+        private List<Tag> tagset = AWSConfigs.InitializeCollections ? new List<Tag>() : null;
         private string websiteRedirectLocation;
         private bool calculateContentMD5Header = false;
         private ChecksumAlgorithm _checksumAlgorithm;
@@ -764,7 +764,7 @@ namespace Amazon.S3.Model
         /// <returns>true if Tagging is set.</returns>
         internal bool IsSetTagSet()
         {
-            return (this.tagset != null) && (this.tagset.Count > 0);
+            return this.tagset != null && (this.tagset.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/PutWithACLRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutWithACLRequest.cs
@@ -28,7 +28,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public abstract class PutWithACLRequest : AmazonWebServiceRequest
     {
-        private List<S3Grant> _grants;
+        private List<S3Grant> _grants = AWSConfigs.InitializeCollections ? new List<S3Grant>() : null;
 
         /// <summary>
         /// Gets the access control lists (ACLs) for this request. 
@@ -37,20 +37,8 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<S3Grant> Grants
         {
-            get
-            {
-                if (null == _grants)
-                {
-                    _grants = new List<S3Grant>();
-                }
-                return _grants;
-            }
-            set
-            {
-                _grants = value;
-            }
+            get { return _grants; }
+            set { _grants = value; }
         }
-
-
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/ReplicationConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/ReplicationConfiguration.cs
@@ -25,7 +25,7 @@ namespace Amazon.S3.Model
     public class ReplicationConfiguration
     {
         private string role;
-        private List<ReplicationRule> rules = new List<ReplicationRule>();
+        private List<ReplicationRule> rules = AWSConfigs.InitializeCollections ? new List<ReplicationRule>() : null;
 
         /// <summary>
         /// Gets and sets the property Role. 
@@ -66,9 +66,7 @@ namespace Amazon.S3.Model
         /// <returns>true if the Rules property is set.</returns>
         internal bool IsSetRules()
         {
-            return this.rules.Count > 0;
+            return this.rules != null && (this.rules.Count > 0 || !AWSConfigs.InitializeCollections);
         }
-
-
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/ReplicationRuleAndOperator.cs
+++ b/sdk/src/Services/S3/Custom/Model/ReplicationRuleAndOperator.cs
@@ -26,7 +26,7 @@ namespace Amazon.S3.Model
     public class ReplicationRuleAndOperator
     {
         private string prefix;
-        private List<Tag> tags = new List<Tag>();
+        private List<Tag> tags = AWSConfigs.InitializeCollections ? new List<Tag>() : null;
 
         /// <summary>
         /// Object keyname prefix that identifies subset of objects to which the rule applies.
@@ -61,7 +61,7 @@ namespace Amazon.S3.Model
         /// <returns>true if Tags property is set.</returns>
         internal bool IsSetTags()
         {
-            return this.tags != null && this.tags.Count > 0;
+            return this.tags != null && (this.tags.Count > 0 || !AWSConfigs.InitializeCollections);
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/S3AccessControlList.cs
+++ b/sdk/src/Services/S3/Custom/Model/S3AccessControlList.cs
@@ -41,7 +41,7 @@ namespace Amazon.S3.Model
     /// </remarks>
     public class S3AccessControlList
     {
-        private List<S3Grant> grantList = null;
+        private List<S3Grant> grantList = AWSConfigs.InitializeCollections ? new List<S3Grant>() : null;
 
         /// <summary>
         /// Creates a S3Grant and adds it to the list of grants.
@@ -51,6 +51,11 @@ namespace Amazon.S3.Model
         public void AddGrant(S3Grantee grantee, S3Permission permission)
         {
             S3Grant grant = new S3Grant { Grantee = grantee, Permission = permission };
+
+            if (this.Grants == null)
+            {
+                this.Grants = new List<S3Grant>();
+            }
             this.Grants.Add(grant);
         }
 
@@ -61,12 +66,15 @@ namespace Amazon.S3.Model
         /// <param name="permission">The permission for the grantee to remove</param>
         public void RemoveGrant(S3Grantee grantee, S3Permission permission)
         {
-            foreach (S3Grant grant in this.Grants)
+            if (this.Grants != null)
             {
-                if (grant.Grantee.Equals(grantee) && grant.Permission == permission)
+                foreach (S3Grant grant in this.Grants)
                 {
-                    this.Grants.Remove(grant);
-                    break;
+                    if (grant.Grantee.Equals(grantee) && grant.Permission == permission)
+                    {
+                        this.Grants.Remove(grant);
+                        break;
+                    }
                 }
             }
         }
@@ -77,17 +85,21 @@ namespace Amazon.S3.Model
         /// <param name="grantee"></param>
         public void RemoveGrant(S3Grantee grantee)
         {
-            List<S3Grant> removeList = new List<S3Grant>();
-            foreach (S3Grant grant in this.Grants)
+            if (this.Grants != null)
             {
-                if (grant.Grantee.Equals(grantee))
+                List<S3Grant> removeList = new List<S3Grant>();
+
+                foreach (S3Grant grant in this.Grants)
                 {
-                    removeList.Add(grant);
+                    if (grant.Grantee.Equals(grantee))
+                    {
+                        removeList.Add(grant);
+                    }
                 }
-            }
-            foreach (S3Grant grant in removeList)
-            {
-                this.Grants.Remove(grant);
+                foreach (S3Grant grant in removeList)
+                {
+                    this.Grants.Remove(grant);
+                }
             }
         }
 
@@ -152,18 +164,8 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<S3Grant> Grants
         {
-            get
-            {
-                if (this.grantList == null)
-                {
-                    this.grantList = new List<S3Grant>();
-                }
-                return this.grantList;
-            }
-            set
-            {
-                this.grantList = value;
-            }
+            get {  return this.grantList; }
+            set { this.grantList = value; }
         }
 
         /// <summary>
@@ -172,17 +174,20 @@ namespace Amazon.S3.Model
         /// <returns>true if Grants property is set.</returns>
         internal bool IsSetGrants()
         {
-            return (this.Grants.Count > 0);
+            return this.grantList != null && (this.grantList.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         internal void Marshall(string memberName, XmlWriter xmlWriter)
         {
             xmlWriter.WriteStartElement(memberName);
-            foreach (var grant in grantList)
+            if (grantList != null)
             {
-                if (grant != null)
+                foreach (var grant in grantList)
                 {
-                    grant.Marshall("Grant", xmlWriter);
+                    if (grant != null)
+                    {
+                        grant.Marshall("Grant", xmlWriter);
+                    }
                 }
             }
             xmlWriter.WriteEndElement();

--- a/sdk/src/Services/S3/Custom/Model/S3BucketLoggingConfig.cs
+++ b/sdk/src/Services/S3/Custom/Model/S3BucketLoggingConfig.cs
@@ -27,7 +27,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public class S3BucketLoggingConfig
     {
-        private List<S3Grant> targetGrants = new List<S3Grant>();
+        private List<S3Grant> targetGrants = AWSConfigs.InitializeCollections ? new List<S3Grant>() : null;
 
         /// <summary>
         /// Specifies the bucket where you want Amazon S3 to store server access logs. You can have your logs delivered to any bucket that you own,
@@ -60,7 +60,7 @@ namespace Amazon.S3.Model
         // Check to see if TargetGrants property is set
         internal bool IsSetGrants()
         {
-            return this.targetGrants.Count > 0;
+            return this.targetGrants != null && (this.targetGrants.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         private TargetObjectKeyFormat _targetObjectKeyFormat;
@@ -105,6 +105,11 @@ namespace Amazon.S3.Model
         /// <param name="permission">The permission for the grantee.</param>
         public void AddGrant(S3Grantee grantee, S3Permission permission)
         {
+            if (Grants == null)
+            {
+                Grants = new List<S3Grant>();
+            }
+
             S3Grant grant = new S3Grant{ Grantee = grantee, Permission = permission };
             Grants.Add(grant);
         }
@@ -116,12 +121,15 @@ namespace Amazon.S3.Model
         /// <param name="permission">The permission for the grantee to remove</param>
         public void RemoveGrant(S3Grantee grantee, S3Permission permission)
         {
-            foreach (S3Grant grant in Grants)
+            if (Grants != null)
             {
-                if (grant.Grantee.Equals(grantee) && grant.Permission == permission)
+                foreach (S3Grant grant in Grants)
                 {
-                    Grants.Remove(grant);
-                    break;
+                    if (grant.Grantee.Equals(grantee) && grant.Permission == permission)
+                    {
+                        Grants.Remove(grant);
+                        break;
+                    }
                 }
             }
         }
@@ -132,17 +140,20 @@ namespace Amazon.S3.Model
         /// <param name="grantee"></param>
         public void RemoveGrant(S3Grantee grantee)
         {
-            List<S3Grant> removeList = new List<S3Grant>();
-            foreach (S3Grant grant in Grants)
+            if (this.Grants != null)
             {
-                if (grant.Grantee.Equals(grantee))
+                List<S3Grant> removeList = new List<S3Grant>();
+                foreach (S3Grant grant in Grants)
                 {
-                    removeList.Add(grant);
+                    if (grant.Grantee.Equals(grantee))
+                    {
+                        removeList.Add(grant);
+                    }
                 }
-            }
-            foreach (S3Grant grant in removeList)
-            {
-                this.Grants.Remove(grant);
+                foreach (S3Grant grant in removeList)
+                {
+                    this.Grants.Remove(grant);
+                }
             }
         }
     }

--- a/sdk/src/Services/S3/Custom/Model/S3KeyFilter.cs
+++ b/sdk/src/Services/S3/Custom/Model/S3KeyFilter.cs
@@ -25,7 +25,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public class S3KeyFilter
     {
-        private List<FilterRule> filterRules;
+        private List<FilterRule> filterRules = AWSConfigs.InitializeCollections ? new List<FilterRule>() : null;
 
         /// <summary>
         /// Gets and sets the filterRules property.
@@ -33,21 +33,14 @@ namespace Amazon.S3.Model
         /// </summary>
         public List<FilterRule> FilterRules
         {
-            get
-            {
-                if (this.filterRules == null)
-                    this.filterRules = new List<FilterRule>();
-
-                return this.filterRules;
-            }
+            get { return this.filterRules; }
             set { this.filterRules = value; }
         }
 
         // Check to see if FilterRules property is set
         internal bool IsSetFilterRules()
         {
-            return this.filterRules != null && this.filterRules.Count > 0;
+            return this.filterRules != null && (this.filterRules.Count > 0 || !AWSConfigs.InitializeCollections);
         }
-
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/S3Object.cs
+++ b/sdk/src/Services/S3/Custom/Model/S3Object.cs
@@ -27,7 +27,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public class S3Object
     {
-        private List<string> _checksumAlgorithm = new List<string>();
+        private List<string> _checksumAlgorithm = AWSConfigs.InitializeCollections ? new List<string>() : null;
         private string eTag;
         private string key;
         private DateTime? lastModified;
@@ -52,7 +52,7 @@ namespace Amazon.S3.Model
         // Check to see if ChecksumAlgorithm property is set
         internal bool IsSetChecksumAlgorithm()
         {
-            return this._checksumAlgorithm != null && this._checksumAlgorithm.Count > 0;
+            return this._checksumAlgorithm != null && (this._checksumAlgorithm.Count > 0 || !AWSConfigs.InitializeCollections);
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/ServerSideEncryptionConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/ServerSideEncryptionConfiguration.cs
@@ -26,7 +26,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public class ServerSideEncryptionConfiguration
     {
-        private List<ServerSideEncryptionRule> serverSideEncryptionRules = new List<ServerSideEncryptionRule>();
+        private List<ServerSideEncryptionRule> serverSideEncryptionRules = AWSConfigs.InitializeCollections ? new List<ServerSideEncryptionRule>() : null;
 
         /// <summary>
         /// Container for information about a particular server-side encryption configuration rule.
@@ -40,7 +40,7 @@ namespace Amazon.S3.Model
         // Check to see if ServerSideEncryptionRules property is set
         internal bool IsSetServerSideEncryptionRules()
         {
-            return this.serverSideEncryptionRules != null && this.serverSideEncryptionRules.Count > 0;
+            return this.serverSideEncryptionRules != null && (this.serverSideEncryptionRules.Count > 0 || !AWSConfigs.InitializeCollections);
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/Tag.cs
+++ b/sdk/src/Services/S3/Custom/Model/Tag.cs
@@ -78,7 +78,7 @@ namespace Amazon.S3.Model
     /// </summary>
     public class Tagging
     {
-        private List<Tag> tagSet = new List<Tag>();
+        private List<Tag> tagSet = AWSConfigs.InitializeCollections ? new List<Tag>() : null;
 
         /// <summary>
         /// TagSet
@@ -95,9 +95,12 @@ namespace Amazon.S3.Model
             {
                 xmlWriter.WriteStartElement("TagSet");
                 {
-                    foreach (var tag in tagSet)
+                    if (this.tagSet != null)
                     {
-                        tag.Marshall("Tag", xmlWriter);
+                        foreach (var tag in tagSet)
+                        {
+                            tag.Marshall("Tag", xmlWriter);
+                        }
                     }
                 }
                 xmlWriter.WriteEndElement();

--- a/sdk/src/Services/S3/Custom/Model/WebsiteConfiguration.cs
+++ b/sdk/src/Services/S3/Custom/Model/WebsiteConfiguration.cs
@@ -28,7 +28,7 @@ namespace Amazon.S3.Model
         private string errorDocument;
         private string indexDocumentSuffix;
         private RoutingRuleRedirect redirectAllRequestsTo;
-        private List<RoutingRule> routingRules = new List<RoutingRule>();
+        private List<RoutingRule> routingRules = AWSConfigs.InitializeCollections ? new List<RoutingRule>() : null;
 
         /// <summary>
         /// The ErrorDocument value, an object key name to use when a 4XX class error occurs.
@@ -100,7 +100,7 @@ namespace Amazon.S3.Model
         // Check to see if RoutingRules property is set
         internal bool IsSetRoutingRules()
         {
-            return this.routingRules.Count > 0;
+            return this.routingRules != null && (this.routingRules.Count > 0 || !AWSConfigs.InitializeCollections);
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListMultipartUploadsPaginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListMultipartUploadsPaginator.cs
@@ -42,13 +42,13 @@ namespace Amazon.S3.Model
         /// Enumerable containing all of the Uploads
         /// </summary>
         public IPaginatedEnumerable<MultipartUpload> Uploads => 
-            new PaginatedResultKeyResponse<ListMultipartUploadsResponse, MultipartUpload>(this, (i) => i.MultipartUploads);
+            new PaginatedResultKeyResponse<ListMultipartUploadsResponse, MultipartUpload>(this, (i) => i.MultipartUploads ?? new List<MultipartUpload>());
 
         /// <summary>
         /// Enumerable containing all of the CommonPrefixes
         /// </summary>
         public IPaginatedEnumerable<string> CommonPrefixes => 
-            new PaginatedResultKeyResponse<ListMultipartUploadsResponse, string>(this, (i) => i.CommonPrefixes);
+            new PaginatedResultKeyResponse<ListMultipartUploadsResponse, string>(this, (i) => i.CommonPrefixes ?? new List<string>());
 
         internal ListMultipartUploadsPaginator(IAmazonS3 client, ListMultipartUploadsRequest request)
         {

--- a/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListObjectsPaginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListObjectsPaginator.cs
@@ -41,13 +41,13 @@ namespace Amazon.S3.Model
         /// Enumerable containing all of the S3Objects
         /// </summary>
         public IPaginatedEnumerable<S3Object> S3Objects =>
-            new PaginatedResultKeyResponse<ListObjectsResponse, S3Object>(this, (i) => i.S3Objects);
+            new PaginatedResultKeyResponse<ListObjectsResponse, S3Object>(this, (i) => i.S3Objects ?? new List<S3Object>());
 
         /// <summary>
         /// Enumerable containing all of the CommonPrefixes
         /// </summary>
         public IPaginatedEnumerable<string> CommonPrefixes =>
-            new PaginatedResultKeyResponse<ListObjectsResponse, string>(this, (i) => i.CommonPrefixes);
+            new PaginatedResultKeyResponse<ListObjectsResponse, string>(this, (i) => i.CommonPrefixes ?? new List<string>());
 
         internal ListObjectsPaginator(IAmazonS3 client, ListObjectsRequest request)
         {

--- a/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListObjectsV2Paginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListObjectsV2Paginator.cs
@@ -41,13 +41,13 @@ namespace Amazon.S3.Model
         /// Enumerable containing all of the S3Objects
         /// </summary>
         public IPaginatedEnumerable<S3Object> S3Objects => 
-            new PaginatedResultKeyResponse<ListObjectsV2Response, S3Object>(this, (i) => i.S3Objects);
+            new PaginatedResultKeyResponse<ListObjectsV2Response, S3Object>(this, (i) => i.S3Objects ?? new List<S3Object>());
 
         /// <summary>
         /// Enumerable containing all of the CommonPrefixes
         /// </summary>
         public IPaginatedEnumerable<string> CommonPrefixes => 
-            new PaginatedResultKeyResponse<ListObjectsV2Response, string>(this, (i) => i.CommonPrefixes);
+            new PaginatedResultKeyResponse<ListObjectsV2Response, string>(this, (i) => i.CommonPrefixes ?? new List<string>());
 
         internal ListObjectsV2Paginator(IAmazonS3 client, ListObjectsV2Request request)
         {

--- a/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListPartsPaginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListPartsPaginator.cs
@@ -41,7 +41,7 @@ namespace Amazon.S3.Model
         /// Enumerable containing all of the Parts
         /// </summary>
         public IPaginatedEnumerable<PartDetail> Parts => 
-            new PaginatedResultKeyResponse<ListPartsResponse, PartDetail>(this, (i) => i.Parts);
+            new PaginatedResultKeyResponse<ListPartsResponse, PartDetail>(this, (i) => i.Parts ?? new List<PartDetail>());
 
         internal ListPartsPaginator(IAmazonS3 client, ListPartsRequest request)
         {

--- a/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListVersionsPaginator.cs
+++ b/sdk/src/Services/S3/Custom/Model/_bcl45+netstandard/ListVersionsPaginator.cs
@@ -36,12 +36,12 @@ namespace Amazon.S3.Model
         /// Enumerable containing all full responses for the operation
         /// </summary>
         public IPaginatedEnumerable<ListVersionsResponse> Responses => new PaginatedResponse<ListVersionsResponse>(this);
-        
+
         /// <summary>
         /// Enumerable containing all of the Versions
         /// </summary>
-        public IPaginatedEnumerable<S3ObjectVersion> Versions => 
-            new PaginatedResultKeyResponse<ListVersionsResponse, S3ObjectVersion>(this, (i) => i.Versions);
+        public IPaginatedEnumerable<S3ObjectVersion> Versions =>
+            new PaginatedResultKeyResponse<ListVersionsResponse, S3ObjectVersion>(this, (i) => i.Versions ?? new List<S3ObjectVersion>());
 
         /// <summary>
         /// Enumerable containing all of the CommonPrefixes

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl35/AbortMultipartUploadsCommand.bcl35.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl35/AbortMultipartUploadsCommand.bcl35.cs
@@ -43,12 +43,15 @@ namespace Amazon.S3.Transfer.Internal
                 ListMultipartUploadsRequest listRequest = ConstructListMultipartUploadsRequest(listResponse);
 
                 listResponse = this._s3Client.ListMultipartUploads(listRequest);
-                foreach (MultipartUpload upload in listResponse.MultipartUploads)
+                if (listResponse.MultipartUploads != null)
                 {
-                    if (upload.Initiated < this._initiatedDate)
+                    foreach (MultipartUpload upload in listResponse.MultipartUploads)
                     {
-                        var abortRequest = ConstructAbortMultipartUploadRequest(upload);
-                        this._s3Client.AbortMultipartUpload(abortRequest);
+                        if (upload.Initiated < this._initiatedDate)
+                        {
+                            var abortRequest = ConstructAbortMultipartUploadRequest(upload);
+                            this._s3Client.AbortMultipartUpload(abortRequest);
+                        }
                     }
                 }
             }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl35/DownloadDirectoryCommand.bcl35.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl35/DownloadDirectoryCommand.bcl35.cs
@@ -83,15 +83,18 @@ namespace Amazon.S3.Transfer.Internal
             {
                 ListObjectsResponse listResponse = this._s3Client.ListObjects(listRequest);
 
-                foreach (S3Object s3o in listResponse.S3Objects)
+                if (listResponse.S3Objects != null)
                 {
-                    if (ShouldDownload(s3o))
+                    foreach (S3Object s3o in listResponse.S3Objects)
                     {
-                        this._totalBytes += s3o.Size;
-                        objs.Add(s3o);
+                        if (ShouldDownload(s3o))
+                        {
+                            this._totalBytes += s3o.Size;
+                            objs.Add(s3o);
+                        }
                     }
+                    listRequest.Marker = listResponse.NextMarker;
                 }
-                listRequest.Marker = listResponse.NextMarker;
             } while (!string.IsNullOrEmpty(listRequest.Marker));
             return objs;
         }
@@ -103,12 +106,15 @@ namespace Amazon.S3.Transfer.Internal
             {
                 ListObjectsV2Response listResponse = this._s3Client.ListObjectsV2(listRequestV2);
 
-                foreach (S3Object s3o in listResponse.S3Objects)
+                if (listResponse.S3Objects != null)
                 {
-                    if (ShouldDownload(s3o))
+                    foreach (S3Object s3o in listResponse.S3Objects)
                     {
-                        this._totalBytes += s3o.Size;
-                        objs.Add(s3o);
+                        if (ShouldDownload(s3o))
+                        {
+                            this._totalBytes += s3o.Size;
+                            objs.Add(s3o);
+                        }
                     }
                 }
                 listRequestV2.ContinuationToken = listResponse.NextContinuationToken;

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl45+netstandard/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl45+netstandard/DownloadDirectoryCommand.cs
@@ -127,12 +127,16 @@ namespace Amazon.S3.Transfer.Internal
             {
                 ListObjectsResponse listResponse = await this._s3Client.ListObjectsAsync(listRequest, cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);
-                foreach (S3Object s3o in listResponse.S3Objects)
+
+                if (listResponse.S3Objects != null)
                 {
-                    if (ShouldDownload(s3o))
+                    foreach (S3Object s3o in listResponse.S3Objects)
                     {
-                        this._totalBytes += s3o.Size;
-                        objs.Add(s3o);
+                        if (ShouldDownload(s3o))
+                        {
+                            this._totalBytes += s3o.Size;
+                            objs.Add(s3o);
+                        }
                     }
                 }
                 listRequest.Marker = listResponse.NextMarker;
@@ -147,12 +151,16 @@ namespace Amazon.S3.Transfer.Internal
             {
                 ListObjectsV2Response listResponse = await this._s3Client.ListObjectsV2Async(listRequestV2, cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);
-                foreach (S3Object s3o in listResponse.S3Objects)
+
+                if (listResponse.S3Objects != null)
                 {
-                    if (ShouldDownload(s3o))
+                    foreach (S3Object s3o in listResponse.S3Objects)
                     {
-                        this._totalBytes += s3o.Size;
-                        objs.Add(s3o);
+                        if (ShouldDownload(s3o))
+                        {
+                            this._totalBytes += s3o.Size;
+                            objs.Add(s3o);
+                        }
                     }
                 }
                 listRequestV2.ContinuationToken = listResponse.NextContinuationToken;

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
@@ -568,7 +568,10 @@ namespace Amazon.S3.Util
             {
                 xmlWriter.WriteStartElement("Tagging", S3Constants.S3RequestXmlNamespace);
 
-                SerializeTagSetToXml(xmlWriter, tagging.TagSet);
+                if (tagging.TagSet != null)
+                {
+                    SerializeTagSetToXml(xmlWriter, tagging.TagSet);
+                }
 
                 xmlWriter.WriteEndElement();
             }

--- a/sdk/src/Services/S3/Custom/Util/_async/AmazonS3Util.Operations.cs
+++ b/sdk/src/Services/S3/Custom/Util/_async/AmazonS3Util.Operations.cs
@@ -218,7 +218,7 @@ namespace Amazon.S3.Util
                 try
                 {
                     listVersionsResponse = await s3Client.ListVersionsAsync(listVersionsRequest, token).ConfigureAwait(false);
-                    if (listVersionsResponse.Versions.Count == 0)
+                    if (listVersionsResponse.Versions == null || listVersionsResponse.Versions.Count == 0)
                     {
                         // If the bucket has no objects break the loop.
                         break;
@@ -239,7 +239,7 @@ namespace Amazon.S3.Util
                     if (ex.StatusCode != HttpStatusCode.NotImplemented)
                         throw;
                     listObjectsV2Response = await s3Client.ListObjectsV2Async(listObjectsV2Request).ConfigureAwait(false);
-                    if (listObjectsV2Response.S3Objects.Count == 0)
+                    if (listObjectsV2Response.S3Objects == null || listObjectsV2Response.S3Objects.Count == 0)
                     {
                         // If the bucket has no objects break the loop.
                         break;

--- a/sdk/src/Services/S3/Custom/Util/_bcl/AmazonS3Util.Operations.cs
+++ b/sdk/src/Services/S3/Custom/Util/_bcl/AmazonS3Util.Operations.cs
@@ -307,7 +307,7 @@ namespace Amazon.S3.Util
                 MaxKeys = 1
             });
 
-            if (listObjectResponse.S3Objects.Count != 1)
+            if (listObjectResponse.S3Objects?.Count != 1)
             {
                 throw new InvalidOperationException("No object exists with this bucket name and key.");
             }

--- a/sdk/src/Services/S3/Custom/Util/_bcl/_bcl35/AmazonS3Util.bcl35.cs
+++ b/sdk/src/Services/S3/Custom/Util/_bcl/_bcl35/AmazonS3Util.bcl35.cs
@@ -264,7 +264,7 @@ namespace Amazon.S3.Util
                 try
                 {
                     listVersionsResponse = s3Client.ListVersions(listVersionsRequest);
-                    if (listVersionsResponse.Versions.Count == 0)
+                    if (listVersionsResponse.Versions == null || listVersionsResponse.Versions.Count == 0)
                     {
                         // If the bucket has no objects break the loop.
                         break;
@@ -285,7 +285,7 @@ namespace Amazon.S3.Util
                     if (ex.StatusCode != HttpStatusCode.NotImplemented)
                         throw;
                     listObjectsV2Response = s3Client.ListObjectsV2(listObjectsV2Request);
-                    if(listObjectsV2Response.S3Objects.Count == 0)
+                    if(listObjectsV2Response.S3Objects == null || listObjectsV2Response.S3Objects.Count == 0)
                     {
                         break; 
                     }

--- a/sdk/src/Services/S3/Custom/_async/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/_async/AmazonS3Client.Extensions.cs
@@ -45,7 +45,7 @@ namespace Amazon.S3
                 InternalSDKUtils.ApplyValues(request, additionalProperties);
 
                 var listResponse = await this.ListObjectsAsync(request).ConfigureAwait(false);
-                keys.AddRange(listResponse.S3Objects.Select(o => o.Key));
+                keys.AddRange(listResponse.S3Objects?.Select(o => o.Key));
                 marker = listResponse.NextMarker;
             } while (!string.IsNullOrEmpty(marker));
 

--- a/sdk/src/Services/S3/Custom/_bcl/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/_bcl/AmazonS3Client.Extensions.cs
@@ -44,7 +44,7 @@ namespace Amazon.S3
                 InternalSDKUtils.ApplyValues(request, additionalProperties);
 
                 var listResponse = this.ListObjects(request);
-                keys.AddRange(listResponse.S3Objects.Select(o => o.Key));
+                keys.AddRange(listResponse.S3Objects?.Select(o => o.Key));
                 marker = listResponse.NextMarker;
             } while (!string.IsNullOrEmpty(marker));
 

--- a/sdk/src/Services/S3/Custom/_bcl/IO/S3DirectoryInfo.cs
+++ b/sdk/src/Services/S3/Custom/_bcl/IO/S3DirectoryInfo.cs
@@ -192,7 +192,7 @@ namespace Amazon.S3.IO
                     ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)request).AddBeforeRequestHandler(S3Helper.FileIORequestEventHandler);
 
                     var response = s3Client.ListObjects(request);
-                    return response.S3Objects.Count > 0;
+                    return response.S3Objects?.Count > 0;
                 }
             }
             catch (AmazonS3Exception e)
@@ -250,12 +250,16 @@ namespace Amazon.S3.IO
                         var listRequest = new ListBucketsRequest();
                         ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)listRequest).AddBeforeRequestHandler(S3Helper.FileIORequestEventHandler);
 
-                        foreach (S3Bucket s3Bucket in s3Client.ListBuckets(listRequest).Buckets)
+                        var buckets = s3Client.ListBuckets(listRequest).Buckets;
+                        if (buckets != null)
                         {
-                            DateTime currentBucketLastWriteTime = new S3DirectoryInfo(s3Client, s3Bucket.BucketName, String.Empty).LastWriteTime;
-                            if (currentBucketLastWriteTime > ret)
+                            foreach (S3Bucket s3Bucket in buckets)
                             {
-                                ret = currentBucketLastWriteTime;
+                                DateTime currentBucketLastWriteTime = new S3DirectoryInfo(s3Client, s3Bucket.BucketName, String.Empty).LastWriteTime;
+                                if (currentBucketLastWriteTime > ret)
+                                {
+                                    ret = currentBucketLastWriteTime;
+                                }
                             }
                         }
                     }
@@ -488,19 +492,21 @@ namespace Amazon.S3.IO
                 {
                     listResponse = s3Client.ListObjects(listRequest);
 
-                    // Sort to make sure the Marker for paging is set to the last lexiographical key.
-                    foreach (S3Object s3o in listResponse.S3Objects.OrderBy(x => x.Key))
+                    if (listResponse.S3Objects != null)
                     {
-                        deleteRequest.AddKey(s3o.Key);
-                        if (deleteRequest.Objects.Count == Util.S3Constants.MULTIPLE_OBJECT_DELETE_LIMIT)
+                        // Sort to make sure the Marker for paging is set to the last lexiographical key.
+                        foreach (S3Object s3o in listResponse.S3Objects.OrderBy(x => x.Key))
                         {
-                            s3Client.DeleteObjects(deleteRequest);
-                            deleteRequest.Objects.Clear();
-                        }
+                            deleteRequest.AddKey(s3o.Key);
+                            if (deleteRequest.Objects.Count == Util.S3Constants.MULTIPLE_OBJECT_DELETE_LIMIT)
+                            {
+                                s3Client.DeleteObjects(deleteRequest);
+                                deleteRequest.Objects.Clear();
+                            }
 
-                        listRequest.Marker = s3o.Key;
+                            listRequest.Marker = s3o.Key;
+                        }
                     }
-                    
                 } while (listResponse.IsTruncated);
 
                 if (deleteRequest.Objects.Count > 0)
@@ -567,8 +573,17 @@ namespace Amazon.S3.IO
             {
                 var request = new ListBucketsRequest();
                 ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)request).AddBeforeRequestHandler(S3Helper.FileIORequestEventHandler);
-                folders = s3Client.ListBuckets(request).Buckets
-                    .ConvertAll(s3Bucket => new S3DirectoryInfo(s3Client,s3Bucket.BucketName,""));
+
+                var buckets = s3Client.ListBuckets(request).Buckets;
+                if (buckets != null)
+                {
+                    folders = buckets
+                        .ConvertAll(s3Bucket => new S3DirectoryInfo(s3Client, s3Bucket.BucketName, ""));
+                }
+                else
+                {
+                    folders = new List<S3DirectoryInfo>();
+                }
             }
             else
             {
@@ -1208,7 +1223,7 @@ namespace Amazon.S3.IO
             do
             {
                 var buckets = this.S3Client.ListBuckets().Buckets;
-                currentState = buckets.FirstOrDefault(x => string.Equals(x.BucketName, this.BucketName)) != null;
+                currentState = buckets?.FirstOrDefault(x => string.Equals(x.BucketName, this.BucketName)) != null;
 
                 if (currentState == exists)
                 {

--- a/sdk/test/IntegrationTests/Tests/General.cs
+++ b/sdk/test/IntegrationTests/Tests/General.cs
@@ -297,7 +297,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
         {
             var dor = new Amazon.S3.Model.DeleteObjectsResponse
             {
-                DeletedObjects =
+                DeletedObjects = new List<DeletedObject>
                     {
                         new DeletedObject
                         {
@@ -314,7 +314,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                             DeleteMarkerVersionId = "mv2"
                         }
                     },
-                DeleteErrors =
+                DeleteErrors = new List<DeleteError>
                     {
                         new DeleteError
                         {

--- a/sdk/test/NetStandard/IntegrationTests/Framework/UtilityMethods.cs
+++ b/sdk/test/NetStandard/IntegrationTests/Framework/UtilityMethods.cs
@@ -169,7 +169,7 @@ namespace Amazon.DNXCore.IntegrationTests
                 }
                 lastRequestId = listVersionsResponse.ResponseMetadata.RequestId;
 
-                if (listVersionsResponse.Versions.Count == 0)
+                if (listVersionsResponse.Versions == null || listVersionsResponse.Versions.Count == 0)
                 {
                     // If the bucket has no objects break the loop.
                     break;

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/CloudFormation.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/CloudFormation.cs
@@ -9,6 +9,7 @@ using Amazon.CloudFormation.Model;
 using Amazon.Runtime;
 using Amazon.DNXCore.IntegrationTests;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Amazon.DNXCore.IntegrationTests
 {
@@ -99,8 +100,17 @@ namespace Amazon.DNXCore.IntegrationTests
         private static void VerifyTemplateSummary(GetTemplateSummaryResponse response)
         {
             Assert.NotNull(response.ResponseMetadata.RequestId);
-            Assert.NotNull(response.Capabilities);
-            Assert.Equal(0, response.Capabilities.Count);
+
+            if (AWSConfigs.InitializeCollections)
+            {
+                Assert.NotNull(response.Capabilities);
+                Assert.Empty(response.Capabilities);
+            }
+            else
+            {
+                Assert.Null(response.Capabilities);
+            }
+
             Assert.Null(response.CapabilitiesReason);
             Assert.NotNull(response.Description);
             Assert.NotNull(response.Parameters);
@@ -132,19 +142,21 @@ namespace Amazon.DNXCore.IntegrationTests
                 CreateStackRequest createRequest = new CreateStackRequest
                 {
                     StackName = stackName,
-                    TemplateBody = TEMPLATE_TEXT
-                };
-
-                createRequest.Parameters.Add(new Parameter
+                    TemplateBody = TEMPLATE_TEXT,
+                    Parameters = new List<Parameter>
                     {
-                        ParameterKey = "TopicName",
-                        ParameterValue = "MyTopic" + DateTime.Now.Ticks
-                    });
-                createRequest.Parameters.Add(new Parameter
-                {
-                    ParameterKey = "QueueName",
-                    ParameterValue = "MyQueue" + DateTime.Now.Ticks
-                });
+                        new Parameter
+                        {
+                            ParameterKey = "TopicName",
+                            ParameterValue = "MyTopic" + DateTime.Now.Ticks
+                        },
+                        new Parameter
+                        {
+                            ParameterKey = "QueueName",
+                            ParameterValue = "MyQueue" + DateTime.Now.Ticks
+                        }
+                    }
+                };
 
                 await Client.CreateStackAsync(createRequest);
 

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/EC2/BasicDescribes.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/EC2/BasicDescribes.cs
@@ -21,8 +21,10 @@ namespace Amazon.DNXCore.IntegrationTests.EC2
             // perform a filtered query to (a) test parameter marshalling
             // and (b) cut down the time to run -- an unfiltered request
             // yields a lot of images
-            var request = new DescribeImagesRequest();
-            request.Owners.Add("amazon");
+            var request = new DescribeImagesRequest()
+            {
+                Owners = new List<string> { "amazon" }
+            };
             var response = await Client.DescribeImagesAsync(request);
 
             Assert.NotNull(response);
@@ -35,8 +37,10 @@ namespace Amazon.DNXCore.IntegrationTests.EC2
             // perform a filtered query to (a) test parameter marshalling
             // and (b) cut down the time to run -- an unfiltered request
             // yields a lot of images
-            var request = new DescribeImagesRequest();
-            request.Owners.Add("amazon");
+            var request = new DescribeImagesRequest()
+            {
+                Owners = new List<string> { "amazon" }
+            };
 
             var cts = new CancellationTokenSource();
             cts.CancelAfter(1000);
@@ -48,7 +52,7 @@ namespace Amazon.DNXCore.IntegrationTests.EC2
             });
 
             //Assert.Equal(token, exception.CancellationToken);
-            Assert.Equal(true, exception.CancellationToken.IsCancellationRequested);
+            Assert.True(exception.CancellationToken.IsCancellationRequested);
 
         }
     }

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/RDS/BasicDescribes.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/RDS/BasicDescribes.cs
@@ -52,7 +52,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
             var response = await Client.DescribeDBParameterGroupsAsync();
             Assert.NotNull(response);
 
-            if (response.DBParameterGroups.Count > 0)
+            if (response.DBParameterGroups != null && response.DBParameterGroups.Count > 0)
             {
                 var dbParamGroupFamily = response.DBParameterGroups[0];
 
@@ -62,7 +62,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
                 });
                 Assert.NotNull(response);
 
-                if (describeResponse.DBEngineVersions.Count > 0)
+                if (describeResponse.DBEngineVersions != null && describeResponse.DBEngineVersions.Count > 0)
                 {
                     foreach (var dbev in describeResponse.DBEngineVersions)
                     {
@@ -79,7 +79,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
             var response = await Client.DescribeDBParameterGroupsAsync();
             Assert.NotNull(response);
 
-            if (response.DBParameterGroups.Count > 0)
+            if (response.DBParameterGroups != null && response.DBParameterGroups.Count > 0)
             {
                 foreach (var dbpg in response.DBParameterGroups)
                 {
@@ -97,7 +97,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
             Assert.NotNull(response);
 
             string dbInstanceIdentifier = null;
-            if (response.DBInstances.Count > 0)
+            if (response.DBInstances != null && response.DBInstances.Count > 0)
             {
                 foreach (var dbi in response.DBInstances)
                 {

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/Route53.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/Route53.cs
@@ -204,7 +204,6 @@ namespace Amazon.DNXCore.IntegrationTests
                 }
             }
             Assert.NotNull(status);
-            Assert.NotNull(status.HealthCheckObservations);
 
             var healthCheck = Client.GetHealthCheckAsync(new GetHealthCheckRequest
             {
@@ -222,8 +221,15 @@ namespace Amazon.DNXCore.IntegrationTests
             Assert.NotNull(tagSet);
             Assert.NotNull(tagSet.ResourceId);
             Assert.NotNull(tagSet.ResourceType);
-            Assert.NotNull(tagSet.Tags);
-            Assert.Equal(0, tagSet.Tags.Count);
+
+            if (AWSConfigs.InitializeCollections)
+            {
+                Assert.Empty(tagSet.Tags);
+            }
+            else
+            {
+                Assert.Null(tagSet.Tags);
+            }
 
             Client.ChangeTagsForResourceAsync(new ChangeTagsForResourceRequest
             {
@@ -244,7 +250,7 @@ namespace Amazon.DNXCore.IntegrationTests
             Assert.NotNull(tagSet.ResourceId);
             Assert.NotNull(tagSet.ResourceType);
             Assert.NotNull(tagSet.Tags);
-            Assert.Equal(1, tagSet.Tags.Count);
+            Assert.Single(tagSet.Tags);
             Assert.Equal("Test", tagSet.Tags[0].Key);
             Assert.Equal("true", tagSet.Tags[0].Value);
 

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/NotificationTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/NotificationTests.cs
@@ -97,7 +97,7 @@ namespace Amazon.DNXCore.IntegrationTests
                             {
                                 Id = "the-queue-test",
                                 Queue = queueArn,
-                                Events = {EventType.ObjectCreatedPut},
+                                Events = new List<EventType>{EventType.ObjectCreatedPut},
                                 Filter = new Filter
                                 {
                                     S3KeyFilter = new S3KeyFilter
@@ -152,7 +152,7 @@ namespace Amazon.DNXCore.IntegrationTests
                         },
                         (r) =>
                         {
-                            return r.Messages.Count == 0;
+                            return r.Messages == null || r.Messages.Count == 0;
                         });
 
                     var putObjectRequest = new PutObjectRequest
@@ -174,7 +174,7 @@ namespace Amazon.DNXCore.IntegrationTests
                         },
                         (r) =>
                         {
-                            return r.Messages.Count > 0;
+                            return r.Messages != null && r.Messages.Count > 0;
                         });
 
                     var evnt = S3EventNotification.ParseJson(response.Messages[0].Body);

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
@@ -56,8 +56,7 @@ namespace Amazon.DNXCore.IntegrationTests.S3
             Assert.Equal(VersionStatus.Off, status);
 
             var objects = (await Client.ListObjectsAsync(bucketName)).S3Objects;
-            Assert.NotNull(objects);
-            var count = objects.Count;
+            var count = objects == null ? 0 : objects.Count;
 
             var key = "test.txt";
             var contents = "Sample content";
@@ -80,8 +79,7 @@ namespace Amazon.DNXCore.IntegrationTests.S3
             await Client.DeleteObjectAsync(bucketName, key);
 
             objects = (await Client.ListObjectsAsync(bucketName)).S3Objects;
-            Assert.NotNull(objects);
-            Assert.Equal(count, objects.Count);
+            Assert.Equal(count, objects == null ? 0 : objects.Count);
         }
 
         [Fact]

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/SQS.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/SQS.cs
@@ -140,7 +140,7 @@ namespace Amazon.DNXCore.IntegrationTests
                     },
                 });
 
-                var count = (await Client.ReceiveMessageAsync(mainQueueURL)).Messages.Count;
+                var count = (await Client.ReceiveMessageAsync(mainQueueURL)).Messages?.Count;
 
                 await s3Client.PutObjectAsync(new PutObjectRequest {
                     ContentBody = "Hello World",
@@ -155,11 +155,14 @@ namespace Amazon.DNXCore.IntegrationTests
                 {
                     var messages = (await Client.ReceiveMessageAsync(mainQueueURL)).Messages;
 
-                    foreach (var message in messages)
+                    if ( messages != null)
                     {
-                        objectCreaedMessageReceived = message.Body.Contains("ObjectCreated:Put");
-                        if (objectCreaedMessageReceived)
-                            return;
+                        foreach (var message in messages)
+                        {
+                            objectCreaedMessageReceived = message.Body.Contains("ObjectCreated:Put");
+                            if (objectCreaedMessageReceived)
+                                return;
+                        }
                     }
 
                     UtilityMethods.Sleep(TimeSpan.FromSeconds(2));

--- a/sdk/test/Services/CloudFormation/IntegrationTests/CloudFormation.cs
+++ b/sdk/test/Services/CloudFormation/IntegrationTests/CloudFormation.cs
@@ -7,6 +7,7 @@ using Amazon;
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using Amazon.Runtime;
+using System.Collections.Generic;
 
 namespace AWSSDK_DotNet.IntegrationTests.Tests
 {
@@ -103,8 +104,15 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
         private static void VerifyTemplateSummary(GetTemplateSummaryResponse response)
         {
             Assert.IsNotNull(response.ResponseMetadata.RequestId);
-            Assert.IsNotNull(response.Capabilities);
-            Assert.AreEqual(0, response.Capabilities.Count);
+            if (AWSConfigs.InitializeCollections)
+            {
+                Assert.IsNotNull(response.Capabilities);
+                Assert.AreEqual(0, response.Capabilities.Count);
+            }
+            else
+            {
+                Assert.IsNull(response.Capabilities);
+            }
             Assert.IsNull(response.CapabilitiesReason);
             Assert.IsNotNull(response.Description);
             Assert.IsNotNull(response.Parameters);
@@ -163,19 +171,21 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                 CreateStackRequest createRequest = new CreateStackRequest
                 {
                     StackName = stackName,
-                    TemplateBody = TEMPLATE_TEXT
-                };
-
-                createRequest.Parameters.Add(new Parameter
+                    TemplateBody = TEMPLATE_TEXT,
+                    Parameters = new List<Parameter>
                     {
-                        ParameterKey = "TopicName",
-                        ParameterValue = "MyTopic" + DateTime.Now.Ticks
-                    });
-                createRequest.Parameters.Add(new Parameter
-                {
-                    ParameterKey = "QueueName",
-                    ParameterValue = "MyQueue" + DateTime.Now.Ticks
-                });
+                        new Parameter
+                        {
+                            ParameterKey = "TopicName",
+                            ParameterValue = "MyTopic" + DateTime.Now.Ticks
+                        },
+                        new Parameter
+                        {
+                            ParameterKey = "QueueName",
+                            ParameterValue = "MyQueue" + DateTime.Now.Ticks
+                        }
+                    }
+                };
 
                 Client.CreateStack(createRequest);
 

--- a/sdk/test/Services/CloudWatch/IntegrationTests/CloudWatch.cs
+++ b/sdk/test/Services/CloudWatch/IntegrationTests/CloudWatch.cs
@@ -111,15 +111,14 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             {
                 MetricName = "NetworkIn",
                 Namespace = "AWS/EC2",
-                StartTime = DateTime.Parse("2008-01-01T19:00:00+00:00"),
-                EndTime = DateTime.Parse("2009-12-01T19:00:00+00:00"),
+                StartTimeUtc = DateTime.Parse("2008-01-01T19:00:00+00:00"),
+                EndTimeUtc = DateTime.Parse("2009-12-01T19:00:00+00:00"),
                 Statistics = new List<string> { "Average" },
                 Unit = "Percent",
                 Period = 42000,
             };
             var getMetricResult = Client.GetMetricStatistics(getMetricRequest);
             Assert.IsNotNull(getMetricResult);
-            Assert.IsTrue(getMetricResult.Datapoints.Count >= 0);
             Assert.IsNotNull(getMetricResult.Label);
         }
 
@@ -257,11 +256,14 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                 AssertNotEmpty(metric.MetricName);
                 AssertNotEmpty(metric.Namespace);
 
-                foreach (Dimension dimension in metric.Dimensions)
+                if (metric.Dimensions != null)
                 {
-                    seenDimensions = true;
-                    AssertNotEmpty(dimension.Name);
-                    AssertNotEmpty(dimension.Value);
+                    foreach (Dimension dimension in metric.Dimensions)
+                    {
+                        seenDimensions = true;
+                        AssertNotEmpty(dimension.Name);
+                        AssertNotEmpty(dimension.Value);
+                    }
                 }
             }
             Assert.IsTrue(seenDimensions);
@@ -288,7 +290,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
 
             GetMetricStatisticsRequest request = new GetMetricStatisticsRequest()
             {
-                StartTime = DateTime.Now.AddMilliseconds(-ONE_WEEK_IN_MILLISECONDS),
+                StartTimeUtc = DateTime.UtcNow.AddMilliseconds(-ONE_WEEK_IN_MILLISECONDS),
                 Namespace = "AWS/EC2",
                 Period = 60 * 60,
                 Dimensions = new List<Dimension>
@@ -297,13 +299,12 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                 },
                 MetricName = measureName,
                 Statistics = new List<string> { "Average", "Maximum", "Minimum", "Sum" },
-                EndTime = DateTime.Now
+                EndTimeUtc = DateTime.UtcNow
             };
             var result = Client.GetMetricStatistics(request);
 
             AssertNotEmpty(result.Label);
             Assert.AreEqual(measureName, result.Label);
-            Assert.IsNotNull(result.Datapoints);
         }
 
         /**

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DocumentTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DocumentTests.cs
@@ -10,6 +10,7 @@ using Amazon.DynamoDBv2.Model;
 using Amazon.DynamoDBv2.DocumentModel;
 using System.IO;
 using ReturnValuesOnConditionCheckFailure = Amazon.DynamoDBv2.DocumentModel.ReturnValuesOnConditionCheckFailure;
+using Amazon;
 
 
 namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
@@ -1163,11 +1164,24 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 Assert.IsNotNull(ex);
                 Assert.AreEqual(3, ex.CancellationReasons.Count);
                 Assert.AreEqual(BatchStatementErrorCodeEnum.ConditionalCheckFailed.Value, ex.CancellationReasons[0].Code);
-                Assert.AreEqual(0, ex.CancellationReasons[0].Item.Count);
+
+                if (AWSConfigs.InitializeCollections)
+                {
+                    Assert.AreEqual(0, ex.CancellationReasons[0].Item.Count);
+                    Assert.AreEqual(0, ex.CancellationReasons[1].Item.Count);
+                    Assert.AreEqual(0, ex.CancellationReasons[2].Item.Count);
+                    Assert.AreEqual(0, transactWrite.ConditionCheckFailedItems.Count);
+                }
+                else
+                {
+                    Assert.IsNull(ex.CancellationReasons[0].Item);
+                    Assert.IsNull(ex.CancellationReasons[1].Item);
+                    Assert.IsNull(ex.CancellationReasons[2].Item);
+                    
+                }
+
                 Assert.AreEqual(BatchStatementErrorCodeEnum.ConditionalCheckFailed.Value, ex.CancellationReasons[1].Code);
-                Assert.AreEqual(0, ex.CancellationReasons[1].Item.Count);
                 Assert.AreEqual("None", ex.CancellationReasons[2].Code);
-                Assert.AreEqual(0, ex.CancellationReasons[2].Item.Count);
                 Assert.AreEqual(0, transactWrite.ConditionCheckFailedItems.Count);
             }
 
@@ -1272,7 +1286,12 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 Assert.AreEqual(BatchStatementErrorCodeEnum.ConditionalCheckFailed.Value, ex.CancellationReasons[1].Code);
                 Assert.AreNotEqual(0, ex.CancellationReasons[1].Item.Count);
                 Assert.AreEqual("None", ex.CancellationReasons[2].Code);
-                Assert.AreEqual(0, ex.CancellationReasons[2].Item.Count);
+
+                if (AWSConfigs.InitializeCollections)
+                    Assert.AreEqual(0, ex.CancellationReasons[2].Item.Count);
+                else
+                    Assert.IsNull(ex.CancellationReasons[2].Item);
+
                 Assert.AreEqual(2, transactWrite.ConditionCheckFailedItems.Count);
                 Assert.IsTrue(AreValuesEqual(doc1, transactWrite.ConditionCheckFailedItems[0], conversion));
                 Assert.IsTrue(AreValuesEqual(doc2, transactWrite.ConditionCheckFailedItems[1], conversion));
@@ -1331,13 +1350,22 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 Assert.IsNotNull(ex);
                 Assert.AreEqual(3, ex.CancellationReasons.Count);
                 Assert.AreEqual("None", ex.CancellationReasons[0].Code);
-                Assert.AreEqual(0, ex.CancellationReasons[0].Item.Count);
                 Assert.AreEqual("None", ex.CancellationReasons[1].Code);
-                Assert.AreEqual(0, ex.CancellationReasons[1].Item.Count);
                 Assert.AreEqual(BatchStatementErrorCodeEnum.ConditionalCheckFailed.Value, ex.CancellationReasons[2].Code);
                 Assert.AreNotEqual(0, ex.CancellationReasons[2].Item.Count);
                 Assert.AreEqual(1, transactWrite.ConditionCheckFailedItems.Count);
                 Assert.IsTrue(AreValuesEqual(doc3, transactWrite.ConditionCheckFailedItems[0], conversion));
+
+                if (AWSConfigs.InitializeCollections)
+                {
+                    Assert.AreEqual(0, ex.CancellationReasons[0].Item.Count);
+                    Assert.AreEqual(0, ex.CancellationReasons[1].Item.Count);
+                }
+                else
+                {
+                    Assert.IsNull(ex.CancellationReasons[0].Item);
+                    Assert.IsNull(ex.CancellationReasons[1].Item);
+                }
             }
 
             {

--- a/sdk/test/Services/EC2/IntegrationTests/BasicDescribes.cs
+++ b/sdk/test/Services/EC2/IntegrationTests/BasicDescribes.cs
@@ -29,8 +29,10 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
             // perform a filtered query to (a) test parameter marshalling
             // and (b) cut down the time to run -- an unfiltered request
             // yields a lot of images
-            var request = new DescribeImagesRequest();
-            request.Owners.Add("amazon");
+            var request = new DescribeImagesRequest()
+            {
+                Owners = new List<string> { "amazon" }
+            };
             var response = Client.DescribeImages(request);
 
             Assert.IsNotNull(response);
@@ -45,8 +47,10 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
             // perform a filtered query to (a) test parameter marshalling
             // and (b) cut down the time to run -- an unfiltered request
             // yields a lot of images
-            var request = new DescribeImagesRequest();
-            request.Owners.Add("amazon");
+            var request = new DescribeImagesRequest()
+            {
+                Owners = new List<string> { "amazon" }
+            };
 
             var cts = new CancellationTokenSource();
             cts.CancelAfter(1000);

--- a/sdk/test/Services/EC2/IntegrationTests/SecurityGroupTests.cs
+++ b/sdk/test/Services/EC2/IntegrationTests/SecurityGroupTests.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.EC2;
+﻿using Amazon;
+using Amazon.EC2;
 using Amazon.EC2.Model;
 using AWSSDK_DotNet.IntegrationTests.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -132,7 +133,16 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
             var authorizeSecurityGroupEgressResponse = Client.AuthorizeSecurityGroupEgress(authorizeSecurityGroupEgressRequest);
 
             Assert.IsNotNull(authorizeSecurityGroupEgressResponse);
-            Assert.IsFalse(authorizeSecurityGroupEgressRequest.IpPermissions[0].Ipv4Ranges.Any());
+
+            if (AWSConfigs.InitializeCollections)
+            {
+                Assert.IsFalse(authorizeSecurityGroupEgressRequest.IpPermissions[0].Ipv4Ranges.Any());
+            }
+            else
+            {
+                Assert.IsNull(authorizeSecurityGroupEgressRequest.IpPermissions[0].Ipv4Ranges);
+            }
+
             UtilityMethods.WaitUntilSuccess(() =>
             {
                 describeSecurityGroupsResponse = DescribeSecurityGroupById();

--- a/sdk/test/Services/EC2/IntegrationTests/SecurityGroupTests.cs
+++ b/sdk/test/Services/EC2/IntegrationTests/SecurityGroupTests.cs
@@ -118,13 +118,19 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
         [TestCategory("EC2")]
         public void IpRangeRoundTripTest()
         {
+#pragma warning disable CS0618
             var describeSecurityGroupsResponse = DescribeSecurityGroupById();
 
             var testCollection = new List<string>();
             var authorizeSecurityGroupEgressRequest = new AuthorizeSecurityGroupEgressRequest();
             authorizeSecurityGroupEgressRequest.GroupId = SECURITY_GROUP_ID;
-            IpPermission authorizeSecurityGroupEgressPermission = new IpPermission();
-            authorizeSecurityGroupEgressPermission.IpRanges.Add("0.0.0.0/7");
+            IpPermission authorizeSecurityGroupEgressPermission = new IpPermission()
+            {
+                IpRanges = new List<string>
+                {
+                    "0.0.0.0/7"
+                }
+            };
             testCollection.Add("0.0.0.0/7");
             authorizeSecurityGroupEgressPermission.IpProtocol = "ICMP";
             authorizeSecurityGroupEgressPermission.FromPort = -1;
@@ -146,8 +152,17 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
             UtilityMethods.WaitUntilSuccess(() =>
             {
                 describeSecurityGroupsResponse = DescribeSecurityGroupById();
-                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, testCollection);
-                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges.Select(p => p.CidrIp).ToList(), testCollection);
+
+                if (!AWSConfigs.InitializeCollections && (testCollection == null || testCollection.Count == 0))
+                {
+                    Assert.IsNull(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges);
+                    Assert.IsNull(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges);
+                }
+                else
+                {
+                    CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, testCollection);
+                    CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges.Select(p => p.CidrIp).ToList(), testCollection);
+                }
             });
 
             authorizeSecurityGroupEgressRequest = new AuthorizeSecurityGroupEgressRequest();
@@ -162,8 +177,17 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
             {
                 describeSecurityGroupsResponse = DescribeSecurityGroupById();
                 validationResult = describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges.Select(p => p.CidrIp).ToList();
-                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, testCollection);
-                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, validationResult);
+
+                if (!AWSConfigs.InitializeCollections && (testCollection == null || testCollection.Count == 0))
+                {
+                    Assert.IsNull(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges);
+                    Assert.IsNull(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges);
+                }
+                else
+                {
+                    CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, testCollection);
+                    CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, validationResult);
+                }
             });
 
             authorizeSecurityGroupEgressRequest = new AuthorizeSecurityGroupEgressRequest();
@@ -187,8 +211,17 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
             {
                 describeSecurityGroupsResponse = DescribeSecurityGroupById();
                 validationResult = describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges.Select(p => p.CidrIp).ToList();
-                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, testCollection);
-                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, validationResult);
+
+                if (!AWSConfigs.InitializeCollections && (testCollection == null || testCollection.Count == 0))
+                {
+                    Assert.IsNull(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges);
+                    Assert.IsNull(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges);
+                }
+                else
+                {
+                    CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, testCollection);
+                    CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, validationResult);
+                }
             });
 
             authorizeSecurityGroupEgressRequest.IpPermissions[0].Ipv4Ranges = new List<IpRange> { new IpRange { CidrIp = "0.0.0.0/10", Description = "TestDescription" }, new IpRange { CidrIp = "0.0.0.0/11", Description = "TestDescription" } };
@@ -201,8 +234,17 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
             {
                 describeSecurityGroupsResponse = DescribeSecurityGroupById();
                 validationResult = describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges.Select(p => p.CidrIp).ToList();
-                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, testCollection);
-                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, validationResult);
+
+                if (!AWSConfigs.InitializeCollections && (testCollection == null || testCollection.Count == 0))
+                {
+                    Assert.IsNull(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges);
+                    Assert.IsNull(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges);
+                }
+                else
+                {
+                    CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, testCollection);
+                    CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, validationResult);
+                }
             });
 
             var updateSecurityGroupEgressRequest = new UpdateSecurityGroupRuleDescriptionsEgressRequest();
@@ -217,9 +259,9 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
             {
                 describeSecurityGroupsResponse = DescribeSecurityGroupById();
                 validationResult = describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges.Select(p => p.CidrIp).ToList();
-                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].IpRanges, validationResult);
+                CollectionAssert.AreEqual(describeSecurityGroupsResponse.SecurityGroups[0]?.IpPermissionsEgress[1]?.IpRanges, validationResult);
 
-                var descriptionTest = describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress[1].Ipv4Ranges.Where(p => p.CidrIp == "0.0.0.0/8").Select(p => p.Description).Single().ToString();
+                var descriptionTest = describeSecurityGroupsResponse.SecurityGroups[0]?.IpPermissionsEgress[1]?.Ipv4Ranges?.Where(p => p.CidrIp == "0.0.0.0/8").Select(p => p.Description).Single().ToString();
                 Assert.AreEqual(descriptionTest, "TestDescription");
             });
 
@@ -233,9 +275,11 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.EC2
             UtilityMethods.WaitUntilSuccess(() =>
             {
                 describeSecurityGroupsResponse = DescribeSecurityGroupById();
-                Assert.IsFalse(describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress
-                    .Where(p => p.Ipv4Ranges.Contains(new IpRange { CidrIp = "0.0.0.0/8", Description = "TestDescription" }) || p.Ipv4Ranges.Contains(new IpRange { CidrIp = "0.0.0.0/7" }) || p.IpRanges.Contains("0.0.0.0/7") || p.IpRanges.Contains("0.0.0.0/8")).ToList().Any());
+                var ipEgress = describeSecurityGroupsResponse.SecurityGroups[0].IpPermissionsEgress ?? new List<IpPermission>();
+                Assert.IsFalse(ipEgress
+                    .Where(p => p.Ipv4Ranges != null && (p.Ipv4Ranges.Contains(new IpRange { CidrIp = "0.0.0.0/8", Description = "TestDescription" }) || p.Ipv4Ranges.Contains(new IpRange { CidrIp = "0.0.0.0/7" }) || p.IpRanges.Contains("0.0.0.0/7") || p.IpRanges.Contains("0.0.0.0/8"))).ToList().Any());
             });
+#pragma warning restore CS0618
         }
 
         private static DescribeSecurityGroupsResponse DescribeSecurityGroupById()

--- a/sdk/test/Services/EC2/UnitTests/Custom/UnmarshallTests.cs
+++ b/sdk/test/Services/EC2/UnitTests/Custom/UnmarshallTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Amazon;
 using Amazon.EC2;
 using Amazon.EC2.Model;
 using Amazon.EC2.Model.Internal.MarshallTransformations;
@@ -348,7 +349,15 @@ namespace AWSSDK_DotNet35.UnitTests.EC2
                 as RunInstancesResponse;
 
             Assert.AreEqual("r-6e46e03a", result.Reservation.ReservationId);
-            Assert.AreEqual(0, result.Reservation.Groups.Count);
+
+            if (AWSConfigs.InitializeCollections)
+            {
+                Assert.AreEqual(0, result.Reservation.Groups.Count);
+            }
+            else
+            {
+                Assert.IsNull(result.Reservation.Groups);
+            }
 
             Assert.AreEqual<int>(1, result.Reservation.Instances.Count);
             var instance = result.Reservation.Instances[0];
@@ -507,7 +516,14 @@ namespace AWSSDK_DotNet35.UnitTests.EC2
             Assert.AreEqual("sg-1a2b3c4d", result.NetworkInterface.Groups[0].GroupId);
             Assert.AreEqual("default", result.NetworkInterface.Groups[0].GroupName);
 
-            Assert.AreEqual(0, result.NetworkInterface.TagSet.Count);
+            if (AWSConfigs.InitializeCollections)
+            {
+                Assert.AreEqual(0, result.NetworkInterface.TagSet.Count);
+            }
+            else
+            {
+                Assert.IsNull(result.NetworkInterface.TagSet);
+            }
 
             Assert.AreEqual(3, result.NetworkInterface.PrivateIpAddresses.Count);
             Assert.AreEqual("10.0.2.130", result.NetworkInterface.PrivateIpAddresses[0].PrivateIpAddress);

--- a/sdk/test/Services/ElastiCache/IntegrationTests/ElastiCache.cs
+++ b/sdk/test/Services/ElastiCache/IntegrationTests/ElastiCache.cs
@@ -66,9 +66,12 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
         public void TestDescribeCacheClusters()
         {
             var response = Client.DescribeCacheClusters();
-            foreach (var cluster in response.CacheClusters)
+            if (response.CacheClusters != null)
             {
-                Assert.IsNotNull(cluster.CacheClusterId);
+                foreach (var cluster in response.CacheClusters)
+                {
+                    Assert.IsNotNull(cluster.CacheClusterId);
+                }
             }
         }
 

--- a/sdk/test/Services/IdentityManagement/IntegrationTests/Util.cs
+++ b/sdk/test/Services/IdentityManagement/IntegrationTests/Util.cs
@@ -28,29 +28,38 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.IAM
         public static void DeleteUsersAndGroupsInTestNameSpace(AmazonIdentityManagementServiceClient client)
         {
             ListGroupsResponse lgRes = client.ListGroups(new ListGroupsRequest() { PathPrefix = TEST_PATH });
-            foreach (Group g in lgRes.Groups)
+            if (lgRes.Groups != null)
             {
-                GetGroupResponse ggRes = client.GetGroup(new GetGroupRequest() { GroupName = g.GroupName });
-                foreach (User u in ggRes.Users)
+                foreach (Group g in lgRes.Groups)
                 {
-                    client.RemoveUserFromGroup(new RemoveUserFromGroupRequest() { GroupName = g.GroupName, UserName = u.UserName });
+                    GetGroupResponse ggRes = client.GetGroup(new GetGroupRequest() { GroupName = g.GroupName });
+                    foreach (User u in ggRes.Users)
+                    {
+                        client.RemoveUserFromGroup(new RemoveUserFromGroupRequest() { GroupName = g.GroupName, UserName = u.UserName });
+                    }
+                    client.DeleteGroup(new DeleteGroupRequest() { GroupName = g.GroupName });
                 }
-                client.DeleteGroup(new DeleteGroupRequest() { GroupName = g.GroupName });
             }
 
             ListUsersResponse luRes = client.ListUsers(new ListUsersRequest() { PathPrefix = TEST_PATH });
-            foreach (User u in luRes.Users)
+            if (luRes.Users != null)
             {
-                DeleteTestUsers(client, u.UserName);
+                foreach (User u in luRes.Users)
+                {
+                    DeleteTestUsers(client, u.UserName);
+                }
             }
         }
 
         public static void DeleteAccessKeysForUser(AmazonIdentityManagementServiceClient client, string username)
         {
             ListAccessKeysResponse response = client.ListAccessKeys(new ListAccessKeysRequest() { UserName = username });
-            foreach (AccessKeyMetadata akm in response.AccessKeyMetadata)
+            if (response.AccessKeyMetadata != null)
             {
-                client.DeleteAccessKey(new DeleteAccessKeyRequest() { UserName = username, AccessKeyId = akm.AccessKeyId });
+                foreach (AccessKeyMetadata akm in response.AccessKeyMetadata)
+                {
+                    client.DeleteAccessKey(new DeleteAccessKeyRequest() { UserName = username, AccessKeyId = akm.AccessKeyId });
+                }
             }
         }
 
@@ -58,9 +67,13 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.IAM
         {
             ListUserPoliciesResponse response =
                 client.ListUserPolicies(new ListUserPoliciesRequest() { UserName = username });
-            foreach (string pName in response.PolicyNames)
+            
+            if (response.PolicyNames != null)
             {
-                client.DeleteUserPolicy(new DeleteUserPolicyRequest() { UserName = username, PolicyName = pName });
+                foreach (string pName in response.PolicyNames)
+                {
+                    client.DeleteUserPolicy(new DeleteUserPolicyRequest() { UserName = username, PolicyName = pName });
+                }
             }
         }
 
@@ -68,9 +81,13 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.IAM
         {
             ListSigningCertificatesResponse response =
                 client.ListSigningCertificates(new ListSigningCertificatesRequest() { UserName = username });
-            foreach (SigningCertificate cert in response.Certificates)
+            
+            if (response.Certificates != null)
             {
-                client.DeleteSigningCertificate(new DeleteSigningCertificateRequest() { UserName = username, CertificateId = cert.CertificateId });
+                foreach (SigningCertificate cert in response.Certificates)
+                {
+                    client.DeleteSigningCertificate(new DeleteSigningCertificateRequest() { UserName = username, CertificateId = cert.CertificateId });
+                }
             }
         }
 

--- a/sdk/test/Services/RDS/IntegrationTests/BasicDescribes.cs
+++ b/sdk/test/Services/RDS/IntegrationTests/BasicDescribes.cs
@@ -59,7 +59,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
                 });
                 Assert.IsNotNull(response);
 
-                if (describeResponse.DBEngineVersions.Count > 0)
+                if (describeResponse.DBEngineVersions != null && describeResponse.DBEngineVersions.Count > 0)
                 {
                     foreach (var dbev in describeResponse.DBEngineVersions)
                     {
@@ -94,7 +94,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
             Assert.IsNotNull(response);
 
             string dbInstanceIdentifier = null;
-            if (response.DBInstances.Count > 0)
+            if (response.DBInstances != null && response.DBInstances.Count > 0)
             {
                 foreach (var dbi in response.DBInstances)
                 {
@@ -302,7 +302,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
 
             string sourceIdentifier = null;
             string sourceType = null;
-            if (response.Events.Count > 0)
+            if (response.Events != null && response.Events.Count > 0)
             {
                 foreach (var e in response.Events)
                 {
@@ -352,7 +352,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
                     if (optionGroupName == null)
                         optionGroupName = og.OptionGroupName;
 
-                    if (og.Options.Count > 0)
+                    if (og.Options != null && og.Options.Count > 0)
                     {
                         foreach (var o in og.Options)
                         {
@@ -449,7 +449,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
             string reservedInstanceId = null;
             string dbInstanceClass = null;
 
-            if (response.ReservedDBInstances.Count > 0)
+            if (response.ReservedDBInstances != null && response.ReservedDBInstances.Count > 0)
             {
                 foreach (var rdbi in response.ReservedDBInstances)
                 {

--- a/sdk/test/Services/RDS/IntegrationTests/BasicDescribes.cs
+++ b/sdk/test/Services/RDS/IntegrationTests/BasicDescribes.cs
@@ -136,7 +136,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
             Assert.IsNotNull(response);
 
             string dbSecurityGroupName = null;
-            if (response.DBSecurityGroups.Count > 0)
+            if (response.DBSecurityGroups != null && response.DBSecurityGroups.Count > 0)
             {
                 foreach (var dbsg in response.DBSecurityGroups)
                 {
@@ -171,7 +171,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
             string dbInstanceIdentifier = null;
             string dbSnapshotIdentifier = null;
 
-            if (response.DBSnapshots.Count > 0)
+            if (response.DBSnapshots != null && response.DBSnapshots.Count > 0)
             {
                 foreach (var dbss in response.DBSnapshots)
                 {
@@ -216,7 +216,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
             Assert.IsNotNull(response);
 
             string dbSubnetGroupName = null;
-            if (response.DBSubnetGroups.Count > 0)
+            if (response.DBSubnetGroups != null && response.DBSubnetGroups.Count > 0)
             {
                 foreach (var dbsng in response.DBSubnetGroups)
                 {

--- a/sdk/test/Services/RDS/IntegrationTests/DBParameters.cs
+++ b/sdk/test/Services/RDS/IntegrationTests/DBParameters.cs
@@ -94,8 +94,9 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.RDS
                 var modifyDbParameterGroupRequest = new ModifyDBParameterGroupRequest
                 {
                     DBParameterGroupName = parameterGroupName,
+                    Parameters = new List<Parameter> { newParameter }
                 };
-                modifyDbParameterGroupRequest.Parameters.Add(newParameter);
+
                 var modifiedParameterGroupName = Client.ModifyDBParameterGroup(modifyDbParameterGroupRequest)
                     .DBParameterGroupName;
                 Assert.AreEqual(parameterGroupName, modifiedParameterGroupName);

--- a/sdk/test/Services/Redshift/IntegrationTests/Redshift.cs
+++ b/sdk/test/Services/Redshift/IntegrationTests/Redshift.cs
@@ -76,8 +76,14 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                 Assert.AreEqual(1, descResponse.ParameterGroups.Count);
                 Assert.AreEqual(name, descResponse.ParameterGroups[0].ParameterGroupName);
 
-                ModifyClusterParameterGroupRequest modRequest = new ModifyClusterParameterGroupRequest() { ParameterGroupName = name };
-                modRequest.Parameters.Add(new Parameter() { ParameterName = "require_ssl", ParameterValue = "true" });
+                ModifyClusterParameterGroupRequest modRequest = new ModifyClusterParameterGroupRequest() 
+                { 
+                    ParameterGroupName = name,
+                    Parameters = new List<Parameter>
+                    {
+                        new Parameter() { ParameterName = "require_ssl", ParameterValue = "true" }
+                    }
+                };
                 var modResponse = Client.ModifyClusterParameterGroup(modRequest);
 
                 var descParameterResponse = Client.DescribeClusterParameters(new DescribeClusterParametersRequest() { ParameterGroupName = name });
@@ -89,7 +95,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             {
                 Client.DeleteClusterParameterGroup(new DeleteClusterParameterGroupRequest() { ParameterGroupName = name });
                 var descResponse = Client.DescribeClusterParameterGroups(new DescribeClusterParameterGroupsRequest());
-                Assert.IsNull(descResponse.ParameterGroups.FirstOrDefault(x => x.ParameterGroupName == name));
+                Assert.IsNull(descResponse.ParameterGroups?.FirstOrDefault(x => x.ParameterGroupName == name));
             }
         }
 

--- a/sdk/test/Services/Route53/IntegrationTests/Route53.cs
+++ b/sdk/test/Services/Route53/IntegrationTests/Route53.cs
@@ -189,7 +189,11 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                 }
             }
             Assert.IsNotNull(status);
-            Assert.IsNotNull(status.HealthCheckObservations);
+
+            if (status.HealthCheckObservations == null)
+                Assert.IsFalse(AWSConfigs.InitializeCollections);
+            else
+                Assert.IsNotNull(status.HealthCheckObservations);
 
             var healthCheck = Client.GetHealthCheck(new GetHealthCheckRequest
             {
@@ -206,9 +210,16 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             }).ResourceTagSet;
             Assert.IsNotNull(tagSet);
             Assert.IsNotNull(tagSet.ResourceId);
-            Assert.IsNotNull(tagSet.ResourceType);
-            Assert.IsNotNull(tagSet.Tags);
-            Assert.AreEqual(0, tagSet.Tags.Count);
+
+            if (AWSConfigs.InitializeCollections)
+            {
+                Assert.IsNotNull(tagSet.Tags);
+                Assert.AreEqual(0, tagSet.Tags.Count);
+            }
+            else
+            {
+                Assert.IsNull(tagSet.Tags);
+            }
 
             Client.ChangeTagsForResource(new ChangeTagsForResourceRequest
             {

--- a/sdk/test/Services/S3/IntegrationTests/AccelerateTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/AccelerateTests.cs
@@ -229,7 +229,11 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         {
             // All other operations should hit accelerate endpoint
             var objects = client.ListObjects(bucketName).S3Objects;
-            Assert.IsNotNull(objects);
+
+            if (objects == null)
+                Assert.IsFalse(AWSConfigs.InitializeCollections);
+            else
+                Assert.IsNotNull(objects);
         }
 
         void TestAccelerateUnsupportedOperations(IAmazonS3 client)

--- a/sdk/test/Services/S3/IntegrationTests/BucketOwnershipControlsTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/BucketOwnershipControlsTests.cs
@@ -92,10 +92,11 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             var putRequest = new PutBucketOwnershipControlsRequest
             {
                 BucketName = bucketName,
-                OwnershipControls = new OwnershipControls()
+                OwnershipControls = new OwnershipControls
+                {
+                    Rules = new List<OwnershipControlsRule> { new OwnershipControlsRule { ObjectOwnership = objectOwnership } }
+                }
             };
-
-            putRequest.OwnershipControls.Rules.Add(new OwnershipControlsRule { ObjectOwnership = objectOwnership });
 
             s3Client.PutBucketOwnershipControls(putRequest);
 

--- a/sdk/test/Services/S3/IntegrationTests/IntelligentTieringTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/IntelligentTieringTests.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.S3;
+﻿using Amazon;
+using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -266,7 +267,11 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             };
 
             var listBucketIntelligentTieringConfigurationsResponse = Client.ListBucketIntelligentTieringConfigurations(listBucketIntelligentTieringConfigurationsRequest);
-            Assert.AreEqual(listBucketIntelligentTieringConfigurationsResponse.IntelligentTieringConfigurationList.Count, 0);
+
+            if (AWSConfigs.InitializeCollections)
+                Assert.AreEqual(listBucketIntelligentTieringConfigurationsResponse.IntelligentTieringConfigurationList.Count, 0);
+            else
+                Assert.IsNull(listBucketIntelligentTieringConfigurationsResponse.IntelligentTieringConfigurationList);
         }
     }
 }

--- a/sdk/test/Services/S3/IntegrationTests/LifecycleTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/LifecycleTests.cs
@@ -29,6 +29,7 @@ using AWSSDK_DotNet.IntegrationTests.Tests;
 using AWSSDK_DotNet.IntegrationTests.Tests.S3;
 using Amazon.S3.Util;
 using AWSSDK_DotNet.IntegrationTests.Utils;
+using Amazon;
 
 namespace S3UnitTest
 {
@@ -84,8 +85,11 @@ namespace S3UnitTest
         {
             var s3Configuration = Client.GetLifecycleConfiguration(bucketName).Configuration;
             Assert.IsNotNull(s3Configuration);
-            Assert.IsNotNull(s3Configuration.Rules);
-            Assert.AreEqual(0, s3Configuration.Rules.Count);
+
+            if (AWSConfigs.InitializeCollections)
+                Assert.AreEqual(0, s3Configuration.Rules.Count);
+            else
+                Assert.IsNull(s3Configuration.Rules);
 
             var configuration = new LifecycleConfiguration
             {
@@ -248,8 +252,11 @@ namespace S3UnitTest
         {
             var s3Configuration = Client.GetLifecycleConfiguration(bucketName).Configuration;
             Assert.IsNotNull(s3Configuration);
-            Assert.IsNotNull(s3Configuration.Rules);
-            Assert.AreEqual(0, s3Configuration.Rules.Count);
+
+            if (AWSConfigs.InitializeCollections)
+                Assert.AreEqual(0, s3Configuration.Rules.Count);
+            else
+                Assert.IsNull(s3Configuration.Rules);
 
             var configuration = new LifecycleConfiguration
             {
@@ -429,7 +436,16 @@ namespace S3UnitTest
             AssertFiltersAreEqual(expected.Filter, actual.Filter);
 
             Assert.AreEqual(expected.Transitions.Count, actual.Transitions.Count);
-            Assert.AreEqual(expected.NoncurrentVersionTransitions.Count, actual.NoncurrentVersionTransitions.Count);
+
+            if (expected.NoncurrentVersionTransitions == null)
+            {
+                Assert.IsNull(actual.NoncurrentVersionTransitions);
+            }
+            else
+            {
+                Assert.AreEqual(expected.NoncurrentVersionTransitions.Count, actual.NoncurrentVersionTransitions.Count);
+            }
+
             if (expected.AbortIncompleteMultipartUpload == null)
             {
                 Assert.IsNull(actual.AbortIncompleteMultipartUpload);

--- a/sdk/test/Services/S3/IntegrationTests/NotificationTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/NotificationTests.cs
@@ -142,7 +142,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                             {
                                 Id = "the-queue-test",
                                 Queue = queueArn,
-                                Events = {EventType.ObjectCreatedPut},
+                                Events = new List<EventType>{EventType.ObjectCreatedPut},
                                 Filter = new Filter
                                 {
                                     S3KeyFilter = new S3KeyFilter

--- a/sdk/test/Services/S3/IntegrationTests/S3ExpressTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/S3ExpressTests.cs
@@ -13,6 +13,7 @@ using Amazon.SecurityToken;
 using Amazon.SecurityToken.Model;
 using Amazon.S3.Transfer;
 using AWSSDK_DotNet.IntegrationTests.Utils;
+using Amazon;
 
 namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 {
@@ -199,8 +200,10 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 BucketName = destinationbucketName
             });
 
-            Assert.IsTrue(response.S3Objects.Count == 0);
-
+            if (AWSConfigs.InitializeCollections)
+                Assert.IsTrue(response.S3Objects.Count == 0);
+            else
+                Assert.IsNull(response.S3Objects);
 
             Client.DeleteBucket(destinationbucketName);
 
@@ -256,7 +259,10 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 BucketName = newRegularBucket
             });
 
-            Assert.IsTrue(listObjectsResponse.S3Objects.Count == 0);
+            if (AWSConfigs.InitializeCollections)
+                Assert.IsTrue(listObjectsResponse.S3Objects.Count == 0);
+            else
+                Assert.IsNull(listObjectsResponse.S3Objects);
 
 
             // Add new object to regular bucket

--- a/sdk/test/Services/S3/IntegrationTests/S3TestUtils.cs
+++ b/sdk/test/Services/S3/IntegrationTests/S3TestUtils.cs
@@ -267,7 +267,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 // List all the versions of all the objects in the bucket.
                 listVersionsResponse = client.ListVersions(listVersionsRequest);
 
-                if (listVersionsResponse.Versions.Count == 0)
+                if (listVersionsResponse.Versions == null || listVersionsResponse.Versions.Count == 0)
                 {
                     // If the bucket has no objects we're finished
                     return;

--- a/sdk/test/Services/S3/IntegrationTests/StorageInsightsAnalyticsTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/StorageInsightsAnalyticsTests.cs
@@ -298,7 +298,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             });
 
             var successFlag = true;
-            if (response.S3Objects.Count > 0)
+            if (response.S3Objects != null && response.S3Objects.Count > 0)
             {
                 successFlag = false;
             }

--- a/sdk/test/Services/S3/IntegrationTests/StorageInsightsInventoryTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/StorageInsightsInventoryTests.cs
@@ -168,7 +168,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             });
 
             var successFlag = true;
-            if (response.S3Objects.Count > 0)
+            if (response.S3Objects != null && response.S3Objects.Count > 0)
             {
                 successFlag = false;
             }

--- a/sdk/test/Services/S3/IntegrationTests/StorageInsightsMetricsTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/StorageInsightsMetricsTests.cs
@@ -290,7 +290,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             });
 
             var successFlag = true;
-            if (response.S3Objects.Count > 0)
+            if (response.S3Objects != null && response.S3Objects.Count > 0)
             {
                 successFlag = false;
             }

--- a/sdk/test/Services/SQS/IntegrationTests/SQS.cs
+++ b/sdk/test/Services/SQS/IntegrationTests/SQS.cs
@@ -33,25 +33,31 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
         {
             var result = Client.ListQueues(new ListQueuesRequest());
             Assert.IsNotNull(result);
-            Assert.IsNotNull(result.QueueUrls);
+            if (result.QueueUrls == null)
+                Assert.IsFalse(AWSConfigs.InitializeCollections);
+            else
+                Assert.IsNotNull(result.QueueUrls);
         }
 
         [TestCleanup]
         public void SQSCleanup()
         {
             var result = Client.ListQueues(new ListQueuesRequest());
-            foreach (string queue in result.QueueUrls)
+            if (result.QueueUrls != null)
             {
-                Console.WriteLine("Queue: {0}", queue);
-                if (queue.Contains("TestQueue"))
+                foreach (string queue in result.QueueUrls)
                 {
-                    try
+                    Console.WriteLine("Queue: {0}", queue);
+                    if (queue.Contains("TestQueue"))
                     {
-                        Client.DeleteQueue(new DeleteQueueRequest() { QueueUrl = queue });
-                    }
-                    catch (Exception)
-                    {
-                        Console.Write("Failed to clean up queue {0}", queue);
+                        try
+                        {
+                            Client.DeleteQueue(new DeleteQueueRequest() { QueueUrl = queue });
+                        }
+                        catch (Exception)
+                        {
+                            Console.Write("Failed to clean up queue {0}", queue);
+                        }
                     }
                 }
             }
@@ -216,7 +222,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             for (int i = 0; i < 10; i++)
             {
                 listResult = Client.ListQueues(new ListQueuesRequest() { QueueNamePrefix = prefix });
-                if (count - 1 == listResult.QueueUrls.Count)
+                if (listResult.QueueUrls == null || count - 1 == listResult.QueueUrls.Count)
                 {
                     return;
                 }

--- a/sdk/test/Services/SimpleDB/IntegrationTests/SimpleDB.cs
+++ b/sdk/test/Services/SimpleDB/IntegrationTests/SimpleDB.cs
@@ -309,10 +309,13 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
         Dictionary<string, string> ConvertAttributesToMap(List<Amazon.SimpleDB.Model.Attribute> attributeList)
         {
             Dictionary<string, string> attributeValuesByName = new Dictionary<string, string>();
-
-            foreach (Amazon.SimpleDB.Model.Attribute attribute in attributeList)
+            
+            if (attributeList != null)
             {
-                attributeValuesByName.Add(attribute.Name, attribute.Value);
+                foreach (Amazon.SimpleDB.Model.Attribute attribute in attributeList)
+                {
+                    attributeValuesByName.Add(attribute.Name, attribute.Value);
+                }
             }
             return attributeValuesByName;
         }

--- a/sdk/test/Services/SimpleNotificationService/IntegrationTests/SNS.cs
+++ b/sdk/test/Services/SimpleNotificationService/IntegrationTests/SNS.cs
@@ -483,11 +483,15 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             do
             {
                 var listResponse = Client.ListTopics(listRequest);
-                allTopics.AddRange(listResponse.Topics);
+
+                if (listResponse.Topics != null)
+                {
+                    allTopics.AddRange(listResponse.Topics);
+                }
 
                 listRequest.NextToken = listResponse.NextToken;
             } while (!string.IsNullOrEmpty(listRequest.NextToken));
-            return allTopics;
+            return allTopics ?? new List<Topic>();
         }
 
         private PublishRequest GetPublishRequest(string topicArn)


### PR DESCRIPTION
## Description
For the .NET types used for service API request and responses the collection properties have always been initialized to an empty collection. This was done for ease of use. It does cause problems though with the SDK and consumers of the SDK to not understand if a property that currently set to an empty string is that way because it is the default value or the user wants to clear out the values of a collection. On a response users don't know if an collection is empty on the resource or just the default value for the collection.

This behavior also cause memory allocation issues because a lot of collections are created that are not even used. This is most pronounced with DynamoDB. In that case every attribute for an item is represented by an `AttributeValue`. This type creates 5 collections when at most 1 collection would actually have a value. A DynamoDB query that returns back 100 items with 10 attributes would end up creating 5000 collection when at most 1000 could be used. The actual value would mostly likely be less considering the frequency of scaler attributes.

This PR adds a new `AWSConfigs.InitializeCollection` property which defaults to `true`. With the value being `true` the behavior of the SDK stays as it has been. SDK decides to send a property as part of the request payload if the collection is not null and has a count greater then 0. This is where the problem the SDK has about clearing out collections. With the value `false` the collections for property on request and response types will be initialized to null. The SDK will send the collection property as part of the request payload whenever the collection is not null. That includes sending the property when the count is 0.

For V3 `AWSConfigs.InitializeCollection` this property will stay default to `true` to not break any behavior. We hope to change the default of this property to `false` in the next major version to address the modeling and performance issues with auto initializing collections.

The generated code changes are not included in this PR. That will be a massive amount of file changes. 

My process for updating S3 since it is hand coded.
* Add the check `AWSConfigs.InitializeCollection` when declaring and initializing the collections.
* Updated the `IsSet` operations to match our new desired behavior.
* To make things consistent I replaced code that was lazily creating the collection in the getter
* Did a VS Find Reference and made sure the calling code in the SDK was null safe. This usually involved updating the unmarshallers.
* A few `IsSet` methods I deleted because they were response only objects that were never called. I seemed better then updating them knowing there was nothing that was going to test them.

I also tried to address some compiler warnings as I was going though the code.

## Testing
Ran successful dry runs with `AWSConfigs.InitializeCollection` set to both `true` and `false`.

