### PR TITLE
Create separate operation-specific configs for the object-mapper Batch and Transact operations

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
@@ -71,7 +71,7 @@ namespace Amazon.DynamoDBv2.DataModel
         public DynamoDBEntryConversion Conversion { get; set; }
 
         /// <summary>
-        /// Contorls how <see cref="DynamoDBContext"/> interprets emptry string values.
+        /// Controls how <see cref="DynamoDBContext"/> interprets empty string values.
         /// If the property is false (or not set), empty string values will be
         /// interpreted as null values.
         /// </summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGetConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGetConfig.cs
@@ -1,0 +1,115 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+
+namespace Amazon.DynamoDBv2.DataModel
+{
+    /// <summary>
+    /// Input for the BatchGet operation in the object-persistence programming model
+    /// </summary>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
+    public class BatchGetConfig
+    {
+        /// <summary>
+        /// Property that indicates which DynamoDB table to use, 
+        /// overriding the DynamoDBTable attribute declared for the object type.
+        /// </summary>
+        public string OverrideTableName { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to prefix all table names
+        /// with a specific string.
+        /// If property is null or empty, no prefix is used and default
+        /// table names are used.
+        /// </summary>
+        public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
+        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
+        /// </remarks>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
+
+        /// <summary>
+        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
+        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
+        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
+        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
+        /// </remarks>
+        public bool? DisableFetchingTableMetadata { get; set; }
+
+        /// <summary>
+        /// Conversion specification which controls how the conversion between
+        /// .NET and DynamoDB types happens.
+        /// </summary>
+        public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to enable empty string values
+        /// on attributes during a Save operation.
+        /// If the property is false (or not set), empty string values will be
+        /// interpreted as null values.
+        /// </summary>
+        public bool? IsEmptyStringValueEnabled { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to use consistent reads.
+        /// If property is not set, behavior defaults to non-consistent reads.
+        /// </summary>
+        public bool? ConsistentRead { get; set; }
+
+        /// <summary>
+        /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
+        /// </summary>
+        /// <remarks>This setting is only applicable to the high-level library. Service calls made via <see cref="AmazonDynamoDBClient"/> will always return <see cref="DateTime"/> attributes in UTC.</remarks>
+        public bool? RetrieveDateTimeInUtc { get; set; }
+
+        /// <summary>
+        /// Converts this to the shared <see cref="DynamoDBOperationConfig"/>
+        /// </summary>
+        /// <remarks>
+        /// Users should interact with the new, operation-specific configs, but we
+        /// convert to the internal shared config for the internal code paths.
+        /// </remarks>
+        /// <returns>New <see cref="DynamoDBOperationConfig"/></returns>
+        internal DynamoDBOperationConfig ToDynamoDBOperationConfig()
+        {
+            return new DynamoDBOperationConfig()
+            {
+                OverrideTableName = OverrideTableName,
+                TableNamePrefix = TableNamePrefix,
+                MetadataCachingMode = MetadataCachingMode,
+                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
+                Conversion = Conversion,
+                IsEmptyStringValueEnabled = IsEmptyStringValueEnabled,
+                ConsistentRead = ConsistentRead,
+                RetrieveDateTimeInUtc = RetrieveDateTimeInUtc
+            };
+        }
+    }
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGetConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGetConfig.cs
@@ -21,64 +21,13 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Input for the BatchGet operation in the object-persistence programming model
     /// </summary>
 #if NET8_0_OR_GREATER
+    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
 #endif
-    public class BatchGetConfig
+    public class BatchGetConfig : BaseOperationConfig
     {
         /// <summary>
-        /// Property that indicates which DynamoDB table to use, 
-        /// overriding the DynamoDBTable attribute declared for the object type.
-        /// </summary>
-        public string OverrideTableName { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to prefix all table names
-        /// with a specific string.
-        /// If property is null or empty, no prefix is used and default
-        /// table names are used.
-        /// </summary>
-        public string TableNamePrefix { get; set; }
-
-        /// <summary>
-        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
-        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
-        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
-        /// </summary>
-        /// <remarks>
-        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
-        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
-        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
-        /// </remarks>
-        public MetadataCachingMode? MetadataCachingMode { get; set; }
-
-        /// <summary>
-        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
-        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
-        /// </summary>
-        /// <remarks>
-        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
-        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
-        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
-        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
-        /// </remarks>
-        public bool? DisableFetchingTableMetadata { get; set; }
-
-        /// <summary>
-        /// Conversion specification which controls how the conversion between
-        /// .NET and DynamoDB types happens.
-        /// </summary>
-        public DynamoDBEntryConversion Conversion { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to enable empty string values
-        /// on attributes during a Save operation.
-        /// If the property is false (or not set), empty string values will be
-        /// interpreted as null values.
-        /// </summary>
-        public bool? IsEmptyStringValueEnabled { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to use consistent reads.
+        /// Property that directs <see cref="DynamoDBContext"/> to use consistent reads.
         /// If property is not set, behavior defaults to non-consistent reads.
         /// </summary>
         public bool? ConsistentRead { get; set; }
@@ -86,30 +35,20 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
         /// </summary>
-        /// <remarks>This setting is only applicable to the high-level library. Service calls made via <see cref="AmazonDynamoDBClient"/> will always return <see cref="DateTime"/> attributes in UTC.</remarks>
+        /// <remarks>
+        /// This setting is only applicable to the high-level library. Service calls made via 
+        /// <see cref="AmazonDynamoDBClient"/> will always return <see cref="DateTime"/> attributes in UTC.
+        /// </remarks>
         public bool? RetrieveDateTimeInUtc { get; set; }
 
-        /// <summary>
-        /// Converts this to the shared <see cref="DynamoDBOperationConfig"/>
-        /// </summary>
-        /// <remarks>
-        /// Users should interact with the new, operation-specific configs, but we
-        /// convert to the internal shared config for the internal code paths.
-        /// </remarks>
-        /// <returns>New <see cref="DynamoDBOperationConfig"/></returns>
-        internal DynamoDBOperationConfig ToDynamoDBOperationConfig()
+        /// <inheritdoc/>
+        internal override DynamoDBOperationConfig ToDynamoDBOperationConfig()
         {
-            return new DynamoDBOperationConfig()
-            {
-                OverrideTableName = OverrideTableName,
-                TableNamePrefix = TableNamePrefix,
-                MetadataCachingMode = MetadataCachingMode,
-                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
-                Conversion = Conversion,
-                IsEmptyStringValueEnabled = IsEmptyStringValueEnabled,
-                ConsistentRead = ConsistentRead,
-                RetrieveDateTimeInUtc = RetrieveDateTimeInUtc
-            };
+            var config = base.ToDynamoDBOperationConfig();
+            config.ConsistentRead = ConsistentRead;
+            config.RetrieveDateTimeInUtc = RetrieveDateTimeInUtc;
+
+            return config;
         }
     }
 }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGetConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGetConfig.cs
@@ -30,6 +30,10 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Property that directs <see cref="DynamoDBContext"/> to use consistent reads.
         /// If property is not set, behavior defaults to non-consistent reads.
         /// </summary>
+        /// <remarks>
+        /// Refer to the <see href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html">
+        /// Read Consistency</see> topic in the DynamoDB Developer Guide for more information.
+        /// </remarks>
         public bool? ConsistentRead { get; set; }
 
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWriteConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWriteConfig.cs
@@ -1,0 +1,116 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.DynamoDBv2.DataModel
+{
+    /// <summary>
+    /// Input for the BatchWrite operation in the object-persistence programming model
+    /// </summary>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
+    public class BatchWriteConfig
+    {
+        /// <summary>
+        /// Property that indicates which DynamoDB table to use, 
+        /// overriding the DynamoDBTable attribute declared for the object type.
+        /// </summary>
+        public string OverrideTableName { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to prefix all table names
+        /// with a specific string.
+        /// If property is null or empty, no prefix is used and default
+        /// table names are used.
+        /// </summary>
+        public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
+        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
+        /// </remarks>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
+
+        /// <summary>
+        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
+        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
+        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
+        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
+        /// </remarks>
+        public bool? DisableFetchingTableMetadata { get; set; }
+
+        /// <summary>
+        /// Conversion specification which controls how the conversion between
+        /// .NET and DynamoDB types happens.
+        /// </summary>
+        public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to enable empty string values
+        /// on attributes during a Save operation.
+        /// If the property is false (or not set), empty string values will be
+        /// interpreted as null values.
+        /// </summary>
+        public bool? IsEmptyStringValueEnabled { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to skip version checks
+        /// when saving or deleting an object with a version attribute.
+        /// If property is not set, version checks are performed.
+        /// </summary>
+        public bool? SkipVersionCheck { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to ignore null values
+        /// on attributes during a Save operation.
+        /// If the property is false (or not set), null values will be
+        /// interpreted as directives to delete the specific attribute.
+        /// </summary>
+        public bool? IgnoreNullValues { get; set; }
+
+        /// <summary>
+        /// Converts this to the shared <see cref="DynamoDBOperationConfig"/>
+        /// </summary>
+        /// <remarks>
+        /// Users should interact with the new, operation-specific configs, but we
+        /// convert to the internal shared config for the internal code paths.
+        /// </remarks>
+        /// <returns>A new <see cref="DynamoDBOperationConfig"/></returns>
+        internal DynamoDBOperationConfig ToDynamoDBOperationConfig()
+        {
+            return new DynamoDBOperationConfig()
+            {
+                OverrideTableName = OverrideTableName,
+                TableNamePrefix = TableNamePrefix,
+                MetadataCachingMode = MetadataCachingMode,
+                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
+                Conversion = Conversion,
+                IsEmptyStringValueEnabled = IsEmptyStringValueEnabled,
+                SkipVersionCheck = SkipVersionCheck,
+                IgnoreNullValues = IgnoreNullValues
+            };
+        }
+    }
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWriteConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWriteConfig.cs
@@ -19,98 +19,34 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Input for the BatchWrite operation in the object-persistence programming model
     /// </summary>
 #if NET8_0_OR_GREATER
+    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
 #endif
-    public class BatchWriteConfig
+    public class BatchWriteConfig : BaseOperationConfig
     {
         /// <summary>
-        /// Property that indicates which DynamoDB table to use, 
-        /// overriding the DynamoDBTable attribute declared for the object type.
-        /// </summary>
-        public string OverrideTableName { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to prefix all table names
-        /// with a specific string.
-        /// If property is null or empty, no prefix is used and default
-        /// table names are used.
-        /// </summary>
-        public string TableNamePrefix { get; set; }
-
-        /// <summary>
-        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
-        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
-        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
-        /// </summary>
-        /// <remarks>
-        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
-        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
-        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
-        /// </remarks>
-        public MetadataCachingMode? MetadataCachingMode { get; set; }
-
-        /// <summary>
-        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
-        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
-        /// </summary>
-        /// <remarks>
-        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
-        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
-        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
-        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
-        /// </remarks>
-        public bool? DisableFetchingTableMetadata { get; set; }
-
-        /// <summary>
-        /// Conversion specification which controls how the conversion between
-        /// .NET and DynamoDB types happens.
-        /// </summary>
-        public DynamoDBEntryConversion Conversion { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to enable empty string values
-        /// on attributes during a Save operation.
-        /// If the property is false (or not set), empty string values will be
-        /// interpreted as null values.
-        /// </summary>
-        public bool? IsEmptyStringValueEnabled { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to skip version checks
+        /// Property that directs <see cref="DynamoDBContext"/> to skip version checks
         /// when saving or deleting an object with a version attribute.
         /// If property is not set, version checks are performed.
         /// </summary>
         public bool? SkipVersionCheck { get; set; }
 
         /// <summary>
-        /// Property that directs DynamoDBContext to ignore null values
-        /// on attributes during a Save operation.
-        /// If the property is false (or not set), null values will be
-        /// interpreted as directives to delete the specific attribute.
+        /// Directs <see cref="DynamoDBContext" /> to ignore null values when 
+        /// converting an object to a DynamoDB item. If the property is false 
+        /// (or not set), null values will be interpreted as directives to 
+        /// delete the specific attributes on the DynamoDB item.
         /// </summary>
         public bool? IgnoreNullValues { get; set; }
 
-        /// <summary>
-        /// Converts this to the shared <see cref="DynamoDBOperationConfig"/>
-        /// </summary>
-        /// <remarks>
-        /// Users should interact with the new, operation-specific configs, but we
-        /// convert to the internal shared config for the internal code paths.
-        /// </remarks>
-        /// <returns>A new <see cref="DynamoDBOperationConfig"/></returns>
-        internal DynamoDBOperationConfig ToDynamoDBOperationConfig()
+        /// <inheritdoc/>
+        internal override DynamoDBOperationConfig ToDynamoDBOperationConfig()
         {
-            return new DynamoDBOperationConfig()
-            {
-                OverrideTableName = OverrideTableName,
-                TableNamePrefix = TableNamePrefix,
-                MetadataCachingMode = MetadataCachingMode,
-                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
-                Conversion = Conversion,
-                IsEmptyStringValueEnabled = IsEmptyStringValueEnabled,
-                SkipVersionCheck = SkipVersionCheck,
-                IgnoreNullValues = IgnoreNullValues
-            };
+            var config = base.ToDynamoDBOperationConfig();
+            config.SkipVersionCheck = SkipVersionCheck;
+            config.IgnoreNullValues = IgnoreNullValues;
+
+            return config;
         }
     }
 }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -228,7 +228,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchGet object</returns>
         [Obsolete("Use the CreateBatchGet overload that takes BatchGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-        public BatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig = null)
+        public BatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchGet<T>(this, config);
@@ -280,7 +280,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-        public BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig = null)
+        public BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<T>(this, config);
@@ -317,7 +317,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-        public BatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig)
+        public BatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig = null)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<object>(this, valuesType, config);
@@ -387,7 +387,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
         [Obsolete("Use the CreateTransactGet overload that takes TransactGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-        public TransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig = null)
+        public TransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new TransactGet<T>(this, config);
@@ -441,7 +441,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
 
         [Obsolete("Use the CreateTransactWrite overload that takes TransactWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to CreateTransactWrite.")]
-        public TransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig = null)
+        public TransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new TransactWrite<T>(this, config);

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -19,7 +19,6 @@ using System.Threading;
 #if AWS_ASYNC_API
 using System.Threading.Tasks;
 #endif
-using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DocumentModel;
 
 namespace Amazon.DynamoDBv2.DataModel
@@ -208,7 +207,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #endregion
 
-        #region Factory Creates
+        #region BatchGet
 
         /// <summary>
         /// Creates a strongly-typed BatchGet object, allowing
@@ -218,7 +217,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>Empty strongly-typed BatchGet object</returns>
         public BatchGet<T> CreateBatchGet<T>()
         {
-            return CreateBatchGet<T>(null);
+            return CreateBatchGet<T>((BatchGetConfig)null);
         }
 
         /// <summary>
@@ -228,10 +227,23 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to get</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchGet object</returns>
+        [Obsolete("Use the CreateBatchGet overload that takes BatchGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
         public BatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchGet<T>(this, config);
+        }
+
+        /// <summary>
+        /// Creates a strongly-typed BatchGet object, allowing
+        /// a batch-get operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to get</typeparam>
+        /// <param name="batchGetConfig">Config object that can be used to override properties on the table's context for this request</param>
+        /// <returns>Empty strongly-typed BatchGet object</returns>
+        public BatchGet<T> CreateBatchGet<T>(BatchGetConfig batchGetConfig)
+        {
+            return new BatchGet<T>(this, new DynamoDBFlatConfig(batchGetConfig?.ToDynamoDBOperationConfig(), Config));
         }
 
         /// <summary>
@@ -245,6 +257,10 @@ namespace Amazon.DynamoDBv2.DataModel
             return new MultiTableBatchGet(batches);
         }
 
+        #endregion
+
+        #region BatchWrite
+
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
         /// a batch-write operation against DynamoDB.
@@ -253,7 +269,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         public BatchWrite<T> CreateBatchWrite<T>()
         {
-            return CreateBatchWrite<T>(null);
+            return CreateBatchWrite<T>((BatchWriteConfig)null);
         }
 
         /// <summary>
@@ -263,6 +279,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
+        [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
         public BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
@@ -283,7 +300,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         public BatchWrite<object> CreateBatchWrite(Type valuesType)
         {
-            return CreateBatchWrite(valuesType, null);
+            return CreateBatchWrite(valuesType, (BatchWriteConfig)null);
         }
 
         /// <summary>
@@ -299,10 +316,41 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="valuesType">Type of objects to write</param>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
+        [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
         public BatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<object>(this, valuesType, config);
+        }
+
+        /// <summary>
+        /// Creates a strongly-typed BatchWrite object, allowing
+        /// a batch-write operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to write</typeparam>
+        /// <param name="batchWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
+        /// <returns>Empty strongly-typed BatchWrite object</returns>
+        public BatchWrite<T> CreateBatchWrite<T>(BatchWriteConfig batchWriteConfig)
+        {
+            return new BatchWrite<T>(this, new DynamoDBFlatConfig(batchWriteConfig?.ToDynamoDBOperationConfig(), Config));
+        }
+
+        /// <summary>
+        /// Creates a strongly-typed BatchWrite object, allowing
+        /// a batch-write operation against DynamoDB.
+        /// 
+        /// This is intended for use only when the valuesType is not known at compile-time, for example,
+        /// when hooking into EF's ChangeTracker to record audit logs from EF into DynamoDB.
+        /// 
+        /// In scenarios when the valuesType is known at compile-time, the 
+        /// <see cref="CreateBatchWrite{T}(DynamoDBOperationConfig)"/> method is generally preferred.
+        /// </summary>
+        /// <param name="valuesType">The type of data which will be persisted in this batch.</param>
+        /// <param name="batchWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
+        /// <returns>Empty strongly-typed BatchWrite object</returns>
+        public BatchWrite<object> CreateBatchWrite(Type valuesType, BatchWriteConfig batchWriteConfig)
+        {
+            return new BatchWrite<object>(this, valuesType, new DynamoDBFlatConfig(batchWriteConfig.ToDynamoDBOperationConfig(), Config));
         }
 
         /// <summary>
@@ -316,6 +364,10 @@ namespace Amazon.DynamoDBv2.DataModel
             return new MultiTableBatchWrite(batches);
         }
 
+        #endregion
+
+        #region TransactGet
+
         /// <summary>
         /// Creates a strongly-typed TransactGet object, allowing
         /// a transactional get operation against DynamoDB.
@@ -324,7 +376,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>Empty strongly-typed TransactGet object.</returns>
         public TransactGet<T> CreateTransactGet<T>()
         {
-            return CreateTransactGet<T>(null);
+            return CreateTransactGet<T>((TransactGetConfig)null);
         }
 
         /// <summary>
@@ -334,9 +386,23 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to get.</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
+        [Obsolete("Use the CreateTransactGet overload that takes TransactGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
         public TransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
+            return new TransactGet<T>(this, config);
+        }
+
+        /// <summary>
+        /// Creates a strongly-typed TransactGet object, allowing
+        /// a transactional get operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to get.</typeparam>
+        /// <param name="transactGetConfig">Config object that can be used to override properties on the table's context for this request.</param>
+        /// <returns>Empty strongly-typed TransactGet object.</returns>
+        public TransactGet<T> CreateTransactGet<T>(TransactGetConfig transactGetConfig)
+        {
+            DynamoDBFlatConfig config = new DynamoDBFlatConfig(transactGetConfig?.ToDynamoDBOperationConfig(), this.Config);
             return new TransactGet<T>(this, config);
         }
 
@@ -351,6 +417,10 @@ namespace Amazon.DynamoDBv2.DataModel
             return new MultiTableTransactGet(transactionParts);
         }
 
+        #endregion
+
+        #region TransactWrite
+
         /// <summary>
         /// Creates a strongly-typed TransactWrite object, allowing
         /// a transactional write operation against DynamoDB.
@@ -359,7 +429,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
         public TransactWrite<T> CreateTransactWrite<T>()
         {
-            return CreateTransactWrite<T>(null);
+            return CreateTransactWrite<T>((TransactWriteConfig)null);
         }
 
         /// <summary>
@@ -369,9 +439,24 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to write.</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
+
+        [Obsolete("Use the CreateTransactWrite overload that takes TransactWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to CreateTransactWrite.")]
         public TransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
+            return new TransactWrite<T>(this, config);
+        }
+
+        /// <summary>
+        /// Creates a strongly-typed TransactWrite object, allowing
+        /// a transactional write operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to write.</typeparam>
+        /// <param name="transactWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
+        /// <returns>Empty strongly-typed TransactWrite object.</returns>
+        public TransactWrite<T> CreateTransactWrite<T>(TransactWriteConfig transactWriteConfig)
+        {
+            DynamoDBFlatConfig config = new DynamoDBFlatConfig(transactWriteConfig?.ToDynamoDBOperationConfig(), this.Config);
             return new TransactWrite<T>(this, config);
         }
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -228,7 +228,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchGet object</returns>
         [Obsolete("Use the CreateBatchGet overload that takes BatchGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-        public BatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig)
+        public BatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig = null)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchGet<T>(this, config);
@@ -280,7 +280,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-        public BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig)
+        public BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig = null)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<T>(this, config);
@@ -387,7 +387,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
         [Obsolete("Use the CreateTransactGet overload that takes TransactGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-        public TransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig)
+        public TransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig = null)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new TransactGet<T>(this, config);
@@ -441,7 +441,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
 
         [Obsolete("Use the CreateTransactWrite overload that takes TransactWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to CreateTransactWrite.")]
-        public TransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig)
+        public TransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig = null)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new TransactWrite<T>(this, config);

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -317,7 +317,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-        public BatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig = null)
+        public BatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<object>(this, valuesType, config);

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
@@ -130,7 +130,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchGet object</returns>
         [Obsolete("Use the CreateBatchGet overload that takes BatchGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-        BatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig);
+        BatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed BatchGet object, allowing
@@ -170,7 +170,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
 
-        BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig);
+        BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -200,7 +200,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-        BatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig);
+        BatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -254,7 +254,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
         [Obsolete("Use the CreateTransactGet overload that takes TransactGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-        TransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig);
+        TransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed TransactGet object, allowing
@@ -293,7 +293,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
         [Obsolete("Use the CreateTransactWrite overload that takes TransactWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to CreateTransactWrite.")]
-        TransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig);
+        TransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed TransactWrite object, allowing

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
@@ -113,6 +113,15 @@ namespace Amazon.DynamoDBv2.DataModel
         #endregion
 
         #region BatchGet
+
+        /// <summary>
+        /// Creates a strongly-typed BatchGet object, allowing
+        /// a batch-get operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to get</typeparam>
+        /// <returns>Empty strongly-typed BatchGet object</returns>
+        BatchGet<T> CreateBatchGet<T>();
+
         /// <summary>
         /// Creates a strongly-typed BatchGet object, allowing
         /// a batch-get operation against DynamoDB.
@@ -120,7 +129,17 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to get</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchGet object</returns>
-        BatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig = null);
+        [Obsolete("Use the CreateBatchGet overload that takes BatchGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
+        BatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig);
+
+        /// <summary>
+        /// Creates a strongly-typed BatchGet object, allowing
+        /// a batch-get operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to get</typeparam>
+        /// <param name="batchGetConfig">Config object that can be used to override properties on the table's context for this request</param>
+        /// <returns>Empty strongly-typed BatchGet object</returns>
+        public BatchGet<T> CreateBatchGet<T>(BatchGetConfig batchGetConfig);
 
         /// <summary>
         /// Creates a MultiTableBatchGet object, composed of multiple
@@ -139,9 +158,33 @@ namespace Amazon.DynamoDBv2.DataModel
         /// a batch-write operation against DynamoDB.
         /// </summary>
         /// <typeparam name="T">Type of objects to write</typeparam>
+        /// <returns>Empty strongly-typed BatchWrite object</returns>
+        BatchWrite<T> CreateBatchWrite<T>();
+
+        /// <summary>
+        /// Creates a strongly-typed BatchWrite object, allowing
+        /// a batch-write operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to write</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-        BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig = null);
+        [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
+
+        BatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig);
+
+        /// <summary>
+        /// Creates a strongly-typed BatchWrite object, allowing
+        /// a batch-write operation against DynamoDB.
+        /// 
+        /// This is intended for use only when the valuesType is not known at compile-time, for example,
+        /// when hooking into EF's ChangeTracker to record audit logs from EF into DynamoDB.
+        /// 
+        /// In scenarios when the valuesType is known at compile-time, the 
+        /// <see cref="CreateBatchWrite{T}(DynamoDBOperationConfig)"/> method is generally preferred.
+        /// </summary>
+        /// <param name="valuesType">The type of data which will be persisted in this batch.</param>
+        /// <returns>Empty strongly-typed BatchWrite object</returns>
+        BatchWrite<object> CreateBatchWrite(Type valuesType);
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -156,7 +199,32 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="valuesType">The type of data which will be persisted in this batch.</param>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-        BatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig = null);
+        [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
+        BatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig);
+
+        /// <summary>
+        /// Creates a strongly-typed BatchWrite object, allowing
+        /// a batch-write operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to write</typeparam>
+        /// <param name="batchWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
+        /// <returns>Empty strongly-typed BatchWrite object</returns>
+        BatchWrite<T> CreateBatchWrite<T>(BatchWriteConfig batchWriteConfig);
+
+        /// <summary>
+        /// Creates a strongly-typed BatchWrite object, allowing
+        /// a batch-write operation against DynamoDB.
+        /// 
+        /// This is intended for use only when the valuesType is not known at compile-time, for example,
+        /// when hooking into EF's ChangeTracker to record audit logs from EF into DynamoDB.
+        /// 
+        /// In scenarios when the valuesType is known at compile-time, the 
+        /// <see cref="CreateBatchWrite{T}(DynamoDBOperationConfig)"/> method is generally preferred.
+        /// </summary>
+        /// <param name="valuesType">The type of data which will be persisted in this batch.</param>
+        /// <param name="batchWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
+        /// <returns>Empty strongly-typed BatchWrite object</returns>
+        BatchWrite<object> CreateBatchWrite(Type valuesType, BatchWriteConfig batchWriteConfig);
 
         /// <summary>
         /// Creates a MultiTableBatchWrite object, composed of multiple
@@ -175,9 +243,27 @@ namespace Amazon.DynamoDBv2.DataModel
         /// a transactional get operation against DynamoDB.
         /// </summary>
         /// <typeparam name="T">Type of objects to get.</typeparam>
+        /// <returns>Empty strongly-typed TransactGet object.</returns>
+        TransactGet<T> CreateTransactGet<T>();
+
+        /// <summary>
+        /// Creates a strongly-typed TransactGet object, allowing
+        /// a transactional get operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to get.</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
-        TransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig = null);
+        [Obsolete("Use the CreateTransactGet overload that takes TransactGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
+        TransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig);
+
+        /// <summary>
+        /// Creates a strongly-typed TransactGet object, allowing
+        /// a transactional get operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to get.</typeparam>
+        /// <param name="transactGetConfig">Config object that can be used to override properties on the table's context for this request.</param>
+        /// <returns>Empty strongly-typed TransactGet object.</returns>
+        TransactGet<T> CreateTransactGet<T>(TransactGetConfig transactGetConfig);
 
         /// <summary>
         /// Creates a MultiTableTransactGet object, composed of multiple
@@ -196,9 +282,27 @@ namespace Amazon.DynamoDBv2.DataModel
         /// a transactional write operation against DynamoDB.
         /// </summary>
         /// <typeparam name="T">Type of objects to write.</typeparam>
+        /// <returns>Empty strongly-typed TransactWrite object.</returns>
+        TransactWrite<T> CreateTransactWrite<T>();
+
+        /// <summary>
+        /// Creates a strongly-typed TransactWrite object, allowing
+        /// a transactional write operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to write.</typeparam>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
-        TransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig = null);
+        [Obsolete("Use the CreateTransactWrite overload that takes TransactWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to CreateTransactWrite.")]
+        TransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig);
+
+        /// <summary>
+        /// Creates a strongly-typed TransactWrite object, allowing
+        /// a transactional write operation against DynamoDB.
+        /// </summary>
+        /// <typeparam name="T">Type of objects to write.</typeparam>
+        /// <param name="transactWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
+        /// <returns>Empty strongly-typed TransactWrite object.</returns>
+        TransactWrite<T> CreateTransactWrite<T>(TransactWriteConfig transactWriteConfig);
 
         /// <summary>
         /// Creates a MultiTableTransactWrite object, composed of multiple

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGetConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGetConfig.cs
@@ -21,88 +21,27 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Input for the TransactGet operation in the object-persistence programming model
     /// </summary>
 #if NET8_0_OR_GREATER
+    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
 #endif
-    public class TransactGetConfig
+    public class TransactGetConfig : BaseOperationConfig
     {
-        /// <summary>
-        /// Property that indicates which DynamoDB table to use, 
-        /// overriding the DynamoDBTable attribute declared for the object type.
-        /// </summary>
-        public string OverrideTableName { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to prefix all table names
-        /// with a specific string.
-        /// If property is null or empty, no prefix is used and default
-        /// table names are used.
-        /// </summary>
-        public string TableNamePrefix { get; set; }
-
-        /// <summary>
-        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
-        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
-        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
-        /// </summary>
-        /// <remarks>
-        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
-        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
-        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
-        /// </remarks>
-        public MetadataCachingMode? MetadataCachingMode { get; set; }
-
-        /// <summary>
-        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
-        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
-        /// </summary>
-        /// <remarks>
-        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
-        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
-        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
-        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
-        /// </remarks>
-        public bool? DisableFetchingTableMetadata { get; set; }
-
-        /// <summary>
-        /// Conversion specification which controls how the conversion between
-        /// .NET and DynamoDB types happens.
-        /// </summary>
-        public DynamoDBEntryConversion Conversion { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to enable empty string values
-        /// on attributes during a Save operation.
-        /// If the property is false (or not set), empty string values will be
-        /// interpreted as null values.
-        /// </summary>
-        public bool? IsEmptyStringValueEnabled { get; set; }
-
         /// <summary>
         /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
         /// </summary>
-        /// <remarks>This setting is only applicable to the high-level library. Service calls made via <see cref="AmazonDynamoDBClient"/> will always return <see cref="DateTime"/> attributes in UTC.</remarks>
+        /// <remarks>
+        /// This setting is only applicable to the high-level library. Service calls made via 
+        /// <see cref="AmazonDynamoDBClient"/> will always return <see cref="DateTime"/> attributes in UTC.
+        /// </remarks>
         public bool? RetrieveDateTimeInUtc { get; set; }
 
-        /// <summary>
-        /// Converts this to the shared <see cref="DynamoDBOperationConfig"/>
-        /// </summary>
-        /// <remarks>
-        /// Users should interact with the new, operation-specific configs, but we
-        /// convert to the internal shared config for the internal code paths.
-        /// </remarks>
-        /// <returns>New <see cref="DynamoDBOperationConfig"/></returns>
-        internal DynamoDBOperationConfig ToDynamoDBOperationConfig()
+        /// <inheritdoc/>
+        internal override DynamoDBOperationConfig ToDynamoDBOperationConfig()
         {
-            return new DynamoDBOperationConfig()
-            {
-                OverrideTableName = OverrideTableName,
-                TableNamePrefix = TableNamePrefix,
-                MetadataCachingMode = MetadataCachingMode,
-                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
-                Conversion = Conversion,
-                IsEmptyStringValueEnabled = IsEmptyStringValueEnabled,
-                RetrieveDateTimeInUtc = RetrieveDateTimeInUtc
-            };
+            var config = base.ToDynamoDBOperationConfig();
+            config.RetrieveDateTimeInUtc = RetrieveDateTimeInUtc;
+
+            return config;
         }
     }
 }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGetConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGetConfig.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+
+namespace Amazon.DynamoDBv2.DataModel
+{
+    /// <summary>
+    /// Input for the TransactGet operation in the object-persistence programming model
+    /// </summary>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
+    public class TransactGetConfig
+    {
+        /// <summary>
+        /// Property that indicates which DynamoDB table to use, 
+        /// overriding the DynamoDBTable attribute declared for the object type.
+        /// </summary>
+        public string OverrideTableName { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to prefix all table names
+        /// with a specific string.
+        /// If property is null or empty, no prefix is used and default
+        /// table names are used.
+        /// </summary>
+        public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
+        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
+        /// </remarks>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
+
+        /// <summary>
+        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
+        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
+        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
+        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
+        /// </remarks>
+        public bool? DisableFetchingTableMetadata { get; set; }
+
+        /// <summary>
+        /// Conversion specification which controls how the conversion between
+        /// .NET and DynamoDB types happens.
+        /// </summary>
+        public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to enable empty string values
+        /// on attributes during a Save operation.
+        /// If the property is false (or not set), empty string values will be
+        /// interpreted as null values.
+        /// </summary>
+        public bool? IsEmptyStringValueEnabled { get; set; }
+
+        /// <summary>
+        /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
+        /// </summary>
+        /// <remarks>This setting is only applicable to the high-level library. Service calls made via <see cref="AmazonDynamoDBClient"/> will always return <see cref="DateTime"/> attributes in UTC.</remarks>
+        public bool? RetrieveDateTimeInUtc { get; set; }
+
+        /// <summary>
+        /// Converts this to the shared <see cref="DynamoDBOperationConfig"/>
+        /// </summary>
+        /// <remarks>
+        /// Users should interact with the new, operation-specific configs, but we
+        /// convert to the internal shared config for the internal code paths.
+        /// </remarks>
+        /// <returns>New <see cref="DynamoDBOperationConfig"/></returns>
+        internal DynamoDBOperationConfig ToDynamoDBOperationConfig()
+        {
+            return new DynamoDBOperationConfig()
+            {
+                OverrideTableName = OverrideTableName,
+                TableNamePrefix = TableNamePrefix,
+                MetadataCachingMode = MetadataCachingMode,
+                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
+                Conversion = Conversion,
+                IsEmptyStringValueEnabled = IsEmptyStringValueEnabled,
+                RetrieveDateTimeInUtc = RetrieveDateTimeInUtc
+            };
+        }
+    }
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWriteConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWriteConfig.cs
@@ -19,90 +19,26 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Input for the TransactWrite operation in the object-persistence programming model
     /// </summary>
 #if NET8_0_OR_GREATER
+    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
 #endif
-    public class TransactWriteConfig
+    public class TransactWriteConfig : BaseOperationConfig
     {
         /// <summary>
-        /// Property that indicates which DynamoDB table to use, 
-        /// overriding the DynamoDBTable attribute declared for the object type.
-        /// </summary>
-        public string OverrideTableName { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to prefix all table names
-        /// with a specific string.
-        /// If property is null or empty, no prefix is used and default
-        /// table names are used.
-        /// </summary>
-        public string TableNamePrefix { get; set; }
-
-        /// <summary>
-        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
-        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
-        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
-        /// </summary>
-        /// <remarks>
-        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
-        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
-        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
-        /// </remarks>
-        public MetadataCachingMode? MetadataCachingMode { get; set; }
-
-        /// <summary>
-        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
-        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
-        /// </summary>
-        /// <remarks>
-        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
-        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
-        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
-        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
-        /// </remarks>
-        public bool? DisableFetchingTableMetadata { get; set; }
-
-        /// <summary>
-        /// Conversion specification which controls how the conversion between
-        /// .NET and DynamoDB types happens.
-        /// </summary>
-        public DynamoDBEntryConversion Conversion { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to enable empty string values
-        /// on attributes during a Save operation.
-        /// If the property is false (or not set), empty string values will be
-        /// interpreted as null values.
-        /// </summary>
-        public bool? IsEmptyStringValueEnabled { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to ignore null values
-        /// on attributes during a Save operation.
-        /// If the property is false (or not set), null values will be
-        /// interpreted as directives to delete the specific attribute.
+        /// Directs <see cref="DynamoDBContext" /> to ignore null values when 
+        /// converting an object to a DynamoDB item. If the property is false 
+        /// (or not set), null values will be interpreted as directives to 
+        /// delete the specific attributes on the DynamoDB item.
         /// </summary>
         public bool? IgnoreNullValues { get; set; }
 
-        /// <summary>
-        /// Converts this to the shared <see cref="DynamoDBOperationConfig"/>
-        /// </summary>
-        /// <remarks>
-        /// Users should interact with the new, operation-specific configs, but we
-        /// convert to the internal shared config for the internal code paths.
-        /// </remarks>
-        /// <returns>New <see cref="DynamoDBOperationConfig"/></returns>
-        internal DynamoDBOperationConfig ToDynamoDBOperationConfig()
+        /// <inheritdoc/>
+        internal override DynamoDBOperationConfig ToDynamoDBOperationConfig()
         {
-            return new DynamoDBOperationConfig()
-            {
-                OverrideTableName = OverrideTableName,
-                TableNamePrefix = TableNamePrefix,
-                MetadataCachingMode = MetadataCachingMode,
-                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
-                Conversion = Conversion,
-                IsEmptyStringValueEnabled = IsEmptyStringValueEnabled,
-                IgnoreNullValues = IgnoreNullValues
-            };
+            var config = base.ToDynamoDBOperationConfig();
+            config.IgnoreNullValues = IgnoreNullValues;
+
+            return config;
         }
     }
 }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWriteConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWriteConfig.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.DynamoDBv2.DataModel
+{
+    /// <summary>
+    /// Input for the TransactWrite operation in the object-persistence programming model
+    /// </summary>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
+    public class TransactWriteConfig
+    {
+        /// <summary>
+        /// Property that indicates which DynamoDB table to use, 
+        /// overriding the DynamoDBTable attribute declared for the object type.
+        /// </summary>
+        public string OverrideTableName { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to prefix all table names
+        /// with a specific string.
+        /// If property is null or empty, no prefix is used and default
+        /// table names are used.
+        /// </summary>
+        public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
+        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
+        /// </remarks>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
+
+        /// <summary>
+        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
+        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
+        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
+        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
+        /// </remarks>
+        public bool? DisableFetchingTableMetadata { get; set; }
+
+        /// <summary>
+        /// Conversion specification which controls how the conversion between
+        /// .NET and DynamoDB types happens.
+        /// </summary>
+        public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to enable empty string values
+        /// on attributes during a Save operation.
+        /// If the property is false (or not set), empty string values will be
+        /// interpreted as null values.
+        /// </summary>
+        public bool? IsEmptyStringValueEnabled { get; set; }
+
+        /// <summary>
+        /// Property that directs DynamoDBContext to ignore null values
+        /// on attributes during a Save operation.
+        /// If the property is false (or not set), null values will be
+        /// interpreted as directives to delete the specific attribute.
+        /// </summary>
+        public bool? IgnoreNullValues { get; set; }
+
+        /// <summary>
+        /// Converts this to the shared <see cref="DynamoDBOperationConfig"/>
+        /// </summary>
+        /// <remarks>
+        /// Users should interact with the new, operation-specific configs, but we
+        /// convert to the internal shared config for the internal code paths.
+        /// </remarks>
+        /// <returns>New <see cref="DynamoDBOperationConfig"/></returns>
+        internal DynamoDBOperationConfig ToDynamoDBOperationConfig()
+        {
+            return new DynamoDBOperationConfig()
+            {
+                OverrideTableName = OverrideTableName,
+                TableNamePrefix = TableNamePrefix,
+                MetadataCachingMode = MetadataCachingMode,
+                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
+                Conversion = Conversion,
+                IsEmptyStringValueEnabled = IsEmptyStringValueEnabled,
+                IgnoreNullValues = IgnoreNullValues
+            };
+        }
+    }
+}

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
@@ -18,5 +18,37 @@ namespace AWSSDK_DotNet.UnitTests
             // `ToDynamoDBOperationConfig` before updating this unit test
             Assert.AreEqual(6, typeof(BaseOperationConfig).GetProperties().Length);
         }
+
+        [TestMethod]
+        public void BatchGetConfig()
+        {
+            // If this fails because you've added a property, be sure to add it to
+            // `ToDynamoDBOperationConfig` before updating this unit test
+            Assert.AreEqual(8, typeof(BatchGetConfig).GetProperties().Length);
+        }
+
+        [TestMethod]
+        public void BatchWriteConfig()
+        {
+            // If this fails because you've added a property, be sure to add it to
+            // `ToDynamoDBOperationConfig` before updating this unit test
+            Assert.AreEqual(8, typeof(BatchWriteConfig).GetProperties().Length);
+        }
+
+        [TestMethod]
+        public void TransactGetConfig()
+        {
+            // If this fails because you've added a property, be sure to add it to
+            // `ToDynamoDBOperationConfig` before updating this unit test
+            Assert.AreEqual(7, typeof(TransactGetConfig).GetProperties().Length);
+        }
+
+        [TestMethod]
+        public void TransactWriteConfig()
+        {
+            // If this fails because you've added a property, be sure to add it to
+            // `ToDynamoDBOperationConfig` before updating this unit test
+            Assert.AreEqual(7, typeof(TransactWriteConfig).GetProperties().Length);
+        }
     }
 }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
@@ -1,11 +1,13 @@
-﻿using Amazon.DynamoDBv2.DataModel;
+﻿using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace AWSSDK_DotNet.UnitTests
 {
     /// <summary>
-    /// These tests serve as a reminder to developers and reviewers to 
-    /// ensure that new DynamoDB operation-specific properties are plumbed
+    /// These tests that new DynamoDB operation-specific properties are plumbed
     /// into the internal code paths correctly
     /// </summary>
     [TestClass]
@@ -28,11 +30,60 @@ namespace AWSSDK_DotNet.UnitTests
         }
 
         [TestMethod]
+        public void BatchGetConfig_OverridesTableName()
+        {
+            var mockClient = new Mock<IAmazonDynamoDB>();
+            mockClient.Setup(client => client.BatchGetItem(It.Is<BatchGetItemRequest>(request => request.RequestItems.ContainsKey("OperationPrefix-TableName"))))
+               .Returns(new BatchGetItemResponse { Responses = new(), UnprocessedKeys = new() })
+               .Verifiable();
+
+            // Set a prefix on the context config, but we'll override it on the operation config so we don't expect it to be used
+            var context = new DynamoDBContext(mockClient.Object, new DynamoDBContextConfig { 
+                TableNamePrefix = "ContextPrefix-",
+                DisableFetchingTableMetadata = true
+            });
+
+            var batchGetConfig = new BatchGetConfig() { TableNamePrefix = "OperationPrefix-" };
+
+            var batchGet = context.CreateBatchGet<DataModel>(batchGetConfig);
+            batchGet.AddKey("123");
+            batchGet.Execute();
+
+            // We expect the setup with the correct prefix to have been called, otherwise an exception would have been thrown
+            mockClient.VerifyAll();
+        }
+
+        [TestMethod]
         public void BatchWriteConfig()
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
             Assert.AreEqual(8, typeof(BatchWriteConfig).GetProperties().Length);
+        }
+
+        [TestMethod]
+        public void BatchWriteConfig_OverridesTableName()
+        {
+            var mockClient = new Mock<IAmazonDynamoDB>();
+            mockClient.Setup(x => x.BatchWriteItem(It.Is<BatchWriteItemRequest>(x => x.RequestItems.ContainsKey("OperationPrefix-TableName"))))
+               .Returns(new BatchWriteItemResponse {  UnprocessedItems = new() })
+               .Verifiable();
+
+            // Set a prefix on the context config, but we'll override it on the operation config so we don't expect it to be used
+            var context = new DynamoDBContext(mockClient.Object, new DynamoDBContextConfig
+            {
+                TableNamePrefix = "ContextPrefix-",
+                DisableFetchingTableMetadata = true
+            });
+
+            var batchWriteConfig = new BatchWriteConfig() { TableNamePrefix = "OperationPrefix-" };
+
+            var batchWrite = context.CreateBatchWrite<DataModel>(batchWriteConfig);
+            batchWrite.AddPutItem(new DataModel { Id = "123" });
+            batchWrite.Execute();
+
+            // We expect the setup with the correct prefix to have been called, otherwise an exception would have been thrown
+            mockClient.VerifyAll();
         }
 
         [TestMethod]
@@ -44,11 +95,68 @@ namespace AWSSDK_DotNet.UnitTests
         }
 
         [TestMethod]
+        public void TransactGetConfig_OverridesTableName()
+        {
+            var mockClient = new Mock<IAmazonDynamoDB>();
+            mockClient.Setup(x => x.TransactGetItems(It.Is<TransactGetItemsRequest>(x => x.TransactItems[0].Get.TableName == "OperationPrefix-TableName")))
+               .Returns(new TransactGetItemsResponse { Responses = new() })
+               .Verifiable();
+
+            // Set a prefix on the context config, but we'll override it on the operation config so we don't expect it to be used
+            var context = new DynamoDBContext(mockClient.Object, new DynamoDBContextConfig
+            {
+                TableNamePrefix = "ContextPrefix-",
+                DisableFetchingTableMetadata = true
+            });
+
+            var transactGetConfig = new TransactGetConfig() { TableNamePrefix = "OperationPrefix-" };
+
+            var transactGet = context.CreateTransactGet<DataModel>(transactGetConfig);
+            transactGet.AddKey("123");
+            transactGet.Execute();
+
+            // We expect the setup with the correct prefix to have been called, otherwise an exception would have been thrown
+            mockClient.VerifyAll();
+        }
+
+        [TestMethod]
         public void TransactWriteConfig()
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
             Assert.AreEqual(7, typeof(TransactWriteConfig).GetProperties().Length);
+        }
+
+        [TestMethod]
+        public void TransactWriteConfig_OverridesTableName()
+        {
+            var mockClient = new Mock<IAmazonDynamoDB>();
+            mockClient.Setup(x => x.TransactWriteItems(It.Is<TransactWriteItemsRequest>(x => x.TransactItems[0].Update.TableName == "OperationPrefix-TableName")))
+               .Returns(new TransactWriteItemsResponse())
+               .Verifiable();
+
+            // Set a prefix on the context config, but we'll override it on the operation config so we don't expect it to be used
+            var context = new DynamoDBContext(mockClient.Object, new DynamoDBContextConfig
+            {
+                TableNamePrefix = "ContextPrefix-",
+                DisableFetchingTableMetadata = true
+            });
+
+            var transactWriteConfig = new TransactWriteConfig { TableNamePrefix = "OperationPrefix-" };
+
+            var transactWrite = context.CreateTransactWrite<DataModel>(transactWriteConfig);
+            transactWrite.AddSaveItem(new DataModel { Id = "123" });
+            transactWrite.Execute();
+
+            // We expect the setup with the correct prefix to have been called, otherwise an exception would have been thrown
+            mockClient.VerifyAll();
+        }
+
+        [DynamoDBTable("TableName")]
+        private class DataModel
+        {
+            [DynamoDBHashKey]
+            public string Id { get; set; }
         }
     }
 }


### PR DESCRIPTION
## Description
Creates new operation-specific config objects for the DynamoDB object-mapper operations.

I'm splitting this into 3 PRs:
1. Batch and Transact - This PR
2. Delete/Load/Save - #3387
3. Query/Scan - #3383 

I have a longer analysis in an internal doc, but I'm planning to apply these properties to all operations because they deal with the table itself or the DynamoDB item <-> .NET object transformation:
1. `OverrideTableName`
2. `TableNamePrefix`
3. `MetadataCachingMode`
4. `IsEmptyStringValueEnabled`
5. `Conversion`
6. `DisableFetchingTableMetadata`

Then these are on a case-by-case basis:
1. `BackwardQuery` - only when querying
2. `IndexName` - only when querying or scanning
3. `ConditionalOperator` - only when querying or scanning
4. `QueryFilter` - only when querying or scanning
5. `ConsistentRead` - when getting items (including querying or scanning)
6. `SkipVersionCheck` - when writing or deleting items
7. `IgnoreNullValues` - when writing items
8. `RetrieveDateTimeInUtc` - when getting items (including querying or scannign)


## Motivation and Context
For V4 of the SDK, we're planning to split the shared `DynamoDBOperationConfig` object into operation-specific configs, since the shared object has grown overtime to include properties that are not relevant for all operations.

DOTNET-7513


## Testing
Ran DynamoDBv2 sln tests locally


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement