### PR TITLE
Fixes unit tests from issue 4 protocol tests change and updated build...

### DIFF
--- a/sdk/AWSSDK.CoreAndCustomUnitTests.Net45.sln
+++ b/sdk/AWSSDK.CoreAndCustomUnitTests.Net45.sln
@@ -48,6 +48,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSSDK.CloudWatch.Net45", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSSDK.SSO.Net45", "src\Services\SSO\AWSSDK.SSO.Net45.csproj", "{685155AC-D4AE-41ED-A76E-388D0F66D6F8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSSDK.KeyManagementService.Net45", "src\Services\KeyManagementService\AWSSDK.KeyManagementService.Net45.csproj", "{742AAA6E-5505-42B2-AA7B-93E1D3FEF88A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -134,6 +136,10 @@ Global
 		{685155AC-D4AE-41ED-A76E-388D0F66D6F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{685155AC-D4AE-41ED-A76E-388D0F66D6F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{685155AC-D4AE-41ED-A76E-388D0F66D6F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{742AAA6E-5505-42B2-AA7B-93E1D3FEF88A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{742AAA6E-5505-42B2-AA7B-93E1D3FEF88A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{742AAA6E-5505-42B2-AA7B-93E1D3FEF88A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{742AAA6E-5505-42B2-AA7B-93E1D3FEF88A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -159,6 +165,7 @@ Global
 		{033B52EA-A8ED-4FFD-9F27-027DA720EC2A} = {4CD78D56-2ABB-4F58-A0CB-08CED1B06370}
 		{4608625B-B089-49B0-A3C3-F18DC5FFCEA5} = {4CD78D56-2ABB-4F58-A0CB-08CED1B06370}
 		{685155AC-D4AE-41ED-A76E-388D0F66D6F8} = {4CD78D56-2ABB-4F58-A0CB-08CED1B06370}
+		{742AAA6E-5505-42B2-AA7B-93E1D3FEF88A} = {4CD78D56-2ABB-4F58-A0CB-08CED1B06370}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BBAD3467-3B24-41C1-898E-1B34BB9931DE}

--- a/sdk/AWSSDK.CoreAndCustomUnitTests.NetStandard.sln
+++ b/sdk/AWSSDK.CoreAndCustomUnitTests.NetStandard.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31702.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34511.84
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSSDK.S3.NetStandard", "src\Services\S3\AWSSDK.S3.NetStandard.csproj", "{89D7A8AA-B164-40AF-B492-46A63ECEB964}"
 EndProject
@@ -22,6 +22,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSSDK.CloudWatchLogs.NetStandard", "src\Services\CloudWatchLogs\AWSSDK.CloudWatchLogs.NetStandard.csproj", "{0BF01833-13DD-4BD5-84AA-BC8844F46470}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSSDK.UnitTests.Custom.NetStandard", "test\NetStandard\UnitTests\AWSSDK.UnitTests.Custom.NetStandard.csproj", "{27D0813B-6FB9-438B-8B8E-C59636A35C30}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSSDK.DynamoDBv2.NetStandard", "src\Services\DynamoDBv2\AWSSDK.DynamoDBv2.NetStandard.csproj", "{B52234D7-08EA-4D07-A9B7-9F71E6AE5490}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +59,10 @@ Global
 		{27D0813B-6FB9-438B-8B8E-C59636A35C30}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27D0813B-6FB9-438B-8B8E-C59636A35C30}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27D0813B-6FB9-438B-8B8E-C59636A35C30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B52234D7-08EA-4D07-A9B7-9F71E6AE5490}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B52234D7-08EA-4D07-A9B7-9F71E6AE5490}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B52234D7-08EA-4D07-A9B7-9F71E6AE5490}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B52234D7-08EA-4D07-A9B7-9F71E6AE5490}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -69,6 +75,7 @@ Global
 		{7E80E4A1-8FBA-438B-A513-97379A5B20D9} = {4CD78D56-2ABB-4F58-A0CB-08CED1B06370}
 		{0BF01833-13DD-4BD5-84AA-BC8844F46470} = {4CD78D56-2ABB-4F58-A0CB-08CED1B06370}
 		{27D0813B-6FB9-438B-8B8E-C59636A35C30} = {CAEA0944-D530-499D-BC5D-4F3EB68407B3}
+		{B52234D7-08EA-4D07-A9B7-9F71E6AE5490} = {4CD78D56-2ABB-4F58-A0CB-08CED1B06370}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BBAD3467-3B24-41C1-898E-1B34BB9931DE}

--- a/sdk/test/UnitTests/Custom/Marshalling/BackwardsCompatibilityForDateTimePropertiesTests.cs
+++ b/sdk/test/UnitTests/Custom/Marshalling/BackwardsCompatibilityForDateTimePropertiesTests.cs
@@ -31,7 +31,8 @@ namespace AWSSDK.UnitTests
     [TestClass]
     public class BackwardsCompatibilityForDateTimePropertiesTests
     {
-        const string EXPECTED_MARSHALLED_STRING = "2018-07-18T00:00:00.000Z";
+        const string EXPECTED_MARSHALLED_STRING = "2018-07-18T00:00:00Z";
+        const string EXPECTED_MARSHALLED_STRING_WITH_MS = "2018-07-18T00:00:00.123Z";
 
         [TestMethod]
         [TestCategory("UnitTest")]
@@ -67,6 +68,38 @@ namespace AWSSDK.UnitTests
 
         [TestMethod]
         [TestCategory("UnitTest")]
+        public void TestLegacyFieldsBackwardsCompatibilityWithMS()
+        {
+            PutScheduledUpdateGroupActionRequest request = new PutScheduledUpdateGroupActionRequest();
+
+            DateTime timeUtc = new DateTime(2018, 7, 18, 0, 0, 0, 123, DateTimeKind.Utc);
+            DateTime timeLocal = new DateTime(2018, 7, 18, 0, 0, 0, 123, DateTimeKind.Local);
+            DateTime timeUnspecified = new DateTime(2018, 7, 18, 0, 0, 0, 123);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            request.StartTime = timeUtc;
+            request.EndTime = timeLocal;
+            request.Time = timeUnspecified;
+
+            Assert.AreEqual(request.StartTime, timeUtc);
+            Assert.AreEqual(request.EndTime, timeLocal);
+            Assert.AreEqual(request.Time, timeUnspecified);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual(request.StartTimeUtc, timeUtc);
+            Assert.AreEqual(request.EndTimeUtc, timeUtc);
+            Assert.AreEqual(request.TimeUtc, timeUtc);
+
+            var marshaller = new PutScheduledUpdateGroupActionRequestMarshaller();
+            var marshalledRequest = marshaller.Marshall(request);
+
+            Assert.AreEqual(marshalledRequest.Parameters["StartTime"], EXPECTED_MARSHALLED_STRING_WITH_MS);
+            Assert.AreEqual(marshalledRequest.Parameters["EndTime"], EXPECTED_MARSHALLED_STRING_WITH_MS);
+            Assert.AreEqual(marshalledRequest.Parameters["Time"], EXPECTED_MARSHALLED_STRING_WITH_MS);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
         public void TestUtcFields()
         {
             PutScheduledUpdateGroupActionRequest request = new PutScheduledUpdateGroupActionRequest();
@@ -95,6 +128,38 @@ namespace AWSSDK.UnitTests
             Assert.AreEqual(marshalledRequest.Parameters["StartTime"], EXPECTED_MARSHALLED_STRING);
             Assert.AreEqual(marshalledRequest.Parameters["EndTime"], EXPECTED_MARSHALLED_STRING);
             Assert.AreEqual(marshalledRequest.Parameters["Time"], EXPECTED_MARSHALLED_STRING);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        public void TestUtcFieldsWithMS()
+        {
+            PutScheduledUpdateGroupActionRequest request = new PutScheduledUpdateGroupActionRequest();
+
+            DateTime timeUtc = new DateTime(2018, 7, 18, 0, 0, 0, 123, DateTimeKind.Utc);
+            DateTime timeLocal = new DateTime(2018, 7, 18, 0, 0, 0, 123, DateTimeKind.Utc).ToLocalTime();
+            DateTime timeUnspecified = new DateTime(timeLocal.Ticks);
+
+            request.StartTimeUtc = timeUtc;
+            request.EndTimeUtc = timeLocal;
+            request.TimeUtc = timeUnspecified;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual(request.StartTime, timeUtc);
+            Assert.AreEqual(request.EndTime, timeLocal);
+            Assert.AreEqual(request.Time, timeUnspecified);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual(request.StartTimeUtc, timeUtc);
+            Assert.AreEqual(request.EndTimeUtc, timeLocal);
+            Assert.AreEqual(request.TimeUtc, timeUnspecified);
+
+            var marshaller = new PutScheduledUpdateGroupActionRequestMarshaller();
+            var marshalledRequest = marshaller.Marshall(request);
+
+            Assert.AreEqual(marshalledRequest.Parameters["StartTime"], EXPECTED_MARSHALLED_STRING_WITH_MS);
+            Assert.AreEqual(marshalledRequest.Parameters["EndTime"], EXPECTED_MARSHALLED_STRING_WITH_MS);
+            Assert.AreEqual(marshalledRequest.Parameters["Time"], EXPECTED_MARSHALLED_STRING_WITH_MS);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes the following unit tests projects so they build:

* sdk/AWSSDK.CoreAndCustomUnitTests.Net45.sln
* sdk/AWSSDK.CoreAndCustomUnitTests.Netstandard.sln

Fixed two unit tests that were broken because of the change for Issue 4 (https://github.com/aws/aws-sdk-net/pull/3243) which adjusted how the milliseconds are returned when they are non zero or not. Added two new tests for non zero milliseconds.

**MERGE into protocol-tests feature branch only**

Ticket: DOTNET-7357

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have run the standard unit tests through the following test projects and confirm they now pass:

* sdk/AWSSDK.CoreAndCustomUnitTests.Net45.sln
* sdk/AWSSDK.CoreAndCustomUnitTests.Netstandard.sln
 
A final dry-run will be done on the protocol-tests feature branch once everything is merged into the feature branch but it requires a rebase on main before that can be completely.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement