### PR TITLE
Add generate redirect bindings property for .NET Framework test projects

### DIFF
--- a/generator/ServiceClientGeneratorLib/Generators/ProjectFiles/VS2017ProjectFile.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/ProjectFiles/VS2017ProjectFile.cs
@@ -246,6 +246,18 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line 102 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
+    if (this.Project.AssemblyName.Contains("UnitTests") && this.Project.TargetFrameworks.Contains("net472"))
+    {
+
+            
+            #line default
+            #line hidden
+            this.Write("  <PropertyGroup>\r\n    <GenerateBindingRedirectsOutputType>true</GenerateBindingR" +
+                    "edirectsOutputType>\r\n  </PropertyGroup>\r\n");
+            
+            #line 110 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+
+    }
 
             
             #line default
@@ -262,7 +274,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
   </PropertyGroup>
 ");
             
-            #line 115 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 123 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
 
 
@@ -270,7 +282,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line default
             #line hidden
             
-            #line 118 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 126 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
 	if (!this.Project.AssemblyName.Contains("UnitTests"))
 	{
@@ -281,7 +293,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("  <PropertyGroup Condition=\" \'$(RuleSetFileForBuild)\' == \'false\' Or \'$(RuleSetFil" +
                     "eForBuild)\' == \'\' \">\r\n\t<CodeAnalysisRuleSet>");
             
-            #line 123 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 131 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.FxcopAnalyzerRuleSetFilePath));
             
             #line default
@@ -289,14 +301,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("</CodeAnalysisRuleSet>\r\n  </PropertyGroup>\r\n  <PropertyGroup Condition=\" \'$(RuleS" +
                     "etFileForBuild)\' == \'true\' \">\r\n\t<CodeAnalysisRuleSet>");
             
-            #line 126 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 134 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.FxcopAnalyzerRuleSetFilePathForBuild));
             
             #line default
             #line hidden
             this.Write("</CodeAnalysisRuleSet>\r\n  </PropertyGroup>\r\n\r\n");
             
-            #line 129 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 137 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
 	}
     if (this.Project.SignBinaries)
@@ -308,7 +320,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("  <Choose>\r\n    <When Condition=\" \'$(AWSKeyFile)\' == \'\' \">\r\n      <PropertyGroup>" +
                     "\r\n");
             
-            #line 137 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 145 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if (this.Project.AssemblyName == "AWSSDK.UnitTests.NetFramework")
     {
@@ -319,7 +331,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("        <AssemblyOriginatorKeyFile>../../awssdk.dll.snk</AssemblyOriginatorKeyFil" +
                     "e>\r\n");
             
-            #line 142 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 150 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -327,7 +339,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line default
             #line hidden
             
-            #line 145 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 153 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     else
     {
@@ -338,7 +350,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             this.Write("        <AssemblyOriginatorKeyFile>../../../awssdk.dll.snk</AssemblyOriginatorKey" +
                     "File>\r\n");
             
-            #line 150 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 158 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -349,7 +361,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
                     "    <AssemblyOriginatorKeyFile>$(AWSKeyFile)</AssemblyOriginatorKeyFile>\r\n      " +
                     "</PropertyGroup>\r\n    </Otherwise>\r\n  </Choose>\r\n\r\n");
             
-            #line 162 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 170 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if(this.Project.CustomRoslynAnalyzersDllDirectory != null)
@@ -360,14 +372,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup Condition=\"$(RunAnalyzersDuringBuild)\">\r\n    <Analyzer Include= \"");
             
-            #line 168 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 176 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Project.CustomRoslynAnalyzersDllDirectory));
             
             #line default
             #line hidden
             this.Write("\" />\r\n  </ItemGroup>\r\n");
             
-            #line 170 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 178 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if(this.Project.IndividualFileIncludes != null)
@@ -378,7 +390,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 176 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 184 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     foreach (var compileIncludeEntry in this.Project.IndividualFileIncludes)
     {
@@ -388,14 +400,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Compile Include=\"");
             
-            #line 180 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 188 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(compileIncludeEntry));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 181 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 189 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -404,7 +416,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n");
             
-            #line 185 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 193 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -416,7 +428,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 192 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 200 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     foreach (var compileRemoveEntry in this.Project.CompileRemoveList)
     {
@@ -428,21 +440,21 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Compile Remove=\"**/");
             
-            #line 198 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 206 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(compileRemoveEntry));
             
             #line default
             #line hidden
             this.Write("/**\"/>\r\n\t<None Remove=\"**/");
             
-            #line 199 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 207 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(compileRemoveEntry));
             
             #line default
             #line hidden
             this.Write("/**\" />\r\n");
             
-            #line 200 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 208 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     continue;
         }
@@ -452,14 +464,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Compile Remove=\"**/");
             
-            #line 204 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 212 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(compileRemoveEntry));
             
             #line default
             #line hidden
             this.Write("/**\"/>\r\n");
             
-            #line 205 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 213 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -468,7 +480,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n\r\n");
             
-            #line 210 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 218 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -476,7 +488,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line default
             #line hidden
             
-            #line 213 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 221 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if (this.Project.ProjectReferences != null)
     {
@@ -486,7 +498,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 218 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 226 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     foreach (var projectReference in this.Project.ProjectReferences)
     {
@@ -496,14 +508,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <ProjectReference Include=\"");
             
-            #line 222 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 230 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(projectReference.IncludePath));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 223 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 231 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -512,7 +524,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n\r\n");
             
-            #line 228 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 236 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -520,7 +532,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line default
             #line hidden
             
-            #line 231 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 239 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     if (this.Project.PackageReferences != null)
     {
@@ -530,7 +542,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup Condition=\"$(RunAnalyzersDuringBuild)\">\r\n");
             
-            #line 236 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 244 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         foreach(var package in this.Project.PackageReferences.Where(p => p.IsAnalyzer))
         {
@@ -542,28 +554,28 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("        <PackageReference Include=\"");
             
-            #line 242 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 250 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Include));
             
             #line default
             #line hidden
             this.Write("\" Version=\"");
             
-            #line 242 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 250 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Version));
             
             #line default
             #line hidden
             this.Write("\">\r\n            <PrivateAssets>");
             
-            #line 243 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 251 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.PrivateAssets));
             
             #line default
             #line hidden
             this.Write("</PrivateAssets>\r\n        </PackageReference>\r\n");
             
-            #line 245 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 253 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
             }
             else
@@ -574,21 +586,21 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("\t    <PackageReference Include=\"");
             
-            #line 250 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 258 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Include));
             
             #line default
             #line hidden
             this.Write("\" Version=\"");
             
-            #line 250 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 258 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Version));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 251 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 259 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
 		    }
         }
@@ -598,7 +610,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n  <ItemGroup>\r\n");
             
-            #line 257 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 265 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         foreach(var package in this.Project.PackageReferences.Where(p => !p.IsAnalyzer))
         {
@@ -610,28 +622,28 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("        <PackageReference Include=\"");
             
-            #line 263 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 271 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Include));
             
             #line default
             #line hidden
             this.Write("\" Version=\"");
             
-            #line 263 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 271 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Version));
             
             #line default
             #line hidden
             this.Write("\">\r\n            <PrivateAssets>");
             
-            #line 264 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 272 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.PrivateAssets));
             
             #line default
             #line hidden
             this.Write("</PrivateAssets>\r\n        </PackageReference>\r\n");
             
-            #line 266 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 274 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
             }
             else
@@ -642,21 +654,21 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("\t    <PackageReference Include=\"");
             
-            #line 271 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 279 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Include));
             
             #line default
             #line hidden
             this.Write("\" Version=\"");
             
-            #line 271 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 279 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(package.Version));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 272 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 280 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
 		    }
         }
@@ -666,7 +678,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n\r\n");
             
-            #line 278 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 286 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if (this.Project.ReferenceDependencies != null)
@@ -677,7 +689,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 284 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 292 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         foreach (var reference in this.Project.ReferenceDependencies)
         {
@@ -689,14 +701,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Reference Include=\"");
             
-            #line 290 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 298 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(reference.Name));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 291 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 299 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
             }
             else
@@ -707,21 +719,21 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Reference Include=\"");
             
-            #line 296 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 304 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(reference.Name));
             
             #line default
             #line hidden
             this.Write("\">\r\n        <HintPath>");
             
-            #line 297 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 305 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(reference.HintPath));
             
             #line default
             #line hidden
             this.Write("</HintPath>\r\n    </Reference>\r\n");
             
-            #line 299 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 307 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
             }
         }
@@ -731,7 +743,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n\r\n");
             
-            #line 305 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 313 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
     if (this.Project.EmbeddedResources != null)
@@ -742,7 +754,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 311 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 319 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     foreach (var resource in this.Project.EmbeddedResources)
     {
@@ -752,14 +764,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <EmbeddedResource Include=\"");
             
-            #line 315 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 323 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resource));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 316 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 324 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -768,7 +780,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n");
             
-            #line 320 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 328 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -780,7 +792,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  <ItemGroup>\r\n");
             
-            #line 327 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 335 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         foreach (var service in this.Project.Services)
         {
@@ -790,14 +802,14 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("    <Service Include=\"");
             
-            #line 331 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 339 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(service));
             
             #line default
             #line hidden
             this.Write("\"/>\r\n");
             
-            #line 332 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 340 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
         }
 
@@ -806,7 +818,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             #line hidden
             this.Write("  </ItemGroup>\r\n");
             
-            #line 336 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+            #line 344 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     }
 
@@ -817,7 +829,7 @@ namespace ServiceClientGenerator.Generators.ProjectFiles
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 342 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
+        #line 350 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\ProjectFiles\VS2017ProjectFile.tt"
 
     public Project Project { get; set; }
     public ServiceConfiguration ServiceConfiguration { get; set; }

--- a/generator/ServiceClientGeneratorLib/Generators/ProjectFiles/VS2017ProjectFile.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/ProjectFiles/VS2017ProjectFile.tt
@@ -101,6 +101,14 @@
   </PropertyGroup>
 <#
     }
+    if (this.Project.AssemblyName.Contains("UnitTests") && this.Project.TargetFrameworks.Contains("net472"))
+    {
+#>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+<#
+    }
 #>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow

--- a/sdk/test/CSMTest/Tests/IntegrationTests/AWSSDK.CSM.IntegrationTests.NetFramework.csproj
+++ b/sdk/test/CSMTest/Tests/IntegrationTests/AWSSDK.CSM.IntegrationTests.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/IntegrationTests/AWSSDK.IntegrationTestUtilities.NetFramework.csproj
+++ b/sdk/test/IntegrationTests/AWSSDK.IntegrationTestUtilities.NetFramework.csproj
@@ -16,7 +16,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
 	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>	
   </PropertyGroup>

--- a/sdk/test/IntegrationTests/AWSSDK.IntegrationTests.NetFramework.csproj
+++ b/sdk/test/IntegrationTests/AWSSDK.IntegrationTests.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
 	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>	
   </PropertyGroup>

