### PR TITLE
Remove Legacy Enums

### DIFF
--- a/generator/ServiceClientGeneratorLib/Customizations.cs
+++ b/generator/ServiceClientGeneratorLib/Customizations.cs
@@ -1554,7 +1554,7 @@ namespace ServiceClientGenerator
                 /// any code that would be valid within the Amazon[ServiceName]Client
                 /// class for the ServiceName where the override is being made. For 
                 /// example, a valid condition is: 
-                /// "if(this.Config.RetryMode == RequestRetryMode.Legacy)"
+                /// "if(this.Config.RetryMode == RequestRetryMode.Standard)"
                 /// </summary>
                 public string Condition { get; set; }
 

--- a/generator/ServiceClientGeneratorLib/DefaultConfiguration/DefaultConfigurationController.cs
+++ b/generator/ServiceClientGeneratorLib/DefaultConfiguration/DefaultConfigurationController.cs
@@ -9,8 +9,7 @@ namespace ServiceClientGenerator.DefaultConfiguration
     {
         /// <summary>
         /// Fully loads and populates <see cref="DefaultConfigurationModel"/> by parsing the
-        /// sdk-default-configurations.json file from disk.  Also adds the 'Legacy'
-        /// <see cref="DefaultConfigurationMode"/> with the correct defaults.
+        /// sdk-default-configurations.json file from disk.
         /// </summary>
         /// <param name="repositoryRootDirectoryPath">
         /// Full path to the root directory, ie contains the 'sdk' directory.
@@ -52,33 +51,11 @@ namespace ServiceClientGenerator.DefaultConfiguration
             }
 
             var parsedModel = _defaultConfigurationParser.Parse(json);
-
-            EnrichLegacyMode(parsedModel);
-
+            
+            var validModes = parsedModel.Modes.Where(m => m.Name.ToPascalCase() != "Legacy").ToList();
+            parsedModel.Modes = validModes;
+            
             return parsedModel;
-        }
-
-        private void EnrichLegacyMode(DefaultConfigurationModel parsedModel)
-        {
-            var legacyMode = 
-                parsedModel
-                    .Modes
-                    .FirstOrDefault(x => string.Equals(x.Name, "Legacy", StringComparison.OrdinalIgnoreCase));
-
-            if (legacyMode == null)
-                throw new Exception(
-                    "Did not find required Default Configuration mode 'Legacy'.  " +
-                    $"Found: {string.Join(",", parsedModel.Modes.Select(x => x.Name))}");
-
-            legacyMode.RetryMode = RequestRetryMode.Legacy;
-            legacyMode.S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy;
-            legacyMode.StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy;
-            // default to null for timeouts - this preserves the ServiceConfig
-            // behavior of defaulting configurable timeouts to null
-            legacyMode.TimeToFirstByteTimeout = null;
-            legacyMode.ConnectTimeout = null;
-            legacyMode.HttpRequestTimeout = null;
-            legacyMode.TlsNegotiationTimeout = null;
         }
     }
 }

--- a/generator/ServiceClientGeneratorLib/DefaultConfiguration/DefaultConfigurationModel.cs
+++ b/generator/ServiceClientGeneratorLib/DefaultConfiguration/DefaultConfigurationModel.cs
@@ -28,7 +28,7 @@ namespace ServiceClientGenerator.DefaultConfiguration
     public class DefaultConfigurationMode
     {
         /// <summary>
-        /// Identifies a specific configuration mode. Example legacy, mobile, cross-region, etc
+        /// Identifies a specific configuration mode. Example mobile, cross-region, etc
         /// </summary>
         public string Name { get; set; }
         /// <summary>
@@ -79,10 +79,6 @@ namespace ServiceClientGenerator.DefaultConfiguration
     /// <remarks>This is a copy of Amazon.Runtime.RequestRetryMode</remarks>
     public enum RequestRetryMode
     {
-        /// <summary>
-        /// Legacy request retry strategy.
-        /// </summary>
-        Legacy,
         /// <summary>
         /// Standardized request retry strategy that is consistent across all SDKs.
         /// </summary>

--- a/generator/ServiceClientGeneratorTests/DefaultConfigurationControllerTests.cs
+++ b/generator/ServiceClientGeneratorTests/DefaultConfigurationControllerTests.cs
@@ -13,11 +13,10 @@ namespace ServiceClientGeneratorTests
     public class DefaultConfigurationControllerTests
     {
         /// <summary>
-        /// Controller should find the 'Legacy' Default Configuration Mode
-        /// and explicitly set timeouts.
+        /// Controller should ignore the 'Legacy' Default Configuration Mode.
         /// </summary>
         [Fact]
-        public void ControllerEnrichesLegacyDefaultConfigurationMode()
+        public void ControllerIgnoresLegacyDefaultConfigurationMode()
         {
             var fakeJson = "fakeJson";
             var fakeDocumentation = "fakeDocumentation";
@@ -51,10 +50,7 @@ namespace ServiceClientGeneratorTests
                     .Modes
                     .FirstOrDefault(x => x.Name == "Legacy");
 
-            legacyMode.ShouldNotBeNull();
-            legacyMode.Documentation.ShouldEqual(fakeDocumentation);
-            // Controller should have modified timeout
-            legacyMode.TimeToFirstByteTimeout.ShouldBeGreaterThan(TimeSpan.Zero);
+            legacyMode.ShouldBeNull();
         }
     }
 }

--- a/generator/ServiceModels/dynamodb/dynamodb-.customizations.json
+++ b/generator/ServiceModels/dynamodb/dynamodb-.customizations.json
@@ -2,17 +2,6 @@
     "noArgOverloads": [
         "ListTables"
     ],
-    "runtimePipelineOverride":{
-        "overrides":[
-            {
-                "condition":"this.Config.RetryMode == RequestRetryMode.Legacy",
-                "operation":"replace",
-                "newType":"Amazon.Runtime.Internal.RetryHandler",
-                "targetType":"Amazon.Runtime.Internal.RetryHandler",
-                "constructorInput":"new Amazon.DynamoDBv2.Internal.DynamoDBRetryPolicy(this.Config)"
-            }
-        ]
-    },
     "emitIsSetProperties":{
         "AttributeValue" : [
             "BOOL",

--- a/generator/ServiceModels/dynamodbstreams/dynamodbstreams.customizations.json
+++ b/generator/ServiceModels/dynamodbstreams/dynamodbstreams.customizations.json
@@ -1,18 +1,7 @@
-{    
-    "runtimePipelineOverride":{
-        "overrides":[
-            {
-                "condition":"this.Config.RetryMode == RequestRetryMode.Legacy",
-                "operation":"replace",
-                "newType":"Amazon.Runtime.Internal.RetryHandler",
-                "targetType":"Amazon.Runtime.Internal.RetryHandler",
-                "constructorInput":"new Amazon.DynamoDBv2.Internal.DynamoDBRetryPolicy(this.Config)"
-            }
-        ]
-    },
-	"shapeSubstitutions": {
-        "Stream": {
-            "renameShape": "StreamSummary"
-        }	
-	}
+{
+  "shapeSubstitutions": {
+    "Stream": {
+      "renameShape": "StreamSummary"
+    }
+  }
 }

--- a/generator/ServiceModels/ec2/ec2.customizations.json
+++ b/generator/ServiceModels/ec2/ec2.customizations.json
@@ -17,21 +17,14 @@
                 "newType": "Amazon.EC2.Internal.AmazonEC2ResponseHandler",
                 "targetType": "Amazon.Runtime.Internal.Unmarshaller"
             },
-			{
-                "condition":"this.Config.RetryMode == RequestRetryMode.Legacy",
-                "operation":"replace",
-                "newType":"Amazon.Runtime.Internal.RetryHandler",
-                "targetType":"Amazon.Runtime.Internal.RetryHandler",
-                "constructorInput":"new Amazon.EC2.Internal.EC2RetryPolicy(this.Config)"
-            },
-			{
+            {
                 "condition":"this.Config.RetryMode == RequestRetryMode.Standard",
                 "operation":"replace",
                 "newType":"Amazon.Runtime.Internal.RetryHandler",
                 "targetType":"Amazon.Runtime.Internal.RetryHandler",
                 "constructorInput":"new Amazon.EC2.Internal.EC2StandardRetryPolicy(this.Config)"
             },
-			{
+            {
                 "condition":"this.Config.RetryMode == RequestRetryMode.Adaptive",
                 "operation":"replace",
                 "newType":"Amazon.Runtime.Internal.RetryHandler",

--- a/generator/ServiceModels/s3/s3.customizations.json
+++ b/generator/ServiceModels/s3/s3.customizations.json
@@ -9,13 +9,6 @@
             { "operation": "addBefore", "newType": "Amazon.S3.Internal.S3Express.S3ExpressPreSigner", "targetType": "Amazon.Runtime.Internal.Signer" },
             { "operation": "addAfter", "newType": "Amazon.S3.Internal.AmazonS3PostMarshallHandler", "targetType": "Amazon.Runtime.Internal.EndpointResolver" },
             {
-                "condition":"this.Config.RetryMode == RequestRetryMode.Legacy",
-                "operation": "replace",
-                "newType": "Amazon.Runtime.Internal.RetryHandler",
-                "targetType": "Amazon.Runtime.Internal.RetryHandler",
-                "constructorInput": "new Amazon.S3.Internal.AmazonS3RetryPolicy(this.Config)"
-            },
-            {
                 "condition":"this.Config.RetryMode == RequestRetryMode.Standard",
                 "operation": "replace",
                 "newType": "Amazon.Runtime.Internal.RetryHandler",

--- a/generator/ServiceModels/sts/sts.customizations.json
+++ b/generator/ServiceModels/sts/sts.customizations.json
@@ -2,13 +2,6 @@
     "runtimePipelineOverride": {
         "overrides": [
             {
-                "condition":"this.Config.RetryMode == RequestRetryMode.Legacy",
-                "operation": "replace",
-                "newType": "Amazon.Runtime.Internal.RetryHandler",
-                "targetType": "Amazon.Runtime.Internal.RetryHandler",
-                "constructorInput": "new SecurityTokenServiceRetryPolicy(this.Config)"
-            },
-            {
                 "condition":"this.Config.RetryMode == RequestRetryMode.Standard",
                 "operation": "replace",
                 "newType": "Amazon.Runtime.Internal.RetryHandler",

--- a/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
+++ b/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
@@ -389,9 +389,6 @@ namespace Amazon.Runtime
                 case RequestRetryMode.Standard:
                     retryPolicy = new StandardRetryPolicy(this.Config);
                     break;
-                case RequestRetryMode.Legacy:
-                    retryPolicy = new DefaultRetryPolicy(this.Config);
-                    break;
                 default:
                     throw new InvalidOperationException("Unknown retry mode");
             }

--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfile.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfile.cs
@@ -70,7 +70,7 @@ namespace Amazon.Runtime.CredentialManagement
         /// The desired <see cref="DefaultConfiguration.Name"/> that
         /// <see cref="IDefaultConfigurationProvider"/> should use.
         /// <para />
-        /// If this is null/empty, then the <see cref="DefaultConfigurationMode.Legacy"/> Mode will be used.
+        /// If this is null/empty, then the <see cref="DefaultConfigurationMode.Standard"/> Mode will be used.
         /// </summary>
         public string DefaultConfigurationModeName { get; set; }
 
@@ -105,7 +105,7 @@ namespace Amazon.Runtime.CredentialManagement
         public S3UsEast1RegionalEndpointValue? S3RegionalEndpoint { get; set; }
 
         /// <summary>
-        /// The request retry mode  as legacy, standard, or adaptive
+        /// The request retry mode as standard or adaptive
         /// </summary>
         public RequestRetryMode? RetryMode { get; set; }
 

--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/SharedCredentialsFile.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/SharedCredentialsFile.cs
@@ -736,7 +736,7 @@ namespace Amazon.Runtime.CredentialManagement
                 {
                     if (!Enum.TryParse<RequestRetryMode>(retryModeString, true, out var retryModeTemp))
                     {
-                        _logger.InfoFormat("Invalid value {0} for {1} in profile {2}. A string legacy/standard/adaptive is expected.", retryModeString, RetryModeField, profileName);
+                        _logger.InfoFormat("Invalid value {0} for {1} in profile {2}. A string standard/adaptive is expected.", retryModeString, RetryModeField, profileName);
                         profile = null;
                         return false;
                     }

--- a/sdk/src/Core/Amazon.Runtime/DefaultConfiguration.cs
+++ b/sdk/src/Core/Amazon.Runtime/DefaultConfiguration.cs
@@ -24,12 +24,8 @@ namespace Amazon.Runtime
     /// <para />
     /// All options above can be configured by users, and the overridden value will take precedence.
     /// <para />
-    /// <b>Note:</b> for any mode other than <see cref="DefaultConfigurationMode.Legacy"/>, the vended default values
-    /// might change as best practices may evolve. As a result, it is encouraged to perform testing when upgrading the SDK
-    /// if you are using a mode other than <see cref="DefaultConfigurationMode.Legacy"/>.
-    /// <para />
-    /// While the <see cref="DefaultConfigurationMode.Legacy"/> defaults mode is specific to .NET,
-    /// other modes are standardized across all of the AWS SDKs.
+    /// <b>Note:</b> the vended default values might change as best practices may evolve. As a result, it is encouraged to perform 
+    /// testing when upgrading the SDK.
     /// <para />
     /// The defaults mode can be configured:
     /// <list type="number">
@@ -41,7 +37,7 @@ namespace Amazon.Runtime
     public interface IDefaultConfiguration
     {
         /// <summary>
-        /// Identifies a specific configuration mode. Example legacy, mobile, cross-region, etc
+        /// Identifies a specific configuration mode. Example mobile, cross-region, etc
         /// </summary>
         DefaultConfigurationMode Name { get; }
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/DefaultConfigurationMode.generated.cs
+++ b/sdk/src/Core/Amazon.Runtime/DefaultConfigurationMode.generated.cs
@@ -49,10 +49,6 @@ namespace Amazon.Runtime
         /// <summary>
         /// <p>The AUTO mode is an experimental mode that builds on the standard mode. The SDK will attempt to discover the execution environment to determine the appropriate settings automatically.</p><p>Note that the auto detection is heuristics-based and does not guarantee 100% accuracy. STANDARD mode will be used if the execution environment cannot be determined. The auto detection might query <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">EC2 Instance Metadata service</a>, which might introduce latency. Therefore we recommend choosing an explicit defaults_mode instead if startup latency is critical to your application</p>
         /// </summary>
-        Auto,
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        Legacy
+        Auto
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Enumerations.cs
+++ b/sdk/src/Core/Amazon.Runtime/Enumerations.cs
@@ -89,10 +89,6 @@ namespace Amazon.Runtime
     public enum RequestRetryMode
     {
         /// <summary>
-        /// Legacy request retry strategy.
-        /// </summary>
-        Legacy,
-        /// <summary>
         /// Standardized request retry strategy that is consistent across all SDKs.
         /// </summary>
         Standard,

--- a/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
@@ -191,10 +191,9 @@ namespace Amazon.Runtime
 
         /// <summary>
         /// Returns the flag indicating how many retry HTTP requests an SDK should
-        /// make for a single SDK operation invocation before giving up. This flag will 
-        /// return 4 when the RetryMode is set to "Legacy" which is the default. For
+        /// make for a single SDK operation invocation before giving up. For
         /// RetryMode values of "Standard" or "Adaptive" this flag will return 2. In 
-        /// addition to the values returned that are dependant on the RetryMode, the
+        /// addition to the values returned that are dependent on the RetryMode, the
         /// value can be set to a specific value by using the AWS_MAX_ATTEMPTS environment
         /// variable, max_attempts in the shared configuration file, or by setting a
         /// value directly on this property. When using AWS_MAX_ATTEMPTS or max_attempts

--- a/sdk/src/Core/Amazon.Runtime/Internal/DefaultConfigurationProvider.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/DefaultConfigurationProvider.cs
@@ -37,7 +37,7 @@ namespace Amazon.Runtime.Internal
         /// <item>Mode matching <paramref name="requestedConfigurationMode"/>.  This should be set via <see cref="ClientConfig.DefaultConfigurationMode"/></item>
         /// <item>The Environment Variable <see cref="DefaultConfigurationProvider.AWS_DEFAULTS_MODE_ENVIRONMENT_VARIABLE"/></item>
         /// <item>Shared config/credential file via <see cref="FallbackInternalConfigurationFactory.DefaultConfigurationModeName"/></item>
-        /// <item><see cref="DefaultConfigurationMode.Legacy"/></item>
+        /// <item><see cref="DefaultConfigurationMode.Standard"/></item>
         /// </list>
         /// </summary>
         /// <remarks>
@@ -99,8 +99,8 @@ namespace Amazon.Runtime.Internal
                 _environmentVariableRetriever.GetEnvironmentVariable(AWS_DEFAULTS_MODE_ENVIRONMENT_VARIABLE) ??
                 // 3) try to get from shared config/credential file
                 FallbackInternalConfigurationFactory.DefaultConfigurationModeName ??
-                // 4) fallback to 'Legacy'
-                DefaultConfigurationMode.Legacy.ToString();
+                // 4) fallback to 'Standard'
+                DefaultConfigurationMode.Standard.ToString();
 
             Logger
                 .GetLogger(GetType())

--- a/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
@@ -37,7 +37,7 @@ namespace Amazon.Runtime.Internal
         public bool? EndpointDiscoveryEnabled { get; set; }
         
         /// <summary>
-        /// The retry mode to use: Legacy, Standard, or Adaptive.
+        /// The retry mode to use: Standard or Adaptive.
         /// </summary>
         public RequestRetryMode? RetryMode { get; set; }
         

--- a/sdk/src/Services/ACMPCA/Generated/AmazonACMPCADefaultConfiguration.cs
+++ b/sdk/src/Services/ACMPCA/Generated/AmazonACMPCADefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ACMPCA
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ACMPCA
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/APIGateway/Generated/AmazonAPIGatewayDefaultConfiguration.cs
+++ b/sdk/src/Services/APIGateway/Generated/AmazonAPIGatewayDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.APIGateway
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.APIGateway
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ARCZonalShift/Generated/AmazonARCZonalShiftDefaultConfiguration.cs
+++ b/sdk/src/Services/ARCZonalShift/Generated/AmazonARCZonalShiftDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ARCZonalShift
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ARCZonalShift
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AWSHealth/Generated/AmazonAWSHealthDefaultConfiguration.cs
+++ b/sdk/src/Services/AWSHealth/Generated/AmazonAWSHealthDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AWSHealth
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AWSHealth
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AWSMarketplaceCommerceAnalytics/Generated/AmazonAWSMarketplaceCommerceAnalyticsDefaultConfiguration.cs
+++ b/sdk/src/Services/AWSMarketplaceCommerceAnalytics/Generated/AmazonAWSMarketplaceCommerceAnalyticsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AWSMarketplaceCommerceAnalytics
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AWSMarketplaceCommerceAnalytics
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AWSMarketplaceMetering/Generated/AmazonAWSMarketplaceMeteringDefaultConfiguration.cs
+++ b/sdk/src/Services/AWSMarketplaceMetering/Generated/AmazonAWSMarketplaceMeteringDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AWSMarketplaceMetering
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AWSMarketplaceMetering
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AWSSupport/Generated/AmazonAWSSupportDefaultConfiguration.cs
+++ b/sdk/src/Services/AWSSupport/Generated/AmazonAWSSupportDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AWSSupport
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AWSSupport
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AccessAnalyzer/Generated/AmazonAccessAnalyzerDefaultConfiguration.cs
+++ b/sdk/src/Services/AccessAnalyzer/Generated/AmazonAccessAnalyzerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AccessAnalyzer
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AccessAnalyzer
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Account/Generated/AmazonAccountDefaultConfiguration.cs
+++ b/sdk/src/Services/Account/Generated/AmazonAccountDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Account
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Account
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AlexaForBusiness/Generated/AmazonAlexaForBusinessDefaultConfiguration.cs
+++ b/sdk/src/Services/AlexaForBusiness/Generated/AmazonAlexaForBusinessDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AlexaForBusiness
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AlexaForBusiness
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Amplify/Generated/AmazonAmplifyDefaultConfiguration.cs
+++ b/sdk/src/Services/Amplify/Generated/AmazonAmplifyDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Amplify
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Amplify
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AmplifyBackend/Generated/AmazonAmplifyBackendDefaultConfiguration.cs
+++ b/sdk/src/Services/AmplifyBackend/Generated/AmazonAmplifyBackendDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AmplifyBackend
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AmplifyBackend
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AmplifyUIBuilder/Generated/AmazonAmplifyUIBuilderDefaultConfiguration.cs
+++ b/sdk/src/Services/AmplifyUIBuilder/Generated/AmazonAmplifyUIBuilderDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AmplifyUIBuilder
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AmplifyUIBuilder
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ApiGatewayManagementApi/Generated/AmazonApiGatewayManagementApiDefaultConfiguration.cs
+++ b/sdk/src/Services/ApiGatewayManagementApi/Generated/AmazonApiGatewayManagementApiDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ApiGatewayManagementApi
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ApiGatewayManagementApi
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ApiGatewayV2/Generated/AmazonApiGatewayV2DefaultConfiguration.cs
+++ b/sdk/src/Services/ApiGatewayV2/Generated/AmazonApiGatewayV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ApiGatewayV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ApiGatewayV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AppConfig/Generated/AmazonAppConfigDefaultConfiguration.cs
+++ b/sdk/src/Services/AppConfig/Generated/AmazonAppConfigDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AppConfig
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AppConfig
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AppConfigData/Generated/AmazonAppConfigDataDefaultConfiguration.cs
+++ b/sdk/src/Services/AppConfigData/Generated/AmazonAppConfigDataDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AppConfigData
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AppConfigData
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AppFabric/Generated/AmazonAppFabricDefaultConfiguration.cs
+++ b/sdk/src/Services/AppFabric/Generated/AmazonAppFabricDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AppFabric
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AppFabric
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AppIntegrationsService/Generated/AmazonAppIntegrationsServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/AppIntegrationsService/Generated/AmazonAppIntegrationsServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AppIntegrationsService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AppIntegrationsService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AppMesh/Generated/AmazonAppMeshDefaultConfiguration.cs
+++ b/sdk/src/Services/AppMesh/Generated/AmazonAppMeshDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AppMesh
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AppMesh
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AppRegistry/Generated/AmazonAppRegistryDefaultConfiguration.cs
+++ b/sdk/src/Services/AppRegistry/Generated/AmazonAppRegistryDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AppRegistry
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AppRegistry
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AppRunner/Generated/AmazonAppRunnerDefaultConfiguration.cs
+++ b/sdk/src/Services/AppRunner/Generated/AmazonAppRunnerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AppRunner
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AppRunner
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AppStream/Generated/AmazonAppStreamDefaultConfiguration.cs
+++ b/sdk/src/Services/AppStream/Generated/AmazonAppStreamDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AppStream
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AppStream
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AppSync/Generated/AmazonAppSyncDefaultConfiguration.cs
+++ b/sdk/src/Services/AppSync/Generated/AmazonAppSyncDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AppSync
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AppSync
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Appflow/Generated/AmazonAppflowDefaultConfiguration.cs
+++ b/sdk/src/Services/Appflow/Generated/AmazonAppflowDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Appflow
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Appflow
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ApplicationAutoScaling/Generated/AmazonApplicationAutoScalingDefaultConfiguration.cs
+++ b/sdk/src/Services/ApplicationAutoScaling/Generated/AmazonApplicationAutoScalingDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ApplicationAutoScaling
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ApplicationAutoScaling
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ApplicationCostProfiler/Generated/AmazonApplicationCostProfilerDefaultConfiguration.cs
+++ b/sdk/src/Services/ApplicationCostProfiler/Generated/AmazonApplicationCostProfilerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ApplicationCostProfiler
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ApplicationCostProfiler
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ApplicationDiscoveryService/Generated/AmazonApplicationDiscoveryServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/ApplicationDiscoveryService/Generated/AmazonApplicationDiscoveryServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ApplicationDiscoveryService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ApplicationDiscoveryService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ApplicationInsights/Generated/AmazonApplicationInsightsDefaultConfiguration.cs
+++ b/sdk/src/Services/ApplicationInsights/Generated/AmazonApplicationInsightsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ApplicationInsights
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ApplicationInsights
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Artifact/Generated/AmazonArtifactDefaultConfiguration.cs
+++ b/sdk/src/Services/Artifact/Generated/AmazonArtifactDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Artifact
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Artifact
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Athena/Generated/AmazonAthenaDefaultConfiguration.cs
+++ b/sdk/src/Services/Athena/Generated/AmazonAthenaDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Athena
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Athena
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AuditManager/Generated/AmazonAuditManagerDefaultConfiguration.cs
+++ b/sdk/src/Services/AuditManager/Generated/AmazonAuditManagerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AuditManager
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AuditManager
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AugmentedAIRuntime/Generated/AmazonAugmentedAIRuntimeDefaultConfiguration.cs
+++ b/sdk/src/Services/AugmentedAIRuntime/Generated/AmazonAugmentedAIRuntimeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AugmentedAIRuntime
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AugmentedAIRuntime
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AutoScaling/Generated/AmazonAutoScalingDefaultConfiguration.cs
+++ b/sdk/src/Services/AutoScaling/Generated/AmazonAutoScalingDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AutoScaling
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AutoScaling
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/AutoScalingPlans/Generated/AmazonAutoScalingPlansDefaultConfiguration.cs
+++ b/sdk/src/Services/AutoScalingPlans/Generated/AmazonAutoScalingPlansDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.AutoScalingPlans
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.AutoScalingPlans
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/B2bi/Generated/AmazonB2biDefaultConfiguration.cs
+++ b/sdk/src/Services/B2bi/Generated/AmazonB2biDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.B2bi
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.B2bi
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/BCMDataExports/Generated/AmazonBCMDataExportsDefaultConfiguration.cs
+++ b/sdk/src/Services/BCMDataExports/Generated/AmazonBCMDataExportsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.BCMDataExports
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.BCMDataExports
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Backup/Generated/AmazonBackupDefaultConfiguration.cs
+++ b/sdk/src/Services/Backup/Generated/AmazonBackupDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Backup
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Backup
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/BackupGateway/Generated/AmazonBackupGatewayDefaultConfiguration.cs
+++ b/sdk/src/Services/BackupGateway/Generated/AmazonBackupGatewayDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.BackupGateway
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.BackupGateway
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/BackupStorage/Generated/AmazonBackupStorageDefaultConfiguration.cs
+++ b/sdk/src/Services/BackupStorage/Generated/AmazonBackupStorageDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.BackupStorage
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.BackupStorage
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Batch/Generated/AmazonBatchDefaultConfiguration.cs
+++ b/sdk/src/Services/Batch/Generated/AmazonBatchDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Batch
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Batch
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Bedrock/Generated/AmazonBedrockDefaultConfiguration.cs
+++ b/sdk/src/Services/Bedrock/Generated/AmazonBedrockDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Bedrock
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Bedrock
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/BedrockAgent/Generated/AmazonBedrockAgentDefaultConfiguration.cs
+++ b/sdk/src/Services/BedrockAgent/Generated/AmazonBedrockAgentDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.BedrockAgent
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.BedrockAgent
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/BedrockAgentRuntime/Generated/AmazonBedrockAgentRuntimeDefaultConfiguration.cs
+++ b/sdk/src/Services/BedrockAgentRuntime/Generated/AmazonBedrockAgentRuntimeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.BedrockAgentRuntime
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.BedrockAgentRuntime
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/BedrockRuntime/Generated/AmazonBedrockRuntimeDefaultConfiguration.cs
+++ b/sdk/src/Services/BedrockRuntime/Generated/AmazonBedrockRuntimeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.BedrockRuntime
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.BedrockRuntime
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/BillingConductor/Generated/AmazonBillingConductorDefaultConfiguration.cs
+++ b/sdk/src/Services/BillingConductor/Generated/AmazonBillingConductorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.BillingConductor
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.BillingConductor
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Braket/Generated/AmazonBraketDefaultConfiguration.cs
+++ b/sdk/src/Services/Braket/Generated/AmazonBraketDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Braket
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Braket
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Budgets/Generated/AmazonBudgetsDefaultConfiguration.cs
+++ b/sdk/src/Services/Budgets/Generated/AmazonBudgetsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Budgets
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Budgets
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CertificateManager/Generated/AmazonCertificateManagerDefaultConfiguration.cs
+++ b/sdk/src/Services/CertificateManager/Generated/AmazonCertificateManagerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CertificateManager
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CertificateManager
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Chatbot/Generated/AmazonChatbotDefaultConfiguration.cs
+++ b/sdk/src/Services/Chatbot/Generated/AmazonChatbotDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Chatbot
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Chatbot
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Chime/Generated/AmazonChimeDefaultConfiguration.cs
+++ b/sdk/src/Services/Chime/Generated/AmazonChimeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Chime
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Chime
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ChimeSDKIdentity/Generated/AmazonChimeSDKIdentityDefaultConfiguration.cs
+++ b/sdk/src/Services/ChimeSDKIdentity/Generated/AmazonChimeSDKIdentityDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ChimeSDKIdentity
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ChimeSDKIdentity
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ChimeSDKMediaPipelines/Generated/AmazonChimeSDKMediaPipelinesDefaultConfiguration.cs
+++ b/sdk/src/Services/ChimeSDKMediaPipelines/Generated/AmazonChimeSDKMediaPipelinesDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ChimeSDKMediaPipelines
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ChimeSDKMediaPipelines
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ChimeSDKMeetings/Generated/AmazonChimeSDKMeetingsDefaultConfiguration.cs
+++ b/sdk/src/Services/ChimeSDKMeetings/Generated/AmazonChimeSDKMeetingsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ChimeSDKMeetings
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ChimeSDKMeetings
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ChimeSDKMessaging/Generated/AmazonChimeSDKMessagingDefaultConfiguration.cs
+++ b/sdk/src/Services/ChimeSDKMessaging/Generated/AmazonChimeSDKMessagingDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ChimeSDKMessaging
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ChimeSDKMessaging
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ChimeSDKVoice/Generated/AmazonChimeSDKVoiceDefaultConfiguration.cs
+++ b/sdk/src/Services/ChimeSDKVoice/Generated/AmazonChimeSDKVoiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ChimeSDKVoice
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ChimeSDKVoice
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CleanRooms/Generated/AmazonCleanRoomsDefaultConfiguration.cs
+++ b/sdk/src/Services/CleanRooms/Generated/AmazonCleanRoomsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CleanRooms
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CleanRooms
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CleanRoomsML/Generated/AmazonCleanRoomsMLDefaultConfiguration.cs
+++ b/sdk/src/Services/CleanRoomsML/Generated/AmazonCleanRoomsMLDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CleanRoomsML
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CleanRoomsML
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Cloud9/Generated/AmazonCloud9DefaultConfiguration.cs
+++ b/sdk/src/Services/Cloud9/Generated/AmazonCloud9DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Cloud9
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Cloud9
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudControlApi/Generated/AmazonCloudControlApiDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudControlApi/Generated/AmazonCloudControlApiDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudControlApi
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudControlApi
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudDirectory/Generated/AmazonCloudDirectoryDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudDirectory/Generated/AmazonCloudDirectoryDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudDirectory
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudDirectory
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudFormation/Generated/AmazonCloudFormationDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudFormation/Generated/AmazonCloudFormationDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudFormation
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudFormation
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudFront/Generated/AmazonCloudFrontDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudFront/Generated/AmazonCloudFrontDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudFront
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudFront
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudFrontKeyValueStore/Generated/AmazonCloudFrontKeyValueStoreDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudFrontKeyValueStore/Generated/AmazonCloudFrontKeyValueStoreDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudFrontKeyValueStore
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudFrontKeyValueStore
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudHSM/Generated/AmazonCloudHSMDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudHSM/Generated/AmazonCloudHSMDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudHSM
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudHSM
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudHSMV2/Generated/AmazonCloudHSMV2DefaultConfiguration.cs
+++ b/sdk/src/Services/CloudHSMV2/Generated/AmazonCloudHSMV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudHSMV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudHSMV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudSearch/Generated/AmazonCloudSearchDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudSearch/Generated/AmazonCloudSearchDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudSearch
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudSearch
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudSearchDomain/Generated/AmazonCloudSearchDomainDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudSearchDomain/Generated/AmazonCloudSearchDomainDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudSearchDomain
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudSearchDomain
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudTrail/Generated/AmazonCloudTrailDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudTrail/Generated/AmazonCloudTrailDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudTrail
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudTrail
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudTrailData/Generated/AmazonCloudTrailDataDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudTrailData/Generated/AmazonCloudTrailDataDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudTrailData
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudTrailData
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudWatch/Generated/AmazonCloudWatchDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudWatch/Generated/AmazonCloudWatchDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudWatch
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudWatch
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudWatchEvents/Generated/AmazonCloudWatchEventsDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudWatchEvents/Generated/AmazonCloudWatchEventsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudWatchEvents
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudWatchEvents
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudWatchEvidently/Generated/AmazonCloudWatchEvidentlyDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudWatchEvidently/Generated/AmazonCloudWatchEvidentlyDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudWatchEvidently
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudWatchEvidently
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudWatchLogs/Generated/AmazonCloudWatchLogsDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudWatchLogs/Generated/AmazonCloudWatchLogsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudWatchLogs
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudWatchLogs
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CloudWatchRUM/Generated/AmazonCloudWatchRUMDefaultConfiguration.cs
+++ b/sdk/src/Services/CloudWatchRUM/Generated/AmazonCloudWatchRUMDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CloudWatchRUM
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CloudWatchRUM
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeArtifact/Generated/AmazonCodeArtifactDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeArtifact/Generated/AmazonCodeArtifactDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeArtifact
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeArtifact
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeBuild/Generated/AmazonCodeBuildDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeBuild/Generated/AmazonCodeBuildDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeBuild
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeBuild
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeCatalyst/Generated/AmazonCodeCatalystDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeCatalyst/Generated/AmazonCodeCatalystDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeCatalyst
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeCatalyst
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeCommit/Generated/AmazonCodeCommitDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeCommit/Generated/AmazonCodeCommitDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeCommit
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeCommit
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeDeploy/Generated/AmazonCodeDeployDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeDeploy/Generated/AmazonCodeDeployDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeDeploy
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeDeploy
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeGuruProfiler/Generated/AmazonCodeGuruProfilerDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeGuruProfiler/Generated/AmazonCodeGuruProfilerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeGuruProfiler
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeGuruProfiler
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeGuruReviewer/Generated/AmazonCodeGuruReviewerDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeGuruReviewer/Generated/AmazonCodeGuruReviewerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeGuruReviewer
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeGuruReviewer
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeGuruSecurity/Generated/AmazonCodeGuruSecurityDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeGuruSecurity/Generated/AmazonCodeGuruSecurityDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeGuruSecurity
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeGuruSecurity
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodePipeline/Generated/AmazonCodePipelineDefaultConfiguration.cs
+++ b/sdk/src/Services/CodePipeline/Generated/AmazonCodePipelineDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodePipeline
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodePipeline
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeStar/Generated/AmazonCodeStarDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeStar/Generated/AmazonCodeStarDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeStar
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeStar
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeStarNotifications/Generated/AmazonCodeStarNotificationsDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeStarNotifications/Generated/AmazonCodeStarNotificationsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeStarNotifications
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeStarNotifications
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CodeStarconnections/Generated/AmazonCodeStarconnectionsDefaultConfiguration.cs
+++ b/sdk/src/Services/CodeStarconnections/Generated/AmazonCodeStarconnectionsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CodeStarconnections
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CodeStarconnections
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CognitoIdentity/Generated/AmazonCognitoIdentityDefaultConfiguration.cs
+++ b/sdk/src/Services/CognitoIdentity/Generated/AmazonCognitoIdentityDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CognitoIdentity
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CognitoIdentity
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CognitoIdentityProvider/Generated/AmazonCognitoIdentityProviderDefaultConfiguration.cs
+++ b/sdk/src/Services/CognitoIdentityProvider/Generated/AmazonCognitoIdentityProviderDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CognitoIdentityProvider
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CognitoIdentityProvider
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CognitoSync/Generated/AmazonCognitoSyncDefaultConfiguration.cs
+++ b/sdk/src/Services/CognitoSync/Generated/AmazonCognitoSyncDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CognitoSync
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CognitoSync
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Comprehend/Generated/AmazonComprehendDefaultConfiguration.cs
+++ b/sdk/src/Services/Comprehend/Generated/AmazonComprehendDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Comprehend
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Comprehend
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ComprehendMedical/Generated/AmazonComprehendMedicalDefaultConfiguration.cs
+++ b/sdk/src/Services/ComprehendMedical/Generated/AmazonComprehendMedicalDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ComprehendMedical
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ComprehendMedical
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ComputeOptimizer/Generated/AmazonComputeOptimizerDefaultConfiguration.cs
+++ b/sdk/src/Services/ComputeOptimizer/Generated/AmazonComputeOptimizerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ComputeOptimizer
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ComputeOptimizer
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ConfigService/Generated/AmazonConfigServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/ConfigService/Generated/AmazonConfigServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ConfigService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ConfigService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Connect/Generated/AmazonConnectDefaultConfiguration.cs
+++ b/sdk/src/Services/Connect/Generated/AmazonConnectDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Connect
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Connect
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ConnectCampaignService/Generated/AmazonConnectCampaignServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/ConnectCampaignService/Generated/AmazonConnectCampaignServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ConnectCampaignService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ConnectCampaignService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ConnectCases/Generated/AmazonConnectCasesDefaultConfiguration.cs
+++ b/sdk/src/Services/ConnectCases/Generated/AmazonConnectCasesDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ConnectCases
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ConnectCases
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ConnectContactLens/Generated/AmazonConnectContactLensDefaultConfiguration.cs
+++ b/sdk/src/Services/ConnectContactLens/Generated/AmazonConnectContactLensDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ConnectContactLens
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ConnectContactLens
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ConnectParticipant/Generated/AmazonConnectParticipantDefaultConfiguration.cs
+++ b/sdk/src/Services/ConnectParticipant/Generated/AmazonConnectParticipantDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ConnectParticipant
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ConnectParticipant
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ConnectWisdomService/Generated/AmazonConnectWisdomServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/ConnectWisdomService/Generated/AmazonConnectWisdomServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ConnectWisdomService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ConnectWisdomService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ControlTower/Generated/AmazonControlTowerDefaultConfiguration.cs
+++ b/sdk/src/Services/ControlTower/Generated/AmazonControlTowerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ControlTower
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ControlTower
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CostAndUsageReport/Generated/AmazonCostAndUsageReportDefaultConfiguration.cs
+++ b/sdk/src/Services/CostAndUsageReport/Generated/AmazonCostAndUsageReportDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CostAndUsageReport
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CostAndUsageReport
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CostExplorer/Generated/AmazonCostExplorerDefaultConfiguration.cs
+++ b/sdk/src/Services/CostExplorer/Generated/AmazonCostExplorerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CostExplorer
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CostExplorer
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CostOptimizationHub/Generated/AmazonCostOptimizationHubDefaultConfiguration.cs
+++ b/sdk/src/Services/CostOptimizationHub/Generated/AmazonCostOptimizationHubDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CostOptimizationHub
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CostOptimizationHub
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/CustomerProfiles/Generated/AmazonCustomerProfilesDefaultConfiguration.cs
+++ b/sdk/src/Services/CustomerProfiles/Generated/AmazonCustomerProfilesDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.CustomerProfiles
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.CustomerProfiles
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DAX/Generated/AmazonDAXDefaultConfiguration.cs
+++ b/sdk/src/Services/DAX/Generated/AmazonDAXDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DAX
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DAX
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DLM/Generated/AmazonDLMDefaultConfiguration.cs
+++ b/sdk/src/Services/DLM/Generated/AmazonDLMDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DLM
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DLM
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DataExchange/Generated/AmazonDataExchangeDefaultConfiguration.cs
+++ b/sdk/src/Services/DataExchange/Generated/AmazonDataExchangeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DataExchange
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DataExchange
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DataPipeline/Generated/AmazonDataPipelineDefaultConfiguration.cs
+++ b/sdk/src/Services/DataPipeline/Generated/AmazonDataPipelineDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DataPipeline
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DataPipeline
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DataSync/Generated/AmazonDataSyncDefaultConfiguration.cs
+++ b/sdk/src/Services/DataSync/Generated/AmazonDataSyncDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DataSync
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DataSync
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DataZone/Generated/AmazonDataZoneDefaultConfiguration.cs
+++ b/sdk/src/Services/DataZone/Generated/AmazonDataZoneDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DataZone
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DataZone
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DatabaseMigrationService/Generated/AmazonDatabaseMigrationServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/DatabaseMigrationService/Generated/AmazonDatabaseMigrationServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DatabaseMigrationService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DatabaseMigrationService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Detective/Generated/AmazonDetectiveDefaultConfiguration.cs
+++ b/sdk/src/Services/Detective/Generated/AmazonDetectiveDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Detective
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Detective
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DevOpsGuru/Generated/AmazonDevOpsGuruDefaultConfiguration.cs
+++ b/sdk/src/Services/DevOpsGuru/Generated/AmazonDevOpsGuruDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DevOpsGuru
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DevOpsGuru
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DeviceFarm/Generated/AmazonDeviceFarmDefaultConfiguration.cs
+++ b/sdk/src/Services/DeviceFarm/Generated/AmazonDeviceFarmDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DeviceFarm
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DeviceFarm
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DirectConnect/Generated/AmazonDirectConnectDefaultConfiguration.cs
+++ b/sdk/src/Services/DirectConnect/Generated/AmazonDirectConnectDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DirectConnect
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DirectConnect
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DirectoryService/Generated/AmazonDirectoryServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/DirectoryService/Generated/AmazonDirectoryServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DirectoryService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DirectoryService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DocDB/Generated/AmazonDocDBDefaultConfiguration.cs
+++ b/sdk/src/Services/DocDB/Generated/AmazonDocDBDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DocDB
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DocDB
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DocDBElastic/Generated/AmazonDocDBElasticDefaultConfiguration.cs
+++ b/sdk/src/Services/DocDBElastic/Generated/AmazonDocDBElasticDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DocDBElastic
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DocDBElastic
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Drs/Generated/AmazonDrsDefaultConfiguration.cs
+++ b/sdk/src/Services/Drs/Generated/AmazonDrsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Drs
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Drs
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DynamoDBv2/Generated/AmazonDynamoDBDefaultConfiguration.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/AmazonDynamoDBDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DynamoDBv2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DynamoDBv2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DynamoDBv2/Generated/AmazonDynamoDBStreamsDefaultConfiguration.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/AmazonDynamoDBStreamsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DynamoDBv2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DynamoDBv2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/DynamoDBv2/Generated/_bcl/AmazonDynamoDBClient.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/_bcl/AmazonDynamoDBClient.cs
@@ -257,10 +257,6 @@ namespace Amazon.DynamoDBv2
         /// <param name="pipeline"></param>
         protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
         {
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.DynamoDBv2.Internal.DynamoDBRetryPolicy(this.Config)));
-            }
             pipeline.RemoveHandler<Amazon.Runtime.Internal.EndpointResolver>();
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.Marshaller>(new AmazonDynamoDBEndpointResolver());
         }    

--- a/sdk/src/Services/DynamoDBv2/Generated/_bcl/AmazonDynamoDBStreamsClient.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/_bcl/AmazonDynamoDBStreamsClient.cs
@@ -223,10 +223,6 @@ namespace Amazon.DynamoDBv2
         /// <param name="pipeline"></param>
         protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
         {
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.DynamoDBv2.Internal.DynamoDBRetryPolicy(this.Config)));
-            }
             pipeline.RemoveHandler<Amazon.Runtime.Internal.EndpointResolver>();
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.Marshaller>(new AmazonDynamoDBStreamsEndpointResolver());
         }    

--- a/sdk/src/Services/DynamoDBv2/Generated/_netstandard/AmazonDynamoDBClient.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/_netstandard/AmazonDynamoDBClient.cs
@@ -261,10 +261,6 @@ namespace Amazon.DynamoDBv2
         /// <param name="pipeline">Runtime pipeline for the current client.</param>
         protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
         {
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.DynamoDBv2.Internal.DynamoDBRetryPolicy(this.Config)));
-            }
             pipeline.RemoveHandler<Amazon.Runtime.Internal.EndpointResolver>();
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.Marshaller>(new AmazonDynamoDBEndpointResolver());
         }

--- a/sdk/src/Services/DynamoDBv2/Generated/_netstandard/AmazonDynamoDBStreamsClient.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/_netstandard/AmazonDynamoDBStreamsClient.cs
@@ -225,10 +225,6 @@ namespace Amazon.DynamoDBv2
         /// <param name="pipeline">Runtime pipeline for the current client.</param>
         protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
         {
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.DynamoDBv2.Internal.DynamoDBRetryPolicy(this.Config)));
-            }
             pipeline.RemoveHandler<Amazon.Runtime.Internal.EndpointResolver>();
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.Marshaller>(new AmazonDynamoDBStreamsEndpointResolver());
         }

--- a/sdk/src/Services/EBS/Generated/AmazonEBSDefaultConfiguration.cs
+++ b/sdk/src/Services/EBS/Generated/AmazonEBSDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.EBS
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.EBS
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/EC2/Generated/AmazonEC2DefaultConfiguration.cs
+++ b/sdk/src/Services/EC2/Generated/AmazonEC2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.EC2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.EC2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/EC2/Generated/_bcl/AmazonEC2Client.cs
+++ b/sdk/src/Services/EC2/Generated/_bcl/AmazonEC2Client.cs
@@ -242,10 +242,6 @@ namespace Amazon.EC2
             pipeline.AddHandlerBefore<Amazon.Runtime.Internal.Marshaller>(new Amazon.EC2.Internal.AmazonEC2PreMarshallHandler(this.Credentials));
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.Marshaller>(new Amazon.EC2.Internal.AmazonEC2PostMarshallHandler());
             pipeline.AddHandlerBefore<Amazon.Runtime.Internal.Unmarshaller>(new Amazon.EC2.Internal.AmazonEC2ResponseHandler());
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.EC2.Internal.EC2RetryPolicy(this.Config)));
-            }
             if(this.Config.RetryMode == RequestRetryMode.Standard)
             {
                 pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.EC2.Internal.EC2StandardRetryPolicy(this.Config)));

--- a/sdk/src/Services/EC2/Generated/_netstandard/AmazonEC2Client.cs
+++ b/sdk/src/Services/EC2/Generated/_netstandard/AmazonEC2Client.cs
@@ -246,10 +246,6 @@ namespace Amazon.EC2
             pipeline.AddHandlerBefore<Amazon.Runtime.Internal.Marshaller>(new Amazon.EC2.Internal.AmazonEC2PreMarshallHandler(this.Credentials));
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.Marshaller>(new Amazon.EC2.Internal.AmazonEC2PostMarshallHandler());
             pipeline.AddHandlerBefore<Amazon.Runtime.Internal.Unmarshaller>(new Amazon.EC2.Internal.AmazonEC2ResponseHandler());
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.EC2.Internal.EC2RetryPolicy(this.Config)));
-            }
             if(this.Config.RetryMode == RequestRetryMode.Standard)
             {
                 pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.EC2.Internal.EC2StandardRetryPolicy(this.Config)));

--- a/sdk/src/Services/EC2InstanceConnect/Generated/AmazonEC2InstanceConnectDefaultConfiguration.cs
+++ b/sdk/src/Services/EC2InstanceConnect/Generated/AmazonEC2InstanceConnectDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.EC2InstanceConnect
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.EC2InstanceConnect
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ECR/Generated/AmazonECRDefaultConfiguration.cs
+++ b/sdk/src/Services/ECR/Generated/AmazonECRDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ECR
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ECR
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ECRPublic/Generated/AmazonECRPublicDefaultConfiguration.cs
+++ b/sdk/src/Services/ECRPublic/Generated/AmazonECRPublicDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ECRPublic
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ECRPublic
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ECS/Generated/AmazonECSDefaultConfiguration.cs
+++ b/sdk/src/Services/ECS/Generated/AmazonECSDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ECS
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ECS
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/EKS/Generated/AmazonEKSDefaultConfiguration.cs
+++ b/sdk/src/Services/EKS/Generated/AmazonEKSDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.EKS
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.EKS
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/EKSAuth/Generated/AmazonEKSAuthDefaultConfiguration.cs
+++ b/sdk/src/Services/EKSAuth/Generated/AmazonEKSAuthDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.EKSAuth
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.EKSAuth
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/EMRContainers/Generated/AmazonEMRContainersDefaultConfiguration.cs
+++ b/sdk/src/Services/EMRContainers/Generated/AmazonEMRContainersDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.EMRContainers
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.EMRContainers
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/EMRServerless/Generated/AmazonEMRServerlessDefaultConfiguration.cs
+++ b/sdk/src/Services/EMRServerless/Generated/AmazonEMRServerlessDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.EMRServerless
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.EMRServerless
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ElastiCache/Generated/AmazonElastiCacheDefaultConfiguration.cs
+++ b/sdk/src/Services/ElastiCache/Generated/AmazonElastiCacheDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ElastiCache
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ElastiCache
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ElasticBeanstalk/Generated/AmazonElasticBeanstalkDefaultConfiguration.cs
+++ b/sdk/src/Services/ElasticBeanstalk/Generated/AmazonElasticBeanstalkDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ElasticBeanstalk
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ElasticBeanstalk
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ElasticFileSystem/Generated/AmazonElasticFileSystemDefaultConfiguration.cs
+++ b/sdk/src/Services/ElasticFileSystem/Generated/AmazonElasticFileSystemDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ElasticFileSystem
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ElasticFileSystem
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ElasticInference/Generated/AmazonElasticInferenceDefaultConfiguration.cs
+++ b/sdk/src/Services/ElasticInference/Generated/AmazonElasticInferenceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ElasticInference
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ElasticInference
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ElasticLoadBalancing/Generated/AmazonElasticLoadBalancingDefaultConfiguration.cs
+++ b/sdk/src/Services/ElasticLoadBalancing/Generated/AmazonElasticLoadBalancingDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ElasticLoadBalancing
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ElasticLoadBalancing
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ElasticLoadBalancingV2/Generated/AmazonElasticLoadBalancingV2DefaultConfiguration.cs
+++ b/sdk/src/Services/ElasticLoadBalancingV2/Generated/AmazonElasticLoadBalancingV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ElasticLoadBalancingV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ElasticLoadBalancingV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ElasticMapReduce/Generated/AmazonElasticMapReduceDefaultConfiguration.cs
+++ b/sdk/src/Services/ElasticMapReduce/Generated/AmazonElasticMapReduceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ElasticMapReduce
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ElasticMapReduce
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ElasticTranscoder/Generated/AmazonElasticTranscoderDefaultConfiguration.cs
+++ b/sdk/src/Services/ElasticTranscoder/Generated/AmazonElasticTranscoderDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ElasticTranscoder
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ElasticTranscoder
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Elasticsearch/Generated/AmazonElasticsearchDefaultConfiguration.cs
+++ b/sdk/src/Services/Elasticsearch/Generated/AmazonElasticsearchDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Elasticsearch
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Elasticsearch
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/EntityResolution/Generated/AmazonEntityResolutionDefaultConfiguration.cs
+++ b/sdk/src/Services/EntityResolution/Generated/AmazonEntityResolutionDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.EntityResolution
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.EntityResolution
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/EventBridge/Generated/AmazonEventBridgeDefaultConfiguration.cs
+++ b/sdk/src/Services/EventBridge/Generated/AmazonEventBridgeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.EventBridge
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.EventBridge
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/FIS/Generated/AmazonFISDefaultConfiguration.cs
+++ b/sdk/src/Services/FIS/Generated/AmazonFISDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.FIS
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.FIS
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/FMS/Generated/AmazonFMSDefaultConfiguration.cs
+++ b/sdk/src/Services/FMS/Generated/AmazonFMSDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.FMS
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.FMS
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/FSx/Generated/AmazonFSxDefaultConfiguration.cs
+++ b/sdk/src/Services/FSx/Generated/AmazonFSxDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.FSx
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.FSx
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/FinSpaceData/Generated/AmazonFinSpaceDataDefaultConfiguration.cs
+++ b/sdk/src/Services/FinSpaceData/Generated/AmazonFinSpaceDataDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.FinSpaceData
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.FinSpaceData
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Finspace/Generated/AmazonFinspaceDefaultConfiguration.cs
+++ b/sdk/src/Services/Finspace/Generated/AmazonFinspaceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Finspace
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Finspace
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ForecastQueryService/Generated/AmazonForecastQueryServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/ForecastQueryService/Generated/AmazonForecastQueryServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ForecastQueryService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ForecastQueryService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ForecastService/Generated/AmazonForecastServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/ForecastService/Generated/AmazonForecastServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ForecastService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ForecastService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/FraudDetector/Generated/AmazonFraudDetectorDefaultConfiguration.cs
+++ b/sdk/src/Services/FraudDetector/Generated/AmazonFraudDetectorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.FraudDetector
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.FraudDetector
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/FreeTier/Generated/AmazonFreeTierDefaultConfiguration.cs
+++ b/sdk/src/Services/FreeTier/Generated/AmazonFreeTierDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.FreeTier
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.FreeTier
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/GameLift/Generated/AmazonGameLiftDefaultConfiguration.cs
+++ b/sdk/src/Services/GameLift/Generated/AmazonGameLiftDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.GameLift
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.GameLift
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Glacier/Generated/AmazonGlacierDefaultConfiguration.cs
+++ b/sdk/src/Services/Glacier/Generated/AmazonGlacierDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Glacier
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Glacier
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/GlobalAccelerator/Generated/AmazonGlobalAcceleratorDefaultConfiguration.cs
+++ b/sdk/src/Services/GlobalAccelerator/Generated/AmazonGlobalAcceleratorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.GlobalAccelerator
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.GlobalAccelerator
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Glue/Generated/AmazonGlueDefaultConfiguration.cs
+++ b/sdk/src/Services/Glue/Generated/AmazonGlueDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Glue
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Glue
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/GlueDataBrew/Generated/AmazonGlueDataBrewDefaultConfiguration.cs
+++ b/sdk/src/Services/GlueDataBrew/Generated/AmazonGlueDataBrewDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.GlueDataBrew
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.GlueDataBrew
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Greengrass/Generated/AmazonGreengrassDefaultConfiguration.cs
+++ b/sdk/src/Services/Greengrass/Generated/AmazonGreengrassDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Greengrass
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Greengrass
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/GreengrassV2/Generated/AmazonGreengrassV2DefaultConfiguration.cs
+++ b/sdk/src/Services/GreengrassV2/Generated/AmazonGreengrassV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.GreengrassV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.GreengrassV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/GroundStation/Generated/AmazonGroundStationDefaultConfiguration.cs
+++ b/sdk/src/Services/GroundStation/Generated/AmazonGroundStationDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.GroundStation
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.GroundStation
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/GuardDuty/Generated/AmazonGuardDutyDefaultConfiguration.cs
+++ b/sdk/src/Services/GuardDuty/Generated/AmazonGuardDutyDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.GuardDuty
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.GuardDuty
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/HealthLake/Generated/AmazonHealthLakeDefaultConfiguration.cs
+++ b/sdk/src/Services/HealthLake/Generated/AmazonHealthLakeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.HealthLake
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.HealthLake
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Honeycode/Generated/AmazonHoneycodeDefaultConfiguration.cs
+++ b/sdk/src/Services/Honeycode/Generated/AmazonHoneycodeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Honeycode
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Honeycode
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IAMRolesAnywhere/Generated/AmazonIAMRolesAnywhereDefaultConfiguration.cs
+++ b/sdk/src/Services/IAMRolesAnywhere/Generated/AmazonIAMRolesAnywhereDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IAMRolesAnywhere
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IAMRolesAnywhere
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IVS/Generated/AmazonIVSDefaultConfiguration.cs
+++ b/sdk/src/Services/IVS/Generated/AmazonIVSDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IVS
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IVS
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IVSRealTime/Generated/AmazonIVSRealTimeDefaultConfiguration.cs
+++ b/sdk/src/Services/IVSRealTime/Generated/AmazonIVSRealTimeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IVSRealTime
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IVSRealTime
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IdentityManagement/Generated/AmazonIdentityManagementServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/IdentityManagement/Generated/AmazonIdentityManagementServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IdentityManagement
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IdentityManagement
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IdentityStore/Generated/AmazonIdentityStoreDefaultConfiguration.cs
+++ b/sdk/src/Services/IdentityStore/Generated/AmazonIdentityStoreDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IdentityStore
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IdentityStore
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Imagebuilder/Generated/AmazonImagebuilderDefaultConfiguration.cs
+++ b/sdk/src/Services/Imagebuilder/Generated/AmazonImagebuilderDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Imagebuilder
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Imagebuilder
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ImportExport/Generated/AmazonImportExportDefaultConfiguration.cs
+++ b/sdk/src/Services/ImportExport/Generated/AmazonImportExportDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ImportExport
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ImportExport
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Inspector/Generated/AmazonInspectorDefaultConfiguration.cs
+++ b/sdk/src/Services/Inspector/Generated/AmazonInspectorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Inspector
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Inspector
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Inspector2/Generated/AmazonInspector2DefaultConfiguration.cs
+++ b/sdk/src/Services/Inspector2/Generated/AmazonInspector2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Inspector2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Inspector2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/InspectorScan/Generated/AmazonInspectorScanDefaultConfiguration.cs
+++ b/sdk/src/Services/InspectorScan/Generated/AmazonInspectorScanDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.InspectorScan
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.InspectorScan
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/InternetMonitor/Generated/AmazonInternetMonitorDefaultConfiguration.cs
+++ b/sdk/src/Services/InternetMonitor/Generated/AmazonInternetMonitorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.InternetMonitor
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.InternetMonitor
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoT/Generated/AmazonIoTDefaultConfiguration.cs
+++ b/sdk/src/Services/IoT/Generated/AmazonIoTDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoT
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoT
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoT1ClickDevicesService/Generated/AmazonIoT1ClickDevicesServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/IoT1ClickDevicesService/Generated/AmazonIoT1ClickDevicesServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoT1ClickDevicesService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoT1ClickDevicesService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoT1ClickProjects/Generated/AmazonIoT1ClickProjectsDefaultConfiguration.cs
+++ b/sdk/src/Services/IoT1ClickProjects/Generated/AmazonIoT1ClickProjectsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoT1ClickProjects
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoT1ClickProjects
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTAnalytics/Generated/AmazonIoTAnalyticsDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTAnalytics/Generated/AmazonIoTAnalyticsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTAnalytics
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTAnalytics
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTDeviceAdvisor/Generated/AmazonIoTDeviceAdvisorDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTDeviceAdvisor/Generated/AmazonIoTDeviceAdvisorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTDeviceAdvisor
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTDeviceAdvisor
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTEvents/Generated/AmazonIoTEventsDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTEvents/Generated/AmazonIoTEventsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTEvents
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTEvents
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTEventsData/Generated/AmazonIoTEventsDataDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTEventsData/Generated/AmazonIoTEventsDataDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTEventsData
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTEventsData
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTFleetHub/Generated/AmazonIoTFleetHubDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTFleetHub/Generated/AmazonIoTFleetHubDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTFleetHub
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTFleetHub
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTFleetWise/Generated/AmazonIoTFleetWiseDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTFleetWise/Generated/AmazonIoTFleetWiseDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTFleetWise
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTFleetWise
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTJobsDataPlane/Generated/AmazonIoTJobsDataPlaneDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTJobsDataPlane/Generated/AmazonIoTJobsDataPlaneDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTJobsDataPlane
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTJobsDataPlane
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTSecureTunneling/Generated/AmazonIoTSecureTunnelingDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTSecureTunneling/Generated/AmazonIoTSecureTunnelingDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTSecureTunneling
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTSecureTunneling
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTSiteWise/Generated/AmazonIoTSiteWiseDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTSiteWise/Generated/AmazonIoTSiteWiseDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTSiteWise
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTSiteWise
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTThingsGraph/Generated/AmazonIoTThingsGraphDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTThingsGraph/Generated/AmazonIoTThingsGraphDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTThingsGraph
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTThingsGraph
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTTwinMaker/Generated/AmazonIoTTwinMakerDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTTwinMaker/Generated/AmazonIoTTwinMakerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTTwinMaker
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTTwinMaker
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IoTWireless/Generated/AmazonIoTWirelessDefaultConfiguration.cs
+++ b/sdk/src/Services/IoTWireless/Generated/AmazonIoTWirelessDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IoTWireless
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IoTWireless
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/IotData/Generated/AmazonIotDataDefaultConfiguration.cs
+++ b/sdk/src/Services/IotData/Generated/AmazonIotDataDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.IotData
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.IotData
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Ivschat/Generated/AmazonIvschatDefaultConfiguration.cs
+++ b/sdk/src/Services/Ivschat/Generated/AmazonIvschatDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Ivschat
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Ivschat
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Kafka/Generated/AmazonKafkaDefaultConfiguration.cs
+++ b/sdk/src/Services/Kafka/Generated/AmazonKafkaDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Kafka
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Kafka
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KafkaConnect/Generated/AmazonKafkaConnectDefaultConfiguration.cs
+++ b/sdk/src/Services/KafkaConnect/Generated/AmazonKafkaConnectDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KafkaConnect
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KafkaConnect
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Kendra/Generated/AmazonKendraDefaultConfiguration.cs
+++ b/sdk/src/Services/Kendra/Generated/AmazonKendraDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Kendra
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Kendra
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KendraRanking/Generated/AmazonKendraRankingDefaultConfiguration.cs
+++ b/sdk/src/Services/KendraRanking/Generated/AmazonKendraRankingDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KendraRanking
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KendraRanking
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KeyManagementService/Generated/AmazonKeyManagementServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/KeyManagementService/Generated/AmazonKeyManagementServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KeyManagementService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KeyManagementService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Keyspaces/Generated/AmazonKeyspacesDefaultConfiguration.cs
+++ b/sdk/src/Services/Keyspaces/Generated/AmazonKeyspacesDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Keyspaces
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Keyspaces
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Kinesis/Generated/AmazonKinesisDefaultConfiguration.cs
+++ b/sdk/src/Services/Kinesis/Generated/AmazonKinesisDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Kinesis
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Kinesis
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KinesisAnalytics/Generated/AmazonKinesisAnalyticsDefaultConfiguration.cs
+++ b/sdk/src/Services/KinesisAnalytics/Generated/AmazonKinesisAnalyticsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KinesisAnalytics
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KinesisAnalytics
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KinesisAnalyticsV2/Generated/AmazonKinesisAnalyticsV2DefaultConfiguration.cs
+++ b/sdk/src/Services/KinesisAnalyticsV2/Generated/AmazonKinesisAnalyticsV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KinesisAnalyticsV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KinesisAnalyticsV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KinesisFirehose/Generated/AmazonKinesisFirehoseDefaultConfiguration.cs
+++ b/sdk/src/Services/KinesisFirehose/Generated/AmazonKinesisFirehoseDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KinesisFirehose
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KinesisFirehose
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KinesisVideo/Generated/AmazonKinesisVideoDefaultConfiguration.cs
+++ b/sdk/src/Services/KinesisVideo/Generated/AmazonKinesisVideoDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KinesisVideo
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KinesisVideo
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KinesisVideoArchivedMedia/Generated/AmazonKinesisVideoArchivedMediaDefaultConfiguration.cs
+++ b/sdk/src/Services/KinesisVideoArchivedMedia/Generated/AmazonKinesisVideoArchivedMediaDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KinesisVideoArchivedMedia
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KinesisVideoArchivedMedia
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KinesisVideoMedia/Generated/AmazonKinesisVideoMediaDefaultConfiguration.cs
+++ b/sdk/src/Services/KinesisVideoMedia/Generated/AmazonKinesisVideoMediaDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KinesisVideoMedia
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KinesisVideoMedia
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KinesisVideoSignalingChannels/Generated/AmazonKinesisVideoSignalingChannelsDefaultConfiguration.cs
+++ b/sdk/src/Services/KinesisVideoSignalingChannels/Generated/AmazonKinesisVideoSignalingChannelsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KinesisVideoSignalingChannels
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KinesisVideoSignalingChannels
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/KinesisVideoWebRTCStorage/Generated/AmazonKinesisVideoWebRTCStorageDefaultConfiguration.cs
+++ b/sdk/src/Services/KinesisVideoWebRTCStorage/Generated/AmazonKinesisVideoWebRTCStorageDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.KinesisVideoWebRTCStorage
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.KinesisVideoWebRTCStorage
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LakeFormation/Generated/AmazonLakeFormationDefaultConfiguration.cs
+++ b/sdk/src/Services/LakeFormation/Generated/AmazonLakeFormationDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LakeFormation
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LakeFormation
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Lambda/Generated/AmazonLambdaDefaultConfiguration.cs
+++ b/sdk/src/Services/Lambda/Generated/AmazonLambdaDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Lambda
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Lambda
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LaunchWizard/Generated/AmazonLaunchWizardDefaultConfiguration.cs
+++ b/sdk/src/Services/LaunchWizard/Generated/AmazonLaunchWizardDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LaunchWizard
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LaunchWizard
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Lex/Generated/AmazonLexDefaultConfiguration.cs
+++ b/sdk/src/Services/Lex/Generated/AmazonLexDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Lex
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Lex
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LexModelBuildingService/Generated/AmazonLexModelBuildingServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/LexModelBuildingService/Generated/AmazonLexModelBuildingServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LexModelBuildingService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LexModelBuildingService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LexModelsV2/Generated/AmazonLexModelsV2DefaultConfiguration.cs
+++ b/sdk/src/Services/LexModelsV2/Generated/AmazonLexModelsV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LexModelsV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LexModelsV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LexRuntimeV2/Generated/AmazonLexRuntimeV2DefaultConfiguration.cs
+++ b/sdk/src/Services/LexRuntimeV2/Generated/AmazonLexRuntimeV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LexRuntimeV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LexRuntimeV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LicenseManager/Generated/AmazonLicenseManagerDefaultConfiguration.cs
+++ b/sdk/src/Services/LicenseManager/Generated/AmazonLicenseManagerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LicenseManager
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LicenseManager
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LicenseManagerLinuxSubscriptions/Generated/AmazonLicenseManagerLinuxSubscriptionsDefaultConfiguration.cs
+++ b/sdk/src/Services/LicenseManagerLinuxSubscriptions/Generated/AmazonLicenseManagerLinuxSubscriptionsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LicenseManagerLinuxSubscriptions
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LicenseManagerLinuxSubscriptions
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LicenseManagerUserSubscriptions/Generated/AmazonLicenseManagerUserSubscriptionsDefaultConfiguration.cs
+++ b/sdk/src/Services/LicenseManagerUserSubscriptions/Generated/AmazonLicenseManagerUserSubscriptionsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LicenseManagerUserSubscriptions
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LicenseManagerUserSubscriptions
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Lightsail/Generated/AmazonLightsailDefaultConfiguration.cs
+++ b/sdk/src/Services/Lightsail/Generated/AmazonLightsailDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Lightsail
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Lightsail
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LocationService/Generated/AmazonLocationServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/LocationService/Generated/AmazonLocationServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LocationService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LocationService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LookoutEquipment/Generated/AmazonLookoutEquipmentDefaultConfiguration.cs
+++ b/sdk/src/Services/LookoutEquipment/Generated/AmazonLookoutEquipmentDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LookoutEquipment
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LookoutEquipment
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LookoutMetrics/Generated/AmazonLookoutMetricsDefaultConfiguration.cs
+++ b/sdk/src/Services/LookoutMetrics/Generated/AmazonLookoutMetricsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LookoutMetrics
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LookoutMetrics
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/LookoutforVision/Generated/AmazonLookoutforVisionDefaultConfiguration.cs
+++ b/sdk/src/Services/LookoutforVision/Generated/AmazonLookoutforVisionDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.LookoutforVision
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.LookoutforVision
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MQ/Generated/AmazonMQDefaultConfiguration.cs
+++ b/sdk/src/Services/MQ/Generated/AmazonMQDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MQ
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MQ
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MTurk/Generated/AmazonMTurkDefaultConfiguration.cs
+++ b/sdk/src/Services/MTurk/Generated/AmazonMTurkDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MTurk
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MTurk
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MWAA/Generated/AmazonMWAADefaultConfiguration.cs
+++ b/sdk/src/Services/MWAA/Generated/AmazonMWAADefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MWAA
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MWAA
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MachineLearning/Generated/AmazonMachineLearningDefaultConfiguration.cs
+++ b/sdk/src/Services/MachineLearning/Generated/AmazonMachineLearningDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MachineLearning
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MachineLearning
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Macie2/Generated/AmazonMacie2DefaultConfiguration.cs
+++ b/sdk/src/Services/Macie2/Generated/AmazonMacie2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Macie2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Macie2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MainframeModernization/Generated/AmazonMainframeModernizationDefaultConfiguration.cs
+++ b/sdk/src/Services/MainframeModernization/Generated/AmazonMainframeModernizationDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MainframeModernization
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MainframeModernization
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ManagedBlockchain/Generated/AmazonManagedBlockchainDefaultConfiguration.cs
+++ b/sdk/src/Services/ManagedBlockchain/Generated/AmazonManagedBlockchainDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ManagedBlockchain
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ManagedBlockchain
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ManagedBlockchainQuery/Generated/AmazonManagedBlockchainQueryDefaultConfiguration.cs
+++ b/sdk/src/Services/ManagedBlockchainQuery/Generated/AmazonManagedBlockchainQueryDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ManagedBlockchainQuery
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ManagedBlockchainQuery
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ManagedGrafana/Generated/AmazonManagedGrafanaDefaultConfiguration.cs
+++ b/sdk/src/Services/ManagedGrafana/Generated/AmazonManagedGrafanaDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ManagedGrafana
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ManagedGrafana
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MarketplaceAgreement/Generated/AmazonMarketplaceAgreementDefaultConfiguration.cs
+++ b/sdk/src/Services/MarketplaceAgreement/Generated/AmazonMarketplaceAgreementDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MarketplaceAgreement
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MarketplaceAgreement
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MarketplaceCatalog/Generated/AmazonMarketplaceCatalogDefaultConfiguration.cs
+++ b/sdk/src/Services/MarketplaceCatalog/Generated/AmazonMarketplaceCatalogDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MarketplaceCatalog
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MarketplaceCatalog
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MarketplaceDeployment/Generated/AmazonMarketplaceDeploymentDefaultConfiguration.cs
+++ b/sdk/src/Services/MarketplaceDeployment/Generated/AmazonMarketplaceDeploymentDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MarketplaceDeployment
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MarketplaceDeployment
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MarketplaceEntitlementService/Generated/AmazonMarketplaceEntitlementServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/MarketplaceEntitlementService/Generated/AmazonMarketplaceEntitlementServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MarketplaceEntitlementService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MarketplaceEntitlementService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MediaConnect/Generated/AmazonMediaConnectDefaultConfiguration.cs
+++ b/sdk/src/Services/MediaConnect/Generated/AmazonMediaConnectDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MediaConnect
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MediaConnect
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MediaConvert/Generated/AmazonMediaConvertDefaultConfiguration.cs
+++ b/sdk/src/Services/MediaConvert/Generated/AmazonMediaConvertDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MediaConvert
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MediaConvert
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MediaLive/Generated/AmazonMediaLiveDefaultConfiguration.cs
+++ b/sdk/src/Services/MediaLive/Generated/AmazonMediaLiveDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MediaLive
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MediaLive
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MediaPackage/Generated/AmazonMediaPackageDefaultConfiguration.cs
+++ b/sdk/src/Services/MediaPackage/Generated/AmazonMediaPackageDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MediaPackage
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MediaPackage
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MediaPackageV2/Generated/AmazonMediaPackageV2DefaultConfiguration.cs
+++ b/sdk/src/Services/MediaPackageV2/Generated/AmazonMediaPackageV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MediaPackageV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MediaPackageV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MediaPackageVod/Generated/AmazonMediaPackageVodDefaultConfiguration.cs
+++ b/sdk/src/Services/MediaPackageVod/Generated/AmazonMediaPackageVodDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MediaPackageVod
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MediaPackageVod
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MediaStore/Generated/AmazonMediaStoreDefaultConfiguration.cs
+++ b/sdk/src/Services/MediaStore/Generated/AmazonMediaStoreDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MediaStore
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MediaStore
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MediaStoreData/Generated/AmazonMediaStoreDataDefaultConfiguration.cs
+++ b/sdk/src/Services/MediaStoreData/Generated/AmazonMediaStoreDataDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MediaStoreData
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MediaStoreData
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MediaTailor/Generated/AmazonMediaTailorDefaultConfiguration.cs
+++ b/sdk/src/Services/MediaTailor/Generated/AmazonMediaTailorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MediaTailor
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MediaTailor
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MedicalImaging/Generated/AmazonMedicalImagingDefaultConfiguration.cs
+++ b/sdk/src/Services/MedicalImaging/Generated/AmazonMedicalImagingDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MedicalImaging
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MedicalImaging
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MemoryDB/Generated/AmazonMemoryDBDefaultConfiguration.cs
+++ b/sdk/src/Services/MemoryDB/Generated/AmazonMemoryDBDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MemoryDB
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MemoryDB
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Mgn/Generated/AmazonMgnDefaultConfiguration.cs
+++ b/sdk/src/Services/Mgn/Generated/AmazonMgnDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Mgn
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Mgn
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MigrationHub/Generated/AmazonMigrationHubDefaultConfiguration.cs
+++ b/sdk/src/Services/MigrationHub/Generated/AmazonMigrationHubDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MigrationHub
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MigrationHub
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MigrationHubConfig/Generated/AmazonMigrationHubConfigDefaultConfiguration.cs
+++ b/sdk/src/Services/MigrationHubConfig/Generated/AmazonMigrationHubConfigDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MigrationHubConfig
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MigrationHubConfig
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MigrationHubOrchestrator/Generated/AmazonMigrationHubOrchestratorDefaultConfiguration.cs
+++ b/sdk/src/Services/MigrationHubOrchestrator/Generated/AmazonMigrationHubOrchestratorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MigrationHubOrchestrator
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MigrationHubOrchestrator
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MigrationHubRefactorSpaces/Generated/AmazonMigrationHubRefactorSpacesDefaultConfiguration.cs
+++ b/sdk/src/Services/MigrationHubRefactorSpaces/Generated/AmazonMigrationHubRefactorSpacesDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MigrationHubRefactorSpaces
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MigrationHubRefactorSpaces
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MigrationHubStrategyRecommendations/Generated/AmazonMigrationHubStrategyRecommendationsDefaultConfiguration.cs
+++ b/sdk/src/Services/MigrationHubStrategyRecommendations/Generated/AmazonMigrationHubStrategyRecommendationsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MigrationHubStrategyRecommendations
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MigrationHubStrategyRecommendations
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Mobile/Generated/AmazonMobileDefaultConfiguration.cs
+++ b/sdk/src/Services/Mobile/Generated/AmazonMobileDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Mobile
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Mobile
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/MobileAnalytics/Generated/AmazonMobileAnalyticsDefaultConfiguration.cs
+++ b/sdk/src/Services/MobileAnalytics/Generated/AmazonMobileAnalyticsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.MobileAnalytics
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.MobileAnalytics
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Neptune/Generated/AmazonNeptuneDefaultConfiguration.cs
+++ b/sdk/src/Services/Neptune/Generated/AmazonNeptuneDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Neptune
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Neptune
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/NeptuneGraph/Generated/AmazonNeptuneGraphDefaultConfiguration.cs
+++ b/sdk/src/Services/NeptuneGraph/Generated/AmazonNeptuneGraphDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.NeptuneGraph
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.NeptuneGraph
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Neptunedata/Generated/AmazonNeptunedataDefaultConfiguration.cs
+++ b/sdk/src/Services/Neptunedata/Generated/AmazonNeptunedataDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Neptunedata
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Neptunedata
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/NetworkFirewall/Generated/AmazonNetworkFirewallDefaultConfiguration.cs
+++ b/sdk/src/Services/NetworkFirewall/Generated/AmazonNetworkFirewallDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.NetworkFirewall
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.NetworkFirewall
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/NetworkManager/Generated/AmazonNetworkManagerDefaultConfiguration.cs
+++ b/sdk/src/Services/NetworkManager/Generated/AmazonNetworkManagerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.NetworkManager
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.NetworkManager
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/NetworkMonitor/Generated/AmazonNetworkMonitorDefaultConfiguration.cs
+++ b/sdk/src/Services/NetworkMonitor/Generated/AmazonNetworkMonitorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.NetworkMonitor
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.NetworkMonitor
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/NimbleStudio/Generated/AmazonNimbleStudioDefaultConfiguration.cs
+++ b/sdk/src/Services/NimbleStudio/Generated/AmazonNimbleStudioDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.NimbleStudio
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.NimbleStudio
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/OAM/Generated/AmazonOAMDefaultConfiguration.cs
+++ b/sdk/src/Services/OAM/Generated/AmazonOAMDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.OAM
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.OAM
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/OSIS/Generated/AmazonOSISDefaultConfiguration.cs
+++ b/sdk/src/Services/OSIS/Generated/AmazonOSISDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.OSIS
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.OSIS
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Omics/Generated/AmazonOmicsDefaultConfiguration.cs
+++ b/sdk/src/Services/Omics/Generated/AmazonOmicsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Omics
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Omics
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/OpenSearchServerless/Generated/AmazonOpenSearchServerlessDefaultConfiguration.cs
+++ b/sdk/src/Services/OpenSearchServerless/Generated/AmazonOpenSearchServerlessDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.OpenSearchServerless
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.OpenSearchServerless
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/OpenSearchService/Generated/AmazonOpenSearchServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/OpenSearchService/Generated/AmazonOpenSearchServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.OpenSearchService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.OpenSearchService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/OpsWorks/Generated/AmazonOpsWorksDefaultConfiguration.cs
+++ b/sdk/src/Services/OpsWorks/Generated/AmazonOpsWorksDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.OpsWorks
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.OpsWorks
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/OpsWorksCM/Generated/AmazonOpsWorksCMDefaultConfiguration.cs
+++ b/sdk/src/Services/OpsWorksCM/Generated/AmazonOpsWorksCMDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.OpsWorksCM
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.OpsWorksCM
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Organizations/Generated/AmazonOrganizationsDefaultConfiguration.cs
+++ b/sdk/src/Services/Organizations/Generated/AmazonOrganizationsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Organizations
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Organizations
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Outposts/Generated/AmazonOutpostsDefaultConfiguration.cs
+++ b/sdk/src/Services/Outposts/Generated/AmazonOutpostsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Outposts
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Outposts
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PI/Generated/AmazonPIDefaultConfiguration.cs
+++ b/sdk/src/Services/PI/Generated/AmazonPIDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PI
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PI
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Panorama/Generated/AmazonPanoramaDefaultConfiguration.cs
+++ b/sdk/src/Services/Panorama/Generated/AmazonPanoramaDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Panorama
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Panorama
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PaymentCryptography/Generated/AmazonPaymentCryptographyDefaultConfiguration.cs
+++ b/sdk/src/Services/PaymentCryptography/Generated/AmazonPaymentCryptographyDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PaymentCryptography
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PaymentCryptography
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PaymentCryptographyData/Generated/AmazonPaymentCryptographyDataDefaultConfiguration.cs
+++ b/sdk/src/Services/PaymentCryptographyData/Generated/AmazonPaymentCryptographyDataDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PaymentCryptographyData
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PaymentCryptographyData
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PcaConnectorAd/Generated/AmazonPcaConnectorAdDefaultConfiguration.cs
+++ b/sdk/src/Services/PcaConnectorAd/Generated/AmazonPcaConnectorAdDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PcaConnectorAd
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PcaConnectorAd
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Personalize/Generated/AmazonPersonalizeDefaultConfiguration.cs
+++ b/sdk/src/Services/Personalize/Generated/AmazonPersonalizeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Personalize
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Personalize
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PersonalizeEvents/Generated/AmazonPersonalizeEventsDefaultConfiguration.cs
+++ b/sdk/src/Services/PersonalizeEvents/Generated/AmazonPersonalizeEventsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PersonalizeEvents
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PersonalizeEvents
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PersonalizeRuntime/Generated/AmazonPersonalizeRuntimeDefaultConfiguration.cs
+++ b/sdk/src/Services/PersonalizeRuntime/Generated/AmazonPersonalizeRuntimeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PersonalizeRuntime
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PersonalizeRuntime
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Pinpoint/Generated/AmazonPinpointDefaultConfiguration.cs
+++ b/sdk/src/Services/Pinpoint/Generated/AmazonPinpointDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Pinpoint
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Pinpoint
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PinpointEmail/Generated/AmazonPinpointEmailDefaultConfiguration.cs
+++ b/sdk/src/Services/PinpointEmail/Generated/AmazonPinpointEmailDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PinpointEmail
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PinpointEmail
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PinpointSMSVoice/Generated/AmazonPinpointSMSVoiceDefaultConfiguration.cs
+++ b/sdk/src/Services/PinpointSMSVoice/Generated/AmazonPinpointSMSVoiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PinpointSMSVoice
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PinpointSMSVoice
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PinpointSMSVoiceV2/Generated/AmazonPinpointSMSVoiceV2DefaultConfiguration.cs
+++ b/sdk/src/Services/PinpointSMSVoiceV2/Generated/AmazonPinpointSMSVoiceV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PinpointSMSVoiceV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PinpointSMSVoiceV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Pipes/Generated/AmazonPipesDefaultConfiguration.cs
+++ b/sdk/src/Services/Pipes/Generated/AmazonPipesDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Pipes
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Pipes
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Polly/Generated/AmazonPollyDefaultConfiguration.cs
+++ b/sdk/src/Services/Polly/Generated/AmazonPollyDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Polly
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Polly
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Pricing/Generated/AmazonPricingDefaultConfiguration.cs
+++ b/sdk/src/Services/Pricing/Generated/AmazonPricingDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Pricing
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Pricing
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Private5G/Generated/AmazonPrivate5GDefaultConfiguration.cs
+++ b/sdk/src/Services/Private5G/Generated/AmazonPrivate5GDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Private5G
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Private5G
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/PrometheusService/Generated/AmazonPrometheusServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/PrometheusService/Generated/AmazonPrometheusServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PrometheusService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PrometheusService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Proton/Generated/AmazonProtonDefaultConfiguration.cs
+++ b/sdk/src/Services/Proton/Generated/AmazonProtonDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Proton
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Proton
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/QBusiness/Generated/AmazonQBusinessDefaultConfiguration.cs
+++ b/sdk/src/Services/QBusiness/Generated/AmazonQBusinessDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.QBusiness
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.QBusiness
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/QConnect/Generated/AmazonQConnectDefaultConfiguration.cs
+++ b/sdk/src/Services/QConnect/Generated/AmazonQConnectDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.QConnect
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.QConnect
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/QLDB/Generated/AmazonQLDBDefaultConfiguration.cs
+++ b/sdk/src/Services/QLDB/Generated/AmazonQLDBDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.QLDB
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.QLDB
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/QLDBSession/Generated/AmazonQLDBSessionDefaultConfiguration.cs
+++ b/sdk/src/Services/QLDBSession/Generated/AmazonQLDBSessionDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.QLDBSession
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.QLDBSession
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/QuickSight/Generated/AmazonQuickSightDefaultConfiguration.cs
+++ b/sdk/src/Services/QuickSight/Generated/AmazonQuickSightDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.QuickSight
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.QuickSight
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/RAM/Generated/AmazonRAMDefaultConfiguration.cs
+++ b/sdk/src/Services/RAM/Generated/AmazonRAMDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.RAM
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.RAM
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/RDS/Generated/AmazonRDSDefaultConfiguration.cs
+++ b/sdk/src/Services/RDS/Generated/AmazonRDSDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.RDS
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.RDS
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/RDSDataService/Generated/AmazonRDSDataServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/RDSDataService/Generated/AmazonRDSDataServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.RDSDataService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.RDSDataService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/RecycleBin/Generated/AmazonRecycleBinDefaultConfiguration.cs
+++ b/sdk/src/Services/RecycleBin/Generated/AmazonRecycleBinDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.RecycleBin
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.RecycleBin
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Redshift/Generated/AmazonRedshiftDefaultConfiguration.cs
+++ b/sdk/src/Services/Redshift/Generated/AmazonRedshiftDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Redshift
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Redshift
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/RedshiftDataAPIService/Generated/AmazonRedshiftDataAPIServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/RedshiftDataAPIService/Generated/AmazonRedshiftDataAPIServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.RedshiftDataAPIService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.RedshiftDataAPIService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/RedshiftServerless/Generated/AmazonRedshiftServerlessDefaultConfiguration.cs
+++ b/sdk/src/Services/RedshiftServerless/Generated/AmazonRedshiftServerlessDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.RedshiftServerless
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.RedshiftServerless
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Rekognition/Generated/AmazonRekognitionDefaultConfiguration.cs
+++ b/sdk/src/Services/Rekognition/Generated/AmazonRekognitionDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Rekognition
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Rekognition
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Repostspace/Generated/AmazonRepostspaceDefaultConfiguration.cs
+++ b/sdk/src/Services/Repostspace/Generated/AmazonRepostspaceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Repostspace
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Repostspace
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ResilienceHub/Generated/AmazonResilienceHubDefaultConfiguration.cs
+++ b/sdk/src/Services/ResilienceHub/Generated/AmazonResilienceHubDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ResilienceHub
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ResilienceHub
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ResourceExplorer2/Generated/AmazonResourceExplorer2DefaultConfiguration.cs
+++ b/sdk/src/Services/ResourceExplorer2/Generated/AmazonResourceExplorer2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ResourceExplorer2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ResourceExplorer2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ResourceGroups/Generated/AmazonResourceGroupsDefaultConfiguration.cs
+++ b/sdk/src/Services/ResourceGroups/Generated/AmazonResourceGroupsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ResourceGroups
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ResourceGroups
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ResourceGroupsTaggingAPI/Generated/AmazonResourceGroupsTaggingAPIDefaultConfiguration.cs
+++ b/sdk/src/Services/ResourceGroupsTaggingAPI/Generated/AmazonResourceGroupsTaggingAPIDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ResourceGroupsTaggingAPI
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ResourceGroupsTaggingAPI
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/RoboMaker/Generated/AmazonRoboMakerDefaultConfiguration.cs
+++ b/sdk/src/Services/RoboMaker/Generated/AmazonRoboMakerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.RoboMaker
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.RoboMaker
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Route53/Generated/AmazonRoute53DefaultConfiguration.cs
+++ b/sdk/src/Services/Route53/Generated/AmazonRoute53DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Route53
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Route53
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Route53Domains/Generated/AmazonRoute53DomainsDefaultConfiguration.cs
+++ b/sdk/src/Services/Route53Domains/Generated/AmazonRoute53DomainsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Route53Domains
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Route53Domains
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Route53RecoveryCluster/Generated/AmazonRoute53RecoveryClusterDefaultConfiguration.cs
+++ b/sdk/src/Services/Route53RecoveryCluster/Generated/AmazonRoute53RecoveryClusterDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Route53RecoveryCluster
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Route53RecoveryCluster
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Route53RecoveryControlConfig/Generated/AmazonRoute53RecoveryControlConfigDefaultConfiguration.cs
+++ b/sdk/src/Services/Route53RecoveryControlConfig/Generated/AmazonRoute53RecoveryControlConfigDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Route53RecoveryControlConfig
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Route53RecoveryControlConfig
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Route53RecoveryReadiness/Generated/AmazonRoute53RecoveryReadinessDefaultConfiguration.cs
+++ b/sdk/src/Services/Route53RecoveryReadiness/Generated/AmazonRoute53RecoveryReadinessDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Route53RecoveryReadiness
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Route53RecoveryReadiness
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Route53Resolver/Generated/AmazonRoute53ResolverDefaultConfiguration.cs
+++ b/sdk/src/Services/Route53Resolver/Generated/AmazonRoute53ResolverDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Route53Resolver
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Route53Resolver
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/S3/Generated/AmazonS3DefaultConfiguration.cs
+++ b/sdk/src/Services/S3/Generated/AmazonS3DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.S3
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.S3
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/S3/Generated/_bcl/AmazonS3Client.cs
+++ b/sdk/src/Services/S3/Generated/_bcl/AmazonS3Client.cs
@@ -241,10 +241,6 @@ namespace Amazon.S3
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.Unmarshaller>(new Amazon.S3.Internal.AmazonS3RedirectHandler());
             pipeline.AddHandlerBefore<Amazon.Runtime.Internal.Signer>(new Amazon.S3.Internal.S3Express.S3ExpressPreSigner());
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.EndpointResolver>(new Amazon.S3.Internal.AmazonS3PostMarshallHandler());
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.S3.Internal.AmazonS3RetryPolicy(this.Config)));
-            }
             if(this.Config.RetryMode == RequestRetryMode.Standard)
             {
                 pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.S3.Internal.AmazonS3StandardRetryPolicy(this.Config)));

--- a/sdk/src/Services/S3/Generated/_netstandard/AmazonS3Client.cs
+++ b/sdk/src/Services/S3/Generated/_netstandard/AmazonS3Client.cs
@@ -245,10 +245,6 @@ namespace Amazon.S3
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.Unmarshaller>(new Amazon.S3.Internal.AmazonS3RedirectHandler());
             pipeline.AddHandlerBefore<Amazon.Runtime.Internal.Signer>(new Amazon.S3.Internal.S3Express.S3ExpressPreSigner());
             pipeline.AddHandlerAfter<Amazon.Runtime.Internal.EndpointResolver>(new Amazon.S3.Internal.AmazonS3PostMarshallHandler());
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.S3.Internal.AmazonS3RetryPolicy(this.Config)));
-            }
             if(this.Config.RetryMode == RequestRetryMode.Standard)
             {
                 pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new Amazon.S3.Internal.AmazonS3StandardRetryPolicy(this.Config)));

--- a/sdk/src/Services/S3Control/Generated/AmazonS3ControlDefaultConfiguration.cs
+++ b/sdk/src/Services/S3Control/Generated/AmazonS3ControlDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.S3Control
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.S3Control
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/S3Outposts/Generated/AmazonS3OutpostsDefaultConfiguration.cs
+++ b/sdk/src/Services/S3Outposts/Generated/AmazonS3OutpostsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.S3Outposts
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.S3Outposts
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SQS/Generated/AmazonSQSDefaultConfiguration.cs
+++ b/sdk/src/Services/SQS/Generated/AmazonSQSDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SQS
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SQS
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SSMContacts/Generated/AmazonSSMContactsDefaultConfiguration.cs
+++ b/sdk/src/Services/SSMContacts/Generated/AmazonSSMContactsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SSMContacts
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SSMContacts
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SSMIncidents/Generated/AmazonSSMIncidentsDefaultConfiguration.cs
+++ b/sdk/src/Services/SSMIncidents/Generated/AmazonSSMIncidentsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SSMIncidents
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SSMIncidents
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SSO/Generated/AmazonSSODefaultConfiguration.cs
+++ b/sdk/src/Services/SSO/Generated/AmazonSSODefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SSO
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SSO
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SSOAdmin/Generated/AmazonSSOAdminDefaultConfiguration.cs
+++ b/sdk/src/Services/SSOAdmin/Generated/AmazonSSOAdminDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SSOAdmin
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SSOAdmin
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SSOOIDC/Generated/AmazonSSOOIDCDefaultConfiguration.cs
+++ b/sdk/src/Services/SSOOIDC/Generated/AmazonSSOOIDCDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SSOOIDC
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SSOOIDC
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SageMaker/Generated/AmazonSageMakerDefaultConfiguration.cs
+++ b/sdk/src/Services/SageMaker/Generated/AmazonSageMakerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SageMaker
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SageMaker
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SageMakerFeatureStoreRuntime/Generated/AmazonSageMakerFeatureStoreRuntimeDefaultConfiguration.cs
+++ b/sdk/src/Services/SageMakerFeatureStoreRuntime/Generated/AmazonSageMakerFeatureStoreRuntimeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SageMakerFeatureStoreRuntime
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SageMakerFeatureStoreRuntime
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SageMakerGeospatial/Generated/AmazonSageMakerGeospatialDefaultConfiguration.cs
+++ b/sdk/src/Services/SageMakerGeospatial/Generated/AmazonSageMakerGeospatialDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SageMakerGeospatial
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SageMakerGeospatial
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SageMakerMetrics/Generated/AmazonSageMakerMetricsDefaultConfiguration.cs
+++ b/sdk/src/Services/SageMakerMetrics/Generated/AmazonSageMakerMetricsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SageMakerMetrics
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SageMakerMetrics
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SageMakerRuntime/Generated/AmazonSageMakerRuntimeDefaultConfiguration.cs
+++ b/sdk/src/Services/SageMakerRuntime/Generated/AmazonSageMakerRuntimeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SageMakerRuntime
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SageMakerRuntime
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SagemakerEdgeManager/Generated/AmazonSagemakerEdgeManagerDefaultConfiguration.cs
+++ b/sdk/src/Services/SagemakerEdgeManager/Generated/AmazonSagemakerEdgeManagerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SagemakerEdgeManager
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SagemakerEdgeManager
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SavingsPlans/Generated/AmazonSavingsPlansDefaultConfiguration.cs
+++ b/sdk/src/Services/SavingsPlans/Generated/AmazonSavingsPlansDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SavingsPlans
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SavingsPlans
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Scheduler/Generated/AmazonSchedulerDefaultConfiguration.cs
+++ b/sdk/src/Services/Scheduler/Generated/AmazonSchedulerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Scheduler
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Scheduler
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Schemas/Generated/AmazonSchemasDefaultConfiguration.cs
+++ b/sdk/src/Services/Schemas/Generated/AmazonSchemasDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Schemas
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Schemas
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SecretsManager/Generated/AmazonSecretsManagerDefaultConfiguration.cs
+++ b/sdk/src/Services/SecretsManager/Generated/AmazonSecretsManagerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SecretsManager
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SecretsManager
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SecurityHub/Generated/AmazonSecurityHubDefaultConfiguration.cs
+++ b/sdk/src/Services/SecurityHub/Generated/AmazonSecurityHubDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SecurityHub
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SecurityHub
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SecurityLake/Generated/AmazonSecurityLakeDefaultConfiguration.cs
+++ b/sdk/src/Services/SecurityLake/Generated/AmazonSecurityLakeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SecurityLake
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SecurityLake
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SecurityToken/Generated/AmazonSecurityTokenServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/SecurityToken/Generated/AmazonSecurityTokenServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SecurityToken
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SecurityToken
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SecurityToken/Generated/_bcl/AmazonSecurityTokenServiceClient.cs
+++ b/sdk/src/Services/SecurityToken/Generated/_bcl/AmazonSecurityTokenServiceClient.cs
@@ -224,10 +224,6 @@ namespace Amazon.SecurityToken
         /// <param name="pipeline"></param>
         protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
         {
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new SecurityTokenServiceRetryPolicy(this.Config)));
-            }
             if(this.Config.RetryMode == RequestRetryMode.Standard)
             {
                 pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new SecurityTokenServiceStandardRetryPolicy(this.Config)));

--- a/sdk/src/Services/SecurityToken/Generated/_netstandard/AmazonSecurityTokenServiceClient.cs
+++ b/sdk/src/Services/SecurityToken/Generated/_netstandard/AmazonSecurityTokenServiceClient.cs
@@ -226,10 +226,6 @@ namespace Amazon.SecurityToken
         /// <param name="pipeline">Runtime pipeline for the current client.</param>
         protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
         {
-            if(this.Config.RetryMode == RequestRetryMode.Legacy)
-            {
-                pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new SecurityTokenServiceRetryPolicy(this.Config)));
-            }
             if(this.Config.RetryMode == RequestRetryMode.Standard)
             {
                 pipeline.ReplaceHandler<Amazon.Runtime.Internal.RetryHandler>(new Amazon.Runtime.Internal.RetryHandler(new SecurityTokenServiceStandardRetryPolicy(this.Config)));

--- a/sdk/src/Services/ServerMigrationService/Generated/AmazonServerMigrationServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/ServerMigrationService/Generated/AmazonServerMigrationServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ServerMigrationService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ServerMigrationService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ServerlessApplicationRepository/Generated/AmazonServerlessApplicationRepositoryDefaultConfiguration.cs
+++ b/sdk/src/Services/ServerlessApplicationRepository/Generated/AmazonServerlessApplicationRepositoryDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ServerlessApplicationRepository
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ServerlessApplicationRepository
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ServiceCatalog/Generated/AmazonServiceCatalogDefaultConfiguration.cs
+++ b/sdk/src/Services/ServiceCatalog/Generated/AmazonServiceCatalogDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ServiceCatalog
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ServiceCatalog
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ServiceDiscovery/Generated/AmazonServiceDiscoveryDefaultConfiguration.cs
+++ b/sdk/src/Services/ServiceDiscovery/Generated/AmazonServiceDiscoveryDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ServiceDiscovery
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ServiceDiscovery
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/ServiceQuotas/Generated/AmazonServiceQuotasDefaultConfiguration.cs
+++ b/sdk/src/Services/ServiceQuotas/Generated/AmazonServiceQuotasDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.ServiceQuotas
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.ServiceQuotas
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Shield/Generated/AmazonShieldDefaultConfiguration.cs
+++ b/sdk/src/Services/Shield/Generated/AmazonShieldDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Shield
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Shield
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Signer/Generated/AmazonSignerDefaultConfiguration.cs
+++ b/sdk/src/Services/Signer/Generated/AmazonSignerDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Signer
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Signer
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SimSpaceWeaver/Generated/AmazonSimSpaceWeaverDefaultConfiguration.cs
+++ b/sdk/src/Services/SimSpaceWeaver/Generated/AmazonSimSpaceWeaverDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SimSpaceWeaver
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SimSpaceWeaver
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SimpleDB/Generated/AmazonSimpleDBDefaultConfiguration.cs
+++ b/sdk/src/Services/SimpleDB/Generated/AmazonSimpleDBDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SimpleDB
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SimpleDB
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SimpleEmail/Generated/AmazonSimpleEmailServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/SimpleEmail/Generated/AmazonSimpleEmailServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SimpleEmail
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SimpleEmail
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SimpleEmailV2/Generated/AmazonSimpleEmailServiceV2DefaultConfiguration.cs
+++ b/sdk/src/Services/SimpleEmailV2/Generated/AmazonSimpleEmailServiceV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SimpleEmailV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SimpleEmailV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SimpleNotificationService/Generated/AmazonSimpleNotificationServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/SimpleNotificationService/Generated/AmazonSimpleNotificationServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SimpleNotificationService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SimpleNotificationService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SimpleSystemsManagement/Generated/AmazonSimpleSystemsManagementDefaultConfiguration.cs
+++ b/sdk/src/Services/SimpleSystemsManagement/Generated/AmazonSimpleSystemsManagementDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SimpleSystemsManagement
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SimpleSystemsManagement
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SimpleWorkflow/Generated/AmazonSimpleWorkflowDefaultConfiguration.cs
+++ b/sdk/src/Services/SimpleWorkflow/Generated/AmazonSimpleWorkflowDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SimpleWorkflow
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SimpleWorkflow
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SnowDeviceManagement/Generated/AmazonSnowDeviceManagementDefaultConfiguration.cs
+++ b/sdk/src/Services/SnowDeviceManagement/Generated/AmazonSnowDeviceManagementDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SnowDeviceManagement
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SnowDeviceManagement
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Snowball/Generated/AmazonSnowballDefaultConfiguration.cs
+++ b/sdk/src/Services/Snowball/Generated/AmazonSnowballDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Snowball
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Snowball
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SsmSap/Generated/AmazonSsmSapDefaultConfiguration.cs
+++ b/sdk/src/Services/SsmSap/Generated/AmazonSsmSapDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SsmSap
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SsmSap
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/StepFunctions/Generated/AmazonStepFunctionsDefaultConfiguration.cs
+++ b/sdk/src/Services/StepFunctions/Generated/AmazonStepFunctionsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.StepFunctions
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.StepFunctions
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/StorageGateway/Generated/AmazonStorageGatewayDefaultConfiguration.cs
+++ b/sdk/src/Services/StorageGateway/Generated/AmazonStorageGatewayDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.StorageGateway
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.StorageGateway
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SupplyChain/Generated/AmazonSupplyChainDefaultConfiguration.cs
+++ b/sdk/src/Services/SupplyChain/Generated/AmazonSupplyChainDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SupplyChain
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SupplyChain
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/SupportApp/Generated/AmazonSupportAppDefaultConfiguration.cs
+++ b/sdk/src/Services/SupportApp/Generated/AmazonSupportAppDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.SupportApp
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.SupportApp
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Synthetics/Generated/AmazonSyntheticsDefaultConfiguration.cs
+++ b/sdk/src/Services/Synthetics/Generated/AmazonSyntheticsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Synthetics
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Synthetics
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Textract/Generated/AmazonTextractDefaultConfiguration.cs
+++ b/sdk/src/Services/Textract/Generated/AmazonTextractDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Textract
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Textract
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/TimestreamInfluxDB/Generated/AmazonTimestreamInfluxDBDefaultConfiguration.cs
+++ b/sdk/src/Services/TimestreamInfluxDB/Generated/AmazonTimestreamInfluxDBDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.TimestreamInfluxDB
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.TimestreamInfluxDB
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/TimestreamQuery/Generated/AmazonTimestreamQueryDefaultConfiguration.cs
+++ b/sdk/src/Services/TimestreamQuery/Generated/AmazonTimestreamQueryDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.TimestreamQuery
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.TimestreamQuery
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/TimestreamWrite/Generated/AmazonTimestreamWriteDefaultConfiguration.cs
+++ b/sdk/src/Services/TimestreamWrite/Generated/AmazonTimestreamWriteDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.TimestreamWrite
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.TimestreamWrite
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Tnb/Generated/AmazonTnbDefaultConfiguration.cs
+++ b/sdk/src/Services/Tnb/Generated/AmazonTnbDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Tnb
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Tnb
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/TranscribeService/Generated/AmazonTranscribeServiceDefaultConfiguration.cs
+++ b/sdk/src/Services/TranscribeService/Generated/AmazonTranscribeServiceDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.TranscribeService
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.TranscribeService
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Transfer/Generated/AmazonTransferDefaultConfiguration.cs
+++ b/sdk/src/Services/Transfer/Generated/AmazonTransferDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Transfer
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Transfer
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/Translate/Generated/AmazonTranslateDefaultConfiguration.cs
+++ b/sdk/src/Services/Translate/Generated/AmazonTranslateDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Translate
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Translate
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/TrustedAdvisor/Generated/AmazonTrustedAdvisorDefaultConfiguration.cs
+++ b/sdk/src/Services/TrustedAdvisor/Generated/AmazonTrustedAdvisorDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.TrustedAdvisor
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.TrustedAdvisor
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/VPCLattice/Generated/AmazonVPCLatticeDefaultConfiguration.cs
+++ b/sdk/src/Services/VPCLattice/Generated/AmazonVPCLatticeDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.VPCLattice
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.VPCLattice
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/VerifiedPermissions/Generated/AmazonVerifiedPermissionsDefaultConfiguration.cs
+++ b/sdk/src/Services/VerifiedPermissions/Generated/AmazonVerifiedPermissionsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.VerifiedPermissions
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.VerifiedPermissions
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/VoiceID/Generated/AmazonVoiceIDDefaultConfiguration.cs
+++ b/sdk/src/Services/VoiceID/Generated/AmazonVoiceIDDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.VoiceID
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.VoiceID
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WAF/Generated/AmazonWAFDefaultConfiguration.cs
+++ b/sdk/src/Services/WAF/Generated/AmazonWAFDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WAF
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WAF
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WAFRegional/Generated/AmazonWAFRegionalDefaultConfiguration.cs
+++ b/sdk/src/Services/WAFRegional/Generated/AmazonWAFRegionalDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WAFRegional
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WAFRegional
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WAFV2/Generated/AmazonWAFV2DefaultConfiguration.cs
+++ b/sdk/src/Services/WAFV2/Generated/AmazonWAFV2DefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WAFV2
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WAFV2
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WellArchitected/Generated/AmazonWellArchitectedDefaultConfiguration.cs
+++ b/sdk/src/Services/WellArchitected/Generated/AmazonWellArchitectedDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WellArchitected
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WellArchitected
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WorkDocs/Generated/AmazonWorkDocsDefaultConfiguration.cs
+++ b/sdk/src/Services/WorkDocs/Generated/AmazonWorkDocsDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WorkDocs
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WorkDocs
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WorkLink/Generated/AmazonWorkLinkDefaultConfiguration.cs
+++ b/sdk/src/Services/WorkLink/Generated/AmazonWorkLinkDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WorkLink
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WorkLink
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WorkMail/Generated/AmazonWorkMailDefaultConfiguration.cs
+++ b/sdk/src/Services/WorkMail/Generated/AmazonWorkMailDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WorkMail
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WorkMail
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WorkMailMessageFlow/Generated/AmazonWorkMailMessageFlowDefaultConfiguration.cs
+++ b/sdk/src/Services/WorkMailMessageFlow/Generated/AmazonWorkMailMessageFlowDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WorkMailMessageFlow
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WorkMailMessageFlow
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WorkSpaces/Generated/AmazonWorkSpacesDefaultConfiguration.cs
+++ b/sdk/src/Services/WorkSpaces/Generated/AmazonWorkSpacesDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WorkSpaces
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WorkSpaces
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WorkSpacesThinClient/Generated/AmazonWorkSpacesThinClientDefaultConfiguration.cs
+++ b/sdk/src/Services/WorkSpacesThinClient/Generated/AmazonWorkSpacesThinClientDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WorkSpacesThinClient
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WorkSpacesThinClient
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/WorkSpacesWeb/Generated/AmazonWorkSpacesWebDefaultConfiguration.cs
+++ b/sdk/src/Services/WorkSpacesWeb/Generated/AmazonWorkSpacesWebDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.WorkSpacesWeb
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.WorkSpacesWeb
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/src/Services/XRay/Generated/AmazonXRayDefaultConfiguration.cs
+++ b/sdk/src/Services/XRay/Generated/AmazonXRayDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.XRay
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.XRay
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/BearerTokenAuthTest/Generated/AmazonBearerTokenAuthTestDefaultConfiguration.cs
+++ b/sdk/test/Services/BearerTokenAuthTest/Generated/AmazonBearerTokenAuthTestDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.BearerTokenAuthTest
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.BearerTokenAuthTest
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/DocumentTypesTest/Generated/AmazonDocumentTypesTestDefaultConfiguration.cs
+++ b/sdk/test/Services/DocumentTypesTest/Generated/AmazonDocumentTypesTestDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.DocumentTypesTest
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.DocumentTypesTest
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/Ep2hostlabel/Generated/AmazonEp2hostlabelDefaultConfiguration.cs
+++ b/sdk/test/Services/Ep2hostlabel/Generated/AmazonEp2hostlabelDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Ep2hostlabel
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Ep2hostlabel
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/Ep2parsearn/Generated/AmazonEp2parsearnDefaultConfiguration.cs
+++ b/sdk/test/Services/Ep2parsearn/Generated/AmazonEp2parsearnDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Ep2parsearn
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Ep2parsearn
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/Ep2s3hostlabel/Generated/AmazonEp2s3hostlabelDefaultConfiguration.cs
+++ b/sdk/test/Services/Ep2s3hostlabel/Generated/AmazonEp2s3hostlabelDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Ep2s3hostlabel
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Ep2s3hostlabel
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/Ep2substring/Generated/AmazonEp2substringDefaultConfiguration.cs
+++ b/sdk/test/Services/Ep2substring/Generated/AmazonEp2substringDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.Ep2substring
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.Ep2substring
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/PaginatorsTest/Generated/AmazonPaginatorsTestDefaultConfiguration.cs
+++ b/sdk/test/Services/PaginatorsTest/Generated/AmazonPaginatorsTestDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.PaginatorsTest
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.PaginatorsTest
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/QueryCompatible/Generated/AmazonQueryCompatibleDefaultConfiguration.cs
+++ b/sdk/test/Services/QueryCompatible/Generated/AmazonQueryCompatibleDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.QueryCompatible
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.QueryCompatible
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/RestJsonTest/Generated/AmazonRestJsonTestDefaultConfiguration.cs
+++ b/sdk/test/Services/RestJsonTest/Generated/AmazonRestJsonTestDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.RestJsonTest
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.RestJsonTest
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/RestXMLTest/Generated/AmazonRestXMLTestDefaultConfiguration.cs
+++ b/sdk/test/Services/RestXMLTest/Generated/AmazonRestXMLTestDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.RestXMLTest
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.RestXMLTest
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/Services/UseServiceIdTestserviceId/Generated/AmazonUseServiceIdTestserviceIdDefaultConfiguration.cs
+++ b/sdk/test/Services/UseServiceIdTestserviceId/Generated/AmazonUseServiceIdTestserviceIdDefaultConfiguration.cs
@@ -43,8 +43,7 @@ namespace Amazon.UseServiceIdTestserviceId
                 InRegion,
                 CrossRegion,
                 Mobile,
-                Auto,
-                Legacy
+                Auto
             });
         }
 
