### PR TITLE
[V4] Updated support for bidi characters in resource paths.

### DIFF
--- a/extensions/test/CrtIntegrationTests/V4aSignerTests.cs
+++ b/extensions/test/CrtIntegrationTests/V4aSignerTests.cs
@@ -131,7 +131,6 @@ namespace CrtIntegrationTests
             IRequest request = mock.Object;
             request.HttpMethod = "POST";
             request.ResourcePath = resourcePath;
-            request.MarshallerVersion = 2;
             request.Content = Encoding.ASCII.GetBytes("Param1=value1");
             request.Endpoint = new Uri("https://" + SigningTestHost + "/");
 
@@ -220,7 +219,6 @@ namespace CrtIntegrationTests
             var request = mock.Object;
             request.HttpMethod = "GET";
             request.ResourcePath = "/";
-            request.MarshallerVersion = 2;
             request.Endpoint = new Uri("https://" + SigningTestHost + "/");
 
             return request;
@@ -276,7 +274,6 @@ namespace CrtIntegrationTests
             mock.SetupGet(x => x.SubResources).Returns(new Dictionary<string, string>());
 
             var request = mock.Object;
-            request.MarshallerVersion = 2;
             request.HttpMethod = "PUT";
             request.ResourcePath = "/examplebucket/chunkObject.txt";
             request.Endpoint = new Uri("https://s3.amazonaws.com/");

--- a/sdk/src/Core/Amazon.Runtime/Internal/DefaultRequest.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/DefaultRequest.cs
@@ -55,7 +55,6 @@ namespace Amazon.Runtime.Internal
         string canonicalResource;
         RegionEndpoint alternateRegion;
         long originalStreamLength;
-        int marshallerVersion = 2; //2 is the default version and must be used whenever a version is not specified in the marshaller.
 
         /// <summary>
         /// Constructs a new DefaultRequest with the specified service name and the
@@ -254,26 +253,6 @@ namespace Amazon.Runtime.Internal
         public void AddPathResource(string key, string value)
         {
             PathResources.Add(key, value);
-        }
-
-        /// <summary>
-        /// Gets and Sets the version number for the marshaller used to create this request. The version number
-        /// is used to support backward compatible changes that would otherwise be breaking changes when a 
-        /// newer core is used with an older service assembly.
-        /// Versions:
-        ///     1 - Legacy version (no longer supported)
-        ///     2 - Default version. Support for path segments
-        /// </summary>
-        public int MarshallerVersion
-        {
-            get
-            {
-                return this.marshallerVersion;
-            }
-            set
-            {
-                this.marshallerVersion = value;
-            }
         }
 
         public string CanonicalResource

--- a/sdk/src/Core/Amazon.Runtime/Internal/IRequest.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/IRequest.cs
@@ -145,17 +145,6 @@ namespace Amazon.Runtime.Internal
         void AddPathResource(string key, string value);
 
         /// <summary>
-        /// Gets and Sets the version number for the marshaller used to create this request. The version number
-        /// is used to support backward compatible changes that would otherwise be breaking changes when a 
-        /// newer core is used with an older service assembly.
-        /// </summary>
-        int MarshallerVersion
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
         /// Gets and Sets the content for this request.
         /// </summary>
         byte[] Content

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -88,8 +88,6 @@ namespace Amazon.Util
         internal const string S3Accelerate = "s3-accelerate";
         internal const string S3Control = "s3-control";
 
-        private const int DefaultMarshallerVersion = 2;
-
         private static readonly string _userAgent = InternalSDKUtils.BuildUserAgentString(string.Empty, string.Empty);
 
 #endregion
@@ -322,107 +320,6 @@ namespace Amazon.Util
                 return string.Empty;
 
             return result.Remove(result.Length - 1);
-        }
-
-        /// <summary>
-        /// Returns the canonicalized resource path for the service endpoint with single URL encoded path segments.
-        /// </summary>
-        /// <param name="endpoint">Endpoint URL for the request</param>
-        /// <param name="resourcePath">Resource path for the request</param>
-        /// <remarks>
-        /// If resourcePath begins or ends with slash, the resulting canonicalized
-        /// path will follow suit.
-        /// </remarks>
-        /// <returns>Canonicalized resource path for the endpoint</returns>
-        [Obsolete("Use CanonicalizeResourcePathV2 instead")]
-        public static string CanonicalizeResourcePath(Uri endpoint, string resourcePath)
-        {
-            // This overload is kept for backward compatibility in existing code bases.
-            return CanonicalizeResourcePath(endpoint, resourcePath, false, null, DefaultMarshallerVersion);
-        }
-
-        /// <summary>
-        /// Returns the canonicalized resource path for the service endpoint
-        /// </summary>
-        /// <param name="endpoint">Endpoint URL for the request</param>
-        /// <param name="resourcePath">Resource path for the request</param>
-        /// <param name="detectPreEncode">If true pre URL encode path segments if necessary.
-        /// S3 is currently the only service that does not expect pre URL encoded segments.</param>
-        /// <remarks>
-        /// If resourcePath begins or ends with slash, the resulting canonicalized
-        /// path will follow suit.
-        /// </remarks>
-        /// <returns>Canonicalized resource path for the endpoint</returns>
-        [Obsolete("Use CanonicalizeResourcePathV2 instead")]
-        public static string CanonicalizeResourcePath(Uri endpoint, string resourcePath, bool detectPreEncode)
-        {
-            // This overload is kept for backward compatibility in existing code bases.
-            return CanonicalizeResourcePath(endpoint, resourcePath, detectPreEncode, null, DefaultMarshallerVersion);
-        }
-
-        /// <summary>
-        /// Returns the canonicalized resource path for the service endpoint
-        /// </summary>
-        /// <param name="endpoint">Endpoint URL for the request</param>
-        /// <param name="resourcePath">Resource path for the request</param>
-        /// <param name="detectPreEncode">If true pre URL encode path segments if necessary.
-        /// S3 is currently the only service that does not expect pre URL encoded segments.</param>
-        /// <param name="pathResources">Dictionary of key/value parameters containing the values for the ResourcePath key replacements</param>
-        /// <param name="marshallerVersion">The version of the marshaller that constructed the request object.</param>
-        /// <remarks>
-        /// If resourcePath begins or ends with slash, the resulting canonicalized
-        /// path will follow suit.
-        /// </remarks>
-        /// <returns>Canonicalized resource path for the endpoint</returns>
-        [Obsolete("Use CanonicalizeResourcePathV2 instead")]
-        public static string CanonicalizeResourcePath(Uri endpoint, string resourcePath, bool detectPreEncode, IDictionary<string, string> pathResources, int marshallerVersion)
-        {
-            if (endpoint != null)
-            {
-                var path = endpoint.AbsolutePath;
-                if (string.IsNullOrEmpty(path) || string.Equals(path, Slash, StringComparison.Ordinal))
-                    path = string.Empty;
-
-                if (!string.IsNullOrEmpty(resourcePath) && resourcePath.StartsWith(Slash, StringComparison.Ordinal))
-                    resourcePath = resourcePath.Substring(1);
-
-                if (!string.IsNullOrEmpty(resourcePath))
-                    path = path + Slash + resourcePath;
-
-                resourcePath = path;
-            }
-
-            if (string.IsNullOrEmpty(resourcePath))
-                return Slash;
-
-            IEnumerable<string> encodedSegments = AWSSDKUtils.SplitResourcePathIntoSegments(resourcePath, pathResources);
-            
-            var pathWasPreEncoded = false;
-            if (detectPreEncode)
-            {
-                if (endpoint == null)
-                    throw new ArgumentNullException(nameof(endpoint), "A non-null endpoint is necessary to decide whether or not to pre URL encode.");
-
-                // S3 is a special case.  For S3 skip the pre encode.
-                // For everything else URL pre encode the resource path segments.
-                if (!S3Uri.IsS3Uri(endpoint))
-                {
-                    encodedSegments = encodedSegments.Select(segment => UrlEncode(segment, true).Replace(Slash, EncodedSlash));
-                    
-                    pathWasPreEncoded = true;
-                }
-            }
-#pragma warning disable 0618
-            var canonicalizedResourcePath = AWSSDKUtils.JoinResourcePathSegments(encodedSegments, false);
-#pragma warning restore 0618
-            // Get the logger each time (it's cached) because we shouldn't store it in a static variable.
-            Logger.GetLogger(typeof(AWSSDKUtils)).DebugFormat("{0} encoded {1}{2} for canonicalization: {3}",
-                pathWasPreEncoded ? "Double" : "Single",
-                resourcePath,
-                endpoint == null ? "" : " with endpoint " + endpoint.AbsoluteUri,
-                canonicalizedResourcePath);
-
-            return canonicalizedResourcePath;
         }
 
         /// <summary>

--- a/sdk/test/IntegrationTests/Tests/General.cs
+++ b/sdk/test/IntegrationTests/Tests/General.cs
@@ -566,36 +566,6 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
 
         [TestMethod]
         [TestCategory("General")]
-        public void TestBidiCharsInUri()
-        {
-            var bidiChar = '\u200E';
-            using(var client = TestBase<AmazonS3Client>.CreateClient())
-            {
-                var part1 = "test";
-                var part2 = "key";
-                var bidiKey = part1 + bidiChar + part2;
-                
-                // verify character is in the string
-                Assert.IsTrue(bidiKey.IndexOf(bidiChar) > 0);
-                Assert.IsTrue(AWSSDKUtils.HasBidiControlCharacters(bidiKey));
-
-                // verify character is dropped by the Uri class
-                Uri uri = new Uri(new Uri("http://www.amazon.com/"), bidiKey);
-                Assert.IsTrue(uri.AbsoluteUri.IndexOf(bidiChar) < 0);
-                Assert.IsFalse(AWSSDKUtils.HasBidiControlCharacters(uri.AbsoluteUri));
-                Assert.IsTrue(uri.AbsoluteUri.IndexOf(part1 + part2) > 0);
-
-                // verify that trying to use key throws the appropriate exception
-                var e = AssertExtensions.ExpectException<AmazonClientException>(() => client.GetObject("fake-bucket", bidiKey));
-                Assert.IsNotNull(e);
-                Assert.IsTrue(e.Message.Contains("[" + bidiKey + "]"));
-                Assert.IsTrue(e.Message.Contains("cannot be handled by the .NET SDK"));
-                Assert.IsTrue(AWSSDKUtils.HasBidiControlCharacters(e.Message));
-            }
-        }
-
-        [TestMethod]
-        [TestCategory("General")]
         public void TestClientDispose()
         {
             IAmazonS3 client;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change adds support for bidi characters in request resource paths in more targets supported by the AWS SDK for .NET. This means applications that target .NET Framework 4.7.2+ and .NET Core 3.1+ will support bidi characters in requests. For the netstandard2.0 target bidi characters may be supported depending on your platform. 

No longer will netstandard2.0 return the following error:

```
Target resource path [???] has bidirectional characters, which are not supported by System.Uri and thus cannot be handled by the .NET SDK.
```

Instead if your platform using netstandard2.0 dlls doesn't correctly support bidi characters in the Uri class the following error will be returned:

```
The request signature we calculated does not match the signature you provided.
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

Expands support for bidi characters opening up usage for more targets.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Added integration test verifying behavior using S3.
* Ran E2E tests on v4-development branch with this update.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement