### PR TITLE
Update endpoint discovery resolver to handle explicit service URLs

### DIFF
--- a/generator/.DevConfigs/743f1d45-47eb-46a0-ae49-e745cc001bb9.json
+++ b/generator/.DevConfigs/743f1d45-47eb-46a0-ae49-e745cc001bb9.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "updateMinimum": true,
+        "type": "Patch",
+        "changeLogMessages": [
+            "Update the SDK not to perform dynamic endpoint discovery when a service URL is explicitly configured"
+        ]
+    }
+}

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/TimestreamQuery.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/TimestreamQuery.cs
@@ -1,0 +1,42 @@
+﻿using Amazon.TimestreamQuery;
+using Amazon.TimestreamQuery.Model;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.DNXCore.IntegrationTests
+{
+    public class TimestreamQuery : TestBase<AmazonTimestreamQueryClient>
+    {
+        [Fact]
+        [Trait(CategoryAttribute, "TimestreamQuery")]
+        public async Task SkipsEndpointDiscoveryWithServiceUrl()
+        {
+            // Timestream is built using a cellular architecture, and the actual service URL is determined using
+            // endpoint discovery (see https://docs.aws.amazon.com/timestream/latest/developerguide/Using.API.html for details).
+
+            // This test validates that when a custom service URL is specified (which is the case when using
+            // VPC endpoints for example), the SDK will not attempt to retrieve endpoints dynamically.
+
+            // This is necessary because the "DescribeEndpoints" API (the first step in endpoint discovery) is
+            // only available via the regional endpoints, and it fails when being accessed through a VPC endpoint (preventing
+            // customers from using the service altogether).
+            var describeResponse = await Client.DescribeEndpointsAsync(new DescribeEndpointsRequest());
+            Assert.Equal(HttpStatusCode.OK, describeResponse.HttpStatusCode);
+            Assert.NotEmpty(describeResponse.Endpoints);
+
+            var customEndpoint = describeResponse.Endpoints.First();
+            var config = new AmazonTimestreamQueryConfig
+            {
+                ServiceURL = $"https://{customEndpoint.Address}"
+            };
+
+            using (var customClient = new AmazonTimestreamQueryClient(config))
+            {
+                var listResponse = await customClient.ListScheduledQueriesAsync(new ListScheduledQueriesRequest());
+                Assert.Equal(HttpStatusCode.OK, listResponse.HttpStatusCode);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3349 

## Motivation and Context
Timestream is one of two services (along with DynamoDB - see notes below) where the SDK attempts to perform [dynamic endpoint discovery](https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoint-discovery.html) (important: this is **not** related to the endpoint resolution change introduced in version `3.7.100`). A longer explanation is available in the [developer guide](https://docs.aws.amazon.com/timestream/latest/developerguide/Using-API.endpoint-discovery.describe-endpoints.implementation.html), but in summary endpoint discovery works like this:
1. If the requested operation requires endpoint discovery, the SDK calls the `DescribeEndpoints` API to fetch which endpoints customers should use (Timestream uses a cellular architecture so each customer is mapped to a specific cell)
2. The SDK caches the returned endpoint and uses it for future invocations (refreshing it in the background)

One unusual thing about Timestream is that the `DescribeEndpoints` API can _only_ be invoked via the regional endpoints (from [usage notes](https://docs.aws.amazon.com/timestream/latest/developerguide/Using-API.endpoint-discovery.describe-endpoints.implementation.html#Using-API.endpoint-discovery.describe-endpoints.usage-notes)). If customers create a VPC endpoint for Timestream and try to use its URL in the service client the operation fails (as the SDK attempts to perform endpoint discovery against an endpoint that doesn't support it).

```csharp
var client = new AmazonTimestreamQueryClient(new AmazonTimestreamQueryConfig
{
    ServiceURL = "https://query-cell1.timestream.us-west-2.amazonaws.com"
});

// This will fail since the SDK attempts to call "DescribeEndpoints" behind the scenes.
await client.QueryAsync(...);
```

This PR updates the `EndpointDiscoveryResolver` not to attempt endpoint discovery if there's a service URL set in the current client config.

## Testing
- Dry-run: `de91537f-92a8-4cc2-ba8a-2a93653ff0dd`
- Ran the console app mentioned in the original issue in a private EC2 instance (i.e. no internet access)

> The outputs below are from the application setting the `ServiceURL` property; behaviour will not change when using `RegionEndpoint` instead.

Before:
```
Amazon Error: 4 : 
  AmazonClientException making request QueryRequest to https://query-cell1.timestream.us-west-2.amazonaws.com/. 
  Attempt 1., Amazon.Runtime.AmazonClientException: Failed to discover the endpoint for the request. 
  Requests will not succeed until an endpoint can be retrieved or an endpoint is manually specified.

Error querying Timestream: Failed to discover the endpoint for the request. 
Requests will not succeed until an endpoint can be retrieved or an endpoint is manually specified.
```

After (connection succeeded without attempting to call `DescribeEndpoints`):
```
Amazon Verbose: 0 : Received response (truncated to 1024 bytes): 
[
    {
        "ColumnInfo": [...],
        "QueryId": "",
        "QueryStatus": {},
        "Rows": [...]
    }
]
```

## Notes
- There's an [environment variable / option](https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoint-discovery.html) to turn off endpoint discovery, but the resolver initially checks whether the operation requires it (which is the case for Timestream): https://github.com/aws/aws-sdk-net/blob/0d195b22ae3fe1248c4d768a0935f0407f112a4e/sdk/src/Core/Amazon.Runtime/Internal/EndpointDiscoveryResolver.cs#L94-L100 
- DynamoDB is the other service with endpoint discovery, but unlike Timestream it's marked as optional: https://github.com/aws/aws-sdk-net/blob/0d195b22ae3fe1248c4d768a0935f0407f112a4e/generator/ServiceModels/dynamodb/dynamodb-2012-08-10.api.json#L489-L490

I couldn't find reports of the same issue happening with DynamoDB, my assumption is that endpoint discovery just isn't a common setup. DynamoDB also supports [gateway endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/gateway-endpoints.html), which in addition to being free of charge don't require setting a custom service URL (traffic is routed using prefix lists instead).

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license