### PR TITLE
Add a StopPaginationOnSameToken customization to CloudWatchLogs.GetLogEvents operation

### DIFF
--- a/generator/.DevConfigs/2f67d0fa-ea88-47b7-a915-e07928cc2bff.json
+++ b/generator/.DevConfigs/2f67d0fa-ea88-47b7-a915-e07928cc2bff.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "CloudWatchLogs",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fixed a bug at GetLogEventsPaginator where it enters an infinite loop."
+      ]
+    }
+  ]
+}

--- a/generator/ServiceClientGeneratorLib/Customizations.cs
+++ b/generator/ServiceClientGeneratorLib/Customizations.cs
@@ -422,6 +422,7 @@ namespace ServiceClientGenerator
         public const string GenerateUnmarshallerKey = "generateUnmarshaller";
         public const string SkipUriPropertyValidationKey = "skipUriPropertyValidation";
         public const string OverrideContentTypeKey = "overrideContentType";
+        public const string StopPaginationOnSameTokenKey = "stopPaginationOnSameToken";
 
         JsonData _documentRoot;
 
@@ -1252,6 +1253,8 @@ namespace ServiceClientGenerator
                 modifiers.Documentation = (string)operation[OperationModifiers.DocumentationKey];
             if (operation[OperationModifiers.DeprecatedMessageKey] != null && operation[OperationModifiers.DeprecatedMessageKey].IsString)
                 modifiers.DeprecatedMessage = (string)operation[OperationModifiers.DeprecatedMessageKey];
+            if (operation[OperationModifiers.StopPaginationOnSameTokenKey] != null && operation[OperationModifiers.StopPaginationOnSameTokenKey].IsBoolean)
+                modifiers.StopPaginationOnSameToken = (bool)operation[OperationModifiers.StopPaginationOnSameTokenKey];
 
             if (operation[OperationModifiers.MarshallNameOverrides] != null &&
                 operation[OperationModifiers.MarshallNameOverrides].IsArray)
@@ -1318,6 +1321,7 @@ namespace ServiceClientGenerator
             public const string DeprecatedKey = "deprecated";
             public const string DeprecatedMessageKey = "deprecatedMessage";
             public const string DocumentationKey = "documentation";
+            public const string StopPaginationOnSameTokenKey = "stopPaginationOnSameToken";
 
             // within a marshal override for a shape; one or both may be present
             public const string MarshallLocationName = "marshallLocationName";
@@ -1395,6 +1399,12 @@ namespace ServiceClientGenerator
             }
 
             public string DeprecatedMessage
+            {
+                get;
+                set;
+            }
+
+            public bool StopPaginationOnSameToken
             {
                 get;
                 set;

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.cs
@@ -18,7 +18,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+    #line 1 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class BasePaginator : BaseGenerator
     {
@@ -29,7 +29,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         public override string TransformText()
         {
             
-            #line 6 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 6 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 	AddLicenseHeader();
 
@@ -40,49 +40,49 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "tem.Collections;\r\nusing System.Threading;\r\nusing System.Threading.Tasks;\r\nusing " +
                     "Amazon.Runtime;\r\n\r\n#pragma warning disable CS0612,CS0618\r\nnamespace ");
             
-            #line 19 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 19 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
             #line hidden
             this.Write(".Model\r\n{\r\n    /// <summary>\r\n    /// Base class for ");
             
-            #line 22 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 22 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write(" paginators.\r\n    /// </summary>\r\n    internal sealed partial class ");
             
-            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 24 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Paginator : IPaginator<");
             
-            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 24 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response>, I");
             
-            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 24 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Paginator\r\n    {\r\n        private readonly IAmazon");
             
-            #line 26 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 26 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write(" _client;\r\n        private readonly ");
             
-            #line 27 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 27 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
@@ -91,21 +91,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "/// <summary>\r\n        /// Enumerable containing all full responses for the oper" +
                     "ation\r\n        /// </summary>\r\n        public IPaginatedEnumerable<");
             
-            #line 33 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 33 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> Responses => new PaginatedResponse<");
             
-            #line 33 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 33 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response>(this);\r\n");
             
-            #line 34 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 34 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListItemType != null))
 {
@@ -115,56 +115,56 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
             #line hidden
             this.Write("\r\n        /// <summary>\r\n        /// Enumerable containing all of the ");
             
-            #line 40 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 40 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.Member.PropertyName));
             
             #line default
             #line hidden
             this.Write("\r\n        /// </summary>\r\n        public IPaginatedEnumerable<");
             
-            #line 42 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 42 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.ListItemType));
             
             #line default
             #line hidden
             this.Write("> ");
             
-            #line 42 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 42 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.Member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" => \r\n            new PaginatedResultKeyResponse<");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 43 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response, ");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 43 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.ListItemType));
             
             #line default
             #line hidden
             this.Write(">(this, (i) => i.");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 43 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.PropertyName));
             
             #line default
             #line hidden
             this.Write(" ?? new ");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 43 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.Member.DetermineType()));
             
             #line default
             #line hidden
             this.Write("());\r\n");
             
-            #line 44 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 44 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -173,21 +173,21 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
             #line hidden
             this.Write("\r\n        internal ");
             
-            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 48 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Paginator(IAmazon");
             
-            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 48 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write(" client, ");
             
-            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 48 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
@@ -195,14 +195,14 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
             this.Write("Request request)\r\n        {\r\n            this._client = client;\r\n            this" +
                     "._request = request;\r\n        }\r\n#if BCL\r\n        IEnumerable<");
             
-            #line 54 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 54 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> IPaginator<");
             
-            #line 54 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 54 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
@@ -216,7 +216,7 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
             PaginatorUtils.SetUserAgentAdditionOnRequest(_request);
 ");
             
-            #line 61 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 61 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var inputToken in this.Operation.Paginators.InputTokens)
 {
@@ -226,21 +226,21 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("            var ");
             
-            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 65 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" = _request.");
             
-            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 65 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.PropertyName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 66 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 66 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -249,14 +249,14 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("            ");
             
-            #line 69 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 69 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response response;\r\n            do\r\n            {\r\n");
             
-            #line 72 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 72 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var inputToken in this.Operation.Paginators.InputTokens)
 {
@@ -266,21 +266,21 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("                _request.");
             
-            #line 76 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 76 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = ");
             
-            #line 76 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 76 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 77 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 77 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -289,14 +289,14 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("                response = _client.");
             
-            #line 80 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 80 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("(_request);\r\n");
             
-            #line 81 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 81 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
 {
@@ -306,21 +306,21 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
             #line hidden
             this.Write("                ");
             
-            #line 85 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 85 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[i].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" = response.");
             
-            #line 85 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 85 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.OutputTokens[i].PropertyName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 86 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 86 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -329,7 +329,7 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
             #line hidden
             this.Write("                yield return response;\r\n            }\r\n");
             
-            #line 91 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 91 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 if (this.Operation.Paginators.MoreResults != null)
 {
@@ -339,14 +339,14 @@ if (this.Operation.Paginators.MoreResults != null)
             #line hidden
             this.Write("            while (response.");
             
-            #line 95 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 95 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.MoreResults.PropertyName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 96 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 96 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 } 
 else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
@@ -357,14 +357,39 @@ else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
             #line hidden
             this.Write("            while (");
             
-            #line 101 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 101 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(".Count > 0);\r\n");
             
-            #line 102 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 102 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+
+}
+else if (this.Operation.StopPaginationOnSameToken)
+{
+
+            
+            #line default
+            #line hidden
+            this.Write("            while (");
+            
+            #line 107 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
+            
+            #line default
+            #line hidden
+            this.Write(" != _request.");
+            
+            #line 107 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(");\r\n");
+            
+            #line 108 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 else
@@ -375,14 +400,14 @@ else
             #line hidden
             this.Write("            while (!string.IsNullOrEmpty(");
             
-            #line 107 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 113 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write("));\r\n");
             
-            #line 108 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 114 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -392,14 +417,14 @@ else
             this.Write("        }\r\n#endif\r\n#if AWS_ASYNC_ENUMERABLES_API\r\n        async IAsyncEnumerable<" +
                     "");
             
-            #line 114 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 120 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> IPaginator<");
             
-            #line 114 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 120 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
@@ -413,7 +438,7 @@ else
             PaginatorUtils.SetUserAgentAdditionOnRequest(_request);
 ");
             
-            #line 121 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 127 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var inputToken in this.Operation.Paginators.InputTokens)
 {
@@ -423,21 +448,21 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("            var ");
             
-            #line 125 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 131 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" = _request.");
             
-            #line 125 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 131 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.PropertyName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 126 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 132 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -446,14 +471,14 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("            ");
             
-            #line 129 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 135 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response response;\r\n            do\r\n            {\r\n");
             
-            #line 132 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 138 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var inputToken in this.Operation.Paginators.InputTokens)
 {
@@ -463,21 +488,21 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("                _request.");
             
-            #line 136 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 142 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = ");
             
-            #line 136 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 142 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 137 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 143 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -486,14 +511,14 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("                response = await _client.");
             
-            #line 140 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 146 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Async(_request, cancellationToken).ConfigureAwait(false);\r\n");
             
-            #line 141 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 147 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
 {
@@ -503,21 +528,21 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
             #line hidden
             this.Write("                ");
             
-            #line 145 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 151 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[i].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" = response.");
             
-            #line 145 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 151 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.OutputTokens[i].PropertyName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 146 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 152 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -527,7 +552,7 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
             this.Write("                cancellationToken.ThrowIfCancellationRequested();\r\n              " +
                     "  yield return response;\r\n            }\r\n");
             
-            #line 152 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 158 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 if (this.Operation.Paginators.MoreResults != null)
 {
@@ -537,14 +562,14 @@ if (this.Operation.Paginators.MoreResults != null)
             #line hidden
             this.Write("            while (response.");
             
-            #line 156 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 162 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.MoreResults.PropertyName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 157 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 163 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 } 
 else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
@@ -555,14 +580,39 @@ else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
             #line hidden
             this.Write("            while (");
             
-            #line 162 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 168 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(".Count > 0);\r\n");
             
-            #line 163 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 169 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+
+}
+else if (this.Operation.StopPaginationOnSameToken)
+{
+
+            
+            #line default
+            #line hidden
+            this.Write("            while (");
+            
+            #line 174 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
+            
+            #line default
+            #line hidden
+            this.Write(" != _request.");
+            
+            #line 174 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].PropertyName));
+            
+            #line default
+            #line hidden
+            this.Write(");\r\n");
+            
+            #line 175 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 else
@@ -573,14 +623,14 @@ else
             #line hidden
             this.Write("            while (!string.IsNullOrEmpty(");
             
-            #line 168 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 180 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write("));\r\n");
             
-            #line 169 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 181 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -591,7 +641,7 @@ else
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 177 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+        #line 189 "C:\repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
     // The operation the marshaller will be used on
 	public Operation Operation { get; set; }	

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.tt
@@ -101,6 +101,12 @@ else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
             while (<#=this.Operation.Paginators.InputTokens[0].Member.ArgumentName#>.Count > 0);
 <#
 }
+else if (this.Operation.StopPaginationOnSameToken)
+{
+#>
+            while (<#=this.Operation.Paginators.InputTokens[0].Member.ArgumentName#> != _request.<#=this.Operation.Paginators.InputTokens[0].PropertyName#>);
+<#
+}
 else
 {
 #>
@@ -160,6 +166,12 @@ else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
 {
 #>
             while (<#=this.Operation.Paginators.InputTokens[0].Member.ArgumentName#>.Count > 0);
+<#
+}
+else if (this.Operation.StopPaginationOnSameToken)
+{
+#>
+            while (<#=this.Operation.Paginators.InputTokens[0].Member.ArgumentName#> != _request.<#=this.Operation.Paginators.InputTokens[0].PropertyName#>);
 <#
 }
 else

--- a/generator/ServiceClientGeneratorLib/Operation.cs
+++ b/generator/ServiceClientGeneratorLib/Operation.cs
@@ -262,6 +262,21 @@ namespace ServiceClientGenerator
             }
         }
 
+        /// <summary>
+        /// Determines if the operation pagination should end when the response equal to the request token
+        /// </summary>
+        public bool StopPaginationOnSameToken
+        {
+            get
+            {
+                var modifiers = this.model.Customizations.GetOperationModifiers(this.name);
+                if (modifiers != null)
+                    return modifiers.StopPaginationOnSameToken;
+
+                return false;
+            }
+        }
+
         public bool WrapsResultShape(string shapeName)
         {
             var modifiers = this.model.Customizations.GetOperationModifiers(this.name);

--- a/generator/ServiceModels/logs/logs.customizations.json
+++ b/generator/ServiceModels/logs/logs.customizations.json
@@ -7,6 +7,11 @@
 	  "retentionInDays"
 	]
   },
+	"operationModifiers": {
+		"GetLogEvents": {
+			"stopPaginationOnSameToken": true
+		}
+	},
   "dataTypeSwap" : {
     "InputLogEvent" : {
 	  "timestamp" : {

--- a/sdk/src/Services/CloudWatchLogs/Generated/Model/_bcl45+netstandard/GetLogEventsPaginator.cs
+++ b/sdk/src/Services/CloudWatchLogs/Generated/Model/_bcl45+netstandard/GetLogEventsPaginator.cs
@@ -70,7 +70,7 @@ namespace Amazon.CloudWatchLogs.Model
                 nextToken = response.NextForwardToken;
                 yield return response;
             }
-            while (!string.IsNullOrEmpty(nextToken));
+            while (nextToken != _request.NextToken);
         }
 #endif
 #if AWS_ASYNC_ENUMERABLES_API
@@ -91,7 +91,7 @@ namespace Amazon.CloudWatchLogs.Model
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return response;
             }
-            while (!string.IsNullOrEmpty(nextToken));
+            while (nextToken != _request.NextToken);
         }
 #endif
     }

--- a/sdk/test/NetStandard/UnitTests/Services/CloudWatchLogsPaginatorTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Services/CloudWatchLogsPaginatorTests.cs
@@ -428,8 +428,10 @@ namespace AWSSDK_NetStandard.UnitTests
         public async Task GetLogEventsTest_TwoResponses()
         {
             var request = new GetLogEventsRequest();
+
+            // GetLogEvents returns the same token sent when reaching the end of the stream
             var firstResponse = new GetLogEventsResponse() { NextForwardToken = "foo" };
-            var secondResponse = new GetLogEventsResponse() { NextForwardToken = null };
+            var secondResponse = new GetLogEventsResponse() { NextForwardToken = "foo" };
             var token = new CancellationToken();
 
             _mockClient.SetupSequence(x => x.GetLogEventsAsync(It.IsAny<GetLogEventsRequest>(), It.IsAny<CancellationToken>()))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes DOTNET-7441 by adding StopPaginationOnSameToken flag to Operation customizations in the generator and adds this flag to CloudWatchLogs.GetLogEvents operation customization.
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

CloudWatchLogs.GetLogEvents operation response includes two pagination tokens (`NextBackwardToken` and `NextForwardToken`), but they won't be null once all events are retrieved (instead, CloudWatch will return the same value sent in the request)
This means the .[NET paginator](https://github.com/aws/aws-sdk-net/blob/main/sdk/src/Services/CloudWatchLogs/Generated/Model/_bcl45%2Bnetstandard/GetLogEventsPaginator.cs#L63-L72) (which is generated from the model to keep invoking the API until the response token is empty) enters an infinite loop as the `NextForwardToken` will never be null.
Additionally this issue was opened #3218 and we couldn't advise to use the paginator since it will enter an infinite loop.

This PR contains the following commits to fix this issue:
* [Added StopPaginationOnSameToken flag to Operation customization in the generator](https://github.com/aws/aws-sdk-net/pull/3296/commits/f5b289aa6a8e94ca34c8e95b4c1bfe6189d00fd4) which updates the paginator to stop when the same token is sent on the response instead of expecting it to be null.
* [Added the newly created StopPaginationOnSameToken customization to CloudWatchLogs.GetLogEvents operation](https://github.com/aws/aws-sdk-net/pull/3296/commits/414e8853a2a219076ee33de8f0466acf184bbec3) 


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Created a console app to test `GetLogEvents` pagination with a long and a short `LogStream` and validated that it the pagination stops when it reaches the end of the stream.
* Updated `GetLogEventsTest_TwoResponses` test to reflect the service response.
* Did a full dry run `DRY_RUN-36b366d9-c447-45f7-8764-df58b7cb716a`.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement