### PR TITLE
Optimize AWS4Signer

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -22,7 +22,7 @@ using Amazon.Internal;
 using Amazon.Util;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.Endpoints;
-using AWSSDK.Core.NetStandard.Amazon.Runtime.Internal.Util;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime.Internal.Auth
 {

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -819,7 +819,7 @@ namespace Amazon.Runtime.Internal.Auth
                                                     IDictionary<string, string> pathResources,
                                                     bool doubleEncode)
         {
-            using var canonicalRequest = new ValueStringBuilder(512);
+            var canonicalRequest = new ValueStringBuilder(512);
             canonicalRequest.Append($"{httpMethod}\n");
             canonicalRequest.Append($"{AWSSDKUtils.CanonicalizeResourcePathV2(endpoint, resourcePath, doubleEncode, pathResources)}\n");
             canonicalRequest.Append($"{canonicalQueryString}\n");
@@ -878,8 +878,7 @@ namespace Amazon.Runtime.Internal.Auth
             if (materializedSortedHeaders.Count == 0)
                 return string.Empty;
 
-            using var builder = new ValueStringBuilder(512);
-            
+            var builder = new ValueStringBuilder(512);
             foreach (var entry in materializedSortedHeaders)
             {
                 // Refer https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html. (Step #4: "To create the canonical headers list, convert all header names to lowercase and remove leading spaces and trailing spaces. Convert sequential spaces in the header value to a single space.").

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -898,7 +898,16 @@ namespace Amazon.Runtime.Internal.Auth
         /// <returns>Formatted string of header names</returns>
         protected static string CanonicalizeHeaderNames(IEnumerable<KeyValuePair<string, string>> sortedHeaders)
         {
-            return string.Join(";", sortedHeaders.Select(x => x.Key.ToLowerInvariant()));
+            var builder = new ValueStringBuilder(512);
+
+            foreach (var header in sortedHeaders)
+            {
+                if (builder.Length > 0)
+                    builder.Append(';');
+                builder.Append(header.Key.ToLowerInvariant());
+            }
+
+            return builder.ToString();
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -820,7 +820,8 @@ namespace Amazon.Runtime.Internal.Auth
                                                     bool doubleEncode)
         {
             var canonicalRequest = new ValueStringBuilder(512);
-            canonicalRequest.Append($"{httpMethod}\n");
+            canonicalRequest.Append(httpMethod);
+            canonicalRequest.Append('\n');
             canonicalRequest.Append($"{AWSSDKUtils.CanonicalizeResourcePathV2(endpoint, resourcePath, doubleEncode, pathResources)}\n");
             canonicalRequest.Append($"{canonicalQueryString}\n");
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -22,6 +22,7 @@ using Amazon.Internal;
 using Amazon.Util;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.Endpoints;
+using AWSSDK.Core.NetStandard.Amazon.Runtime.Internal.Util;
 
 namespace Amazon.Runtime.Internal.Auth
 {
@@ -818,13 +819,13 @@ namespace Amazon.Runtime.Internal.Auth
                                                     IDictionary<string, string> pathResources,
                                                     bool doubleEncode)
         {
-            var canonicalRequest = new StringBuilder();
-            canonicalRequest.AppendFormat("{0}\n", httpMethod);
-            canonicalRequest.AppendFormat("{0}\n", AWSSDKUtils.CanonicalizeResourcePathV2(endpoint, resourcePath, doubleEncode, pathResources));
-            canonicalRequest.AppendFormat("{0}\n", canonicalQueryString);
+            using var canonicalRequest = new ValueStringBuilder(512);
+            canonicalRequest.Append($"{httpMethod}\n");
+            canonicalRequest.Append($"{AWSSDKUtils.CanonicalizeResourcePathV2(endpoint, resourcePath, doubleEncode, pathResources)}\n");
+            canonicalRequest.Append($"{canonicalQueryString}\n");
 
-            canonicalRequest.AppendFormat("{0}\n", CanonicalizeHeaders(sortedHeaders));
-            canonicalRequest.AppendFormat("{0}\n", CanonicalizeHeaderNames(sortedHeaders));
+            canonicalRequest.Append($"{CanonicalizeHeaders(sortedHeaders)}\n");
+            canonicalRequest.Append($"{CanonicalizeHeaderNames(sortedHeaders)}\n");
 
             if (precomputedBodyHash != null)
             {
@@ -832,8 +833,7 @@ namespace Amazon.Runtime.Internal.Auth
             }
             else
             {
-                string contentHash;
-                if (sortedHeaders.TryGetValue(HeaderKeys.XAmzContentSha256Header, out contentHash))
+                if (sortedHeaders.TryGetValue(HeaderKeys.XAmzContentSha256Header, out var contentHash))
                     canonicalRequest.Append(contentHash);
             }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -893,16 +893,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// <returns>Formatted string of header names</returns>
         protected static string CanonicalizeHeaderNames(IEnumerable<KeyValuePair<string, string>> sortedHeaders)
         {
-            var builder = new StringBuilder();
-            
-            foreach (var header in sortedHeaders)
-            {
-                if (builder.Length > 0)
-                    builder.Append(";");
-                builder.Append(header.Key.ToLowerInvariant());
-            }
-            
-            return builder.ToString();
+            return string.Join(";", sortedHeaders.Select(x => x.Key.ToLowerInvariant()));
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ValueStringBuilder.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ValueStringBuilder.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 namespace AWSSDK.Core.NetStandard.Amazon.Runtime.Internal.Util
 {
 #pragma warning disable CA1815
-    public ref struct ValueStringBuilder
+    internal ref struct ValueStringBuilder
 #pragma warning restore CA1815
     {
         private char[]? _arrayToReturnToPool;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ValueStringBuilder.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ValueStringBuilder.cs
@@ -98,6 +98,13 @@ namespace AWSSDK.Core.NetStandard.Amazon.Runtime.Internal.Util
             return s;
         }
 
+        public string ToString(int start, int length)
+        {
+            string s = _chars.Slice(start, length).ToString();
+            Dispose();
+            return s;
+        }
+
         /// <summary>Returns the underlying storage of the builder.</summary>
         public Span<char> RawChars => _chars;
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ValueStringBuilder.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ValueStringBuilder.cs
@@ -1,0 +1,309 @@
+// Partially adapted from https://raw.githubusercontent.com/dotnet/runtime/main/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#nullable enable
+
+namespace AWSSDK.Core.NetStandard.Amazon.Runtime.Internal.Util
+{
+#pragma warning disable CA1815
+    public ref struct ValueStringBuilder
+#pragma warning restore CA1815
+    {
+        private char[]? _arrayToReturnToPool;
+        private Span<char> _chars;
+        private int _pos;
+
+        public ValueStringBuilder(Span<char> initialBuffer)
+        {
+            _arrayToReturnToPool = null;
+            _chars = initialBuffer;
+            _pos = 0;
+        }
+
+        public ValueStringBuilder(int initialCapacity)
+        {
+            _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+            _chars = _arrayToReturnToPool;
+            _pos = 0;
+        }
+
+        public int Length
+        {
+            get => _pos;
+            set
+            {
+                Debug.Assert(value >= 0);
+                Debug.Assert(value <= _chars.Length);
+                _pos = value;
+            }
+        }
+
+        public int Capacity => _chars.Length;
+
+        public void EnsureCapacity(int capacity)
+        {
+            // This is not expected to be called this with negative capacity
+            Debug.Assert(capacity >= 0);
+
+            // If the caller has a bug and calls this with negative capacity, make sure to call Grow to throw an exception.
+            if ((uint)capacity > (uint)_chars.Length)
+                Grow(capacity - _pos);
+        }
+
+        /// <summary>
+        /// Get a pinnable reference to the builder.
+        /// Does not ensure there is a null char after <see cref="Length"/>
+        /// This overload is pattern matched in the C# 7.3+ compiler so you can omit
+        /// the explicit method call, and write eg "fixed (char* c = builder)"
+        /// </summary>
+        public ref char GetPinnableReference()
+        {
+            return ref MemoryMarshal.GetReference(_chars);
+        }
+
+        /// <summary>
+        /// Get a pinnable reference to the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+        public ref char GetPinnableReference(bool terminate)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+            return ref MemoryMarshal.GetReference(_chars);
+        }
+
+        public ref char this[int index]
+        {
+            get
+            {
+                Debug.Assert(index < _pos);
+                return ref _chars[index];
+            }
+        }
+
+        public override string ToString()
+        {
+            string s = _chars.Slice(0, _pos).ToString();
+            Dispose();
+            return s;
+        }
+
+        /// <summary>Returns the underlying storage of the builder.</summary>
+        public Span<char> RawChars => _chars;
+
+        /// <summary>
+        /// Returns a span around the contents of the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+        public ReadOnlySpan<char> AsSpan(bool terminate)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+            return _chars.Slice(0, _pos);
+        }
+
+        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+        public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+        public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
+
+        public bool TryCopyTo(Span<char> destination, out int charsWritten)
+        {
+            if (_chars.Slice(0, _pos).TryCopyTo(destination))
+            {
+                charsWritten = _pos;
+                Dispose();
+                return true;
+            }
+            else
+            {
+                charsWritten = 0;
+                Dispose();
+                return false;
+            }
+        }
+
+        public void Insert(int index, char value, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            _chars.Slice(index, count).Fill(value);
+            _pos += count;
+        }
+
+        public void Insert(int index, string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int count = s.Length;
+
+            if (_pos > (_chars.Length - count))
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            s
+#if !NET
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(index));
+            _pos += count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char c)
+        {
+            int pos = _pos;
+            Span<char> chars = _chars;
+            if ((uint)pos < (uint)chars.Length)
+            {
+                chars[pos] = c;
+                _pos = pos + 1;
+            }
+            else
+            {
+                GrowAndAppend(c);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int pos = _pos;
+            if (s.Length == 1 && (uint)pos < (uint)_chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+            {
+                _chars[pos] = s[0];
+                _pos = pos + 1;
+            }
+            else
+            {
+                AppendSlow(s);
+            }
+        }
+
+        private void AppendSlow(string s)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - s.Length)
+            {
+                Grow(s.Length);
+            }
+
+            s
+#if !NET
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(pos));
+            _pos += s.Length;
+        }
+
+        public void Append(char c, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            Span<char> dst = _chars.Slice(_pos, count);
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] = c;
+            }
+            _pos += count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<char> AppendSpan(int length)
+        {
+            int origPos = _pos;
+            if (origPos > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            _pos = origPos + length;
+            return _chars.Slice(origPos, length);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowAndAppend(char c)
+        {
+            Grow(1);
+            Append(c);
+        }
+
+        /// <summary>
+        /// Resize the internal buffer either by doubling current buffer size or
+        /// by adding <paramref name="additionalCapacityBeyondPos"/> to
+        /// <see cref="_pos"/> whichever is greater.
+        /// </summary>
+        /// <param name="additionalCapacityBeyondPos">
+        /// Number of chars requested beyond current position.
+        /// </param>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int additionalCapacityBeyondPos)
+        {
+            Debug.Assert(additionalCapacityBeyondPos > 0);
+            Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+            const uint ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+            // Increase to at least the required size (_pos + additionalCapacityBeyondPos), but try
+            // to double the size if possible, bounding the doubling to not go beyond the max array length.
+            int newCapacity = (int)Math.Max(
+                (uint)(_pos + additionalCapacityBeyondPos),
+                Math.Min((uint)_chars.Length * 2, ArrayMaxLength));
+
+            // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative.
+            // This could also go negative if the actual required length wraps around.
+            char[] poolArray = ArrayPool<char>.Shared.Rent(newCapacity);
+
+            _chars.Slice(0, _pos).CopyTo(poolArray);
+
+            char[]? toReturn = _arrayToReturnToPool;
+            _chars = _arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            char[]? toReturn = _arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+    }
+}

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -35,6 +35,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
 using Amazon.Runtime.Endpoints;
+using AWSSDK.Core.NetStandard.Amazon.Runtime.Internal.Util;
 
 #if AWS_ASYNC_API
 using System.Threading.Tasks;
@@ -1643,21 +1644,24 @@ namespace Amazon.Util
                 return null;
             }
 
-            if (data.Length == 0)
+            var dataLength = data.Length;
+            if (dataLength == 0)
             {
                 return string.Empty;
             }
 
-            var stringBuilder = new StringBuilder();
+            var stringBuilder = new ValueStringBuilder(dataLength);
+            int index = 0;
             var isWhiteSpace = false;
             foreach (var character in data)
             {
                 if (!isWhiteSpace | !(isWhiteSpace = char.IsWhiteSpace(character)))
                 {
                     stringBuilder.Append(isWhiteSpace ? ' ' : character);
+                    index++;
                 }
             }
-            return stringBuilder.ToString();
+            return stringBuilder.ToString(0, index);
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -35,7 +35,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
 using Amazon.Runtime.Endpoints;
-using AWSSDK.Core.NetStandard.Amazon.Runtime.Internal.Util;
+using ThirdParty.RuntimeBackports;
 
 #if AWS_ASYNC_API
 using System.Threading.Tasks;

--- a/sdk/src/Core/ThirdParty/RuntimeBackports/ValueStringBuilder.cs
+++ b/sdk/src/Core/ThirdParty/RuntimeBackports/ValueStringBuilder.cs
@@ -2,15 +2,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
-namespace AWSSDK.Core.NetStandard.Amazon.Runtime.Internal.Util
+namespace ThirdParty.RuntimeBackports
 {
 #pragma warning disable CA1815
     internal ref struct ValueStringBuilder

--- a/sdk/test/NetStandard/UnitTests/Core/AWS4SignerTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/AWS4SignerTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using Amazon.Runtime.Internal.Auth;
+using Xunit;
+
+namespace UnitTests.NetStandard.Core
+{
+    [Trait("Category", "Core")]
+    public class AWS4SignerTests
+    {
+        [Fact]
+        public void CanonicalizeHeaderNames()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { "Header1", "Value1" },
+                { "Header2", "Value2" },
+                { "Header3", "Value3" }
+            };
+
+            var signer = new AWS4SignerTestee();
+            var canonicalizedHeaders = signer.TestCanonicalizeHeaderNames(headers);
+
+            Assert.Equal("header1;header2;header3", canonicalizedHeaders);
+        }
+
+        [Fact]
+        public void CanonicalizeHeaders()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { "Header1", "Value1" },
+                { "Header2", " Value2 " },
+                { "Header3", "   Value3   " }
+            };
+
+            var signer = new AWS4SignerTestee();
+            var canonicalizedHeaders = signer.TestCanonicalizeHeaders(headers);
+
+            Assert.Equal("header1:Value1\nheader2:Value2\nheader3:Value3\n", canonicalizedHeaders);
+        }
+
+        class AWS4SignerTestee : AWS4Signer
+        {
+            public string TestCanonicalizeHeaderNames(IDictionary<string, string> headers)
+            {
+                return CanonicalizeHeaderNames(headers);
+            }
+
+            public string TestCanonicalizeHeaders(IDictionary<string, string> headers)
+            {
+                return CanonicalizeHeaders(headers);
+            }
+        }
+    }
+}

--- a/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
@@ -24,5 +24,13 @@ namespace UnitTests.NetStandard.Core
 
             Assert.Equal("48656c6c6f20576f726c64", hexString);
         }
+
+        [Fact]
+        public void CompressSpaces()
+        {
+            var data = "Hello,   World!";
+            var compressed = AWSSDKUtils.CompressSpaces(data);
+            Assert.Equal("Hello, World!", compressed);
+        }
     }
 }


### PR DESCRIPTION
This PR heavily optimizes the HTTP header path on the AWS4Signer to reduce the number of allocations.

## Description

See screenshots

## Motivation and Context

Making sure the request path is less allocation heavy will drastically improve the throughput of the AWS SDK.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

### CanonicalHeaderNames

<img width="1324" alt="CanonicalizeHeaderNames" src="https://github.com/aws/aws-sdk-net/assets/174258/e0877f6f-8f6c-423e-8e34-51fbbe35c0d8">

https://github.com/danielmarbach/aws-sdk-net-benchmarks/blob/main/CanonicalHeaderNames.cs

### CanonicalHeaders

<img width="1403" alt="CanonicalHeaders" src="https://github.com/aws/aws-sdk-net/assets/174258/31abb69c-31e7-4eeb-af41-efbc57f6ae7b">

https://github.com/danielmarbach/aws-sdk-net-benchmarks/blob/main/CanonicalHeaderNames.cs

### CompressSpace

<img width="1385" alt="CompressSpace" src="https://github.com/aws/aws-sdk-net/assets/174258/a1ec2466-1605-422d-8cef-291dbbfa09f2">

https://github.com/danielmarbach/aws-sdk-net-benchmarks/blob/main/CompressSpace.cs

### CanonicalHeaders with CompressSpace

<img width="1005" alt="CanonicalHeadersCompressSpace" src="https://github.com/aws/aws-sdk-net/assets/174258/a7aadf47-86f5-46bd-9512-73f162fce2a4">

https://github.com/danielmarbach/aws-sdk-net-benchmarks/blob/main/CanonicalHeaderNames.cs

Attention this was just a short run because things take ages otherwise

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement