### PR TITLE
Update CopyObjectRequestMarshaller to throw ArgumentException for missing properties

### DIFF
--- a/generator/.DevConfigs/40980b2b-ec4c-4081-9a64-6a8a4a47d6bc.json
+++ b/generator/.DevConfigs/40980b2b-ec4c-4081-9a64-6a8a4a47d6bc.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+      {
+          "serviceName": "S3",
+          "type": "patch",
+          "changeLogMessages": [
+              "Fix: Update CopyObjectRequestMarshaller to throw ArgumentException for missing properties"
+          ]
+      }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
@@ -37,12 +37,12 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         public IRequest Marshall(CopyObjectRequest copyObjectRequest)
         {
             var sourceKey = 
-                copyObjectRequest.DisableTrimmingLeadingSlash ?
+                copyObjectRequest.DisableTrimmingLeadingSlash || string.IsNullOrEmpty(copyObjectRequest.SourceKey) ?
                 copyObjectRequest.SourceKey :
                 AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.SourceKey);
 
             var destinationKey = 
-                copyObjectRequest.DisableTrimmingLeadingSlash ?
+                copyObjectRequest.DisableTrimmingLeadingSlash || string.IsNullOrEmpty(copyObjectRequest.DestinationKey) ?
                 copyObjectRequest.DestinationKey:
                 AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.DestinationKey);
             
@@ -148,6 +148,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 throw new System.ArgumentException("DestinationBucket is a required property and must be set before making this call.", "CopyObjectRequest.DestinationBucket");
             if (string.IsNullOrEmpty(destinationKey))
                 throw new System.ArgumentException("DestinationKey is a required property and must be set before making this call.", "CopyObjectRequest.DestinationKey");
+            if (string.IsNullOrEmpty(copyObjectRequest.SourceBucket))
+                throw new System.ArgumentException("SourceBucket is a required property and must be set before making this call.", "CopyObjectRequest.SourceBucket");
+            if (string.IsNullOrEmpty(sourceKey))
+                throw new System.ArgumentException("SourceKey is a required property and must be set before making this call.", "CopyObjectRequest.SourceKey");
 
             request.ResourcePath = string.Format(CultureInfo.InvariantCulture, "/{0}",
                                                  S3Transforms.ToStringValue(destinationKey));

--- a/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
@@ -98,5 +98,33 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 Assert.AreEqual(testContent, actualText);
             }
         }
+
+        [DataRow(testKey, true, "/destinationTestKey1.txt", true, null)]
+        [DataRow(null, true, "/destinationTestKey1.txt", true, "CopyObjectRequest.SourceKey")]
+        [DataRow(testKey, false, "/destinationTestKey1.txt", true, "CopyObjectRequest.SourceBucket")]
+        [DataRow(testKey, true, null, true, "CopyObjectRequest.DestinationKey")]
+        [DataRow(testKey, true, "/destinationTestKey1.txt", false, "CopyObjectRequest.DestinationBucket")]
+        [DataTestMethod]
+        [TestCategory("S3")]
+        public void TestCopyObjectWithMissingParameters(string sourceKey, bool includeSourceBucket, string destinationKey, bool includeDestinationBucket, string expectedMissingParameter)
+        {
+            string missingParameter = null;
+            try
+            {
+                var copyObjectResponse = usEastClient.CopyObject(new CopyObjectRequest
+                {
+                    SourceKey = sourceKey,
+                    SourceBucket = includeSourceBucket ? eastBucketName : null,
+
+                    DestinationKey = destinationKey,
+                    DestinationBucket = includeDestinationBucket ? eastBucketName : null,
+                });
+            }
+            catch (ArgumentException ex)
+            {
+                missingParameter = ex.ParamName;
+            }
+            Assert.AreEqual(missingParameter, expectedMissingParameter);
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
CopyObject request is throwing unmeaningful exception when one of its required parameters is missing (except `DestinationBucket` which is handled correctly).

## Motivation and Context
A customer raised this issue https://github.com/aws/aws-sdk-net/issues/3193 when using `CopyObjectAsync`.

## Testing
* Tested the same code that was included in the issue and added unit tests to cover all cases of missing properties.
* Did a full dry run `DRY_RUN-d3c91a42-e7d1-4c82-ba55-7a4cd64112e0`.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement