### PR TITLE
Add equals override for ActionIdentifier

### DIFF
--- a/sdk/src/Core/Amazon.Auth/AccessControlPolicy/ActionIdentifier.cs
+++ b/sdk/src/Core/Amazon.Auth/AccessControlPolicy/ActionIdentifier.cs
@@ -77,6 +77,35 @@ namespace Amazon.Auth.AccessControlPolicy
         {
             return new ActionIdentifier(value);
         }
+
+        public override bool Equals(object obj)
+        {
+            string targetActionName;
+            if (obj is ActionIdentifier)
+            {
+                targetActionName = ((ActionIdentifier)obj).ActionName;
+            }
+            else if(obj is string)
+            {
+                targetActionName = obj as string;
+            }
+            else
+            {
+                return false;
+            }
+
+            return string.Equals(ActionName, targetActionName);
+        }
+
+        public override int GetHashCode()
+        {
+            return ActionName.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return ActionName;
+        }
     }
 }
 


### PR DESCRIPTION
In a recent [PR](https://github.com/aws/aws-sdk-net/pull/3357) we added string implicit conversions to ActionIdentifiers. The test for confirming the removal of action identifiers was written with the assumption of there being a same instance. Now that we are using implicit conversions new instances will be created. The PR adds equals overrides to allow comparison beyond instance comparison.