### PR TITLE
Replace custom implementation of Join with string.Join

### DIFF
--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -631,18 +631,7 @@ namespace Amazon.Util
         /// specified list together, with a comma between strings.</returns>
         public static String Join(List<String> strings)
         {
-            StringBuilder result = new StringBuilder();
-
-            Boolean first = true;
-            foreach (String s in strings)
-            {
-                if (!first) result.Append(", ");
-
-                result.Append(s);
-                first = false;
-            }
-
-            return result.ToString();
+            return string.Join(", ", strings);
         }
 
         /// <summary>


### PR DESCRIPTION
The custom implementation of Join seems unnecessary given the .NET SDK has an efficient method to achieve the same.

## Description
Replace custom implementation of Join with string.Join

## Motivation and Context

<img width="736" alt="Screenshot 2024-04-21 at 13 26 29" src="https://github.com/aws/aws-sdk-net/assets/174258/638e2efc-6def-4d5f-99bd-04bb8df1d3c8">

https://github.com/danielmarbach/aws-sdk-net-benchmarks/blob/main/ListJoin.cs

## Testing
https://dotnetfiddle.net/aOtqnN
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement