### PR TITLE
fix: Improve handling of primary keys with property converters with DisableFetchingTableMetadata

### DIFF
--- a/generator/.DevConfigs/19e376c7-4b4b-4ee4-b0e7-564ecc5bc748.json
+++ b/generator/.DevConfigs/19e376c7-4b4b-4ee4-b0e7-564ecc5bc748.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Improve handling of primary keys with property converters when using the object-persistence programming model with DisableFetchingTableMetadata set to true."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
@@ -480,6 +480,13 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 {
                     // If the property has a property converter, use it to convert the hypothetical value
                     convertedEntry = property.Converter.ToEntry(hypotheticalValue);
+
+                    // If the converter's output was cast to an UnconvertedDynamoDBEntry, 
+                    // try converting it again so we can determine the corresponding primitive type
+                    if (convertedEntry is UnconvertedDynamoDBEntry unconvertedEntry)
+                    {
+                        convertedEntry = unconvertedEntry.Convert(flatConfig.Conversion);
+                    }
                 }
                 else
                 {
@@ -491,7 +498,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException($"Failed to determine the DynamoDB primitive type for property {property.PropertyName} of type {property.MemberType}.", e);
+                throw new InvalidOperationException($"Failed to determine the DynamoDB primitive type for property {property.PropertyName} " +
+                    $"of type {property.MemberType}. If using {nameof(DataModel.DynamoDBContextConfig.DisableFetchingTableMetadata)} and a converter " +
+                    $"on a primary key, ensure that the converted entry can be cast to a {nameof(Primitive)}.", e);
             }
         }
 

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -1,21 +1,17 @@
-﻿using System;
+﻿using Amazon;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+using Amazon.DynamoDBv2.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using Amazon.Auth.AccessControlPolicy;
-using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
-using Amazon.DynamoDBv2;
-using Amazon.DynamoDBv2.DocumentModel;
-using Amazon.DynamoDBv2.DataModel;
-using Amazon.DynamoDBv2.Model;
 using ThirdParty.Json.LitJson;
-
-using Moq;
-using Amazon;
 
 namespace AWSSDK_DotNet35.UnitTests
 {
@@ -468,6 +464,7 @@ namespace AWSSDK_DotNet35.UnitTests
         /// that relies on the hash key without correct table metadata
         /// </summary>
         [TestMethod]
+        [TestCategory("DynamoDBv2")]
         public void DisableFetchingTableMetadata_QueryWithMissingHashKey_ThrowsException()
         {
             var config = new DynamoDBContextConfig()
@@ -485,6 +482,7 @@ namespace AWSSDK_DotNet35.UnitTests
         /// that relies on a range key without correct table metadata
         /// </summary>
         [TestMethod]
+        [TestCategory("DynamoDBv2")]
         public void DisableFetchingTableMetadata_QueryWithMissingRangeKey_ThrowsException()
         {
             var config = new DynamoDBContextConfig()
@@ -501,6 +499,98 @@ namespace AWSSDK_DotNet35.UnitTests
             // This is a GSI's range key, which is not attributed
             Assert.ThrowsException<InvalidOperationException>(() =>
                 context.Query<EmployeeMissingRangeKeys>("123", QueryOperator.GreaterThan, new List<object> { 5 }, new DynamoDBOperationConfig { IndexName = "GlobalIndex"}));
+        }
+
+        /// <summary>
+        /// Asserts that we can infer the type of the primary key is "String" 
+        /// when using a property converter and DisableFetchingTableMetadata
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DisableFetchingTableMetadata_KeyWithConverter_DateTimeToString()
+        {
+            var mock = new Mock<IAmazonDynamoDB>();
+            mock.Setup(x => x.GetItem(It.IsAny<GetItemRequest>())).Returns(
+                new GetItemResponse() {  Item = new Dictionary<string, AttributeValue>()});
+
+            var context = new DynamoDBContext(mock.Object, new DynamoDBContextConfig() { DisableFetchingTableMetadata = true });
+            
+            context.Load<HashKeyConverter_DateTimeToString>(DateTime.MinValue);
+
+            // Verify that the DateTime was cast to a string attribute correctly
+            mock.Verify(x => 
+                x.GetItem(It.Is<GetItemRequest>(request => 
+                    request.Key.ContainsKey("CreationDate") && 
+                    request.Key["CreationDate"].S == "0001-01-01T00:00:00.000Z")));
+
+            mock.VerifyNoOtherCalls();
+        }
+
+        /// <summary>
+        /// Asserts that we can infer the type of the primary key is "Number" 
+        /// when using a property converter and DisableFetchingTableMetadata
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DisableFetchingTableMetadata_KeyWithConverter_DateTimeToNumber()
+        {
+            var mock = new Mock<IAmazonDynamoDB>();
+            mock.Setup(x => x.GetItem(It.IsAny<GetItemRequest>())).Returns(
+                new GetItemResponse() { Item = new Dictionary<string, AttributeValue>() });
+
+            var context = new DynamoDBContext(mock.Object, new DynamoDBContextConfig() { DisableFetchingTableMetadata = true });
+
+            context.Load<HashKeyConverter_DateTimeToNumber>(new DateTime(1024, DateTimeKind.Utc));
+
+            // Verify that the DateTime was cast to a number attribute correctly
+            mock.Verify(x => 
+                x.GetItem(It.Is<GetItemRequest>(request =>
+                    request.Key.ContainsKey("CreationDate") &&
+                    request.Key["CreationDate"].N == "1024")));
+
+            mock.VerifyNoOtherCalls();
+        }
+
+        /// <summary>
+        /// Asserts that we can infer the type of the primary key is "Binary" 
+        /// when using a property converter and DisableFetchingTableMetadata
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DisableFetchingTableMetadata_KeyWithConverter_DateTimeToBinary()
+        {
+            var mock = new Mock<IAmazonDynamoDB>();
+            mock.Setup(x => x.GetItem(It.IsAny<GetItemRequest>())).Returns(
+                new GetItemResponse() { Item = new Dictionary<string, AttributeValue>() });
+
+            var context = new DynamoDBContext(mock.Object, new DynamoDBContextConfig() { DisableFetchingTableMetadata = true });
+
+            context.Load<HashKeyConverter_DateTimeToBinary>(new DateTime(1024, DateTimeKind.Utc));
+
+            // Verify that the DateTime was cast to a binary attribute correctly (converts to a string just for the comparison)
+            mock.Verify(x => 
+                x.GetItem(It.Is<GetItemRequest>(request =>
+                    request.Key.ContainsKey("CreationDate") &&
+                    BitConverter.ToString(request.Key["CreationDate"].B.ToArray()) == "00-04-00-00-00-00-00-40")));
+
+            mock.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void DisableFetchingTableMetadata_KeyWithConverter_DateTimeToBool_ThrowsException()
+        {
+            var mock = new Mock<IAmazonDynamoDB>();
+            mock.Setup(x => x.GetItem(It.IsAny<GetItemRequest>())).Returns(
+                new GetItemResponse() { Item = new Dictionary<string, AttributeValue>() });
+
+            var context = new DynamoDBContext(mock.Object, new DynamoDBContextConfig() { DisableFetchingTableMetadata = true });
+
+            // A boolean isn't valid as a primary key, so we expect an exception 
+            Assert.ThrowsException<InvalidOperationException>(() => 
+                context.Load<HashKeyConverter_DateTimeToBool>(new DateTime(1024, DateTimeKind.Utc)));
+
+            mock.VerifyNoOtherCalls();
         }
 
         [DynamoDBTable("EmployeeDetails")]
@@ -528,6 +618,80 @@ namespace AWSSDK_DotNet35.UnitTests
 
             // This is the range key for "GlobalIndex" for our typical testing table
             public int Score { get; set; }
+        }
+
+        private class HashKeyConverter_DateTimeToString
+        {
+            [DynamoDBHashKey(typeof(DateTimeConverter))]
+            public DateTime CreationDate { get; set; }
+
+            private class DateTimeConverter : IPropertyConverter
+            {
+                public DynamoDBEntry ToEntry(object value)
+                {
+                    return ((DateTime)value).ToString(@"yyyy-MM-dd\THH:mm:ss.fff\Z", CultureInfo.InvariantCulture);
+                }
+                public object FromEntry(DynamoDBEntry entry)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+
+        private class HashKeyConverter_DateTimeToNumber
+        {
+            [DynamoDBHashKey(typeof(DateTimeConverter))]
+            public DateTime CreationDate { get; set; }
+
+            private class DateTimeConverter : IPropertyConverter
+            {
+                public DynamoDBEntry ToEntry(object value)
+                {
+                    return ((DateTime)value).Ticks;
+                }
+                public object FromEntry(DynamoDBEntry entry)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+
+        private class HashKeyConverter_DateTimeToBinary
+        {
+            [DynamoDBHashKey(typeof(DateTimeConverter))]
+            public DateTime CreationDate { get; set; }
+
+            private class DateTimeConverter : IPropertyConverter
+            {
+                public DynamoDBEntry ToEntry(object value)
+                {
+                    return BitConverter.GetBytes(((DateTime)value).ToBinary());
+                }
+                public object FromEntry(DynamoDBEntry entry)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+
+        private class HashKeyConverter_DateTimeToBool
+        {
+            // This isn't valid, it's for testing that we throw an exception when a
+            // converter on a key doesn't return an entry that can be cast to a Primitive
+            [DynamoDBHashKey(typeof(DateTimeConverter))]
+            public DateTime CreationDate { get; set; }
+
+            private class DateTimeConverter : IPropertyConverter
+            {
+                public DynamoDBEntry ToEntry(object value)
+                {
+                    return new DynamoDBBool(true);
+                }
+                public object FromEntry(DynamoDBEntry entry)
+                {
+                    throw new NotImplementedException();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
When using `DisableFetchingTableMetadata` in the object-persistence programming model, the SDK infers its understanding of a DynamoDB table and/or index's key structure based on the attributed data model, as opposed to calling `DescribeTable` to load the actual table/index configuration.

The data type of primary keys is expected to be one of our `DynamoDBEntryType ` and can be represented by a `Primitive`. https://github.com/aws/aws-sdk-net/blob/1b8348b32e19e3286946e50123fc8d380b6d2593/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Primitive.cs#L31-L44

The SDK was throwing an exception for the case when:
1. A property converter is applied to an attribute that is part of a key
2. That property converter returns an `UnconvertedDynamoDBEntry` (as opposed to a `Primitive` directly)

Now, if a property converter returns an `UnconvertedDynamoDBEntry` for a property used in a key, the SDK will attempt to convert it again towards a `Primitive`. If it still cannot, I clarified the exception that is thrown.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
DOTNET-7524 -> #3323

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement