### PR TITLE
Added support for RequestPayer property in TransferUtility BaseDownloadRequest class.

### DIFF
--- a/generator/.DevConfigs/56bf47d1-afc2-46b6-be6a-499d27bb059a.json
+++ b/generator/.DevConfigs/56bf47d1-afc2-46b6-be6a-499d27bb059a.json
@@ -1,0 +1,9 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [ "Added support for RequestPayer property in TransferUtility BaseDownloadRequest class." ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/BaseDownloadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/BaseDownloadRequest.cs
@@ -45,6 +45,7 @@ namespace Amazon.S3.Transfer
         private string serverSideEncryptionCustomerProvidedKey;
         private string serverSideEncryptionCustomerProvidedKeyMD5;
 
+        private RequestPayer requestPayer;
 
         /// <summary>
         /// 	Gets or sets the name of the bucket.
@@ -270,6 +271,16 @@ namespace Amazon.S3.Transfer
         {
             get { return this.checksumMode; }
             set { this.checksumMode = value; }
+        }
+
+        /// <summary>
+        /// Confirms that the requester knows that they will be charged for the request. 
+        /// Bucket owners need not specify this parameter in their requests.
+        /// </summary>
+        public RequestPayer RequestPayer
+        {
+            get { return this.requestPayer; }
+            set { this.requestPayer = value; }
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/BaseCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/BaseCommand.cs
@@ -63,6 +63,7 @@ namespace Amazon.S3.Transfer.Internal
             getRequest.ServerSideEncryptionCustomerProvidedKey = request.ServerSideEncryptionCustomerProvidedKey;
             getRequest.ServerSideEncryptionCustomerProvidedKeyMD5 = request.ServerSideEncryptionCustomerProvidedKeyMD5;
             getRequest.ChecksumMode = request.ChecksumMode;
+            getRequest.RequestPayer = request.RequestPayer;
 
             return getRequest;
         }


### PR DESCRIPTION
## Description
Added support for `RequestPayer` property in `TransferUtility` `BaseDownloadRequest` class.

## Motivation and Context
Fixes #3301 

## Testing
Tested locally by setting cross account access (refer https://repost.aws/knowledge-center/cross-account-access-s3) and enabling Request Payer in the bucket. Used Visual Studio debug session to first replicate the issue and then validate the fix using code below:
```C#
try
{
    IAmazonS3 s3Client = new AmazonS3Client("<<access-key-id>>", "<<secret-id>>", <<bucket-regionendpoint>>);
    var transferUtil = new TransferUtility(s3Client);
    await transferUtil.DownloadAsync(new TransferUtilityDownloadRequest
    {
        BucketName = "<<bucket-name>>",
        Key = "<<key-name>>",
        FilePath = @"<<absolute-file-path>>",
        RequestPayer = RequestPayer.Requester
    });
}
catch (Exception ex)
{
    await Console.Out.WriteLineAsync(ex.Message);
    throw;
}
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement