### PR TITLE
Optimize GetExtension execution time on NET8

### DIFF
--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -195,33 +195,29 @@ namespace Amazon.Util
         /// <returns></returns>
         public static string GetExtension(string path)
         {
-            if (path == null)
+            if (path is null)
                 return null;
-            int length = path.Length;
-            int index = length;
 
-            while (--index >= 0)
+#if NETFRAMEWORK
+            int sepIdx = path.LastIndexOf('.');
+            int dirIdx = path.LastIndexOfAny(PathSeps);
+#else
+            int sepIdx = MemoryExtensions.LastIndexOf(path.AsSpan(), '.');
+            int dirIdx = MemoryExtensions.LastIndexOfAny(path.AsSpan(), '/', '\\', ':');
+#endif
+
+            // extension separator is found and exists before path separator or path separator doesn't exist
+            // AND it's not the last one in the string
+            if (dirIdx < sepIdx && sepIdx < path.Length - 1)
             {
-                char ch = path[index];
-                if (ch == '.')
-                {
-                    if (index != length - 1)
-                        return path.Substring(index, length - index);
-                    else
-                        return string.Empty;
-                }
-                else if (IsPathSeparator(ch))
-                    break;
+                return path.Substring(sepIdx);
             }
-            return string.Empty;
-        }
 
-        // Checks if the character is one \ / :
-        private static bool IsPathSeparator(char ch)
-        {
-            return (ch == '\\' ||
-                    ch == '/' ||
-                    ch == ':');
+            // If we're here we either:
+            // 1. Can't find the extension separator
+            // 2. Found but it's at the end of the string
+            // 3. Found but there is a directory separator after
+            return string.Empty;
         }
 
         /*

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -198,26 +198,45 @@ namespace Amazon.Util
             if (path is null)
                 return null;
 
-#if NETFRAMEWORK
-            int sepIdx = path.LastIndexOf('.');
-            int dirIdx = path.LastIndexOfAny(PathSeps);
-#else
-            int sepIdx = MemoryExtensions.LastIndexOf(path.AsSpan(), '.');
-            int dirIdx = MemoryExtensions.LastIndexOfAny(path.AsSpan(), '/', '\\', ':');
-#endif
+#if NET8_0_OR_GREATER
+            int extensionIndex = path.AsSpan().LastIndexOf('.');
+            int directoryIndex = path.AsSpan().LastIndexOfAny('/', '\\', ':');
 
             // extension separator is found and exists before path separator or path separator doesn't exist
             // AND it's not the last one in the string
-            if (dirIdx < sepIdx && sepIdx < path.Length - 1)
+            if (directoryIndex < extensionIndex && extensionIndex < path.Length - 1)
             {
-                return path.Substring(sepIdx);
+                return path.Substring(extensionIndex);
             }
 
-            // If we're here we either:
-            // 1. Can't find the extension separator
-            // 2. Found but it's at the end of the string
-            // 3. Found but there is a directory separator after
             return string.Empty;
+#else
+            int length = path.Length;
+            int index = length;
+
+            while (--index >= 0)
+            {
+                char ch = path[index];
+                if (ch == '.')
+                {
+                    if (index != length - 1)
+                        return path.Substring(index, length - index);
+                    else
+                        return string.Empty;
+                }
+                else if (IsPathSeparator(ch))
+                    break;
+            }
+
+            return string.Empty;
+
+            bool IsPathSeparator(char ch)
+            {
+                return (ch == '\\' ||
+                        ch == '/' ||
+                        ch == ':');
+            }
+#endif
         }
 
         /*

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -200,21 +200,22 @@ namespace Amazon.Util
 
 #if NET8_0_OR_GREATER
             // LastIndexOf and LastIndexOfAny is vectorized on .NET8+ and is
-            // signifigantly faster for cases where 'path' does not end with a short file
+            // significantly faster for cases where 'path' does not end with a short file
             // extension, such as GUIDs
-            int extensionIndex = path.AsSpan().LastIndexOf('.');
+            ReadOnlySpan<char> pathSpan = path.AsSpan();
+            int extensionIndex = pathSpan.LastIndexOf('.');
             if (extensionIndex == -1)
             {
                 return string.Empty;
             }
 
-            int directoryIndex = path.AsSpan().LastIndexOfAny('/', '\\', ':');
+            int directoryIndex = pathSpan.LastIndexOfAny('/', '\\', ':');
 
             // extension separator is found and exists before path separator or path separator doesn't exist
             // AND it's not the last one in the string
-            if (directoryIndex < extensionIndex && extensionIndex < path.Length - 1)
+            if (directoryIndex < extensionIndex && extensionIndex < pathSpan.Length - 1)
             {
-                return path.Substring(extensionIndex);
+                return pathSpan.Slice(extensionIndex).ToString();
             }
 
             return string.Empty;

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -199,7 +199,15 @@ namespace Amazon.Util
                 return null;
 
 #if NET8_0_OR_GREATER
+            // LastIndexOf and LastIndexOfAny is vectorized on .NET8+ and is
+            // signifigantly faster for cases where 'path' does not end with a short file
+            // extension, such as GUIDs
             int extensionIndex = path.AsSpan().LastIndexOf('.');
+            if (extensionIndex == -1)
+            {
+                return string.Empty;
+            }
+
             int directoryIndex = path.AsSpan().LastIndexOfAny('/', '\\', ':');
 
             // extension separator is found and exists before path separator or path separator doesn't exist

--- a/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
@@ -90,6 +90,8 @@ namespace UnitTests.NetStandard.Core
         [InlineData("no-delimiters-at-all", "")]
         [InlineData("delimiter-end-of-string.", "")]
         [InlineData("relative-path/no-file-extension", "")]
+        [InlineData("relative-path\\no-file-extension", "")]
+        [InlineData("relative-path:no-file-extension", "")]
         [InlineData("simple-file.pdf", ".pdf")]
         [InlineData("relative-path/with-file-extension.pdf", ".pdf")]
         [InlineData("relative-path.with-dot/with-file-extension.pdf", ".pdf")]

--- a/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
@@ -84,5 +84,20 @@ namespace UnitTests.NetStandard.Core
 
             Assert.Equal(expected, encoded);
         }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("no-delimiters-at-all", "")]
+        [InlineData("delimiter-end-of-string.", "")]
+        [InlineData("relative-path/no-file-extension", "")]
+        [InlineData("simple-file.pdf", ".pdf")]
+        [InlineData("relative-path/with-file-extension.pdf", ".pdf")]
+        [InlineData("relative-path.with-dot/with-file-extension.pdf", ".pdf")]
+        public void GetExtension(string input, string expected)
+        {
+            var actual = AWSSDKUtils.GetExtension(input);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
+++ b/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
@@ -12,13 +12,11 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+using Amazon.Util;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
-using Amazon.Util;
 using System.Reflection;
-using Moq;
-using Amazon.Util.Internal;
 using System.Text;
 
 namespace AWSSDK.UnitTests
@@ -177,6 +175,25 @@ namespace AWSSDK.UnitTests
             var hexString = AWSSDKUtils.ToHex(bytes, lowercase);
 
             Assert.AreEqual(expectedResult, hexString);
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("no-delimiters-at-all", "")]
+        [DataRow("delimiter-end-of-string.", "")]
+        [DataRow("relative-path/no-file-extension", "")]
+        [DataRow("relative-path\\no-file-extension", "")]
+        [DataRow("relative-path:no-file-extension", "")]
+        [DataRow("simple-file.pdf", ".pdf")]
+        [DataRow("relative-path/with-file-extension.pdf", ".pdf")]
+        [DataRow("relative-path.with-dot/with-file-extension.pdf", ".pdf")]
+        public void GetExtension(string input, string expected)
+        {
+            var actual = AWSSDKUtils.GetExtension(input);
+
+            Assert.AreEqual(expected, actual);
         }
     }
 }


### PR DESCRIPTION
## Description
Newer versions of .NET have improved the performance of the IndexOf() methods such that it's often quicker for many cases to do two `LastIndexOf[Any]()` calls rather than one manual loop. This PR uses this to provide a 4x speedup (on my hardware) over the "worst-case" time of the old algorithm where no delimeters can be found, such as when processing a GUID in string format. The "best case" for the original implementation where a value ends in a short 3-letter extension remains comparable, +/- 0.5ns.

Despite the APIs being available as far back as netcore2.1, I have chosen to target this hotpath against v4 and NET8+ as the BCL speed-ups to make this worthwhile are only available on later runtimes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

This function appears used by S3 client. Optimizing handling of non-file names such as GUIDS as keys will help when used against S3 buckets using GUIDs or similar keys.

## Testing
The changes are essentially .NET8-only though I added equivalent unit tests for both the NetStandard and NetFramework projects to demonstrate matching functionality.

## Screenshots (if appropriate)

![image](https://github.com/aws/aws-sdk-net/assets/439844/b10692bd-b48e-4479-90f1-73dc457c3173)

## Benchmarks

<details>
  <summary>Benchmark Code</summary>
  
  ```csharp
[MemoryDiagnoser]
public class GetExtension
{
    [Params(".htaccess", "amazon-s3.pdf", "relative/path-no-file-sep", "086219F2-E4AC-4ECA-8962-8C2879F9B6B2")]
    public string Scenario { get; set; }

    [Benchmark(Baseline = true)]
    public string Original() => OriginalImpl.GetExtension(Scenario);

    [Benchmark]
    public string Optimized() => OptimizedImpl.GetExtension(Scenario);

    [Benchmark]
    public string BuiltIn() => Path.GetExtension(Scenario);

    public static class OptimizedImpl
    {
        public static string GetExtension(string path)
        {
            if (path is null)
                return null;

            int extensionIndex = path.AsSpan().LastIndexOf('.');
            if (extensionIndex == -1)
            {
                return string.Empty;
            }

            int directoryIndex = path.AsSpan().LastIndexOfAny('/', '\\', ':');

            // extension separator is found and exists before path separator or path separator doesn't exist
            // AND it's not the last one in the string
            if (directoryIndex < extensionIndex && extensionIndex < path.Length - 1)
            {
                return path.Substring(extensionIndex);
            }

            return string.Empty;
        }
    }

    private static class OriginalImpl
    {
        public static string GetExtension(string path)
        {
            if (path == null)
                return null;
            int length = path.Length;
            int index = length;

            while (--index >= 0)
            {
                char ch = path[index];
                if (ch == '.')
                {
                    if (index != length - 1)
                        return path.Substring(index, length - index);
                    else
                        return string.Empty;
                }
                else if (IsPathSeparator(ch))
                    break;
            }
            return string.Empty;
        }

        // Checks if the character is one \ / :
        private static bool IsPathSeparator(char ch)
        {
            return (ch == '\\' ||
                    ch == '/' ||
                    ch == ':');
        }
    }
}
  ```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement