### PR TITLE
Add check for .NET Framework assembly binding errors

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
+++ b/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
@@ -417,8 +417,11 @@ namespace Amazon.Runtime
                     new Marshaller(),
                     preMarshallHandler,
                     errorCallbackHandler,
-                    new MetricsHandler()
-                },
+                    new MetricsHandler(),
+#if BCL
+                    new BindingRedirectCheckHandler(),
+#endif
+            },
                 _logger
             );
 

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/_bcl/BindingRedirectCheckHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/_bcl/BindingRedirectCheckHandler.cs
@@ -1,0 +1,94 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using System.IO;
+
+namespace Amazon.Runtime.Internal
+{
+    /// <summary>
+    /// .NET Framework uses .NET Standard 2.0 packages like System.Text.Json and System.Memory.
+    /// These dependencies can issues loading assemblies like System.Runtime.CompilerServices.Unsafe
+    /// do to how .NET Framework binds assemblies. The default exception is an unhelpful System.IO.FileNotFoundException.
+    /// This handler checks for that exception in the request pipeline and gives an error message
+    /// with details about the binding issues.
+    /// </summary>
+    public class BindingRedirectCheckHandler : PipelineHandler
+    {
+        private const string ERROR_MSG = 
+            "The AWS SDK for .NET uses .NET Standard 2.0 packages like System.Text.Json and " +
+            "System.Memory. These packages force newer versions of other system runtime assemblies like " +
+            "System.Runtime.CompilerServices.Unsafe to be loaded. Depending on applications other dependencies this " + 
+            "can cause assembly binding issues. To mitigated the issue enable assembly redirects. " +
+            "https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection";
+
+        /// <summary>
+        /// Check FileNotFoundException for binding errors.
+        /// </summary>
+        /// <param name="executionContext">The execution context which contains both the
+        /// requests and response context.</param>
+        public override void InvokeSync(IExecutionContext executionContext)
+        {
+            try
+            {
+                base.InvokeSync(executionContext);
+            }
+            catch(FileNotFoundException e)
+            {
+                if (IsBindingException(e))
+                {
+                    throw new AmazonClientException(ERROR_MSG, e);
+                }
+
+                throw;
+            }
+        }
+
+#if AWS_ASYNC_API 
+        /// <summary>
+        /// Check FileNotFoundException for binding errors.
+        /// </summary>
+        /// <typeparam name="T">The response type for the current request.</typeparam>
+        /// <param name="executionContext">The execution context, it contains the
+        /// request and response context.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public override async System.Threading.Tasks.Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+        {
+            try
+            {
+                return await base.InvokeAsync<T>(executionContext).ConfigureAwait(false);
+            }
+            catch (FileNotFoundException e)
+            {
+                if (IsBindingException(e))
+                {
+                    throw new AmazonClientException(ERROR_MSG, e);
+                }
+
+                throw;
+            }
+        }
+#endif
+
+        public static bool IsBindingException(FileNotFoundException e)
+        {
+            if (e.Message.Contains("Could not load file or assembly") && 
+                e.Message.Contains("System.Runtime."))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/sdk/test/UnitTests/Custom/Runtime/_bcl/BindingRedirectCheckHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/_bcl/BindingRedirectCheckHandlerTests.cs
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.IO;
+using Amazon.Runtime.Internal;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSSDK.UnitTests.Runtime
+{
+    [TestClass]
+    public class BindingRedirectCheckHandlerTests
+    {
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CheckIsBindingError()
+        {
+            var fe = new FileNotFoundException("Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.");
+            Assert.IsTrue(BindingRedirectCheckHandler.IsBindingException(fe));
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CheckIsNotBindingError()
+        {
+            var fe = new FileNotFoundException("Could not load file or assembly 'AWSSDK.S3, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aaaaaaaaaaa' or one of its dependencies.");
+            Assert.IsFalse(BindingRedirectCheckHandler.IsBindingException(fe));
+        }
+    }
+}


### PR DESCRIPTION
As a follow up to the previous [PR](https://github.com/aws/aws-sdk-net/pull/3371) adding redirect bindings for .NET Framework test this PR adds a check in the .NET Framework version of the SDK to see if an exception during the request pipeline is a possible binding issue. This way we can give a more meaningful error message with instructions on how to correct the situation. Otherwise the user just gets a file not found exception.

Error before PR:
```
System.IO.FileNotFoundException: System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified..
```

Error with PR:
```
Amazon.Runtime.AmazonClientException: The AWS SDK for .NET uses .NET Standard 2.0 packages like System.Text.Json and System.Memory. These packages force newer versions of other system runtime assemblies like System.Runtime.CompilerServices.Unsafe to be loaded. Depending on applications other dependencies this can cause assembly binding issues. To mitigated the issue enable assembly redirects. https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection ---> System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified..
``` 