### PR TITLE
Remove assembly scanning from DynamoDBEntryConversion

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -384,54 +384,59 @@ namespace Amazon.DynamoDBv2
         private ConverterCache ConverterCache = new ConverterCache();
         private ConversionSchema OriginalConversion;
 
-        private void AddConverters(string suffix)
-        {
-            var typedConverterType = typeof(Converter);
-            var assembly = typeof(DynamoDBEntryConversion).Assembly;
-
-            var allTypes = assembly.GetTypes();
-
-            foreach (var type in allTypes)
-            {
-                string fullName = type.FullName;
-
-                //if (type.Namespace != typedConverterType.Namespace)
-                //    continue;
-
-                if (type.IsAbstract)
-                    continue;
-
-                if (!type.Name.EndsWith(suffix, StringComparison.Ordinal))
-                    continue;
-
-                if (!typedConverterType.IsAssignableFrom(type))
-                    continue;
-
-                AddConverter(type);
-            }
-        }
         internal void AddConverter(Converter converter)
         {
             ConverterCache.AddConverter(converter, this);
         }
 
-#if NET8_0_OR_GREATER
-        internal void AddConverter([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
-#else
-        internal void AddConverter(Type type)
-#endif
-        {
-            var converter = Activator.CreateInstance(type) as Converter;
-            AddConverter(converter);
-        }
-
         private void SetV1Converters()
         {
-            AddConverters("ConverterV1");
+            AddConverter(new ByteConverterV1());
+            AddConverter(new SByteConverterV1());
+            AddConverter(new UInt16ConverterV1());
+            AddConverter(new Int16ConverterV1());
+            AddConverter(new UInt32ConverterV1());
+            AddConverter(new Int32ConverterV1());
+            AddConverter(new UInt64ConverterV1());
+            AddConverter(new Int64ConverterV1());
+            AddConverter(new SingleConverterV1());
+            AddConverter(new DoubleConverterV1());
+            AddConverter(new DecimalConverterV1());
+            AddConverter(new CharConverterV1());
+            AddConverter(new StringConverterV1());
+            AddConverter(new DateTimeConverterV1());
+            AddConverter(new GuidConverterV1());
+            AddConverter(new BytesConverterV1());
+            AddConverter(new MemoryStreamConverterV1());
+            AddConverter(new EnumConverterV1());
+            AddConverter(new BoolConverterV1());
+            AddConverter(new PrimitiveCollectionConverterV1());
+            AddConverter(new DictionaryConverterV1());
         }
+
         private void SetV2Converters()
         {
-            AddConverters("ConverterV2");
+            AddConverter(new ByteConverterV2());
+            AddConverter(new SByteConverterV2());
+            AddConverter(new UInt16ConverterV2());
+            AddConverter(new Int16ConverterV2());
+            AddConverter(new UInt32ConverterV2());
+            AddConverter(new Int32ConverterV2());
+            AddConverter(new UInt64ConverterV2());
+            AddConverter(new Int64ConverterV2());
+            AddConverter(new SingleConverterV2());
+            AddConverter(new DoubleConverterV2());
+            AddConverter(new DecimalConverterV2());
+            AddConverter(new CharConverterV2());
+            AddConverter(new StringConverterV2());
+            AddConverter(new DateTimeConverterV2());
+            AddConverter(new GuidConverterV2());
+            AddConverter(new BytesConverterV2());
+            AddConverter(new MemoryStreamConverterV2());
+            AddConverter(new DictionaryConverterV2());
+            AddConverter(new EnumConverterV2());
+            AddConverter(new BoolConverterV2());
+            AddConverter(new CollectionConverterV2());
         }
 
         // Converts items to Primitives.
@@ -460,7 +465,7 @@ namespace Amazon.DynamoDBv2
             }
         }
 
-#endregion
+        #endregion
     }
 
     internal abstract class Converter

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBEntryConversionTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBEntryConversionTests.cs
@@ -1,0 +1,71 @@
+﻿using Amazon.DynamoDBv2;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace AWSSDK_DotNet35.UnitTests
+{
+    [TestClass]
+    public class DynamoDBEntryConversionTests
+    {
+        [TestMethod]
+        public void ValidateAllConvertersAreRegisteredForConversionV1()
+        {
+            AssertAllConvertersAreRegistered(DynamoDBEntryConversion.V1, "ConverterV1");
+        }
+
+        [TestMethod]
+        public void ValidateAllConvertersAreRegisteredForConversionV2()
+        {
+            AssertAllConvertersAreRegistered(DynamoDBEntryConversion.V2, "ConverterV2");
+        }
+
+        private void AssertAllConvertersAreRegistered(DynamoDBEntryConversion conversion, string suffix)
+        {
+            var converters = GetConverters(suffix);
+
+            var tryGetConverterInfo = conversion.GetType().GetMethod("TryGetConverter", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            foreach (var converter in converters)
+            {
+                var getTargetTypeInfo = converter.GetType().GetMethod("GetTargetTypes");
+                IEnumerable<Type> targetTypes = (IEnumerable<Type>)getTargetTypeInfo.Invoke(converter, new object[0]);
+                foreach (var type in targetTypes)
+                {
+                    var tryGetConverterParams = new object[] { type, null };
+                    tryGetConverterInfo.Invoke(conversion, tryGetConverterParams);
+                    var registeredConverter = tryGetConverterParams[1];
+
+                    Assert.IsNotNull(registeredConverter);
+                    Assert.AreEqual(converter.GetType(), registeredConverter.GetType());
+                }
+            }
+        }
+
+        private IEnumerable<object> GetConverters(string suffix)
+        {
+            const string converterTypeName = "Amazon.DynamoDBv2.Converter";
+            var assembly = typeof(DynamoDBEntryConversion).Assembly;
+
+            var allTypes = assembly.GetTypes();
+            var typedConverterType = allTypes.FirstOrDefault(x => string.Equals(converterTypeName, x.FullName));
+
+            foreach (var type in allTypes)
+            {
+                if (type.IsAbstract)
+                    continue;
+
+                if (!type.Name.EndsWith(suffix, StringComparison.Ordinal))
+                    continue;
+
+                if (!typedConverterType.IsAssignableFrom(type))
+                    continue;
+
+                var constructor = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, new Type[0], null);
+                yield return constructor.Invoke(new object[0]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Replace assembly scanning in DynamoDBEntryConversion which finds converter types with explicit types created.

## Motivation and Context
Assembly scanning has a cold start performance impact, which is especially important for serverless applications. In this case, it scans own assembly for types, which doesn't have much sense, as the results of that scan is static, it will never change. Therefore, it doesn't make sense to find those types in runtime.

Besides, it is more AOT-friendly, and it probably allows to remove most of RequiresUnreferencedCode attributes (not sure).

## Testing

I have created a small benchmark to test cold start performance.

<details>
  <summary>Benchmark</summary>
  
  ```csharp
    [SimpleJob(RunStrategy.ColdStart, launchCount: 20, iterationCount: 1, invocationCount: 1)]
    [MinColumn, MaxColumn, MeanColumn, MedianColumn]
    public class ConversionBenchmark
    {
        [Benchmark]
        public void CreateConversions()
        {
            _ = DynamoDBEntryConversion.V1;
            _ = DynamoDBEntryConversion.V2;
        }
    }
  ```
  
</details>


Before:
| Method            | Mean     | Error    | StdDev   | Min      | Max      | Median   |
|------------------ |---------:|---------:|---------:|---------:|---------:|---------:|
| CreateConversions | 44.38 ms | 4.562 ms | 5.253 ms | 33.70 ms | 53.47 ms | 44.96 ms |7 ms |

After:
| Method            | Mean     | Error    | StdDev   | Min      | Max      | Median   |
|------------------ |---------:|---------:|---------:|---------:|---------:|---------:|
| CreateConversions | 14.87 ms | 2.421 ms | 2.788 ms | 10.34 ms | 22.29 ms | 14.33 ms |


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement