### PR TITLE
Switch AWSSDK.Extensions.NETCore.Setup to use project reference

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.csproj
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.csproj
@@ -12,10 +12,10 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 	
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <WarningsAsErrors>IL2026,IL2075</WarningsAsErrors>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>  
 
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.300" />
+    <ProjectReference Include="..\..\..\sdk\src\Core\AWSSDK.Core.NetStandard.csproj" />
   </ItemGroup>
 
 </Project>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
@@ -13,14 +13,25 @@
     <icon>images\AWSLogo.png</icon>
 	
     <dependencies>
-      <group>
-        <dependency id="AWSSDK.Core" version="3.7.300" />
+      <group targetFramework="netstandard2.0">
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
-	  
-    </dependencies>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview" />
+        <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview" />
+        <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
+      </group>
+	</dependencies>
 
   </metadata> 
   <files>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
@@ -241,12 +241,13 @@ namespace Amazon.Extensions.NETCore.Setup
                     if (string.Equals(property.Name, "DefaultConfigurationMode", StringComparison.Ordinal))
                         continue;
 
-                    // Skip setting RetryMode if it is set to legacy but the DefaultConfigurationMode is not legacy.
+                    // Skip setting RetryMode if it is set to standard, the default mode, but the DefaultConfigurationMode
+                    // on the new service config is not legacy.
                     // This will allow the retry mode to be configured from the DefaultConfiguration.
                     // This is a workaround to handle the inability to tell if RetryMode was explicitly set.
                     if (string.Equals(property.Name, "RetryMode", StringComparison.Ordinal) && 
-                        defaultConfig.RetryMode == RequestRetryMode.Legacy && 
-                        config.DefaultConfigurationMode != DefaultConfigurationMode.Legacy)
+                        defaultConfig.RetryMode == RequestRetryMode.Standard && 
+                        config.DefaultConfigurationMode != DefaultConfigurationMode.Standard)
                         continue;
 
                     singleArray[0] = property.GetMethod.Invoke(defaultConfig, emptyArray);

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/DefaultClientConfig.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/DefaultClientConfig.cs
@@ -13,11 +13,9 @@
  * permissions and limitations under the License.
  */
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 using Amazon.Runtime;
+using Amazon.Runtime.Endpoints;
 
 namespace Amazon.Extensions.NETCore.Setup
 {
@@ -27,6 +25,7 @@ namespace Amazon.Extensions.NETCore.Setup
     internal class DefaultClientConfig : ClientConfig
     {
         public DefaultClientConfig()
+            : base(null)
         {
 
         }
@@ -53,6 +52,16 @@ namespace Amazon.Extensions.NETCore.Setup
             {
                 return null;
             }
+        }
+
+        protected override void Initialize()
+        {
+            // Override the initialize method to avoid use with the null IDefaultConfigurationProvider
+        }
+
+        public override Endpoint DetermineServiceOperationEndpoint(ServiceOperationEndpointParameters parameters)
+        {
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Description

Changes for getting `AWSSDK.Extensions.NETCore.Setup` ready for V4.

* Switch `AWSSDK.Extensions.NETCore.Setup` to use a project reference to `AWSSDK.Core`. The package reference was a legacy issue when the repo used to swap out different `snk` files.
* Update version of AWSSDK.Core in nuspec file to `4.0.0.0-preview`
* Add individual dependency groups in nuspec file to remove pack warnings
* Address issues in the `DefaultConfig` now that it taking a dependency on V4
* Enable treat warnings as errors. 

I tested this by building the NuGet package locally and confirming no warnings and the package contained the correct layout.