--- a/sdk/test/Services/ACMPCA/UnitTests/AWSSDK.UnitTests.ACMPCA.NetFramework.csproj
+++ b/sdk/test/Services/ACMPCA/UnitTests/AWSSDK.UnitTests.ACMPCA.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/APIGateway/IntegrationTests/AWSSDK.IntegrationTests.APIGateway.NetFramework.csproj
+++ b/sdk/test/Services/APIGateway/IntegrationTests/AWSSDK.IntegrationTests.APIGateway.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/APIGateway/UnitTests/AWSSDK.UnitTests.APIGateway.NetFramework.csproj
+++ b/sdk/test/Services/APIGateway/UnitTests/AWSSDK.UnitTests.APIGateway.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ARCZonalShift/UnitTests/AWSSDK.UnitTests.ARCZonalShift.NetFramework.csproj
+++ b/sdk/test/Services/ARCZonalShift/UnitTests/AWSSDK.UnitTests.ARCZonalShift.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AWSHealth/UnitTests/AWSSDK.UnitTests.AWSHealth.NetFramework.csproj
+++ b/sdk/test/Services/AWSHealth/UnitTests/AWSSDK.UnitTests.AWSHealth.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AWSMarketplaceCommerceAnalytics/IntegrationTests/AWSSDK.IntegrationTests.AWSMarketplaceCommerceAnalytics.NetFramework.csproj
+++ b/sdk/test/Services/AWSMarketplaceCommerceAnalytics/IntegrationTests/AWSSDK.IntegrationTests.AWSMarketplaceCommerceAnalytics.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/AWSMarketplaceCommerceAnalytics/UnitTests/AWSSDK.UnitTests.AWSMarketplaceCommerceAnalytics.NetFramework.csproj
+++ b/sdk/test/Services/AWSMarketplaceCommerceAnalytics/UnitTests/AWSSDK.UnitTests.AWSMarketplaceCommerceAnalytics.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AWSMarketplaceMetering/UnitTests/AWSSDK.UnitTests.AWSMarketplaceMetering.NetFramework.csproj
+++ b/sdk/test/Services/AWSMarketplaceMetering/UnitTests/AWSSDK.UnitTests.AWSMarketplaceMetering.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AWSSupport/IntegrationTests/AWSSDK.IntegrationTests.AWSSupport.NetFramework.csproj
+++ b/sdk/test/Services/AWSSupport/IntegrationTests/AWSSDK.IntegrationTests.AWSSupport.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/AWSSupport/UnitTests/AWSSDK.UnitTests.AWSSupport.NetFramework.csproj
+++ b/sdk/test/Services/AWSSupport/UnitTests/AWSSDK.UnitTests.AWSSupport.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AccessAnalyzer/UnitTests/AWSSDK.UnitTests.AccessAnalyzer.NetFramework.csproj
+++ b/sdk/test/Services/AccessAnalyzer/UnitTests/AWSSDK.UnitTests.AccessAnalyzer.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Account/UnitTests/AWSSDK.UnitTests.Account.NetFramework.csproj
+++ b/sdk/test/Services/Account/UnitTests/AWSSDK.UnitTests.Account.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AlexaForBusiness/UnitTests/AWSSDK.UnitTests.AlexaForBusiness.NetFramework.csproj
+++ b/sdk/test/Services/AlexaForBusiness/UnitTests/AWSSDK.UnitTests.AlexaForBusiness.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Amplify/UnitTests/AWSSDK.UnitTests.Amplify.NetFramework.csproj
+++ b/sdk/test/Services/Amplify/UnitTests/AWSSDK.UnitTests.Amplify.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AmplifyBackend/UnitTests/AWSSDK.UnitTests.AmplifyBackend.NetFramework.csproj
+++ b/sdk/test/Services/AmplifyBackend/UnitTests/AWSSDK.UnitTests.AmplifyBackend.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AmplifyUIBuilder/UnitTests/AWSSDK.UnitTests.AmplifyUIBuilder.NetFramework.csproj
+++ b/sdk/test/Services/AmplifyUIBuilder/UnitTests/AWSSDK.UnitTests.AmplifyUIBuilder.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ApiGatewayManagementApi/UnitTests/AWSSDK.UnitTests.ApiGatewayManagementApi.NetFramework.csproj
+++ b/sdk/test/Services/ApiGatewayManagementApi/UnitTests/AWSSDK.UnitTests.ApiGatewayManagementApi.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ApiGatewayV2/UnitTests/AWSSDK.UnitTests.ApiGatewayV2.NetFramework.csproj
+++ b/sdk/test/Services/ApiGatewayV2/UnitTests/AWSSDK.UnitTests.ApiGatewayV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AppConfig/UnitTests/AWSSDK.UnitTests.AppConfig.NetFramework.csproj
+++ b/sdk/test/Services/AppConfig/UnitTests/AWSSDK.UnitTests.AppConfig.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AppConfigData/UnitTests/AWSSDK.UnitTests.AppConfigData.NetFramework.csproj
+++ b/sdk/test/Services/AppConfigData/UnitTests/AWSSDK.UnitTests.AppConfigData.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AppFabric/UnitTests/AWSSDK.UnitTests.AppFabric.NetFramework.csproj
+++ b/sdk/test/Services/AppFabric/UnitTests/AWSSDK.UnitTests.AppFabric.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AppIntegrationsService/UnitTests/AWSSDK.UnitTests.AppIntegrationsService.NetFramework.csproj
+++ b/sdk/test/Services/AppIntegrationsService/UnitTests/AWSSDK.UnitTests.AppIntegrationsService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AppMesh/UnitTests/AWSSDK.UnitTests.AppMesh.NetFramework.csproj
+++ b/sdk/test/Services/AppMesh/UnitTests/AWSSDK.UnitTests.AppMesh.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AppRegistry/UnitTests/AWSSDK.UnitTests.AppRegistry.NetFramework.csproj
+++ b/sdk/test/Services/AppRegistry/UnitTests/AWSSDK.UnitTests.AppRegistry.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AppRunner/UnitTests/AWSSDK.UnitTests.AppRunner.NetFramework.csproj
+++ b/sdk/test/Services/AppRunner/UnitTests/AWSSDK.UnitTests.AppRunner.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AppStream/UnitTests/AWSSDK.UnitTests.AppStream.NetFramework.csproj
+++ b/sdk/test/Services/AppStream/UnitTests/AWSSDK.UnitTests.AppStream.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AppSync/UnitTests/AWSSDK.UnitTests.AppSync.NetFramework.csproj
+++ b/sdk/test/Services/AppSync/UnitTests/AWSSDK.UnitTests.AppSync.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Appflow/UnitTests/AWSSDK.UnitTests.Appflow.NetFramework.csproj
+++ b/sdk/test/Services/Appflow/UnitTests/AWSSDK.UnitTests.Appflow.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ApplicationAutoScaling/UnitTests/AWSSDK.UnitTests.ApplicationAutoScaling.NetFramework.csproj
+++ b/sdk/test/Services/ApplicationAutoScaling/UnitTests/AWSSDK.UnitTests.ApplicationAutoScaling.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ApplicationCostProfiler/UnitTests/AWSSDK.UnitTests.ApplicationCostProfiler.NetFramework.csproj
+++ b/sdk/test/Services/ApplicationCostProfiler/UnitTests/AWSSDK.UnitTests.ApplicationCostProfiler.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ApplicationDiscoveryService/IntegrationTests/AWSSDK.IntegrationTests.ApplicationDiscoveryService.NetFramework.csproj
+++ b/sdk/test/Services/ApplicationDiscoveryService/IntegrationTests/AWSSDK.IntegrationTests.ApplicationDiscoveryService.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ApplicationDiscoveryService/UnitTests/AWSSDK.UnitTests.ApplicationDiscoveryService.NetFramework.csproj
+++ b/sdk/test/Services/ApplicationDiscoveryService/UnitTests/AWSSDK.UnitTests.ApplicationDiscoveryService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ApplicationInsights/UnitTests/AWSSDK.UnitTests.ApplicationInsights.NetFramework.csproj
+++ b/sdk/test/Services/ApplicationInsights/UnitTests/AWSSDK.UnitTests.ApplicationInsights.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Artifact/UnitTests/AWSSDK.UnitTests.Artifact.NetFramework.csproj
+++ b/sdk/test/Services/Artifact/UnitTests/AWSSDK.UnitTests.Artifact.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Athena/UnitTests/AWSSDK.UnitTests.Athena.NetFramework.csproj
+++ b/sdk/test/Services/Athena/UnitTests/AWSSDK.UnitTests.Athena.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AuditManager/UnitTests/AWSSDK.UnitTests.AuditManager.NetFramework.csproj
+++ b/sdk/test/Services/AuditManager/UnitTests/AWSSDK.UnitTests.AuditManager.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AugmentedAIRuntime/UnitTests/AWSSDK.UnitTests.AugmentedAIRuntime.NetFramework.csproj
+++ b/sdk/test/Services/AugmentedAIRuntime/UnitTests/AWSSDK.UnitTests.AugmentedAIRuntime.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AutoScaling/IntegrationTests/AWSSDK.IntegrationTests.AutoScaling.NetFramework.csproj
+++ b/sdk/test/Services/AutoScaling/IntegrationTests/AWSSDK.IntegrationTests.AutoScaling.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/AutoScaling/UnitTests/AWSSDK.UnitTests.AutoScaling.NetFramework.csproj
+++ b/sdk/test/Services/AutoScaling/UnitTests/AWSSDK.UnitTests.AutoScaling.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/AutoScalingPlans/UnitTests/AWSSDK.UnitTests.AutoScalingPlans.NetFramework.csproj
+++ b/sdk/test/Services/AutoScalingPlans/UnitTests/AWSSDK.UnitTests.AutoScalingPlans.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/B2bi/UnitTests/AWSSDK.UnitTests.B2bi.NetFramework.csproj
+++ b/sdk/test/Services/B2bi/UnitTests/AWSSDK.UnitTests.B2bi.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/BCMDataExports/UnitTests/AWSSDK.UnitTests.BCMDataExports.NetFramework.csproj
+++ b/sdk/test/Services/BCMDataExports/UnitTests/AWSSDK.UnitTests.BCMDataExports.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Backup/UnitTests/AWSSDK.UnitTests.Backup.NetFramework.csproj
+++ b/sdk/test/Services/Backup/UnitTests/AWSSDK.UnitTests.Backup.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/BackupGateway/UnitTests/AWSSDK.UnitTests.BackupGateway.NetFramework.csproj
+++ b/sdk/test/Services/BackupGateway/UnitTests/AWSSDK.UnitTests.BackupGateway.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/BackupStorage/UnitTests/AWSSDK.UnitTests.BackupStorage.NetFramework.csproj
+++ b/sdk/test/Services/BackupStorage/UnitTests/AWSSDK.UnitTests.BackupStorage.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Batch/UnitTests/AWSSDK.UnitTests.Batch.NetFramework.csproj
+++ b/sdk/test/Services/Batch/UnitTests/AWSSDK.UnitTests.Batch.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/BearerTokenAuthTest/UnitTests/AWSSDK.UnitTests.BearerTokenAuthTest.NetFramework.csproj
+++ b/sdk/test/Services/BearerTokenAuthTest/UnitTests/AWSSDK.UnitTests.BearerTokenAuthTest.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Bedrock/UnitTests/AWSSDK.UnitTests.Bedrock.NetFramework.csproj
+++ b/sdk/test/Services/Bedrock/UnitTests/AWSSDK.UnitTests.Bedrock.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/BedrockAgent/UnitTests/AWSSDK.UnitTests.BedrockAgent.NetFramework.csproj
+++ b/sdk/test/Services/BedrockAgent/UnitTests/AWSSDK.UnitTests.BedrockAgent.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/BedrockAgentRuntime/UnitTests/AWSSDK.UnitTests.BedrockAgentRuntime.NetFramework.csproj
+++ b/sdk/test/Services/BedrockAgentRuntime/UnitTests/AWSSDK.UnitTests.BedrockAgentRuntime.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/BedrockRuntime/IntegrationTests/AWSSDK.IntegrationTests.BedrockRuntime.NetFramework.csproj
+++ b/sdk/test/Services/BedrockRuntime/IntegrationTests/AWSSDK.IntegrationTests.BedrockRuntime.NetFramework.csproj
@@ -15,7 +15,7 @@
 		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
 		<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
 		<GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+        <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
 		<NoWarn>CS1591</NoWarn>
 	</PropertyGroup>
 

--- a/sdk/test/Services/BedrockRuntime/UnitTests/AWSSDK.UnitTests.BedrockRuntime.NetFramework.csproj
+++ b/sdk/test/Services/BedrockRuntime/UnitTests/AWSSDK.UnitTests.BedrockRuntime.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/BillingConductor/UnitTests/AWSSDK.UnitTests.BillingConductor.NetFramework.csproj
+++ b/sdk/test/Services/BillingConductor/UnitTests/AWSSDK.UnitTests.BillingConductor.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Braket/UnitTests/AWSSDK.UnitTests.Braket.NetFramework.csproj
+++ b/sdk/test/Services/Braket/UnitTests/AWSSDK.UnitTests.Braket.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Budgets/UnitTests/AWSSDK.UnitTests.Budgets.NetFramework.csproj
+++ b/sdk/test/Services/Budgets/UnitTests/AWSSDK.UnitTests.Budgets.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CertificateManager/IntegrationTests/AWSSDK.IntegrationTests.CertificateManager.NetFramework.csproj
+++ b/sdk/test/Services/CertificateManager/IntegrationTests/AWSSDK.IntegrationTests.CertificateManager.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CertificateManager/UnitTests/AWSSDK.UnitTests.CertificateManager.NetFramework.csproj
+++ b/sdk/test/Services/CertificateManager/UnitTests/AWSSDK.UnitTests.CertificateManager.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Chatbot/UnitTests/AWSSDK.UnitTests.Chatbot.NetFramework.csproj
+++ b/sdk/test/Services/Chatbot/UnitTests/AWSSDK.UnitTests.Chatbot.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Chime/UnitTests/AWSSDK.UnitTests.Chime.NetFramework.csproj
+++ b/sdk/test/Services/Chime/UnitTests/AWSSDK.UnitTests.Chime.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ChimeSDKIdentity/UnitTests/AWSSDK.UnitTests.ChimeSDKIdentity.NetFramework.csproj
+++ b/sdk/test/Services/ChimeSDKIdentity/UnitTests/AWSSDK.UnitTests.ChimeSDKIdentity.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ChimeSDKMediaPipelines/UnitTests/AWSSDK.UnitTests.ChimeSDKMediaPipelines.NetFramework.csproj
+++ b/sdk/test/Services/ChimeSDKMediaPipelines/UnitTests/AWSSDK.UnitTests.ChimeSDKMediaPipelines.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ChimeSDKMeetings/UnitTests/AWSSDK.UnitTests.ChimeSDKMeetings.NetFramework.csproj
+++ b/sdk/test/Services/ChimeSDKMeetings/UnitTests/AWSSDK.UnitTests.ChimeSDKMeetings.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ChimeSDKMessaging/UnitTests/AWSSDK.UnitTests.ChimeSDKMessaging.NetFramework.csproj
+++ b/sdk/test/Services/ChimeSDKMessaging/UnitTests/AWSSDK.UnitTests.ChimeSDKMessaging.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ChimeSDKVoice/UnitTests/AWSSDK.UnitTests.ChimeSDKVoice.NetFramework.csproj
+++ b/sdk/test/Services/ChimeSDKVoice/UnitTests/AWSSDK.UnitTests.ChimeSDKVoice.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CleanRooms/UnitTests/AWSSDK.UnitTests.CleanRooms.NetFramework.csproj
+++ b/sdk/test/Services/CleanRooms/UnitTests/AWSSDK.UnitTests.CleanRooms.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CleanRoomsML/UnitTests/AWSSDK.UnitTests.CleanRoomsML.NetFramework.csproj
+++ b/sdk/test/Services/CleanRoomsML/UnitTests/AWSSDK.UnitTests.CleanRoomsML.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Cloud9/UnitTests/AWSSDK.UnitTests.Cloud9.NetFramework.csproj
+++ b/sdk/test/Services/Cloud9/UnitTests/AWSSDK.UnitTests.Cloud9.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudControlApi/UnitTests/AWSSDK.UnitTests.CloudControlApi.NetFramework.csproj
+++ b/sdk/test/Services/CloudControlApi/UnitTests/AWSSDK.UnitTests.CloudControlApi.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudDirectory/IntegrationTests/AWSSDK.IntegrationTests.CloudDirectory.NetFramework.csproj
+++ b/sdk/test/Services/CloudDirectory/IntegrationTests/AWSSDK.IntegrationTests.CloudDirectory.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CloudDirectory/UnitTests/AWSSDK.UnitTests.CloudDirectory.NetFramework.csproj
+++ b/sdk/test/Services/CloudDirectory/UnitTests/AWSSDK.UnitTests.CloudDirectory.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudFormation/IntegrationTests/AWSSDK.IntegrationTests.CloudFormation.NetFramework.csproj
+++ b/sdk/test/Services/CloudFormation/IntegrationTests/AWSSDK.IntegrationTests.CloudFormation.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CloudFormation/UnitTests/AWSSDK.UnitTests.CloudFormation.NetFramework.csproj
+++ b/sdk/test/Services/CloudFormation/UnitTests/AWSSDK.UnitTests.CloudFormation.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudFront/IntegrationTests/AWSSDK.IntegrationTests.CloudFront.NetFramework.csproj
+++ b/sdk/test/Services/CloudFront/IntegrationTests/AWSSDK.IntegrationTests.CloudFront.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CloudFront/UnitTests/AWSSDK.UnitTests.CloudFront.NetFramework.csproj
+++ b/sdk/test/Services/CloudFront/UnitTests/AWSSDK.UnitTests.CloudFront.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudFrontKeyValueStore/UnitTests/AWSSDK.UnitTests.CloudFrontKeyValueStore.NetFramework.csproj
+++ b/sdk/test/Services/CloudFrontKeyValueStore/UnitTests/AWSSDK.UnitTests.CloudFrontKeyValueStore.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudHSM/IntegrationTests/AWSSDK.IntegrationTests.CloudHSM.NetFramework.csproj
+++ b/sdk/test/Services/CloudHSM/IntegrationTests/AWSSDK.IntegrationTests.CloudHSM.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CloudHSM/UnitTests/AWSSDK.UnitTests.CloudHSM.NetFramework.csproj
+++ b/sdk/test/Services/CloudHSM/UnitTests/AWSSDK.UnitTests.CloudHSM.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudHSMV2/UnitTests/AWSSDK.UnitTests.CloudHSMV2.NetFramework.csproj
+++ b/sdk/test/Services/CloudHSMV2/UnitTests/AWSSDK.UnitTests.CloudHSMV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudSearch/IntegrationTests/AWSSDK.IntegrationTests.CloudSearch.NetFramework.csproj
+++ b/sdk/test/Services/CloudSearch/IntegrationTests/AWSSDK.IntegrationTests.CloudSearch.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CloudSearch/UnitTests/AWSSDK.UnitTests.CloudSearch.NetFramework.csproj
+++ b/sdk/test/Services/CloudSearch/UnitTests/AWSSDK.UnitTests.CloudSearch.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudSearchDomain/UnitTests/AWSSDK.UnitTests.CloudSearchDomain.NetFramework.csproj
+++ b/sdk/test/Services/CloudSearchDomain/UnitTests/AWSSDK.UnitTests.CloudSearchDomain.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudTrail/IntegrationTests/AWSSDK.IntegrationTests.CloudTrail.NetFramework.csproj
+++ b/sdk/test/Services/CloudTrail/IntegrationTests/AWSSDK.IntegrationTests.CloudTrail.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CloudTrail/UnitTests/AWSSDK.UnitTests.CloudTrail.NetFramework.csproj
+++ b/sdk/test/Services/CloudTrail/UnitTests/AWSSDK.UnitTests.CloudTrail.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudTrailData/UnitTests/AWSSDK.UnitTests.CloudTrailData.NetFramework.csproj
+++ b/sdk/test/Services/CloudTrailData/UnitTests/AWSSDK.UnitTests.CloudTrailData.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudWatch/IntegrationTests/AWSSDK.IntegrationTests.CloudWatch.NetFramework.csproj
+++ b/sdk/test/Services/CloudWatch/IntegrationTests/AWSSDK.IntegrationTests.CloudWatch.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CloudWatch/UnitTests/AWSSDK.UnitTests.CloudWatch.NetFramework.csproj
+++ b/sdk/test/Services/CloudWatch/UnitTests/AWSSDK.UnitTests.CloudWatch.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudWatchEvents/IntegrationTests/AWSSDK.IntegrationTests.CloudWatchEvents.NetFramework.csproj
+++ b/sdk/test/Services/CloudWatchEvents/IntegrationTests/AWSSDK.IntegrationTests.CloudWatchEvents.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CloudWatchEvents/UnitTests/AWSSDK.UnitTests.CloudWatchEvents.NetFramework.csproj
+++ b/sdk/test/Services/CloudWatchEvents/UnitTests/AWSSDK.UnitTests.CloudWatchEvents.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudWatchEvidently/UnitTests/AWSSDK.UnitTests.CloudWatchEvidently.NetFramework.csproj
+++ b/sdk/test/Services/CloudWatchEvidently/UnitTests/AWSSDK.UnitTests.CloudWatchEvidently.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudWatchLogs/IntegrationTests/AWSSDK.IntegrationTests.CloudWatchLogs.NetFramework.csproj
+++ b/sdk/test/Services/CloudWatchLogs/IntegrationTests/AWSSDK.IntegrationTests.CloudWatchLogs.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CloudWatchLogs/UnitTests/AWSSDK.UnitTests.CloudWatchLogs.NetFramework.csproj
+++ b/sdk/test/Services/CloudWatchLogs/UnitTests/AWSSDK.UnitTests.CloudWatchLogs.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CloudWatchRUM/UnitTests/AWSSDK.UnitTests.CloudWatchRUM.NetFramework.csproj
+++ b/sdk/test/Services/CloudWatchRUM/UnitTests/AWSSDK.UnitTests.CloudWatchRUM.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeArtifact/UnitTests/AWSSDK.UnitTests.CodeArtifact.NetFramework.csproj
+++ b/sdk/test/Services/CodeArtifact/UnitTests/AWSSDK.UnitTests.CodeArtifact.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeBuild/UnitTests/AWSSDK.UnitTests.CodeBuild.NetFramework.csproj
+++ b/sdk/test/Services/CodeBuild/UnitTests/AWSSDK.UnitTests.CodeBuild.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeCatalyst/UnitTests/AWSSDK.UnitTests.CodeCatalyst.NetFramework.csproj
+++ b/sdk/test/Services/CodeCatalyst/UnitTests/AWSSDK.UnitTests.CodeCatalyst.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeCommit/UnitTests/AWSSDK.UnitTests.CodeCommit.NetFramework.csproj
+++ b/sdk/test/Services/CodeCommit/UnitTests/AWSSDK.UnitTests.CodeCommit.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeConnections/UnitTests/AWSSDK.UnitTests.CodeConnections.NetFramework.csproj
+++ b/sdk/test/Services/CodeConnections/UnitTests/AWSSDK.UnitTests.CodeConnections.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeDeploy/IntegrationTests/AWSSDK.IntegrationTests.CodeDeploy.NetFramework.csproj
+++ b/sdk/test/Services/CodeDeploy/IntegrationTests/AWSSDK.IntegrationTests.CodeDeploy.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CodeDeploy/UnitTests/AWSSDK.UnitTests.CodeDeploy.NetFramework.csproj
+++ b/sdk/test/Services/CodeDeploy/UnitTests/AWSSDK.UnitTests.CodeDeploy.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeGuruProfiler/UnitTests/AWSSDK.UnitTests.CodeGuruProfiler.NetFramework.csproj
+++ b/sdk/test/Services/CodeGuruProfiler/UnitTests/AWSSDK.UnitTests.CodeGuruProfiler.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeGuruReviewer/UnitTests/AWSSDK.UnitTests.CodeGuruReviewer.NetFramework.csproj
+++ b/sdk/test/Services/CodeGuruReviewer/UnitTests/AWSSDK.UnitTests.CodeGuruReviewer.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeGuruSecurity/UnitTests/AWSSDK.UnitTests.CodeGuruSecurity.NetFramework.csproj
+++ b/sdk/test/Services/CodeGuruSecurity/UnitTests/AWSSDK.UnitTests.CodeGuruSecurity.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodePipeline/UnitTests/AWSSDK.UnitTests.CodePipeline.NetFramework.csproj
+++ b/sdk/test/Services/CodePipeline/UnitTests/AWSSDK.UnitTests.CodePipeline.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeStar/UnitTests/AWSSDK.UnitTests.CodeStar.NetFramework.csproj
+++ b/sdk/test/Services/CodeStar/UnitTests/AWSSDK.UnitTests.CodeStar.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeStarNotifications/UnitTests/AWSSDK.UnitTests.CodeStarNotifications.NetFramework.csproj
+++ b/sdk/test/Services/CodeStarNotifications/UnitTests/AWSSDK.UnitTests.CodeStarNotifications.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CodeStarconnections/UnitTests/AWSSDK.UnitTests.CodeStarconnections.NetFramework.csproj
+++ b/sdk/test/Services/CodeStarconnections/UnitTests/AWSSDK.UnitTests.CodeStarconnections.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CognitoIdentity/UnitTests/AWSSDK.UnitTests.CognitoIdentity.NetFramework.csproj
+++ b/sdk/test/Services/CognitoIdentity/UnitTests/AWSSDK.UnitTests.CognitoIdentity.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CognitoIdentityProvider/UnitTests/AWSSDK.UnitTests.CognitoIdentityProvider.NetFramework.csproj
+++ b/sdk/test/Services/CognitoIdentityProvider/UnitTests/AWSSDK.UnitTests.CognitoIdentityProvider.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CognitoSync/IntegrationTests/AWSSDK.IntegrationTests.CognitoSync.NetFramework.csproj
+++ b/sdk/test/Services/CognitoSync/IntegrationTests/AWSSDK.IntegrationTests.CognitoSync.NetFramework.csproj
@@ -16,7 +16,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/CognitoSync/UnitTests/AWSSDK.UnitTests.CognitoSync.NetFramework.csproj
+++ b/sdk/test/Services/CognitoSync/UnitTests/AWSSDK.UnitTests.CognitoSync.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Comprehend/UnitTests/AWSSDK.UnitTests.Comprehend.NetFramework.csproj
+++ b/sdk/test/Services/Comprehend/UnitTests/AWSSDK.UnitTests.Comprehend.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ComprehendMedical/UnitTests/AWSSDK.UnitTests.ComprehendMedical.NetFramework.csproj
+++ b/sdk/test/Services/ComprehendMedical/UnitTests/AWSSDK.UnitTests.ComprehendMedical.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ComputeOptimizer/UnitTests/AWSSDK.UnitTests.ComputeOptimizer.NetFramework.csproj
+++ b/sdk/test/Services/ComputeOptimizer/UnitTests/AWSSDK.UnitTests.ComputeOptimizer.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ConfigService/IntegrationTests/AWSSDK.IntegrationTests.ConfigService.NetFramework.csproj
+++ b/sdk/test/Services/ConfigService/IntegrationTests/AWSSDK.IntegrationTests.ConfigService.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ConfigService/UnitTests/AWSSDK.UnitTests.ConfigService.NetFramework.csproj
+++ b/sdk/test/Services/ConfigService/UnitTests/AWSSDK.UnitTests.ConfigService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Connect/UnitTests/AWSSDK.UnitTests.Connect.NetFramework.csproj
+++ b/sdk/test/Services/Connect/UnitTests/AWSSDK.UnitTests.Connect.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ConnectCampaignService/UnitTests/AWSSDK.UnitTests.ConnectCampaignService.NetFramework.csproj
+++ b/sdk/test/Services/ConnectCampaignService/UnitTests/AWSSDK.UnitTests.ConnectCampaignService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ConnectCases/UnitTests/AWSSDK.UnitTests.ConnectCases.NetFramework.csproj
+++ b/sdk/test/Services/ConnectCases/UnitTests/AWSSDK.UnitTests.ConnectCases.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ConnectContactLens/UnitTests/AWSSDK.UnitTests.ConnectContactLens.NetFramework.csproj
+++ b/sdk/test/Services/ConnectContactLens/UnitTests/AWSSDK.UnitTests.ConnectContactLens.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ConnectParticipant/UnitTests/AWSSDK.UnitTests.ConnectParticipant.NetFramework.csproj
+++ b/sdk/test/Services/ConnectParticipant/UnitTests/AWSSDK.UnitTests.ConnectParticipant.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ConnectWisdomService/UnitTests/AWSSDK.UnitTests.ConnectWisdomService.NetFramework.csproj
+++ b/sdk/test/Services/ConnectWisdomService/UnitTests/AWSSDK.UnitTests.ConnectWisdomService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ControlCatalog/UnitTests/AWSSDK.UnitTests.ControlCatalog.NetFramework.csproj
+++ b/sdk/test/Services/ControlCatalog/UnitTests/AWSSDK.UnitTests.ControlCatalog.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ControlTower/UnitTests/AWSSDK.UnitTests.ControlTower.NetFramework.csproj
+++ b/sdk/test/Services/ControlTower/UnitTests/AWSSDK.UnitTests.ControlTower.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CostAndUsageReport/UnitTests/AWSSDK.UnitTests.CostAndUsageReport.NetFramework.csproj
+++ b/sdk/test/Services/CostAndUsageReport/UnitTests/AWSSDK.UnitTests.CostAndUsageReport.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CostExplorer/UnitTests/AWSSDK.UnitTests.CostExplorer.NetFramework.csproj
+++ b/sdk/test/Services/CostExplorer/UnitTests/AWSSDK.UnitTests.CostExplorer.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CostOptimizationHub/UnitTests/AWSSDK.UnitTests.CostOptimizationHub.NetFramework.csproj
+++ b/sdk/test/Services/CostOptimizationHub/UnitTests/AWSSDK.UnitTests.CostOptimizationHub.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/CustomerProfiles/UnitTests/AWSSDK.UnitTests.CustomerProfiles.NetFramework.csproj
+++ b/sdk/test/Services/CustomerProfiles/UnitTests/AWSSDK.UnitTests.CustomerProfiles.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DAX/UnitTests/AWSSDK.UnitTests.DAX.NetFramework.csproj
+++ b/sdk/test/Services/DAX/UnitTests/AWSSDK.UnitTests.DAX.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DLM/UnitTests/AWSSDK.UnitTests.DLM.NetFramework.csproj
+++ b/sdk/test/Services/DLM/UnitTests/AWSSDK.UnitTests.DLM.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DataExchange/UnitTests/AWSSDK.UnitTests.DataExchange.NetFramework.csproj
+++ b/sdk/test/Services/DataExchange/UnitTests/AWSSDK.UnitTests.DataExchange.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DataPipeline/IntegrationTests/AWSSDK.IntegrationTests.DataPipeline.NetFramework.csproj
+++ b/sdk/test/Services/DataPipeline/IntegrationTests/AWSSDK.IntegrationTests.DataPipeline.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/DataPipeline/UnitTests/AWSSDK.UnitTests.DataPipeline.NetFramework.csproj
+++ b/sdk/test/Services/DataPipeline/UnitTests/AWSSDK.UnitTests.DataPipeline.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DataSync/UnitTests/AWSSDK.UnitTests.DataSync.NetFramework.csproj
+++ b/sdk/test/Services/DataSync/UnitTests/AWSSDK.UnitTests.DataSync.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DataZone/UnitTests/AWSSDK.UnitTests.DataZone.NetFramework.csproj
+++ b/sdk/test/Services/DataZone/UnitTests/AWSSDK.UnitTests.DataZone.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DatabaseMigrationService/IntegrationTests/AWSSDK.IntegrationTests.DatabaseMigrationService.NetFramework.csproj
+++ b/sdk/test/Services/DatabaseMigrationService/IntegrationTests/AWSSDK.IntegrationTests.DatabaseMigrationService.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/DatabaseMigrationService/UnitTests/AWSSDK.UnitTests.DatabaseMigrationService.NetFramework.csproj
+++ b/sdk/test/Services/DatabaseMigrationService/UnitTests/AWSSDK.UnitTests.DatabaseMigrationService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Deadline/UnitTests/AWSSDK.UnitTests.Deadline.NetFramework.csproj
+++ b/sdk/test/Services/Deadline/UnitTests/AWSSDK.UnitTests.Deadline.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Detective/UnitTests/AWSSDK.UnitTests.Detective.NetFramework.csproj
+++ b/sdk/test/Services/Detective/UnitTests/AWSSDK.UnitTests.Detective.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DevOpsGuru/UnitTests/AWSSDK.UnitTests.DevOpsGuru.NetFramework.csproj
+++ b/sdk/test/Services/DevOpsGuru/UnitTests/AWSSDK.UnitTests.DevOpsGuru.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DeviceFarm/UnitTests/AWSSDK.UnitTests.DeviceFarm.NetFramework.csproj
+++ b/sdk/test/Services/DeviceFarm/UnitTests/AWSSDK.UnitTests.DeviceFarm.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DirectConnect/IntegrationTests/AWSSDK.IntegrationTests.DirectConnect.NetFramework.csproj
+++ b/sdk/test/Services/DirectConnect/IntegrationTests/AWSSDK.IntegrationTests.DirectConnect.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/DirectConnect/UnitTests/AWSSDK.UnitTests.DirectConnect.NetFramework.csproj
+++ b/sdk/test/Services/DirectConnect/UnitTests/AWSSDK.UnitTests.DirectConnect.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DirectoryService/IntegrationTests/AWSSDK.IntegrationTests.DirectoryService.NetFramework.csproj
+++ b/sdk/test/Services/DirectoryService/IntegrationTests/AWSSDK.IntegrationTests.DirectoryService.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/DirectoryService/UnitTests/AWSSDK.UnitTests.DirectoryService.NetFramework.csproj
+++ b/sdk/test/Services/DirectoryService/UnitTests/AWSSDK.UnitTests.DirectoryService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DocDB/UnitTests/AWSSDK.UnitTests.DocDB.NetFramework.csproj
+++ b/sdk/test/Services/DocDB/UnitTests/AWSSDK.UnitTests.DocDB.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DocDBElastic/UnitTests/AWSSDK.UnitTests.DocDBElastic.NetFramework.csproj
+++ b/sdk/test/Services/DocDBElastic/UnitTests/AWSSDK.UnitTests.DocDBElastic.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DocumentTypesTest/UnitTests/AWSSDK.UnitTests.DocumentTypesTest.NetFramework.csproj
+++ b/sdk/test/Services/DocumentTypesTest/UnitTests/AWSSDK.UnitTests.DocumentTypesTest.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Drs/UnitTests/AWSSDK.UnitTests.Drs.NetFramework.csproj
+++ b/sdk/test/Services/Drs/UnitTests/AWSSDK.UnitTests.Drs.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/AWSSDK.IntegrationTests.DynamoDBv2.NetFramework.csproj
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/AWSSDK.IntegrationTests.DynamoDBv2.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/DynamoDBv2/UnitTests/AWSSDK.UnitTests.DynamoDBv2.NetFramework.csproj
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/AWSSDK.UnitTests.DynamoDBv2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EBS/UnitTests/AWSSDK.UnitTests.EBS.NetFramework.csproj
+++ b/sdk/test/Services/EBS/UnitTests/AWSSDK.UnitTests.EBS.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EC2/IntegrationTests/AWSSDK.IntegrationTests.EC2.NetFramework.csproj
+++ b/sdk/test/Services/EC2/IntegrationTests/AWSSDK.IntegrationTests.EC2.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/EC2/UnitTests/AWSSDK.UnitTests.EC2.NetFramework.csproj
+++ b/sdk/test/Services/EC2/UnitTests/AWSSDK.UnitTests.EC2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EC2InstanceConnect/UnitTests/AWSSDK.UnitTests.EC2InstanceConnect.NetFramework.csproj
+++ b/sdk/test/Services/EC2InstanceConnect/UnitTests/AWSSDK.UnitTests.EC2InstanceConnect.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EC2Protocol/UnitTests/AWSSDK.UnitTests.EC2Protocol.NetFramework.csproj
+++ b/sdk/test/Services/EC2Protocol/UnitTests/AWSSDK.UnitTests.EC2Protocol.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ECR/IntegrationTests/AWSSDK.IntegrationTests.ECR.NetFramework.csproj
+++ b/sdk/test/Services/ECR/IntegrationTests/AWSSDK.IntegrationTests.ECR.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ECR/UnitTests/AWSSDK.UnitTests.ECR.NetFramework.csproj
+++ b/sdk/test/Services/ECR/UnitTests/AWSSDK.UnitTests.ECR.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ECRPublic/UnitTests/AWSSDK.UnitTests.ECRPublic.NetFramework.csproj
+++ b/sdk/test/Services/ECRPublic/UnitTests/AWSSDK.UnitTests.ECRPublic.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ECS/IntegrationTests/AWSSDK.IntegrationTests.ECS.NetFramework.csproj
+++ b/sdk/test/Services/ECS/IntegrationTests/AWSSDK.IntegrationTests.ECS.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ECS/UnitTests/AWSSDK.UnitTests.ECS.NetFramework.csproj
+++ b/sdk/test/Services/ECS/UnitTests/AWSSDK.UnitTests.ECS.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EKS/UnitTests/AWSSDK.UnitTests.EKS.NetFramework.csproj
+++ b/sdk/test/Services/EKS/UnitTests/AWSSDK.UnitTests.EKS.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EKSAuth/UnitTests/AWSSDK.UnitTests.EKSAuth.NetFramework.csproj
+++ b/sdk/test/Services/EKSAuth/UnitTests/AWSSDK.UnitTests.EKSAuth.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EMRContainers/UnitTests/AWSSDK.UnitTests.EMRContainers.NetFramework.csproj
+++ b/sdk/test/Services/EMRContainers/UnitTests/AWSSDK.UnitTests.EMRContainers.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EMRServerless/UnitTests/AWSSDK.UnitTests.EMRServerless.NetFramework.csproj
+++ b/sdk/test/Services/EMRServerless/UnitTests/AWSSDK.UnitTests.EMRServerless.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ElastiCache/IntegrationTests/AWSSDK.IntegrationTests.ElastiCache.NetFramework.csproj
+++ b/sdk/test/Services/ElastiCache/IntegrationTests/AWSSDK.IntegrationTests.ElastiCache.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ElastiCache/UnitTests/AWSSDK.UnitTests.ElastiCache.NetFramework.csproj
+++ b/sdk/test/Services/ElastiCache/UnitTests/AWSSDK.UnitTests.ElastiCache.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ElasticBeanstalk/IntegrationTests/AWSSDK.IntegrationTests.ElasticBeanstalk.NetFramework.csproj
+++ b/sdk/test/Services/ElasticBeanstalk/IntegrationTests/AWSSDK.IntegrationTests.ElasticBeanstalk.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ElasticBeanstalk/UnitTests/AWSSDK.UnitTests.ElasticBeanstalk.NetFramework.csproj
+++ b/sdk/test/Services/ElasticBeanstalk/UnitTests/AWSSDK.UnitTests.ElasticBeanstalk.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ElasticFileSystem/UnitTests/AWSSDK.UnitTests.ElasticFileSystem.NetFramework.csproj
+++ b/sdk/test/Services/ElasticFileSystem/UnitTests/AWSSDK.UnitTests.ElasticFileSystem.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ElasticInference/UnitTests/AWSSDK.UnitTests.ElasticInference.NetFramework.csproj
+++ b/sdk/test/Services/ElasticInference/UnitTests/AWSSDK.UnitTests.ElasticInference.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ElasticLoadBalancing/IntegrationTests/AWSSDK.IntegrationTests.ElasticLoadBalancing.NetFramework.csproj
+++ b/sdk/test/Services/ElasticLoadBalancing/IntegrationTests/AWSSDK.IntegrationTests.ElasticLoadBalancing.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ElasticLoadBalancing/UnitTests/AWSSDK.UnitTests.ElasticLoadBalancing.NetFramework.csproj
+++ b/sdk/test/Services/ElasticLoadBalancing/UnitTests/AWSSDK.UnitTests.ElasticLoadBalancing.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ElasticLoadBalancingV2/IntegrationTests/AWSSDK.IntegrationTests.ElasticLoadBalancingV2.NetFramework.csproj
+++ b/sdk/test/Services/ElasticLoadBalancingV2/IntegrationTests/AWSSDK.IntegrationTests.ElasticLoadBalancingV2.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ElasticLoadBalancingV2/UnitTests/AWSSDK.UnitTests.ElasticLoadBalancingV2.NetFramework.csproj
+++ b/sdk/test/Services/ElasticLoadBalancingV2/UnitTests/AWSSDK.UnitTests.ElasticLoadBalancingV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ElasticMapReduce/UnitTests/AWSSDK.UnitTests.ElasticMapReduce.NetFramework.csproj
+++ b/sdk/test/Services/ElasticMapReduce/UnitTests/AWSSDK.UnitTests.ElasticMapReduce.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ElasticTranscoder/IntegrationTests/AWSSDK.IntegrationTests.ElasticTranscoder.NetFramework.csproj
+++ b/sdk/test/Services/ElasticTranscoder/IntegrationTests/AWSSDK.IntegrationTests.ElasticTranscoder.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ElasticTranscoder/UnitTests/AWSSDK.UnitTests.ElasticTranscoder.NetFramework.csproj
+++ b/sdk/test/Services/ElasticTranscoder/UnitTests/AWSSDK.UnitTests.ElasticTranscoder.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Elasticsearch/IntegrationTests/AWSSDK.IntegrationTests.Elasticsearch.NetFramework.csproj
+++ b/sdk/test/Services/Elasticsearch/IntegrationTests/AWSSDK.IntegrationTests.Elasticsearch.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Elasticsearch/UnitTests/AWSSDK.UnitTests.Elasticsearch.NetFramework.csproj
+++ b/sdk/test/Services/Elasticsearch/UnitTests/AWSSDK.UnitTests.Elasticsearch.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EntityResolution/UnitTests/AWSSDK.UnitTests.EntityResolution.NetFramework.csproj
+++ b/sdk/test/Services/EntityResolution/UnitTests/AWSSDK.UnitTests.EntityResolution.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Ep2hostlabel/UnitTests/AWSSDK.UnitTests.Ep2hostlabel.NetFramework.csproj
+++ b/sdk/test/Services/Ep2hostlabel/UnitTests/AWSSDK.UnitTests.Ep2hostlabel.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Ep2parsearn/UnitTests/AWSSDK.UnitTests.Ep2parsearn.NetFramework.csproj
+++ b/sdk/test/Services/Ep2parsearn/UnitTests/AWSSDK.UnitTests.Ep2parsearn.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Ep2s3hostlabel/UnitTests/AWSSDK.UnitTests.Ep2s3hostlabel.NetFramework.csproj
+++ b/sdk/test/Services/Ep2s3hostlabel/UnitTests/AWSSDK.UnitTests.Ep2s3hostlabel.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Ep2substring/UnitTests/AWSSDK.UnitTests.Ep2substring.NetFramework.csproj
+++ b/sdk/test/Services/Ep2substring/UnitTests/AWSSDK.UnitTests.Ep2substring.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/EventBridge/UnitTests/AWSSDK.UnitTests.EventBridge.NetFramework.csproj
+++ b/sdk/test/Services/EventBridge/UnitTests/AWSSDK.UnitTests.EventBridge.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/FIS/UnitTests/AWSSDK.UnitTests.FIS.NetFramework.csproj
+++ b/sdk/test/Services/FIS/UnitTests/AWSSDK.UnitTests.FIS.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/FMS/UnitTests/AWSSDK.UnitTests.FMS.NetFramework.csproj
+++ b/sdk/test/Services/FMS/UnitTests/AWSSDK.UnitTests.FMS.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/FSx/UnitTests/AWSSDK.UnitTests.FSx.NetFramework.csproj
+++ b/sdk/test/Services/FSx/UnitTests/AWSSDK.UnitTests.FSx.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/FinSpaceData/UnitTests/AWSSDK.UnitTests.FinSpaceData.NetFramework.csproj
+++ b/sdk/test/Services/FinSpaceData/UnitTests/AWSSDK.UnitTests.FinSpaceData.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Finspace/UnitTests/AWSSDK.UnitTests.Finspace.NetFramework.csproj
+++ b/sdk/test/Services/Finspace/UnitTests/AWSSDK.UnitTests.Finspace.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ForecastQueryService/UnitTests/AWSSDK.UnitTests.ForecastQueryService.NetFramework.csproj
+++ b/sdk/test/Services/ForecastQueryService/UnitTests/AWSSDK.UnitTests.ForecastQueryService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ForecastService/UnitTests/AWSSDK.UnitTests.ForecastService.NetFramework.csproj
+++ b/sdk/test/Services/ForecastService/UnitTests/AWSSDK.UnitTests.ForecastService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/FraudDetector/UnitTests/AWSSDK.UnitTests.FraudDetector.NetFramework.csproj
+++ b/sdk/test/Services/FraudDetector/UnitTests/AWSSDK.UnitTests.FraudDetector.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/FreeTier/UnitTests/AWSSDK.UnitTests.FreeTier.NetFramework.csproj
+++ b/sdk/test/Services/FreeTier/UnitTests/AWSSDK.UnitTests.FreeTier.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/GameLift/IntegrationTests/AWSSDK.IntegrationTests.GameLift.NetFramework.csproj
+++ b/sdk/test/Services/GameLift/IntegrationTests/AWSSDK.IntegrationTests.GameLift.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/GameLift/UnitTests/AWSSDK.UnitTests.GameLift.NetFramework.csproj
+++ b/sdk/test/Services/GameLift/UnitTests/AWSSDK.UnitTests.GameLift.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Glacier/IntegrationTests/AWSSDK.IntegrationTests.Glacier.NetFramework.csproj
+++ b/sdk/test/Services/Glacier/IntegrationTests/AWSSDK.IntegrationTests.Glacier.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Glacier/UnitTests/AWSSDK.UnitTests.Glacier.NetFramework.csproj
+++ b/sdk/test/Services/Glacier/UnitTests/AWSSDK.UnitTests.Glacier.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/GlobalAccelerator/UnitTests/AWSSDK.UnitTests.GlobalAccelerator.NetFramework.csproj
+++ b/sdk/test/Services/GlobalAccelerator/UnitTests/AWSSDK.UnitTests.GlobalAccelerator.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Glue/UnitTests/AWSSDK.UnitTests.Glue.NetFramework.csproj
+++ b/sdk/test/Services/Glue/UnitTests/AWSSDK.UnitTests.Glue.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/GlueDataBrew/UnitTests/AWSSDK.UnitTests.GlueDataBrew.NetFramework.csproj
+++ b/sdk/test/Services/GlueDataBrew/UnitTests/AWSSDK.UnitTests.GlueDataBrew.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Greengrass/UnitTests/AWSSDK.UnitTests.Greengrass.NetFramework.csproj
+++ b/sdk/test/Services/Greengrass/UnitTests/AWSSDK.UnitTests.Greengrass.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/GreengrassV2/UnitTests/AWSSDK.UnitTests.GreengrassV2.NetFramework.csproj
+++ b/sdk/test/Services/GreengrassV2/UnitTests/AWSSDK.UnitTests.GreengrassV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/GroundStation/UnitTests/AWSSDK.UnitTests.GroundStation.NetFramework.csproj
+++ b/sdk/test/Services/GroundStation/UnitTests/AWSSDK.UnitTests.GroundStation.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/GuardDuty/UnitTests/AWSSDK.UnitTests.GuardDuty.NetFramework.csproj
+++ b/sdk/test/Services/GuardDuty/UnitTests/AWSSDK.UnitTests.GuardDuty.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/HealthLake/UnitTests/AWSSDK.UnitTests.HealthLake.NetFramework.csproj
+++ b/sdk/test/Services/HealthLake/UnitTests/AWSSDK.UnitTests.HealthLake.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Honeycode/UnitTests/AWSSDK.UnitTests.Honeycode.NetFramework.csproj
+++ b/sdk/test/Services/Honeycode/UnitTests/AWSSDK.UnitTests.Honeycode.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IAMRolesAnywhere/UnitTests/AWSSDK.UnitTests.IAMRolesAnywhere.NetFramework.csproj
+++ b/sdk/test/Services/IAMRolesAnywhere/UnitTests/AWSSDK.UnitTests.IAMRolesAnywhere.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IVS/UnitTests/AWSSDK.UnitTests.IVS.NetFramework.csproj
+++ b/sdk/test/Services/IVS/UnitTests/AWSSDK.UnitTests.IVS.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IVSRealTime/UnitTests/AWSSDK.UnitTests.IVSRealTime.NetFramework.csproj
+++ b/sdk/test/Services/IVSRealTime/UnitTests/AWSSDK.UnitTests.IVSRealTime.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IdentityManagement/IntegrationTests/AWSSDK.IntegrationTests.IdentityManagement.NetFramework.csproj
+++ b/sdk/test/Services/IdentityManagement/IntegrationTests/AWSSDK.IntegrationTests.IdentityManagement.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/IdentityManagement/UnitTests/AWSSDK.UnitTests.IdentityManagement.NetFramework.csproj
+++ b/sdk/test/Services/IdentityManagement/UnitTests/AWSSDK.UnitTests.IdentityManagement.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IdentityStore/UnitTests/AWSSDK.UnitTests.IdentityStore.NetFramework.csproj
+++ b/sdk/test/Services/IdentityStore/UnitTests/AWSSDK.UnitTests.IdentityStore.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Imagebuilder/UnitTests/AWSSDK.UnitTests.Imagebuilder.NetFramework.csproj
+++ b/sdk/test/Services/Imagebuilder/UnitTests/AWSSDK.UnitTests.Imagebuilder.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ImportExport/IntegrationTests/AWSSDK.IntegrationTests.ImportExport.NetFramework.csproj
+++ b/sdk/test/Services/ImportExport/IntegrationTests/AWSSDK.IntegrationTests.ImportExport.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ImportExport/UnitTests/AWSSDK.UnitTests.ImportExport.NetFramework.csproj
+++ b/sdk/test/Services/ImportExport/UnitTests/AWSSDK.UnitTests.ImportExport.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Inspector/IntegrationTests/AWSSDK.IntegrationTests.Inspector.NetFramework.csproj
+++ b/sdk/test/Services/Inspector/IntegrationTests/AWSSDK.IntegrationTests.Inspector.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Inspector/UnitTests/AWSSDK.UnitTests.Inspector.NetFramework.csproj
+++ b/sdk/test/Services/Inspector/UnitTests/AWSSDK.UnitTests.Inspector.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Inspector2/UnitTests/AWSSDK.UnitTests.Inspector2.NetFramework.csproj
+++ b/sdk/test/Services/Inspector2/UnitTests/AWSSDK.UnitTests.Inspector2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/InspectorScan/UnitTests/AWSSDK.UnitTests.InspectorScan.NetFramework.csproj
+++ b/sdk/test/Services/InspectorScan/UnitTests/AWSSDK.UnitTests.InspectorScan.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/InternetMonitor/UnitTests/AWSSDK.UnitTests.InternetMonitor.NetFramework.csproj
+++ b/sdk/test/Services/InternetMonitor/UnitTests/AWSSDK.UnitTests.InternetMonitor.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoT/IntegrationTests/AWSSDK.IntegrationTests.IoT.NetFramework.csproj
+++ b/sdk/test/Services/IoT/IntegrationTests/AWSSDK.IntegrationTests.IoT.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/IoT/UnitTests/AWSSDK.UnitTests.IoT.NetFramework.csproj
+++ b/sdk/test/Services/IoT/UnitTests/AWSSDK.UnitTests.IoT.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoT1ClickDevicesService/UnitTests/AWSSDK.UnitTests.IoT1ClickDevicesService.NetFramework.csproj
+++ b/sdk/test/Services/IoT1ClickDevicesService/UnitTests/AWSSDK.UnitTests.IoT1ClickDevicesService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoT1ClickProjects/UnitTests/AWSSDK.UnitTests.IoT1ClickProjects.NetFramework.csproj
+++ b/sdk/test/Services/IoT1ClickProjects/UnitTests/AWSSDK.UnitTests.IoT1ClickProjects.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTAnalytics/UnitTests/AWSSDK.UnitTests.IoTAnalytics.NetFramework.csproj
+++ b/sdk/test/Services/IoTAnalytics/UnitTests/AWSSDK.UnitTests.IoTAnalytics.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTDeviceAdvisor/UnitTests/AWSSDK.UnitTests.IoTDeviceAdvisor.NetFramework.csproj
+++ b/sdk/test/Services/IoTDeviceAdvisor/UnitTests/AWSSDK.UnitTests.IoTDeviceAdvisor.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTEvents/UnitTests/AWSSDK.UnitTests.IoTEvents.NetFramework.csproj
+++ b/sdk/test/Services/IoTEvents/UnitTests/AWSSDK.UnitTests.IoTEvents.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTEventsData/UnitTests/AWSSDK.UnitTests.IoTEventsData.NetFramework.csproj
+++ b/sdk/test/Services/IoTEventsData/UnitTests/AWSSDK.UnitTests.IoTEventsData.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTFleetHub/UnitTests/AWSSDK.UnitTests.IoTFleetHub.NetFramework.csproj
+++ b/sdk/test/Services/IoTFleetHub/UnitTests/AWSSDK.UnitTests.IoTFleetHub.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTFleetWise/UnitTests/AWSSDK.UnitTests.IoTFleetWise.NetFramework.csproj
+++ b/sdk/test/Services/IoTFleetWise/UnitTests/AWSSDK.UnitTests.IoTFleetWise.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTJobsDataPlane/UnitTests/AWSSDK.UnitTests.IoTJobsDataPlane.NetFramework.csproj
+++ b/sdk/test/Services/IoTJobsDataPlane/UnitTests/AWSSDK.UnitTests.IoTJobsDataPlane.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTSecureTunneling/UnitTests/AWSSDK.UnitTests.IoTSecureTunneling.NetFramework.csproj
+++ b/sdk/test/Services/IoTSecureTunneling/UnitTests/AWSSDK.UnitTests.IoTSecureTunneling.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTSiteWise/UnitTests/AWSSDK.UnitTests.IoTSiteWise.NetFramework.csproj
+++ b/sdk/test/Services/IoTSiteWise/UnitTests/AWSSDK.UnitTests.IoTSiteWise.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTThingsGraph/UnitTests/AWSSDK.UnitTests.IoTThingsGraph.NetFramework.csproj
+++ b/sdk/test/Services/IoTThingsGraph/UnitTests/AWSSDK.UnitTests.IoTThingsGraph.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTTwinMaker/UnitTests/AWSSDK.UnitTests.IoTTwinMaker.NetFramework.csproj
+++ b/sdk/test/Services/IoTTwinMaker/UnitTests/AWSSDK.UnitTests.IoTTwinMaker.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IoTWireless/UnitTests/AWSSDK.UnitTests.IoTWireless.NetFramework.csproj
+++ b/sdk/test/Services/IoTWireless/UnitTests/AWSSDK.UnitTests.IoTWireless.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/IotData/IntegrationTests/AWSSDK.IntegrationTests.IotData.NetFramework.csproj
+++ b/sdk/test/Services/IotData/IntegrationTests/AWSSDK.IntegrationTests.IotData.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/IotData/UnitTests/AWSSDK.UnitTests.IotData.NetFramework.csproj
+++ b/sdk/test/Services/IotData/UnitTests/AWSSDK.UnitTests.IotData.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Ivschat/UnitTests/AWSSDK.UnitTests.Ivschat.NetFramework.csproj
+++ b/sdk/test/Services/Ivschat/UnitTests/AWSSDK.UnitTests.Ivschat.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/JSONRPC10/UnitTests/AWSSDK.UnitTests.JSONRPC10.NetFramework.csproj
+++ b/sdk/test/Services/JSONRPC10/UnitTests/AWSSDK.UnitTests.JSONRPC10.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/JsonProtocol/UnitTests/AWSSDK.UnitTests.JsonProtocol.NetFramework.csproj
+++ b/sdk/test/Services/JsonProtocol/UnitTests/AWSSDK.UnitTests.JsonProtocol.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Kafka/UnitTests/AWSSDK.UnitTests.Kafka.NetFramework.csproj
+++ b/sdk/test/Services/Kafka/UnitTests/AWSSDK.UnitTests.Kafka.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KafkaConnect/UnitTests/AWSSDK.UnitTests.KafkaConnect.NetFramework.csproj
+++ b/sdk/test/Services/KafkaConnect/UnitTests/AWSSDK.UnitTests.KafkaConnect.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Kendra/UnitTests/AWSSDK.UnitTests.Kendra.NetFramework.csproj
+++ b/sdk/test/Services/Kendra/UnitTests/AWSSDK.UnitTests.Kendra.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KendraRanking/UnitTests/AWSSDK.UnitTests.KendraRanking.NetFramework.csproj
+++ b/sdk/test/Services/KendraRanking/UnitTests/AWSSDK.UnitTests.KendraRanking.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KeyManagementService/IntegrationTests/AWSSDK.IntegrationTests.KeyManagementService.NetFramework.csproj
+++ b/sdk/test/Services/KeyManagementService/IntegrationTests/AWSSDK.IntegrationTests.KeyManagementService.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/KeyManagementService/UnitTests/AWSSDK.UnitTests.KeyManagementService.NetFramework.csproj
+++ b/sdk/test/Services/KeyManagementService/UnitTests/AWSSDK.UnitTests.KeyManagementService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Keyspaces/UnitTests/AWSSDK.UnitTests.Keyspaces.NetFramework.csproj
+++ b/sdk/test/Services/Keyspaces/UnitTests/AWSSDK.UnitTests.Keyspaces.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Kinesis/IntegrationTests/AWSSDK.IntegrationTests.Kinesis.NetFramework.csproj
+++ b/sdk/test/Services/Kinesis/IntegrationTests/AWSSDK.IntegrationTests.Kinesis.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Kinesis/UnitTests/AWSSDK.UnitTests.Kinesis.NetFramework.csproj
+++ b/sdk/test/Services/Kinesis/UnitTests/AWSSDK.UnitTests.Kinesis.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KinesisAnalytics/UnitTests/AWSSDK.UnitTests.KinesisAnalytics.NetFramework.csproj
+++ b/sdk/test/Services/KinesisAnalytics/UnitTests/AWSSDK.UnitTests.KinesisAnalytics.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KinesisAnalyticsV2/UnitTests/AWSSDK.UnitTests.KinesisAnalyticsV2.NetFramework.csproj
+++ b/sdk/test/Services/KinesisAnalyticsV2/UnitTests/AWSSDK.UnitTests.KinesisAnalyticsV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KinesisFirehose/IntegrationTests/AWSSDK.IntegrationTests.KinesisFirehose.NetFramework.csproj
+++ b/sdk/test/Services/KinesisFirehose/IntegrationTests/AWSSDK.IntegrationTests.KinesisFirehose.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/KinesisFirehose/UnitTests/AWSSDK.UnitTests.KinesisFirehose.NetFramework.csproj
+++ b/sdk/test/Services/KinesisFirehose/UnitTests/AWSSDK.UnitTests.KinesisFirehose.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KinesisVideo/UnitTests/AWSSDK.UnitTests.KinesisVideo.NetFramework.csproj
+++ b/sdk/test/Services/KinesisVideo/UnitTests/AWSSDK.UnitTests.KinesisVideo.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KinesisVideoArchivedMedia/UnitTests/AWSSDK.UnitTests.KinesisVideoArchivedMedia.NetFramework.csproj
+++ b/sdk/test/Services/KinesisVideoArchivedMedia/UnitTests/AWSSDK.UnitTests.KinesisVideoArchivedMedia.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KinesisVideoMedia/UnitTests/AWSSDK.UnitTests.KinesisVideoMedia.NetFramework.csproj
+++ b/sdk/test/Services/KinesisVideoMedia/UnitTests/AWSSDK.UnitTests.KinesisVideoMedia.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KinesisVideoSignalingChannels/UnitTests/AWSSDK.UnitTests.KinesisVideoSignalingChannels.NetFramework.csproj
+++ b/sdk/test/Services/KinesisVideoSignalingChannels/UnitTests/AWSSDK.UnitTests.KinesisVideoSignalingChannels.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/KinesisVideoWebRTCStorage/UnitTests/AWSSDK.UnitTests.KinesisVideoWebRTCStorage.NetFramework.csproj
+++ b/sdk/test/Services/KinesisVideoWebRTCStorage/UnitTests/AWSSDK.UnitTests.KinesisVideoWebRTCStorage.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LakeFormation/UnitTests/AWSSDK.UnitTests.LakeFormation.NetFramework.csproj
+++ b/sdk/test/Services/LakeFormation/UnitTests/AWSSDK.UnitTests.LakeFormation.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Lambda/IntegrationTests/AWSSDK.IntegrationTests.Lambda.NetFramework.csproj
+++ b/sdk/test/Services/Lambda/IntegrationTests/AWSSDK.IntegrationTests.Lambda.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Lambda/UnitTests/AWSSDK.UnitTests.Lambda.NetFramework.csproj
+++ b/sdk/test/Services/Lambda/UnitTests/AWSSDK.UnitTests.Lambda.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LaunchWizard/UnitTests/AWSSDK.UnitTests.LaunchWizard.NetFramework.csproj
+++ b/sdk/test/Services/LaunchWizard/UnitTests/AWSSDK.UnitTests.LaunchWizard.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Lex/UnitTests/AWSSDK.UnitTests.Lex.NetFramework.csproj
+++ b/sdk/test/Services/Lex/UnitTests/AWSSDK.UnitTests.Lex.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LexModelBuildingService/UnitTests/AWSSDK.UnitTests.LexModelBuildingService.NetFramework.csproj
+++ b/sdk/test/Services/LexModelBuildingService/UnitTests/AWSSDK.UnitTests.LexModelBuildingService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LexModelsV2/UnitTests/AWSSDK.UnitTests.LexModelsV2.NetFramework.csproj
+++ b/sdk/test/Services/LexModelsV2/UnitTests/AWSSDK.UnitTests.LexModelsV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LexRuntimeV2/UnitTests/AWSSDK.UnitTests.LexRuntimeV2.NetFramework.csproj
+++ b/sdk/test/Services/LexRuntimeV2/UnitTests/AWSSDK.UnitTests.LexRuntimeV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LicenseManager/UnitTests/AWSSDK.UnitTests.LicenseManager.NetFramework.csproj
+++ b/sdk/test/Services/LicenseManager/UnitTests/AWSSDK.UnitTests.LicenseManager.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LicenseManagerLinuxSubscriptions/UnitTests/AWSSDK.UnitTests.LicenseManagerLinuxSubscriptions.NetFramework.csproj
+++ b/sdk/test/Services/LicenseManagerLinuxSubscriptions/UnitTests/AWSSDK.UnitTests.LicenseManagerLinuxSubscriptions.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LicenseManagerUserSubscriptions/UnitTests/AWSSDK.UnitTests.LicenseManagerUserSubscriptions.NetFramework.csproj
+++ b/sdk/test/Services/LicenseManagerUserSubscriptions/UnitTests/AWSSDK.UnitTests.LicenseManagerUserSubscriptions.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Lightsail/IntegrationTests/AWSSDK.IntegrationTests.Lightsail.NetFramework.csproj
+++ b/sdk/test/Services/Lightsail/IntegrationTests/AWSSDK.IntegrationTests.Lightsail.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Lightsail/UnitTests/AWSSDK.UnitTests.Lightsail.NetFramework.csproj
+++ b/sdk/test/Services/Lightsail/UnitTests/AWSSDK.UnitTests.Lightsail.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LocationService/UnitTests/AWSSDK.UnitTests.LocationService.NetFramework.csproj
+++ b/sdk/test/Services/LocationService/UnitTests/AWSSDK.UnitTests.LocationService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LookoutEquipment/UnitTests/AWSSDK.UnitTests.LookoutEquipment.NetFramework.csproj
+++ b/sdk/test/Services/LookoutEquipment/UnitTests/AWSSDK.UnitTests.LookoutEquipment.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LookoutMetrics/UnitTests/AWSSDK.UnitTests.LookoutMetrics.NetFramework.csproj
+++ b/sdk/test/Services/LookoutMetrics/UnitTests/AWSSDK.UnitTests.LookoutMetrics.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/LookoutforVision/UnitTests/AWSSDK.UnitTests.LookoutforVision.NetFramework.csproj
+++ b/sdk/test/Services/LookoutforVision/UnitTests/AWSSDK.UnitTests.LookoutforVision.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MQ/UnitTests/AWSSDK.UnitTests.MQ.NetFramework.csproj
+++ b/sdk/test/Services/MQ/UnitTests/AWSSDK.UnitTests.MQ.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MTurk/UnitTests/AWSSDK.UnitTests.MTurk.NetFramework.csproj
+++ b/sdk/test/Services/MTurk/UnitTests/AWSSDK.UnitTests.MTurk.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MWAA/UnitTests/AWSSDK.UnitTests.MWAA.NetFramework.csproj
+++ b/sdk/test/Services/MWAA/UnitTests/AWSSDK.UnitTests.MWAA.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MachineLearning/IntegrationTests/AWSSDK.IntegrationTests.MachineLearning.NetFramework.csproj
+++ b/sdk/test/Services/MachineLearning/IntegrationTests/AWSSDK.IntegrationTests.MachineLearning.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/MachineLearning/UnitTests/AWSSDK.UnitTests.MachineLearning.NetFramework.csproj
+++ b/sdk/test/Services/MachineLearning/UnitTests/AWSSDK.UnitTests.MachineLearning.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Macie2/UnitTests/AWSSDK.UnitTests.Macie2.NetFramework.csproj
+++ b/sdk/test/Services/Macie2/UnitTests/AWSSDK.UnitTests.Macie2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MainframeModernization/UnitTests/AWSSDK.UnitTests.MainframeModernization.NetFramework.csproj
+++ b/sdk/test/Services/MainframeModernization/UnitTests/AWSSDK.UnitTests.MainframeModernization.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ManagedBlockchain/UnitTests/AWSSDK.UnitTests.ManagedBlockchain.NetFramework.csproj
+++ b/sdk/test/Services/ManagedBlockchain/UnitTests/AWSSDK.UnitTests.ManagedBlockchain.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ManagedBlockchainQuery/UnitTests/AWSSDK.UnitTests.ManagedBlockchainQuery.NetFramework.csproj
+++ b/sdk/test/Services/ManagedBlockchainQuery/UnitTests/AWSSDK.UnitTests.ManagedBlockchainQuery.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ManagedGrafana/UnitTests/AWSSDK.UnitTests.ManagedGrafana.NetFramework.csproj
+++ b/sdk/test/Services/ManagedGrafana/UnitTests/AWSSDK.UnitTests.ManagedGrafana.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MarketplaceAgreement/UnitTests/AWSSDK.UnitTests.MarketplaceAgreement.NetFramework.csproj
+++ b/sdk/test/Services/MarketplaceAgreement/UnitTests/AWSSDK.UnitTests.MarketplaceAgreement.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MarketplaceCatalog/UnitTests/AWSSDK.UnitTests.MarketplaceCatalog.NetFramework.csproj
+++ b/sdk/test/Services/MarketplaceCatalog/UnitTests/AWSSDK.UnitTests.MarketplaceCatalog.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MarketplaceDeployment/UnitTests/AWSSDK.UnitTests.MarketplaceDeployment.NetFramework.csproj
+++ b/sdk/test/Services/MarketplaceDeployment/UnitTests/AWSSDK.UnitTests.MarketplaceDeployment.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MarketplaceEntitlementService/UnitTests/AWSSDK.UnitTests.MarketplaceEntitlementService.NetFramework.csproj
+++ b/sdk/test/Services/MarketplaceEntitlementService/UnitTests/AWSSDK.UnitTests.MarketplaceEntitlementService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MediaConnect/UnitTests/AWSSDK.UnitTests.MediaConnect.NetFramework.csproj
+++ b/sdk/test/Services/MediaConnect/UnitTests/AWSSDK.UnitTests.MediaConnect.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MediaConvert/UnitTests/AWSSDK.UnitTests.MediaConvert.NetFramework.csproj
+++ b/sdk/test/Services/MediaConvert/UnitTests/AWSSDK.UnitTests.MediaConvert.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MediaLive/UnitTests/AWSSDK.UnitTests.MediaLive.NetFramework.csproj
+++ b/sdk/test/Services/MediaLive/UnitTests/AWSSDK.UnitTests.MediaLive.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MediaPackage/UnitTests/AWSSDK.UnitTests.MediaPackage.NetFramework.csproj
+++ b/sdk/test/Services/MediaPackage/UnitTests/AWSSDK.UnitTests.MediaPackage.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MediaPackageV2/UnitTests/AWSSDK.UnitTests.MediaPackageV2.NetFramework.csproj
+++ b/sdk/test/Services/MediaPackageV2/UnitTests/AWSSDK.UnitTests.MediaPackageV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MediaPackageVod/UnitTests/AWSSDK.UnitTests.MediaPackageVod.NetFramework.csproj
+++ b/sdk/test/Services/MediaPackageVod/UnitTests/AWSSDK.UnitTests.MediaPackageVod.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MediaStore/UnitTests/AWSSDK.UnitTests.MediaStore.NetFramework.csproj
+++ b/sdk/test/Services/MediaStore/UnitTests/AWSSDK.UnitTests.MediaStore.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MediaStoreData/UnitTests/AWSSDK.UnitTests.MediaStoreData.NetFramework.csproj
+++ b/sdk/test/Services/MediaStoreData/UnitTests/AWSSDK.UnitTests.MediaStoreData.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MediaTailor/UnitTests/AWSSDK.UnitTests.MediaTailor.NetFramework.csproj
+++ b/sdk/test/Services/MediaTailor/UnitTests/AWSSDK.UnitTests.MediaTailor.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MedicalImaging/UnitTests/AWSSDK.UnitTests.MedicalImaging.NetFramework.csproj
+++ b/sdk/test/Services/MedicalImaging/UnitTests/AWSSDK.UnitTests.MedicalImaging.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MemoryDB/UnitTests/AWSSDK.UnitTests.MemoryDB.NetFramework.csproj
+++ b/sdk/test/Services/MemoryDB/UnitTests/AWSSDK.UnitTests.MemoryDB.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Mgn/UnitTests/AWSSDK.UnitTests.Mgn.NetFramework.csproj
+++ b/sdk/test/Services/Mgn/UnitTests/AWSSDK.UnitTests.Mgn.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MigrationHub/UnitTests/AWSSDK.UnitTests.MigrationHub.NetFramework.csproj
+++ b/sdk/test/Services/MigrationHub/UnitTests/AWSSDK.UnitTests.MigrationHub.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MigrationHubConfig/UnitTests/AWSSDK.UnitTests.MigrationHubConfig.NetFramework.csproj
+++ b/sdk/test/Services/MigrationHubConfig/UnitTests/AWSSDK.UnitTests.MigrationHubConfig.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MigrationHubOrchestrator/UnitTests/AWSSDK.UnitTests.MigrationHubOrchestrator.NetFramework.csproj
+++ b/sdk/test/Services/MigrationHubOrchestrator/UnitTests/AWSSDK.UnitTests.MigrationHubOrchestrator.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MigrationHubRefactorSpaces/UnitTests/AWSSDK.UnitTests.MigrationHubRefactorSpaces.NetFramework.csproj
+++ b/sdk/test/Services/MigrationHubRefactorSpaces/UnitTests/AWSSDK.UnitTests.MigrationHubRefactorSpaces.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MigrationHubStrategyRecommendations/UnitTests/AWSSDK.UnitTests.MigrationHubStrategyRecommendations.NetFramework.csproj
+++ b/sdk/test/Services/MigrationHubStrategyRecommendations/UnitTests/AWSSDK.UnitTests.MigrationHubStrategyRecommendations.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Mobile/UnitTests/AWSSDK.UnitTests.Mobile.NetFramework.csproj
+++ b/sdk/test/Services/Mobile/UnitTests/AWSSDK.UnitTests.Mobile.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/MobileAnalytics/UnitTests/AWSSDK.UnitTests.MobileAnalytics.NetFramework.csproj
+++ b/sdk/test/Services/MobileAnalytics/UnitTests/AWSSDK.UnitTests.MobileAnalytics.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Neptune/UnitTests/AWSSDK.UnitTests.Neptune.NetFramework.csproj
+++ b/sdk/test/Services/Neptune/UnitTests/AWSSDK.UnitTests.Neptune.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/NeptuneGraph/UnitTests/AWSSDK.UnitTests.NeptuneGraph.NetFramework.csproj
+++ b/sdk/test/Services/NeptuneGraph/UnitTests/AWSSDK.UnitTests.NeptuneGraph.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Neptunedata/UnitTests/AWSSDK.UnitTests.Neptunedata.NetFramework.csproj
+++ b/sdk/test/Services/Neptunedata/UnitTests/AWSSDK.UnitTests.Neptunedata.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/NetworkFirewall/UnitTests/AWSSDK.UnitTests.NetworkFirewall.NetFramework.csproj
+++ b/sdk/test/Services/NetworkFirewall/UnitTests/AWSSDK.UnitTests.NetworkFirewall.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/NetworkManager/UnitTests/AWSSDK.UnitTests.NetworkManager.NetFramework.csproj
+++ b/sdk/test/Services/NetworkManager/UnitTests/AWSSDK.UnitTests.NetworkManager.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/NetworkMonitor/UnitTests/AWSSDK.UnitTests.NetworkMonitor.NetFramework.csproj
+++ b/sdk/test/Services/NetworkMonitor/UnitTests/AWSSDK.UnitTests.NetworkMonitor.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/NimbleStudio/UnitTests/AWSSDK.UnitTests.NimbleStudio.NetFramework.csproj
+++ b/sdk/test/Services/NimbleStudio/UnitTests/AWSSDK.UnitTests.NimbleStudio.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/OAM/UnitTests/AWSSDK.UnitTests.OAM.NetFramework.csproj
+++ b/sdk/test/Services/OAM/UnitTests/AWSSDK.UnitTests.OAM.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/OSIS/UnitTests/AWSSDK.UnitTests.OSIS.NetFramework.csproj
+++ b/sdk/test/Services/OSIS/UnitTests/AWSSDK.UnitTests.OSIS.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Omics/UnitTests/AWSSDK.UnitTests.Omics.NetFramework.csproj
+++ b/sdk/test/Services/Omics/UnitTests/AWSSDK.UnitTests.Omics.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/OpenSearchServerless/UnitTests/AWSSDK.UnitTests.OpenSearchServerless.NetFramework.csproj
+++ b/sdk/test/Services/OpenSearchServerless/UnitTests/AWSSDK.UnitTests.OpenSearchServerless.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/OpenSearchService/UnitTests/AWSSDK.UnitTests.OpenSearchService.NetFramework.csproj
+++ b/sdk/test/Services/OpenSearchService/UnitTests/AWSSDK.UnitTests.OpenSearchService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/OpsWorks/IntegrationTests/AWSSDK.IntegrationTests.OpsWorks.NetFramework.csproj
+++ b/sdk/test/Services/OpsWorks/IntegrationTests/AWSSDK.IntegrationTests.OpsWorks.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/OpsWorks/UnitTests/AWSSDK.UnitTests.OpsWorks.NetFramework.csproj
+++ b/sdk/test/Services/OpsWorks/UnitTests/AWSSDK.UnitTests.OpsWorks.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/OpsWorksCM/UnitTests/AWSSDK.UnitTests.OpsWorksCM.NetFramework.csproj
+++ b/sdk/test/Services/OpsWorksCM/UnitTests/AWSSDK.UnitTests.OpsWorksCM.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Organizations/UnitTests/AWSSDK.UnitTests.Organizations.NetFramework.csproj
+++ b/sdk/test/Services/Organizations/UnitTests/AWSSDK.UnitTests.Organizations.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Outposts/UnitTests/AWSSDK.UnitTests.Outposts.NetFramework.csproj
+++ b/sdk/test/Services/Outposts/UnitTests/AWSSDK.UnitTests.Outposts.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PI/UnitTests/AWSSDK.UnitTests.PI.NetFramework.csproj
+++ b/sdk/test/Services/PI/UnitTests/AWSSDK.UnitTests.PI.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PaginatorsTest/UnitTests/AWSSDK.UnitTests.PaginatorsTest.NetFramework.csproj
+++ b/sdk/test/Services/PaginatorsTest/UnitTests/AWSSDK.UnitTests.PaginatorsTest.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Panorama/UnitTests/AWSSDK.UnitTests.Panorama.NetFramework.csproj
+++ b/sdk/test/Services/Panorama/UnitTests/AWSSDK.UnitTests.Panorama.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PaymentCryptography/UnitTests/AWSSDK.UnitTests.PaymentCryptography.NetFramework.csproj
+++ b/sdk/test/Services/PaymentCryptography/UnitTests/AWSSDK.UnitTests.PaymentCryptography.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PaymentCryptographyData/UnitTests/AWSSDK.UnitTests.PaymentCryptographyData.NetFramework.csproj
+++ b/sdk/test/Services/PaymentCryptographyData/UnitTests/AWSSDK.UnitTests.PaymentCryptographyData.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PcaConnectorAd/UnitTests/AWSSDK.UnitTests.PcaConnectorAd.NetFramework.csproj
+++ b/sdk/test/Services/PcaConnectorAd/UnitTests/AWSSDK.UnitTests.PcaConnectorAd.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Personalize/UnitTests/AWSSDK.UnitTests.Personalize.NetFramework.csproj
+++ b/sdk/test/Services/Personalize/UnitTests/AWSSDK.UnitTests.Personalize.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PersonalizeEvents/UnitTests/AWSSDK.UnitTests.PersonalizeEvents.NetFramework.csproj
+++ b/sdk/test/Services/PersonalizeEvents/UnitTests/AWSSDK.UnitTests.PersonalizeEvents.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PersonalizeRuntime/UnitTests/AWSSDK.UnitTests.PersonalizeRuntime.NetFramework.csproj
+++ b/sdk/test/Services/PersonalizeRuntime/UnitTests/AWSSDK.UnitTests.PersonalizeRuntime.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Pinpoint/UnitTests/AWSSDK.UnitTests.Pinpoint.NetFramework.csproj
+++ b/sdk/test/Services/Pinpoint/UnitTests/AWSSDK.UnitTests.Pinpoint.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PinpointEmail/UnitTests/AWSSDK.UnitTests.PinpointEmail.NetFramework.csproj
+++ b/sdk/test/Services/PinpointEmail/UnitTests/AWSSDK.UnitTests.PinpointEmail.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PinpointSMSVoice/UnitTests/AWSSDK.UnitTests.PinpointSMSVoice.NetFramework.csproj
+++ b/sdk/test/Services/PinpointSMSVoice/UnitTests/AWSSDK.UnitTests.PinpointSMSVoice.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PinpointSMSVoiceV2/UnitTests/AWSSDK.UnitTests.PinpointSMSVoiceV2.NetFramework.csproj
+++ b/sdk/test/Services/PinpointSMSVoiceV2/UnitTests/AWSSDK.UnitTests.PinpointSMSVoiceV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Pipes/UnitTests/AWSSDK.UnitTests.Pipes.NetFramework.csproj
+++ b/sdk/test/Services/Pipes/UnitTests/AWSSDK.UnitTests.Pipes.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Polly/IntegrationTests/AWSSDK.IntegrationTests.Polly.NetFramework.csproj
+++ b/sdk/test/Services/Polly/IntegrationTests/AWSSDK.IntegrationTests.Polly.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Polly/UnitTests/AWSSDK.UnitTests.Polly.NetFramework.csproj
+++ b/sdk/test/Services/Polly/UnitTests/AWSSDK.UnitTests.Polly.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Pricing/UnitTests/AWSSDK.UnitTests.Pricing.NetFramework.csproj
+++ b/sdk/test/Services/Pricing/UnitTests/AWSSDK.UnitTests.Pricing.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Private5G/UnitTests/AWSSDK.UnitTests.Private5G.NetFramework.csproj
+++ b/sdk/test/Services/Private5G/UnitTests/AWSSDK.UnitTests.Private5G.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/PrometheusService/UnitTests/AWSSDK.UnitTests.PrometheusService.NetFramework.csproj
+++ b/sdk/test/Services/PrometheusService/UnitTests/AWSSDK.UnitTests.PrometheusService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Proton/UnitTests/AWSSDK.UnitTests.Proton.NetFramework.csproj
+++ b/sdk/test/Services/Proton/UnitTests/AWSSDK.UnitTests.Proton.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/QBusiness/UnitTests/AWSSDK.UnitTests.QBusiness.NetFramework.csproj
+++ b/sdk/test/Services/QBusiness/UnitTests/AWSSDK.UnitTests.QBusiness.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/QConnect/UnitTests/AWSSDK.UnitTests.QConnect.NetFramework.csproj
+++ b/sdk/test/Services/QConnect/UnitTests/AWSSDK.UnitTests.QConnect.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/QLDB/UnitTests/AWSSDK.UnitTests.QLDB.NetFramework.csproj
+++ b/sdk/test/Services/QLDB/UnitTests/AWSSDK.UnitTests.QLDB.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/QLDBSession/UnitTests/AWSSDK.UnitTests.QLDBSession.NetFramework.csproj
+++ b/sdk/test/Services/QLDBSession/UnitTests/AWSSDK.UnitTests.QLDBSession.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/QueryCompatible/UnitTests/AWSSDK.UnitTests.QueryCompatible.NetFramework.csproj
+++ b/sdk/test/Services/QueryCompatible/UnitTests/AWSSDK.UnitTests.QueryCompatible.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/QueryProtocol/UnitTests/AWSSDK.UnitTests.QueryProtocol.NetFramework.csproj
+++ b/sdk/test/Services/QueryProtocol/UnitTests/AWSSDK.UnitTests.QueryProtocol.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/QuickSight/UnitTests/AWSSDK.UnitTests.QuickSight.NetFramework.csproj
+++ b/sdk/test/Services/QuickSight/UnitTests/AWSSDK.UnitTests.QuickSight.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RAM/UnitTests/AWSSDK.UnitTests.RAM.NetFramework.csproj
+++ b/sdk/test/Services/RAM/UnitTests/AWSSDK.UnitTests.RAM.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RDS/IntegrationTests/AWSSDK.IntegrationTests.RDS.NetFramework.csproj
+++ b/sdk/test/Services/RDS/IntegrationTests/AWSSDK.IntegrationTests.RDS.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/RDS/UnitTests/AWSSDK.UnitTests.RDS.NetFramework.csproj
+++ b/sdk/test/Services/RDS/UnitTests/AWSSDK.UnitTests.RDS.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RDSDataService/UnitTests/AWSSDK.UnitTests.RDSDataService.NetFramework.csproj
+++ b/sdk/test/Services/RDSDataService/UnitTests/AWSSDK.UnitTests.RDSDataService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RecycleBin/UnitTests/AWSSDK.UnitTests.RecycleBin.NetFramework.csproj
+++ b/sdk/test/Services/RecycleBin/UnitTests/AWSSDK.UnitTests.RecycleBin.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Redshift/IntegrationTests/AWSSDK.IntegrationTests.Redshift.NetFramework.csproj
+++ b/sdk/test/Services/Redshift/IntegrationTests/AWSSDK.IntegrationTests.Redshift.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Redshift/UnitTests/AWSSDK.UnitTests.Redshift.NetFramework.csproj
+++ b/sdk/test/Services/Redshift/UnitTests/AWSSDK.UnitTests.Redshift.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RedshiftDataAPIService/UnitTests/AWSSDK.UnitTests.RedshiftDataAPIService.NetFramework.csproj
+++ b/sdk/test/Services/RedshiftDataAPIService/UnitTests/AWSSDK.UnitTests.RedshiftDataAPIService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RedshiftServerless/UnitTests/AWSSDK.UnitTests.RedshiftServerless.NetFramework.csproj
+++ b/sdk/test/Services/RedshiftServerless/UnitTests/AWSSDK.UnitTests.RedshiftServerless.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Rekognition/UnitTests/AWSSDK.UnitTests.Rekognition.NetFramework.csproj
+++ b/sdk/test/Services/Rekognition/UnitTests/AWSSDK.UnitTests.Rekognition.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Repostspace/UnitTests/AWSSDK.UnitTests.Repostspace.NetFramework.csproj
+++ b/sdk/test/Services/Repostspace/UnitTests/AWSSDK.UnitTests.Repostspace.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ResilienceHub/UnitTests/AWSSDK.UnitTests.ResilienceHub.NetFramework.csproj
+++ b/sdk/test/Services/ResilienceHub/UnitTests/AWSSDK.UnitTests.ResilienceHub.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ResourceExplorer2/UnitTests/AWSSDK.UnitTests.ResourceExplorer2.NetFramework.csproj
+++ b/sdk/test/Services/ResourceExplorer2/UnitTests/AWSSDK.UnitTests.ResourceExplorer2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ResourceGroups/UnitTests/AWSSDK.UnitTests.ResourceGroups.NetFramework.csproj
+++ b/sdk/test/Services/ResourceGroups/UnitTests/AWSSDK.UnitTests.ResourceGroups.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ResourceGroupsTaggingAPI/UnitTests/AWSSDK.UnitTests.ResourceGroupsTaggingAPI.NetFramework.csproj
+++ b/sdk/test/Services/ResourceGroupsTaggingAPI/UnitTests/AWSSDK.UnitTests.ResourceGroupsTaggingAPI.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RestJsonProtocol/UnitTests/AWSSDK.UnitTests.RestJsonProtocol.NetFramework.csproj
+++ b/sdk/test/Services/RestJsonProtocol/UnitTests/AWSSDK.UnitTests.RestJsonProtocol.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RestJsonTest/UnitTests/AWSSDK.UnitTests.RestJsonTest.NetFramework.csproj
+++ b/sdk/test/Services/RestJsonTest/UnitTests/AWSSDK.UnitTests.RestJsonTest.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RestXMLTest/UnitTests/AWSSDK.UnitTests.RestXMLTest.NetFramework.csproj
+++ b/sdk/test/Services/RestXMLTest/UnitTests/AWSSDK.UnitTests.RestXMLTest.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RestXmlProtocol/UnitTests/AWSSDK.UnitTests.RestXmlProtocol.NetFramework.csproj
+++ b/sdk/test/Services/RestXmlProtocol/UnitTests/AWSSDK.UnitTests.RestXmlProtocol.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RestXmlProtocolNamespace/UnitTests/AWSSDK.UnitTests.RestXmlProtocolNamespace.NetFramework.csproj
+++ b/sdk/test/Services/RestXmlProtocolNamespace/UnitTests/AWSSDK.UnitTests.RestXmlProtocolNamespace.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/RoboMaker/UnitTests/AWSSDK.UnitTests.RoboMaker.NetFramework.csproj
+++ b/sdk/test/Services/RoboMaker/UnitTests/AWSSDK.UnitTests.RoboMaker.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Route53/IntegrationTests/AWSSDK.IntegrationTests.Route53.NetFramework.csproj
+++ b/sdk/test/Services/Route53/IntegrationTests/AWSSDK.IntegrationTests.Route53.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Route53/UnitTests/AWSSDK.UnitTests.Route53.NetFramework.csproj
+++ b/sdk/test/Services/Route53/UnitTests/AWSSDK.UnitTests.Route53.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Route53Domains/IntegrationTests/AWSSDK.IntegrationTests.Route53Domains.NetFramework.csproj
+++ b/sdk/test/Services/Route53Domains/IntegrationTests/AWSSDK.IntegrationTests.Route53Domains.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Route53Domains/UnitTests/AWSSDK.UnitTests.Route53Domains.NetFramework.csproj
+++ b/sdk/test/Services/Route53Domains/UnitTests/AWSSDK.UnitTests.Route53Domains.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Route53Profiles/UnitTests/AWSSDK.UnitTests.Route53Profiles.NetFramework.csproj
+++ b/sdk/test/Services/Route53Profiles/UnitTests/AWSSDK.UnitTests.Route53Profiles.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Route53RecoveryCluster/UnitTests/AWSSDK.UnitTests.Route53RecoveryCluster.NetFramework.csproj
+++ b/sdk/test/Services/Route53RecoveryCluster/UnitTests/AWSSDK.UnitTests.Route53RecoveryCluster.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Route53RecoveryControlConfig/UnitTests/AWSSDK.UnitTests.Route53RecoveryControlConfig.NetFramework.csproj
+++ b/sdk/test/Services/Route53RecoveryControlConfig/UnitTests/AWSSDK.UnitTests.Route53RecoveryControlConfig.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Route53RecoveryReadiness/UnitTests/AWSSDK.UnitTests.Route53RecoveryReadiness.NetFramework.csproj
+++ b/sdk/test/Services/Route53RecoveryReadiness/UnitTests/AWSSDK.UnitTests.Route53RecoveryReadiness.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Route53Resolver/UnitTests/AWSSDK.UnitTests.Route53Resolver.NetFramework.csproj
+++ b/sdk/test/Services/Route53Resolver/UnitTests/AWSSDK.UnitTests.Route53Resolver.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/S3/IntegrationTests/AWSSDK.IntegrationTests.S3.NetFramework.csproj
+++ b/sdk/test/Services/S3/IntegrationTests/AWSSDK.IntegrationTests.S3.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>

--- a/sdk/test/Services/S3/UnitTests/AWSSDK.UnitTests.S3.NetFramework.csproj
+++ b/sdk/test/Services/S3/UnitTests/AWSSDK.UnitTests.S3.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/S3Control/UnitTests/AWSSDK.UnitTests.S3Control.NetFramework.csproj
+++ b/sdk/test/Services/S3Control/UnitTests/AWSSDK.UnitTests.S3Control.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/S3Outposts/UnitTests/AWSSDK.UnitTests.S3Outposts.NetFramework.csproj
+++ b/sdk/test/Services/S3Outposts/UnitTests/AWSSDK.UnitTests.S3Outposts.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SQS/IntegrationTests/AWSSDK.IntegrationTests.SQS.NetFramework.csproj
+++ b/sdk/test/Services/SQS/IntegrationTests/AWSSDK.IntegrationTests.SQS.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/SQS/UnitTests/AWSSDK.UnitTests.SQS.NetFramework.csproj
+++ b/sdk/test/Services/SQS/UnitTests/AWSSDK.UnitTests.SQS.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SSMContacts/UnitTests/AWSSDK.UnitTests.SSMContacts.NetFramework.csproj
+++ b/sdk/test/Services/SSMContacts/UnitTests/AWSSDK.UnitTests.SSMContacts.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SSMIncidents/UnitTests/AWSSDK.UnitTests.SSMIncidents.NetFramework.csproj
+++ b/sdk/test/Services/SSMIncidents/UnitTests/AWSSDK.UnitTests.SSMIncidents.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SSO/UnitTests/AWSSDK.UnitTests.SSO.NetFramework.csproj
+++ b/sdk/test/Services/SSO/UnitTests/AWSSDK.UnitTests.SSO.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SSOAdmin/UnitTests/AWSSDK.UnitTests.SSOAdmin.NetFramework.csproj
+++ b/sdk/test/Services/SSOAdmin/UnitTests/AWSSDK.UnitTests.SSOAdmin.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SSOOIDC/UnitTests/AWSSDK.UnitTests.SSOOIDC.NetFramework.csproj
+++ b/sdk/test/Services/SSOOIDC/UnitTests/AWSSDK.UnitTests.SSOOIDC.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SageMaker/UnitTests/AWSSDK.UnitTests.SageMaker.NetFramework.csproj
+++ b/sdk/test/Services/SageMaker/UnitTests/AWSSDK.UnitTests.SageMaker.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SageMakerFeatureStoreRuntime/UnitTests/AWSSDK.UnitTests.SageMakerFeatureStoreRuntime.NetFramework.csproj
+++ b/sdk/test/Services/SageMakerFeatureStoreRuntime/UnitTests/AWSSDK.UnitTests.SageMakerFeatureStoreRuntime.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SageMakerGeospatial/UnitTests/AWSSDK.UnitTests.SageMakerGeospatial.NetFramework.csproj
+++ b/sdk/test/Services/SageMakerGeospatial/UnitTests/AWSSDK.UnitTests.SageMakerGeospatial.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SageMakerMetrics/UnitTests/AWSSDK.UnitTests.SageMakerMetrics.NetFramework.csproj
+++ b/sdk/test/Services/SageMakerMetrics/UnitTests/AWSSDK.UnitTests.SageMakerMetrics.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SageMakerRuntime/UnitTests/AWSSDK.UnitTests.SageMakerRuntime.NetFramework.csproj
+++ b/sdk/test/Services/SageMakerRuntime/UnitTests/AWSSDK.UnitTests.SageMakerRuntime.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SagemakerEdgeManager/UnitTests/AWSSDK.UnitTests.SagemakerEdgeManager.NetFramework.csproj
+++ b/sdk/test/Services/SagemakerEdgeManager/UnitTests/AWSSDK.UnitTests.SagemakerEdgeManager.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SavingsPlans/UnitTests/AWSSDK.UnitTests.SavingsPlans.NetFramework.csproj
+++ b/sdk/test/Services/SavingsPlans/UnitTests/AWSSDK.UnitTests.SavingsPlans.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Scheduler/UnitTests/AWSSDK.UnitTests.Scheduler.NetFramework.csproj
+++ b/sdk/test/Services/Scheduler/UnitTests/AWSSDK.UnitTests.Scheduler.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Schemas/UnitTests/AWSSDK.UnitTests.Schemas.NetFramework.csproj
+++ b/sdk/test/Services/Schemas/UnitTests/AWSSDK.UnitTests.Schemas.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SecretsManager/UnitTests/AWSSDK.UnitTests.SecretsManager.NetFramework.csproj
+++ b/sdk/test/Services/SecretsManager/UnitTests/AWSSDK.UnitTests.SecretsManager.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SecurityHub/UnitTests/AWSSDK.UnitTests.SecurityHub.NetFramework.csproj
+++ b/sdk/test/Services/SecurityHub/UnitTests/AWSSDK.UnitTests.SecurityHub.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SecurityLake/UnitTests/AWSSDK.UnitTests.SecurityLake.NetFramework.csproj
+++ b/sdk/test/Services/SecurityLake/UnitTests/AWSSDK.UnitTests.SecurityLake.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SecurityToken/IntegrationTests/AWSSDK.IntegrationTests.SecurityToken.NetFramework.csproj
+++ b/sdk/test/Services/SecurityToken/IntegrationTests/AWSSDK.IntegrationTests.SecurityToken.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/SecurityToken/UnitTests/AWSSDK.UnitTests.SecurityToken.NetFramework.csproj
+++ b/sdk/test/Services/SecurityToken/UnitTests/AWSSDK.UnitTests.SecurityToken.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ServerMigrationService/IntegrationTests/AWSSDK.IntegrationTests.ServerMigrationService.NetFramework.csproj
+++ b/sdk/test/Services/ServerMigrationService/IntegrationTests/AWSSDK.IntegrationTests.ServerMigrationService.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/ServerMigrationService/UnitTests/AWSSDK.UnitTests.ServerMigrationService.NetFramework.csproj
+++ b/sdk/test/Services/ServerMigrationService/UnitTests/AWSSDK.UnitTests.ServerMigrationService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ServerlessApplicationRepository/UnitTests/AWSSDK.UnitTests.ServerlessApplicationRepository.NetFramework.csproj
+++ b/sdk/test/Services/ServerlessApplicationRepository/UnitTests/AWSSDK.UnitTests.ServerlessApplicationRepository.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ServiceCatalog/UnitTests/AWSSDK.UnitTests.ServiceCatalog.NetFramework.csproj
+++ b/sdk/test/Services/ServiceCatalog/UnitTests/AWSSDK.UnitTests.ServiceCatalog.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ServiceDiscovery/UnitTests/AWSSDK.UnitTests.ServiceDiscovery.NetFramework.csproj
+++ b/sdk/test/Services/ServiceDiscovery/UnitTests/AWSSDK.UnitTests.ServiceDiscovery.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/ServiceQuotas/UnitTests/AWSSDK.UnitTests.ServiceQuotas.NetFramework.csproj
+++ b/sdk/test/Services/ServiceQuotas/UnitTests/AWSSDK.UnitTests.ServiceQuotas.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Shield/UnitTests/AWSSDK.UnitTests.Shield.NetFramework.csproj
+++ b/sdk/test/Services/Shield/UnitTests/AWSSDK.UnitTests.Shield.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Signer/UnitTests/AWSSDK.UnitTests.Signer.NetFramework.csproj
+++ b/sdk/test/Services/Signer/UnitTests/AWSSDK.UnitTests.Signer.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SimSpaceWeaver/UnitTests/AWSSDK.UnitTests.SimSpaceWeaver.NetFramework.csproj
+++ b/sdk/test/Services/SimSpaceWeaver/UnitTests/AWSSDK.UnitTests.SimSpaceWeaver.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SimpleDB/IntegrationTests/AWSSDK.IntegrationTests.SimpleDB.NetFramework.csproj
+++ b/sdk/test/Services/SimpleDB/IntegrationTests/AWSSDK.IntegrationTests.SimpleDB.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/SimpleDB/UnitTests/AWSSDK.UnitTests.SimpleDB.NetFramework.csproj
+++ b/sdk/test/Services/SimpleDB/UnitTests/AWSSDK.UnitTests.SimpleDB.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SimpleEmail/IntegrationTests/AWSSDK.IntegrationTests.SimpleEmail.NetFramework.csproj
+++ b/sdk/test/Services/SimpleEmail/IntegrationTests/AWSSDK.IntegrationTests.SimpleEmail.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/SimpleEmail/UnitTests/AWSSDK.UnitTests.SimpleEmail.NetFramework.csproj
+++ b/sdk/test/Services/SimpleEmail/UnitTests/AWSSDK.UnitTests.SimpleEmail.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SimpleEmailV2/UnitTests/AWSSDK.UnitTests.SimpleEmailV2.NetFramework.csproj
+++ b/sdk/test/Services/SimpleEmailV2/UnitTests/AWSSDK.UnitTests.SimpleEmailV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SimpleNotificationService/IntegrationTests/AWSSDK.IntegrationTests.SimpleNotificationService.NetFramework.csproj
+++ b/sdk/test/Services/SimpleNotificationService/IntegrationTests/AWSSDK.IntegrationTests.SimpleNotificationService.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/SimpleNotificationService/UnitTests/AWSSDK.UnitTests.SimpleNotificationService.NetFramework.csproj
+++ b/sdk/test/Services/SimpleNotificationService/UnitTests/AWSSDK.UnitTests.SimpleNotificationService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SimpleSystemsManagement/IntegrationTests/AWSSDK.IntegrationTests.SimpleSystemsManagement.NetFramework.csproj
+++ b/sdk/test/Services/SimpleSystemsManagement/IntegrationTests/AWSSDK.IntegrationTests.SimpleSystemsManagement.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/SimpleSystemsManagement/UnitTests/AWSSDK.UnitTests.SimpleSystemsManagement.NetFramework.csproj
+++ b/sdk/test/Services/SimpleSystemsManagement/UnitTests/AWSSDK.UnitTests.SimpleSystemsManagement.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SimpleWorkflow/IntegrationTests/AWSSDK.IntegrationTests.SimpleWorkflow.NetFramework.csproj
+++ b/sdk/test/Services/SimpleWorkflow/IntegrationTests/AWSSDK.IntegrationTests.SimpleWorkflow.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/SimpleWorkflow/UnitTests/AWSSDK.UnitTests.SimpleWorkflow.NetFramework.csproj
+++ b/sdk/test/Services/SimpleWorkflow/UnitTests/AWSSDK.UnitTests.SimpleWorkflow.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SnowDeviceManagement/UnitTests/AWSSDK.UnitTests.SnowDeviceManagement.NetFramework.csproj
+++ b/sdk/test/Services/SnowDeviceManagement/UnitTests/AWSSDK.UnitTests.SnowDeviceManagement.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Snowball/IntegrationTests/AWSSDK.IntegrationTests.Snowball.NetFramework.csproj
+++ b/sdk/test/Services/Snowball/IntegrationTests/AWSSDK.IntegrationTests.Snowball.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/Snowball/UnitTests/AWSSDK.UnitTests.Snowball.NetFramework.csproj
+++ b/sdk/test/Services/Snowball/UnitTests/AWSSDK.UnitTests.Snowball.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SsmSap/UnitTests/AWSSDK.UnitTests.SsmSap.NetFramework.csproj
+++ b/sdk/test/Services/SsmSap/UnitTests/AWSSDK.UnitTests.SsmSap.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/StepFunctions/UnitTests/AWSSDK.UnitTests.StepFunctions.NetFramework.csproj
+++ b/sdk/test/Services/StepFunctions/UnitTests/AWSSDK.UnitTests.StepFunctions.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/StorageGateway/IntegrationTests/AWSSDK.IntegrationTests.StorageGateway.NetFramework.csproj
+++ b/sdk/test/Services/StorageGateway/IntegrationTests/AWSSDK.IntegrationTests.StorageGateway.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/StorageGateway/UnitTests/AWSSDK.UnitTests.StorageGateway.NetFramework.csproj
+++ b/sdk/test/Services/StorageGateway/UnitTests/AWSSDK.UnitTests.StorageGateway.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SupplyChain/UnitTests/AWSSDK.UnitTests.SupplyChain.NetFramework.csproj
+++ b/sdk/test/Services/SupplyChain/UnitTests/AWSSDK.UnitTests.SupplyChain.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/SupportApp/UnitTests/AWSSDK.UnitTests.SupportApp.NetFramework.csproj
+++ b/sdk/test/Services/SupportApp/UnitTests/AWSSDK.UnitTests.SupportApp.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Synthetics/UnitTests/AWSSDK.UnitTests.Synthetics.NetFramework.csproj
+++ b/sdk/test/Services/Synthetics/UnitTests/AWSSDK.UnitTests.Synthetics.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Textract/UnitTests/AWSSDK.UnitTests.Textract.NetFramework.csproj
+++ b/sdk/test/Services/Textract/UnitTests/AWSSDK.UnitTests.Textract.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/TimestreamInfluxDB/UnitTests/AWSSDK.UnitTests.TimestreamInfluxDB.NetFramework.csproj
+++ b/sdk/test/Services/TimestreamInfluxDB/UnitTests/AWSSDK.UnitTests.TimestreamInfluxDB.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/TimestreamQuery/UnitTests/AWSSDK.UnitTests.TimestreamQuery.NetFramework.csproj
+++ b/sdk/test/Services/TimestreamQuery/UnitTests/AWSSDK.UnitTests.TimestreamQuery.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/TimestreamWrite/UnitTests/AWSSDK.UnitTests.TimestreamWrite.NetFramework.csproj
+++ b/sdk/test/Services/TimestreamWrite/UnitTests/AWSSDK.UnitTests.TimestreamWrite.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Tnb/UnitTests/AWSSDK.UnitTests.Tnb.NetFramework.csproj
+++ b/sdk/test/Services/Tnb/UnitTests/AWSSDK.UnitTests.Tnb.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/TranscribeService/UnitTests/AWSSDK.UnitTests.TranscribeService.NetFramework.csproj
+++ b/sdk/test/Services/TranscribeService/UnitTests/AWSSDK.UnitTests.TranscribeService.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Transfer/UnitTests/AWSSDK.UnitTests.Transfer.NetFramework.csproj
+++ b/sdk/test/Services/Transfer/UnitTests/AWSSDK.UnitTests.Transfer.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/Translate/UnitTests/AWSSDK.UnitTests.Translate.NetFramework.csproj
+++ b/sdk/test/Services/Translate/UnitTests/AWSSDK.UnitTests.Translate.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/TrustedAdvisor/UnitTests/AWSSDK.UnitTests.TrustedAdvisor.NetFramework.csproj
+++ b/sdk/test/Services/TrustedAdvisor/UnitTests/AWSSDK.UnitTests.TrustedAdvisor.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/UseServiceIdTestserviceId/UnitTests/AWSSDK.UnitTests.UseServiceIdTestserviceId.NetFramework.csproj
+++ b/sdk/test/Services/UseServiceIdTestserviceId/UnitTests/AWSSDK.UnitTests.UseServiceIdTestserviceId.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/VPCLattice/UnitTests/AWSSDK.UnitTests.VPCLattice.NetFramework.csproj
+++ b/sdk/test/Services/VPCLattice/UnitTests/AWSSDK.UnitTests.VPCLattice.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/VerifiedPermissions/UnitTests/AWSSDK.UnitTests.VerifiedPermissions.NetFramework.csproj
+++ b/sdk/test/Services/VerifiedPermissions/UnitTests/AWSSDK.UnitTests.VerifiedPermissions.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/VoiceID/UnitTests/AWSSDK.UnitTests.VoiceID.NetFramework.csproj
+++ b/sdk/test/Services/VoiceID/UnitTests/AWSSDK.UnitTests.VoiceID.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WAF/IntegrationTests/AWSSDK.IntegrationTests.WAF.NetFramework.csproj
+++ b/sdk/test/Services/WAF/IntegrationTests/AWSSDK.IntegrationTests.WAF.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/Services/WAF/UnitTests/AWSSDK.UnitTests.WAF.NetFramework.csproj
+++ b/sdk/test/Services/WAF/UnitTests/AWSSDK.UnitTests.WAF.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WAFRegional/UnitTests/AWSSDK.UnitTests.WAFRegional.NetFramework.csproj
+++ b/sdk/test/Services/WAFRegional/UnitTests/AWSSDK.UnitTests.WAFRegional.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WAFV2/UnitTests/AWSSDK.UnitTests.WAFV2.NetFramework.csproj
+++ b/sdk/test/Services/WAFV2/UnitTests/AWSSDK.UnitTests.WAFV2.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WellArchitected/UnitTests/AWSSDK.UnitTests.WellArchitected.NetFramework.csproj
+++ b/sdk/test/Services/WellArchitected/UnitTests/AWSSDK.UnitTests.WellArchitected.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WorkDocs/UnitTests/AWSSDK.UnitTests.WorkDocs.NetFramework.csproj
+++ b/sdk/test/Services/WorkDocs/UnitTests/AWSSDK.UnitTests.WorkDocs.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WorkLink/UnitTests/AWSSDK.UnitTests.WorkLink.NetFramework.csproj
+++ b/sdk/test/Services/WorkLink/UnitTests/AWSSDK.UnitTests.WorkLink.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WorkMail/UnitTests/AWSSDK.UnitTests.WorkMail.NetFramework.csproj
+++ b/sdk/test/Services/WorkMail/UnitTests/AWSSDK.UnitTests.WorkMail.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WorkMailMessageFlow/UnitTests/AWSSDK.UnitTests.WorkMailMessageFlow.NetFramework.csproj
+++ b/sdk/test/Services/WorkMailMessageFlow/UnitTests/AWSSDK.UnitTests.WorkMailMessageFlow.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WorkSpaces/UnitTests/AWSSDK.UnitTests.WorkSpaces.NetFramework.csproj
+++ b/sdk/test/Services/WorkSpaces/UnitTests/AWSSDK.UnitTests.WorkSpaces.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WorkSpacesThinClient/UnitTests/AWSSDK.UnitTests.WorkSpacesThinClient.NetFramework.csproj
+++ b/sdk/test/Services/WorkSpacesThinClient/UnitTests/AWSSDK.UnitTests.WorkSpacesThinClient.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/WorkSpacesWeb/UnitTests/AWSSDK.UnitTests.WorkSpacesWeb.NetFramework.csproj
+++ b/sdk/test/Services/WorkSpacesWeb/UnitTests/AWSSDK.UnitTests.WorkSpacesWeb.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/Services/XRay/UnitTests/AWSSDK.UnitTests.XRay.NetFramework.csproj
+++ b/sdk/test/Services/XRay/UnitTests/AWSSDK.UnitTests.XRay.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.

--- a/sdk/test/UnitTests/AWSSDK.UnitTests.NetFramework.csproj
+++ b/sdk/test/UnitTests/AWSSDK.UnitTests.NetFramework.csproj
@@ -21,6 +21,9 @@
 
     <NoWarn>CS1591,CS0612,CS0618</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <!-- 
     For .NET 8 LangVersion is set to 11 to allow using static interface methods. This is to allow
     the service interface factory method to exist for AWSSDK.Extensions.NETCore.Setup.


### PR DESCRIPTION
V4 has added several .NET Standard 2.0 packages to the .NET Framework targets like System.Text.Json. This can cause target applications like our test projects to need to add binding redirects. This PR updates all of the unit and integ test projects in the SDK to generate binding redirects in the .NET Framework app.config.

Tested this by building the .NET Framework and .NET Standard solutions. I have also confirmed the binding issue with running the DynamoDB integ tests is resolved and at least the subset I ran locally passed.