@@ -125,20 +124,6 @@ namespace Amazon.UseServiceIdTestserviceId
             ConnectTimeout = TimeSpan.FromMilliseconds(1100L),
             // 0:00:01.1
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(1100L),
-            TimeToFirstByteTimeout = null,
-            HttpRequestTimeout = null
-        };
-        /// <summary>
-        /// <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
-        /// </summary>
-        public static IDefaultConfiguration Legacy {get;} = new DefaultConfiguration
-        {
-            Name = DefaultConfigurationMode.Legacy,
-            RetryMode = RequestRetryMode.Legacy,
-            StsRegionalEndpoints = StsRegionalEndpointsValue.Legacy,
-            S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Legacy,
-            ConnectTimeout = null,
-            TlsNegotiationTimeout = null,
             TimeToFirstByteTimeout = null,
             HttpRequestTimeout = null
         };

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/SharedCredentialsFileTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/SharedCredentialsFileTest.cs
@@ -194,12 +194,6 @@ namespace AWSSDK.UnitTests
         private static readonly string BasicProfileCredentialsText =
             BasicProfileConfigText.Replace("[profile ", "[");
 
-        private static readonly string LegacyBasicProfileCredentialsText = new StringBuilder()
-            .AppendLine("[basic_profile]")
-            .AppendLine("aws_access_key_id=basic_aws_access_key_id")
-            .AppendLine("aws_secret_access_key=basic_aws_secret_access_key")
-            .ToString();
-
         private static readonly string BasicProfileTextConfigPartial = new StringBuilder()
             .AppendLine("[profile basic_profile]")
             .Append("aws_secret_access_key=basic_aws_secret_access_key")
@@ -304,11 +298,6 @@ namespace AWSSDK.UnitTests
         private static readonly string AlwaysDisableRequestCompressionOnlyProfileText_Invalid = new StringBuilder()
             .AppendLine("[any_disable_request_compression]")
             .AppendLine("disable_request_compression=always")
-            .ToString();
-
-        private static readonly string RetriesLegacyModeProfileText = new StringBuilder()
-            .AppendLine("[retries_legacymode_profile_text]")
-            .Append("retry_mode=legacy")
             .ToString();
 
         private static readonly string RetriesStandardModeProfileText = new StringBuilder()
@@ -847,24 +836,6 @@ namespace AWSSDK.UnitTests
             {
                 CredentialProfile profile1;
                 Assert.IsFalse(tester.CredentialsFile.TryGetProfile("any_disable_request_compression", out profile1));
-            }
-        }
-
-        [TestMethod]
-        public void ReadRetriesLegacyModeProfile()
-        {
-            using (var tester = new SharedCredentialsFileTestFixture(RetriesLegacyModeProfileText))
-            {
-                tester.TestTryGetProfile("retries_legacymode_profile_text", true, false);
-            }
-        }
-
-        [TestMethod]
-        public void WriteRetriesLegacyModeProfile()
-        {
-            using (var tester = new SharedCredentialsFileTestFixture())
-            {
-                tester.AssertWriteProfileRetryMode("retries_legacymode_profile_text", RetriesOnlyProfileOptions, RequestRetryMode.Legacy, RetriesLegacyModeProfileText);
             }
         }
 

--- a/sdk/test/UnitTests/Custom/Runtime/DefaultConfigurationAutoModeResolverTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/DefaultConfigurationAutoModeResolverTests.cs
@@ -16,14 +16,14 @@
 using Amazon.Runtime;
 using Amazon;
 using Moq;
-using Xunit;
-using System;
 using Amazon.Runtime.Internal;
 using Amazon.Util;
 using Amazon.Util.Internal;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace AWSSDK.UnitTests.Runtime
 {
+    [TestClass]
     public class DefaultConfigurationAutoModeResolverTests
     {
         private const string ExecutionEnvironmentEnvVar = "AWS_EXECUTION_ENV";
@@ -37,15 +37,15 @@ namespace AWSSDK.UnitTests.Runtime
             _runtimeInformationProvider.Setup(p => p.IsMobile()).Returns(false);
         }
 
-        [Theory]
-        [InlineData(true, "AWS_Lambda_java8", "us-east-1", null, null, null, "us-east-1", DefaultConfigurationMode.Mobile)]
-        [InlineData(false, "AWS_Lambda_java8", "us-east-1", null, null, null, "us-east-1", DefaultConfigurationMode.InRegion)]
-        [InlineData(false, "AWS_Lambda_java8", null, "us-west-2", null, null, "us-east-1", DefaultConfigurationMode.CrossRegion)]
-        [InlineData(false, "AWS_Lambda_java8", null, null, null, "us-west-2", "us-east-1", DefaultConfigurationMode.CrossRegion)]
-        [InlineData(false, null, "us-east-1", null, null, "us-east-1", "us-east-1", DefaultConfigurationMode.InRegion)]
-        [InlineData(false, null, null, null, "false", "us-west-2", "us-east-1", DefaultConfigurationMode.CrossRegion)]
-        [InlineData(false, null, null, null, "false", null, "us-west-2", DefaultConfigurationMode.Standard)]
-        [InlineData(false, null, null, null, "true", null, "us-west-2", DefaultConfigurationMode.Standard)]
+        [DataTestMethod]
+        [DataRow(true, "AWS_Lambda_java8", "us-east-1", null, null, null, "us-east-1", DefaultConfigurationMode.Mobile)]
+        [DataRow(false, "AWS_Lambda_java8", "us-east-1", null, null, null, "us-east-1", DefaultConfigurationMode.InRegion)]
+        [DataRow(false, "AWS_Lambda_java8", null, "us-west-2", null, null, "us-east-1", DefaultConfigurationMode.CrossRegion)]
+        [DataRow(false, "AWS_Lambda_java8", null, null, null, "us-west-2", "us-east-1", DefaultConfigurationMode.CrossRegion)]
+        [DataRow(false, null, "us-east-1", null, null, "us-east-1", "us-east-1", DefaultConfigurationMode.InRegion)]
+        [DataRow(false, null, null, null, "false", "us-west-2", "us-east-1", DefaultConfigurationMode.CrossRegion)]
+        [DataRow(false, null, null, null, "false", null, "us-west-2", DefaultConfigurationMode.Standard)]
+        [DataRow(false, null, null, null, "true", null, "us-west-2", DefaultConfigurationMode.Standard)]
         public void Resolve(
             bool isMobile,
             string exeEnvVar,
@@ -72,7 +72,7 @@ namespace AWSSDK.UnitTests.Runtime
 
             var mode = _resolver.Resolve(clientRegionEndpoint, () => imdsRegionEndpoint);
 
-            Assert.Equal(expectedMode, mode);
+            Assert.AreEqual(expectedMode, mode);
         }
     }
 }

--- a/sdk/test/UnitTests/Custom/Runtime/DefaultConfigurationProviderTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/DefaultConfigurationProviderTests.cs
@@ -50,7 +50,7 @@ namespace AWSSDK.UnitTests
             },
             new DefaultConfiguration
             {
-                Name = DefaultConfigurationMode.Legacy,
+                Name = DefaultConfigurationMode.Standard,
                 TimeToFirstByteTimeout = TimeSpan.FromMilliseconds(40000)
             }
         };
@@ -81,9 +81,9 @@ namespace AWSSDK.UnitTests
         // Shared Config/Credential wins
         [DataRow(
             null, null, DefaultConfigurationMode.Mobile, DefaultConfigurationMode.Mobile)]
-        // Legacy (default) wins
+        // Standard (default) wins
         [DataRow(
-            null, null, null, DefaultConfigurationMode.Legacy)]
+            null, null, null, DefaultConfigurationMode.Standard)]
         public void OrderOfOperationsTest(
             DefaultConfigurationMode? clientConfigDefaultMode,
             DefaultConfigurationMode? environmentVariableDefaultMode,
@@ -122,8 +122,7 @@ namespace AWSSDK.UnitTests
         }
 
         /// <summary>
-        /// Make sure wan error is thrown if <see cref="SharedCredentialsFile.DefaultConfigurationModeField"/>
-        /// has an invalid <inheritdoc cref="DefaultConfigurationMode"/>
+        /// Make sure wan error is thrown if the shared credentials file has an invalid <inheritdoc cref="DefaultConfigurationMode"/>
         /// </summary>
         [TestMethod]
         public void UnknownDefaultConfigurationModeThrowsAnError()

--- a/sdk/test/UnitTests/Custom/Runtime/EndpointResolverTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/EndpointResolverTests.cs
@@ -19,7 +19,8 @@ namespace AWSSDK.UnitTests
         private const string AwsStsRegionalEndpointsEnvironmentVariable = "AWS_STS_REGIONAL_ENDPOINTS";
         private const string DefaultStsEndpoint = @"https://sts.amazonaws.com/";
 
-        [TestMethod][TestCategory("UnitTest")]
+        [TestMethod]
+        [TestCategory("UnitTest")]
         [TestCategory("Runtime")]
         public void TestSuccessfulCall()
         {
@@ -27,7 +28,7 @@ namespace AWSSDK.UnitTests
             var executionContext = CreateExecutionContext(SetupConfig());
             Uri endpoint = endpointResolver.DetermineEndpoint(executionContext.RequestContext);
 
-            Assert.AreEqual(@"https://testprefix.test123-s3.amazonaws.com/", endpoint.ToString());
+            Assert.AreEqual(@"https://testprefix.test123-s3.us-east-1.amazonaws.com/", endpoint.ToString());
         }
 
         [DataTestMethod]
@@ -68,7 +69,7 @@ namespace AWSSDK.UnitTests
             var executionContext = CreateExecutionContext(config);
             Uri endpoint = endpointResolver.DetermineEndpoint(executionContext.RequestContext);
 
-            Assert.AreEqual(@"https://s3.amazonaws.com/", endpoint.ToString());
+            Assert.AreEqual(@"https://s3.us-east-1.amazonaws.com/", endpoint.ToString());
         }
 
         [TestMethod]
@@ -84,7 +85,7 @@ namespace AWSSDK.UnitTests
             executionContext.RequestContext.Request.HostPrefix = string.Empty;
             Uri endpoint = endpointResolver.DetermineEndpoint(executionContext.RequestContext);
 
-            Assert.AreEqual(@"https://s3.amazonaws.com/", endpoint.ToString());
+            Assert.AreEqual(@"https://s3.us-east-1.amazonaws.com/", endpoint.ToString());
         }
 
         private ExecutionContext CreateExecutionContext(IClientConfig config)

--- a/sdk/test/UnitTests/Custom/Runtime/MockClientConfig.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/MockClientConfig.cs
@@ -13,12 +13,26 @@
  * permissions and limitations under the License.
  */
 
+using Amazon;
 using Amazon.Runtime;
+using Amazon.Runtime.Internal;
 
 namespace AWSSDK.UnitTests
 {
     public class MockClientConfig : ClientConfig
     {
+        public MockClientConfig() : base(new MockConfigurationProvider()) { }
+
+        private class MockConfigurationProvider : IDefaultConfigurationProvider
+        {
+            public IDefaultConfiguration GetDefaultConfiguration(
+                RegionEndpoint clientRegion,
+                DefaultConfigurationMode? requestedConfigurationMode = null)
+            {
+                return new DefaultConfiguration();
+            }
+        }
+
         public override string RegionEndpointServiceName { get; } = nameof(MockClientConfig);
         public override string ServiceVersion { get; } = "UnitTest";
         public override string UserAgent { get; } = "UnitTest";

--- a/sdk/test/UnitTests/Custom/Runtime/RetryHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RetryHandlerTests.cs
@@ -381,21 +381,11 @@ namespace AWSSDK.UnitTests
             RetryHandler handler;
             var credentials = new BasicAWSCredentials("access_key", "secret_key");
 
-            //Test that DefaultRetryPolicy is selected for no specified RetryMode which defaults to Legacy
+            //Test that StandardRetryPolicy is selected for no specified RetryMode which defaults to Standard
             client = new MockServicePipelineValueClient(credentials, new AmazonS3Config());
 
             handler = (RetryHandler)client.Pipeline.Handlers.Find(h => h is RetryHandler);
-            Assert.IsTrue(handler.RetryPolicy is DefaultRetryPolicy);
-
-            //Test that DefaultRetryPolicy is selected for Legacy
-            client = new MockServicePipelineValueClient(credentials,
-                new AmazonS3Config
-                {
-                    RetryMode = RequestRetryMode.Legacy
-                });
-
-            handler = (RetryHandler)client.Pipeline.Handlers.Find(h => h is RetryHandler);
-            Assert.IsTrue(handler.RetryPolicy is DefaultRetryPolicy);
+            Assert.IsTrue(handler.RetryPolicy is StandardRetryPolicy);
 
             //Test that StandardRetryPolicy is selected for Standard
             client = new MockServicePipelineValueClient(credentials,


### PR DESCRIPTION
## Description
Removes the `RequestRetryMode.Legacy` and `DefaultConfigurationMode.Legacy` enum values; in V4, the .NET SDK will default to `Standard`.

There are 2 commits in this PR:
- [Must be reviewed] Manual changes to update the enums: https://github.com/aws/aws-sdk-net/pull/3235/commits/0d23038b269f6ce3de28bce9904e058b4edb79e9
- Generated changes to the `DefaultConfiguration` class for all services: https://github.com/aws/aws-sdk-net/pull/3235/commits/4f56a074aa409d387676c499abf862e9e1541711

## Testing
- Built the `AWSSDK.CoreAndCustomUnitTests.NetFramework.sln` and `AWSSDK.NetFramework.sln` solutions
- Ran the unit tests for the custom solution; there are a few failures but those happen in the `v4` branch as well:
  - `RetryForHttpStatus200WithErrorResponse`
  - `LongerTokenCaseAsync`
  - `MinimalBearerAuthCaseAsync`
  - `SingerShouldOverrideExistingHeaderAsync`

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
