### PR TITLE
Optimize DetermineService

### DIFF
--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -668,32 +668,31 @@ namespace Amazon.Util
         /// </returns>
         public static string DetermineService(string url)
         {
-            int delimIndex = url.IndexOf("//", StringComparison.Ordinal);
-            if (delimIndex >= 0)
-                url = url.Substring(delimIndex + 2);
+            var urlSpan = url.AsSpan();
 
-            string[] urlParts = url.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
-            if (urlParts == null || urlParts.Length == 0)
+            var doubleSlashIndex = urlSpan.IndexOf(DoubleSlash, StringComparison.Ordinal);
+            if (doubleSlashIndex >= 0)
+                urlSpan = urlSpan.Slice(doubleSlashIndex + 2);
+
+            var dotIndex = urlSpan.IndexOf('.');
+
+            if (dotIndex < 0)
                 return string.Empty;
 
-            string servicePart = urlParts[0];
-            int hyphenated = servicePart.IndexOf('-');
-            string service;
-            if (hyphenated < 0)
-            { service = servicePart; }
-            else
-            { service = servicePart.Substring(0, hyphenated); }
+            var servicePartSpan = urlSpan.Slice(0, dotIndex);
+            var hyphenIndex = servicePartSpan.IndexOf('-');
+            if (hyphenIndex > 0)
+            {
+                servicePartSpan = servicePartSpan.Slice(0, hyphenIndex);
+            }
 
-            // Check for SQS : return "sqs" incase service is determined to be "queue" as per the URL.
-            if (service.Equals("queue"))
-            {
-                return "sqs";
-            }
-            else
-            {
-                return service;
-            }
+            // Check for SQS : return "sqs" in case service is determined to be "queue" as per the URL.
+            return servicePartSpan.Equals(Queue, StringComparison.OrdinalIgnoreCase) ? "sqs" : servicePartSpan.ToString();
         }
+
+        // Compiler trick to directly refer to static data in the assembly
+        private static ReadOnlySpan<char> DoubleSlash => new[] { '/', '/' };
+        private static ReadOnlySpan<char> Queue => new[] { 'q', 'u', 'e', 'u', 'e' };
 
         /// <summary>
         /// Utility method for converting Unix epoch seconds to DateTime structure.

--- a/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
@@ -32,5 +32,18 @@ namespace UnitTests.NetStandard.Core
             var compressed = AWSSDKUtils.CompressSpaces(data);
             Assert.Equal("Hello, World!", compressed);
         }
+
+        [Theory]
+        [InlineData("https://s3.amazonaws.com", "s3")]
+        [InlineData("sqs.us-west-2.amazonaws.com", "sqs")]
+        [InlineData("queue.amazonaws.com", "sqs")]
+        [InlineData("https://sns.us-west-2.amazonaws.com", "sns")]
+        [InlineData("https://s3-external-1.amazonaws.com", "s3")]
+        public void DetermineService(string url, string expectedService)
+        {
+            var service = AWSSDKUtils.DetermineService(url);
+
+            Assert.Equal(expectedService, service);
+        }
     }
 }


### PR DESCRIPTION
## Description

Heavily optimizes DetermineService method which is also used on the Signing request path

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

![image](https://github.com/aws/aws-sdk-net/assets/174258/67d0123f-4a5e-4ea5-aee3-7e5e28b3a445)

https://github.com/danielmarbach/aws-sdk-net-benchmarks/blob/main/DetermineService.cs

Proof of embedding (also works on .NET)

https://sharplab.io/#gist:c381a4555b6ad204c609be729ee4e864

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added a theory test with some inline data to make sure the existing functionality is preserved

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement