### PR TITLE
Optimize logger

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
@@ -46,8 +46,7 @@ namespace Amazon.Runtime.Internal.Util
             {
                 loggers = new List<InternalLogger>(3);
 #pragma warning disable
-                InternalLog4netLogger log4netLogger = new InternalLog4netLogger(type);
-                loggers.Add(log4netLogger);
+                loggers.Add(new InternalLog4netLogger(type));
 #pragma warning restore
             }
             else
@@ -56,8 +55,7 @@ namespace Amazon.Runtime.Internal.Util
             }
 
             loggers.Add(new InternalConsoleLogger(type));
-            InternalSystemDiagnosticsLogger sdLogger = new InternalSystemDiagnosticsLogger(type);
-            loggers.Add(sdLogger);
+            loggers.Add(new InternalSystemDiagnosticsLogger(type));
             ConfigureLoggers();
             AWSConfigs.PropertyChanged += ConfigsChanged;
         }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using Amazon.Util.Internal;
 
@@ -119,7 +120,7 @@ namespace Amazon.Runtime.Internal.Util
             } while (Interlocked.CompareExchange(ref cachedLoggers, newLoggerCache, oldLoggerCache) != oldLoggerCache);
 
             // Unregister all the loggers in the old cache
-            foreach (var item in oldLoggerCache)
+            foreach (var item in oldLoggerCache ?? Enumerable.Empty<KeyValuePair<Type, Lazy<Logger>>>())
             {
                 var lazyLogger = item.Value;
                 if (lazyLogger.IsValueCreated)

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
@@ -42,14 +42,17 @@ namespace Amazon.Runtime.Internal.Util
 #endif
         private Logger(Type type)
         {
-            loggers = new List<InternalLogger>(3);
-
             if(!InternalSDKUtils.IsRunningNativeAot())
             {
+                loggers = new List<InternalLogger>(3);
 #pragma warning disable
                 InternalLog4netLogger log4netLogger = new InternalLog4netLogger(type);
                 loggers.Add(log4netLogger);
 #pragma warning restore
+            }
+            else
+            {
+                loggers = new List<InternalLogger>(2);
             }
 
             loggers.Add(new InternalConsoleLogger(type));

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
@@ -15,14 +15,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Diagnostics;
-using System.Globalization;
-using System.Reflection;
-using System.Text;
 using System.ComponentModel;
 using System.Threading;
-using Amazon.Runtime;
 using Amazon.Util.Internal;
 
 namespace Amazon.Runtime.Internal.Util

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
@@ -80,6 +80,23 @@ namespace Amazon.Runtime.Internal.Util
                     il.IsEnabled = (logging & LoggingOptions.Console) == LoggingOptions.Console;
                 if (il is InternalSystemDiagnosticsLogger)
                     il.IsEnabled = (logging & LoggingOptions.SystemDiagnostics) == LoggingOptions.SystemDiagnostics;
+
+                if (!IsEnabled)
+                {
+                    IsEnabled = il.IsEnabled;
+                }
+                if (!IsErrorEnabled)
+                {
+                    IsErrorEnabled = il.IsErrorEnabled;
+                }
+                if (!IsInfoEnabled)
+                {
+                    IsInfoEnabled = il.IsInfoEnabled;
+                }
+                if (!IsDebugEnabled)
+                {
+                    IsDebugEnabled = il.IsDebugEnabled;
+                }
             }
         }
 
@@ -112,6 +129,14 @@ namespace Amazon.Runtime.Internal.Util
         public static Logger EmptyLogger { get { return emptyLogger; } }
 
         #endregion
+
+        internal bool IsEnabled { get; private set; }
+
+        internal virtual bool IsErrorEnabled { get; private set; }
+
+        internal virtual bool IsDebugEnabled { get; private set; }
+
+        internal virtual bool IsInfoEnabled { get; private set; }
 
         #region Logging methods
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
@@ -30,7 +30,6 @@ namespace Amazon.Runtime.Internal.Util
     {
         private static ConcurrentDictionary<Type, Lazy<Logger>> cachedLoggers = new ConcurrentDictionary<Type, Lazy<Logger>>();
         private List<InternalLogger> loggers;
-        private static Logger emptyLogger = new Logger();
 
         private Logger()
         {
@@ -130,7 +129,7 @@ namespace Amazon.Runtime.Internal.Util
             }
         }
 
-        public static Logger EmptyLogger { get { return emptyLogger; } }
+        public static Logger EmptyLogger { get; } = new Logger();
 
         #endregion
 

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -385,11 +385,15 @@ namespace Amazon.Util
             string canonicalizedResourcePath = JoinResourcePathSegmentsV2(encodedSegments);
 
             // Get the logger each time (it's cached) because we shouldn't store it in a static variable.
-            Logger.GetLogger(typeof(AWSSDKUtils)).DebugFormat("{0} encoded {1}{2} for canonicalization: {3}",
-                pathWasPreEncoded ? "Double" : "Single",
-                resourcePath,
-                endpoint == null ? "" : " with endpoint " + endpoint.AbsoluteUri,
-                canonicalizedResourcePath);
+            var logger = Logger.GetLogger(typeof(AWSSDKUtils));
+            if (logger.IsDebugEnabled)
+            {
+                logger.DebugFormat("{0} encoded {1}{2} for canonicalization: {3}",
+                    pathWasPreEncoded ? "Double" : "Single",
+                    resourcePath,
+                    endpoint == null ? "" : $" with endpoint {endpoint.AbsoluteUri}",
+                    canonicalizedResourcePath);
+            }
 
             return canonicalizedResourcePath;
         }


### PR DESCRIPTION
## Description

This PR removes the global lock on the logger and introduces currently internal properties to check on the hot path whether the logger is enabled to avoid resource intensive operations for log levels that are not enabled.

## Motivation and Context

When requests are canonicalized (is that even a word :D) the resource path runs for the canonicalization process which then acquires a logger. This acquires a global lock to then access a dictionary that quite likely already contains the logger. Furthermore it always allocates strings for debug logging that might not be required when that log level is not even requested.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement