### PR TITLE
Change version strategy in V4 to set AssemblyVersion

### DIFF
--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/AssemblyInfo.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/AssemblyInfo.cs
@@ -15,7 +15,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class AssemblyInfo : BaseGenerator
     {
@@ -36,35 +36,35 @@ using System.Runtime.CompilerServices;
 // associated with an assembly.
 [assembly: AssemblyTitle(""");
             
-            #line 12 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 12 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyTitle));
             
             #line default
             #line hidden
             this.Write("\")]\r\n#if BCL\r\n[assembly: AssemblyDescription(\"");
             
-            #line 14 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 14 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyDescription(versionIdentifier: "4.6.2")));
             
             #line default
             #line hidden
             this.Write("\")]\r\n#elif NETSTANDARD20\r\n[assembly: AssemblyDescription(\"");
             
-            #line 16 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 16 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyDescription(versionIdentifier: "NetStandard 2.0")));
             
             #line default
             #line hidden
             this.Write("\")]\r\n#elif NETCOREAPP3_1\r\n[assembly: AssemblyDescription(\"");
             
-            #line 18 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 18 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyDescription(versionIdentifier: ".NET Core 3.1")));
             
             #line default
             #line hidden
             this.Write("\")]\r\n#elif NET8_0\r\n[assembly: AssemblyDescription(\"");
             
-            #line 20 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 20 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyDescription(versionIdentifier: ".NET 8.0")));
             
             #line default
@@ -96,16 +96,24 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion(""1.0.*"")]
+#if BCL
 [assembly: AssemblyVersion(""");
             
-            #line 47 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceVersion));
             
             #line default
             #line hidden
-            this.Write("\")]\r\n[assembly: AssemblyFileVersion(\"");
+            this.Write("\")]\r\n#else\r\n[assembly: AssemblyVersion(\"");
             
-            #line 48 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 50 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceFileVersion));
+            
+            #line default
+            #line hidden
+            this.Write("\")]\r\n#endif\r\n[assembly: AssemblyFileVersion(\"");
+            
+            #line 52 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceFileVersion));
             
             #line default

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/AssemblyInfo.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/AssemblyInfo.tt
@@ -44,5 +44,9 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
+#if BCL
 [assembly: AssemblyVersion("<#=this.Config.ServiceVersion #>")]
+#else
+[assembly: AssemblyVersion("<#=this.Config.ServiceFileVersion #>")]
+#endif
 [assembly: AssemblyFileVersion("<#=this.Config.ServiceFileVersion #>")]

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/CoreAssemblyInfo.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/CoreAssemblyInfo.cs
@@ -68,16 +68,24 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "he following four values:\r\n//\r\n//      Major Version\r\n//      Minor Version \r\n//" +
                     "      Build Number\r\n//      Revision\r\n//\r\n// You can specify all the values or y" +
                     "ou can default the Build and Revision Numbers \r\n// by using the \'*\' as shown bel" +
-                    "ow:\r\n// [assembly: AssemblyVersion(\"1.0.*\")]\r\n[assembly: AssemblyVersion(\"");
+                    "ow:\r\n// [assembly: AssemblyVersion(\"1.0.*\")]\r\n#if BCL\r\n[assembly: AssemblyVersio" +
+                    "n(\"");
             
-            #line 52 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
+            #line 53 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Session["Version"]));
             
             #line default
             #line hidden
-            this.Write("\")]\r\n[assembly: AssemblyFileVersion(\"");
+            this.Write("\")]\r\n#else\r\n[assembly: AssemblyVersion(\"");
             
-            #line 53 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
+            #line 55 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(this.Session["FileVersion"]));
+            
+            #line default
+            #line hidden
+            this.Write("\")]\r\n#endif\r\n[assembly: AssemblyFileVersion(\"");
+            
+            #line 57 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Session["FileVersion"]));
             
             #line default

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/CoreAssemblyInfo.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/CoreAssemblyInfo.tt
@@ -49,7 +49,11 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
+#if BCL
 [assembly: AssemblyVersion("<#=this.Session["Version"]#>")]
+#else
+[assembly: AssemblyVersion("<#=this.Session["FileVersion"] #>")]
+#endif
 [assembly: AssemblyFileVersion("<#=this.Session["FileVersion"] #>")]
 
 #if BCL


### PR DESCRIPTION
V3 we always set the `AssemblyVersion` because the version number is part of the assembly identity. If you change the version number any assemblies that depend on have to recompile for the new version. This strategy dated back to when the SDK only targeted .NET Framework. 

In .NET Core the version number is not part of the assembly identity so users are not required to recompile. This PR changes the strategy for .NET Core set the `AssemblyVersion` to the same value of `AssemblyFileVersion`. For the .NET Framework targets we continue to use the same strategy.

Example of a generated `AssemblyInfo.cs
```csharp
using System;
using System.Reflection;
using System.Runtime.InteropServices;
using System.Runtime.CompilerServices;

// General Information about an assembly is controlled through the following 
// set of attributes. Change these attribute values to modify the information
// associated with an assembly.
[assembly: AssemblyTitle("AWSSDK.AmplifyBackend")]
#if BCL
[assembly: AssemblyDescription("The Amazon Web Services SDK for .NET (4.6.2) - AmplifyBackend. (New Service) The Amplify Admin UI offers an accessible way to develop app backends and manage app content. We recommend that you use the Amplify Admin UI to manage the backend of your Amplify app.")]
#elif NETSTANDARD20
[assembly: AssemblyDescription("The Amazon Web Services SDK for .NET (NetStandard 2.0) - AmplifyBackend. (New Service) The Amplify Admin UI offers an accessible way to develop app backends and manage app content. We recommend that you use the Amplify Admin UI to manage the backend of your Amplify app.")]
#elif NETCOREAPP3_1
[assembly: AssemblyDescription("The Amazon Web Services SDK for .NET (.NET Core 3.1) - AmplifyBackend. (New Service) The Amplify Admin UI offers an accessible way to develop app backends and manage app content. We recommend that you use the Amplify Admin UI to manage the backend of your Amplify app.")]
#elif NET8_0
[assembly: AssemblyDescription("The Amazon Web Services SDK for .NET (.NET 8.0) - AmplifyBackend. (New Service) The Amplify Admin UI offers an accessible way to develop app backends and manage app content. We recommend that you use the Amplify Admin UI to manage the backend of your Amplify app.")]
#else
#error Unknown platform constant - unable to set correct AssemblyDescription
#endif

[assembly: AssemblyConfiguration("")]
[assembly: AssemblyProduct("Amazon Web Services SDK for .NET")]
[assembly: AssemblyCompany("Amazon.com, Inc")]
[assembly: AssemblyCopyright("Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.")]
[assembly: AssemblyTrademark("")]
[assembly: AssemblyCulture("")]

// Setting ComVisible to false makes the types in this assembly not visible 
// to COM components.  If you need to access a type in this assembly from 
// COM, set the ComVisible attribute to true on that type.
[assembly: ComVisible(false)]

// Version information for an assembly consists of the following four values:
//
//      Major Version
//      Minor Version 
//      Build Number
//      Revision
//
// You can specify all the values or you can default the Build and Revision Numbers 
// by using the '*' as shown below:
// [assembly: AssemblyVersion("1.0.*")]
#if BCL
[assembly: AssemblyVersion("3.3")]
#else
[assembly: AssemblyVersion("3.7.300.84")]
#endif
[assembly: AssemblyFileVersion("3.7.300.84")]
```