### PR TITLE
Add telemetry metrics to cover the SDK operations

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseEndpointResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseEndpointResolver.cs
@@ -18,6 +18,8 @@ using System.Collections;
 using System.Collections.Generic;
 using Amazon.Runtime.Endpoints;
 using Amazon.Runtime.Internal.Auth;
+using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Telemetry.Metrics;
 
 namespace Amazon.Runtime.Internal
 {
@@ -50,7 +52,10 @@ namespace Amazon.Runtime.Internal
 
         protected virtual void PreInvoke(IExecutionContext executionContext)
         {
-            ProcessRequestHandlers(executionContext);
+            using (MetricsUtilities.MeasureDuration(executionContext.RequestContext, TelemetryConstants.ResolveEndpointDurationMetricName))
+            {
+                ProcessRequestHandlers(executionContext);
+            }
         }
 
         public virtual void ProcessRequestHandlers(IExecutionContext executionContext)

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/CompressionHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/CompressionHandler.cs
@@ -107,7 +107,7 @@ namespace Amazon.Runtime.Internal
                 if (input.Length >= minCompressionSize)
                 {
                     executionContext.RequestContext.Metrics.AddProperty(Metric.UncompressedRequestSize, input.Length);
-                    using (var traceSpan = TracingUtilities.CreateSpan(executionContext.RequestContext, TelemetryConstants.RequestCompressionSpanName))
+                    using (TracingUtilities.CreateSpan(executionContext.RequestContext, TelemetryConstants.RequestCompressionSpanName))
                     using (executionContext.RequestContext.Metrics.StartEvent(Metric.RequestCompressionTime))
                     {
                         request.Content = compressionAlgorithm.Compress(input);

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/CredentialsRetriever.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/CredentialsRetriever.cs
@@ -16,6 +16,7 @@
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Telemetry.Metrics;
 using Amazon.Runtime.Telemetry.Tracing;
 using Amazon.Util;
 using System;
@@ -53,8 +54,9 @@ namespace Amazon.Runtime.Internal
             ImmutableCredentials ic = null;
             if (Credentials != null && !(Credentials is AnonymousAWSCredentials) && !(executionContext.RequestContext.Signer is BearerTokenSigner))
             {
-                using (var traceSpan = TracingUtilities.CreateSpan(executionContext.RequestContext, TelemetryConstants.CredentialsRetrievalSpanName))
-                using(executionContext.RequestContext.Metrics.StartEvent(Metric.CredentialsRequestTime))
+                using (TracingUtilities.CreateSpan(executionContext.RequestContext, TelemetryConstants.CredentialsRetrievalSpanName))
+                using (MetricsUtilities.MeasureDuration(executionContext.RequestContext, TelemetryConstants.ResolveIdentityDurationMetricName))
+                using (executionContext.RequestContext.Metrics.StartEvent(Metric.CredentialsRequestTime))
                 {
                     ic = Credentials.GetCredentials();
                 }
@@ -90,7 +92,8 @@ namespace Amazon.Runtime.Internal
             ImmutableCredentials ic = null;
             if (Credentials != null && !(Credentials is AnonymousAWSCredentials))
             {
-                using (var traceSpan = TracingUtilities.CreateSpan(executionContext.RequestContext, TelemetryConstants.CredentialsRetrievalSpanName))
+                using (TracingUtilities.CreateSpan(executionContext.RequestContext, TelemetryConstants.CredentialsRetrievalSpanName))
+                using (MetricsUtilities.MeasureDuration(executionContext.RequestContext, TelemetryConstants.ResolveIdentityDurationMetricName))
                 using(executionContext.RequestContext.Metrics.StartEvent(Metric.CredentialsRequestTime))
                 {
                     ic = await Credentials.GetCredentialsAsync().ConfigureAwait(false);

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Signer.cs
@@ -15,6 +15,8 @@
 
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Runtime.Internal.Util;
+using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Telemetry.Metrics;
 using Amazon.Util;
 using System;
 using System.IO;
@@ -122,6 +124,7 @@ namespace Amazon.Runtime.Internal
                 return;
 
             using (requestContext.Metrics.StartEvent(Metric.RequestSigningTime))
+            using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.AuthSigningDurationMetricName))
             {
                 if (immutableCredentials?.UseToken == true && 
                     !(requestContext.Signer is NullSigner) && 
@@ -158,6 +161,7 @@ namespace Amazon.Runtime.Internal
                 return;
 
             using (requestContext.Metrics.StartEvent(Metric.RequestSigningTime))
+            using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.AuthSigningDurationMetricName))
             {
                 if (immutableCredentials?.UseToken == true &&
                     !(requestContext.Signer is NullSigner) &&

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Unmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Unmarshaller.cs
@@ -15,6 +15,8 @@
 
 using System;
 using Amazon.Runtime.Internal.Transform;
+using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Telemetry.Metrics;
 using Amazon.Util;
 
 namespace Amazon.Runtime.Internal
@@ -211,6 +213,7 @@ namespace Amazon.Runtime.Internal
                 var unmarshaller = requestContext.Unmarshaller;
                 AmazonWebServiceResponse response = null;
                 using (requestContext.Metrics.StartEvent(Metric.ResponseUnmarshallTime))
+                using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.DeserializationDurationMetricName))
                 {
                     response = unmarshaller.UnmarshallResponse(context);
                 }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryHandler.cs
@@ -14,6 +14,8 @@
  */
 
 using Amazon.Runtime.Internal.Util;
+using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Telemetry.Metrics;
 using Amazon.Util;
 using System;
 using System.Net;
@@ -90,6 +92,8 @@ namespace Amazon.Runtime.Internal
                     {
                         requestContext.Retries++;
                         requestContext.Metrics.SetCounter(Metric.AttemptCount, requestContext.Retries);
+                        MetricsUtilities.AddMonotonicCounterValue(requestContext, TelemetryConstants.CallAttemptsMetricName, TelemetryConstants.AttemptUnitName);
+
                         LogForRetry(requestContext, exception);
                     }
 
@@ -149,6 +153,8 @@ namespace Amazon.Runtime.Internal
                     {
                         requestContext.Retries++;
                         requestContext.Metrics.SetCounter(Metric.AttemptCount, requestContext.Retries);
+                        MetricsUtilities.AddMonotonicCounterValue(requestContext, TelemetryConstants.CallAttemptsMetricName, TelemetryConstants.AttemptUnitName);
+
                         LogForRetry(requestContext, capturedException.SourceException);
                     }
 
@@ -188,6 +194,8 @@ namespace Amazon.Runtime.Internal
                 {
                     requestContext.Retries++;
                     requestContext.Metrics.SetCounter(Metric.AttemptCount, requestContext.Retries);
+                    MetricsUtilities.AddMonotonicCounterValue(requestContext, TelemetryConstants.CallAttemptsMetricName, TelemetryConstants.AttemptUnitName);
+
                     LogForRetry(requestContext, exception);
 
                     PrepareForRetry(requestContext);

--- a/sdk/src/Core/Amazon.Runtime/Telemetry/DefaultTelemetryProvider.cs
+++ b/sdk/src/Core/Amazon.Runtime/Telemetry/DefaultTelemetryProvider.cs
@@ -13,10 +13,7 @@
  * permissions and limitations under the License.
  */
 
-using System;
-using Amazon.Runtime.Telemetry.Metrics;
 using Amazon.Runtime.Telemetry.Metrics.NoOp;
-using Amazon.Runtime.Telemetry.Tracing;
 using Amazon.Runtime.Telemetry.Tracing.NoOp;
 
 namespace Amazon.Runtime.Telemetry
@@ -31,48 +28,9 @@ namespace Amazon.Runtime.Telemetry
         /// This setup prevents any telemetry actions from being performed unless explicitly registered using the
         /// registration methods.
         /// </summary>
-        public DefaultTelemetryProvider()
+        public DefaultTelemetryProvider() :
+            base(new NoOpMeterProvider(), new NoOpTracerProvider())
         {
-            TracerProvider = new NoOpTracerProvider();
-            MeterProvider = new NoOpMeterProvider();
-        }
-
-        /// <summary>
-        /// Gets the <see cref="TracerProvider"/> used to create new tracers.
-        /// This property is initialized with a no-op implementation by default.
-        /// </summary>
-        public override TracerProvider TracerProvider { get; protected set; }
-
-        /// <summary>
-        /// Gets the <see cref="MeterProvider"/> used to create new metrics.
-        /// This property is initialized with a no-op implementation by default.
-        /// </summary>
-        public override MeterProvider MeterProvider { get; protected set; }
-
-        /// <summary>
-        /// Registers a new <see cref="TracerProvider"/>.
-        /// This method sets a custom tracer provider to replace the default no-op provider,
-        /// enabling the collection of tracing data.
-        /// </summary>
-        /// <param name="tracerProvider">The tracer provider to register.</param>
-        public override void RegisterTracerProvider(TracerProvider tracerProvider)
-        {
-            if (tracerProvider == null)
-                throw new ArgumentNullException(nameof(tracerProvider));
-            TracerProvider = tracerProvider;
-        }
-
-        /// <summary>
-        /// Registers a new <see cref="MeterProvider"/>.
-        /// This method sets a custom meter provider to replace the default no-op provider,
-        /// enabling the collection of metrics data.
-        /// </summary>
-        /// <param name="meterProvider">The meter provider to register.</param>
-        public override void RegisterMeterProvider(MeterProvider meterProvider)
-        {
-            if (meterProvider == null)
-                throw new ArgumentNullException(nameof(meterProvider));
-            MeterProvider = meterProvider;
         }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Telemetry/Metrics/MetricsUtilities.cs
+++ b/sdk/src/Core/Amazon.Runtime/Telemetry/Metrics/MetricsUtilities.cs
@@ -1,0 +1,133 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using Amazon.Util;
+
+namespace Amazon.Runtime.Telemetry.Metrics
+{
+    /// <summary>
+    /// Utility class for metrics related operations.
+    /// </summary>
+    internal static class MetricsUtilities
+    {
+        /// <summary>
+        /// Records an error using a MonotonicCounter.
+        /// </summary>
+        /// <param name="requestContext">The request context object.</param>
+        /// <param name="exception">The exception that occurred.</param>
+        public static void RecordError(IRequestContext requestContext, Exception exception)
+        {
+            var attributes = new Attributes();
+            attributes.Set(TelemetryConstants.ExceptionTypeAttributeKey, exception.GetType().Name);
+
+            AddMonotonicCounterValue(requestContext, TelemetryConstants.CallErrorsMetricName, TelemetryConstants.ErrorUnitName, 1, attributes);
+        }
+
+        /// <summary>
+        /// Records a value using a MonotonicCounter.
+        /// </summary>
+        /// <param name="requestContext">The request context object.</param>
+        /// <param name="metricName">The name of the metric to record.</param>
+        /// <param name="unit">The unit of the metric.</param>
+        /// <param name="value">The value to be recorded by the MonotonicCounter.</param>
+        /// <param name="initialAttributes">The attributes associated with the metric.</param>
+        public static void AddMonotonicCounterValue(IRequestContext requestContext, string metricName, string unit, long value = 1, Attributes initialAttributes = null)
+        {
+            var serviceId = requestContext.ServiceMetaData.ServiceId;
+
+            if (initialAttributes == null)
+                initialAttributes = new Attributes();
+
+            var operationName = AWSSDKUtils.ExtractOperationName(requestContext.RequestName);
+            initialAttributes.Set(TelemetryConstants.MethodAttributeKey, operationName);
+
+            initialAttributes.Set(TelemetryConstants.SystemAttributeKey, TelemetryConstants.SystemAttributeValue);
+            initialAttributes.Set(TelemetryConstants.ServiceAttributeKey, serviceId);
+
+            var scope = $"{TelemetryConstants.TelemetryScopePrefix}.{serviceId}";
+
+            var meter = requestContext.ClientConfig.TelemetryProvider.MeterProvider.GetMeter(scope);
+            var monotonicCounter = meter.CreateMonotonicCounter<long>(metricName, unit);
+
+            monotonicCounter.Add(value, initialAttributes);
+        }
+
+        /// <summary>
+        /// Measures the duration of an event in seconds. The duration is recorded into a histogram.
+        /// </summary>
+        /// <param name="requestContext">The request context object.</param>
+        /// <param name="metricName">The name of the metric to record.</param>
+        /// <param name="initialAttributes">The attributes associated with the metric.</param>
+        /// <returns>A disposable object that records the duration when disposed.</returns>
+        public static IDisposable MeasureDuration(IRequestContext requestContext, string metricName, Attributes initialAttributes = null)
+        {
+            if (initialAttributes == null)
+                initialAttributes = new Attributes();
+
+            var operationName = AWSSDKUtils.ExtractOperationName(requestContext.RequestName);
+            initialAttributes.Set(TelemetryConstants.MethodAttributeKey, operationName);
+
+            return MeasureDuration(requestContext.ClientConfig, metricName, initialAttributes);
+        }
+
+        /// <summary>
+        /// Measures the duration of an event in seconds. The duration is recorded into a histogram.
+        /// </summary>
+        /// <param name="config">The client configuration object.</param>
+        /// <param name="metricName">The name of the metric to record.</param>
+        /// <param name="attributes">The attributes associated with the metric.</param>
+        /// <returns>A disposable object that records the duration when disposed.</returns>
+        public static IDisposable MeasureDuration(IClientConfig config, string metricName, Attributes attributes = null)
+        {
+            var serviceId = config.ServiceId;
+
+            if (attributes == null)
+                attributes = new Attributes();
+            attributes.Set(TelemetryConstants.ServiceAttributeKey, serviceId);
+            attributes.Set(TelemetryConstants.SystemAttributeKey, TelemetryConstants.SystemAttributeValue);
+
+            var scope = $"{TelemetryConstants.TelemetryScopePrefix}.{serviceId}";
+            var meter = config.TelemetryProvider.MeterProvider.GetMeter(scope);
+
+            return new DurationMetricsMeasurer(meter, metricName, attributes);
+        }
+
+        private class DurationMetricsMeasurer: IDisposable
+        {
+            private readonly Histogram<double> _histogram;
+            private readonly Attributes _attributes;
+            private readonly DateTime _startTime;
+
+            public DurationMetricsMeasurer(Meter meter, string metricName, Attributes attributes)
+            {
+                _histogram = meter.CreateHistogram<double>(metricName, TelemetryConstants.SecondsUnitName);
+                _attributes = attributes;
+                _startTime = AWSSDKUtils.CorrectedUtcNow;
+            }
+
+            public void Dispose()
+            {
+                // Record the duration in seconds using ticks precision to ensure high precision
+                // and to avoid data loss that may occur due to rounding when using seconds.
+
+                var ticks = (AWSSDKUtils.CorrectedUtcNow - _startTime).Ticks;
+                var durationInSeconds  = (double)ticks / TimeSpan.TicksPerSecond;
+
+                _histogram.Record(durationInSeconds, _attributes);
+            }
+        }
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Telemetry/TelemetryConstants.cs
+++ b/sdk/src/Core/Amazon.Runtime/Telemetry/TelemetryConstants.cs
@@ -40,11 +40,32 @@ namespace Amazon.Runtime.Telemetry
         public const string HTTPRequestContentLengthAttributeKey = "http.request_content_length";
         public const string HTTPResponseContentLengthAttributeKey = "http.response_content_length";
         public const string HTTPMethodAttributeKey = "http.method";
+        public const string ServerAddressAttributeKey = "server.address";
 
         public const string ExceptionMessageAttributeKey = "exception.message";
         public const string ExceptionStackTraceAttributeKey = "exception.stacktrace";
         public const string ExceptionTypeAttributeKey = "exception.type";
         public const string ErrorAttributeKey = "error";
         public const string AWSErrorCodeAttributeKey = "aws.error_code";
+
+        public const string CallDurationMetricName = "client.call.duration";
+        public const string ClientUptimeMetricName = "client.uptime";
+        public const string CallAttemptsMetricName = "client.call.attempts";
+        public const string CallErrorsMetricName = "client.call.errors";
+        public const string CallAttemptDurationMetricName = "client.call.attempt_duration";
+
+        public const string ResolveEndpointDurationMetricName = "client.call.resolve_endpoint_duration";
+        public const string SerializationDurationMetricName = "client.call.serialization_duration";
+        public const string DeserializationDurationMetricName = "client.call.deserialization_duration";
+        public const string AuthSigningDurationMetricName = "client.call.auth.signing_duration";
+        public const string ResolveIdentityDurationMetricName = "client.call.auth.resolve_identity_duration";
+
+        public const string HTTPBytesSentMetricName = "client.http.bytes_sent";
+        public const string HTTPBytesReceivedMetricName = "client.http.bytes_received";
+
+        public const string AttemptUnitName = "{attempt}";
+        public const string ErrorUnitName = "{error}";
+        public const string BytesUnitName = "By";
+        public const string SecondsUnitName = "s";
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Telemetry/TelemetryProvider.cs
+++ b/sdk/src/Core/Amazon.Runtime/Telemetry/TelemetryProvider.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using System;
 using Amazon.Runtime.Telemetry.Metrics;
 using Amazon.Runtime.Telemetry.Tracing;
 
@@ -27,25 +28,46 @@ namespace Amazon.Runtime.Telemetry
         /// <summary>
         /// Gets the <see cref="MeterProvider"/> used to create new metrics.
         /// </summary>
-        public abstract MeterProvider MeterProvider { get; protected set; }
+        public MeterProvider MeterProvider { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="TracerProvider"/> used to create new tracers.
         /// </summary>
-        public abstract TracerProvider TracerProvider { get; protected set; }
+        public TracerProvider TracerProvider { get; private set; }
+
+        public TelemetryProvider(MeterProvider meterProvider, TracerProvider tracerProvider)
+        {
+            if (meterProvider == null)
+                throw new ArgumentNullException(nameof(meterProvider));
+            MeterProvider = meterProvider;
+
+            if (tracerProvider == null)
+                throw new ArgumentNullException(nameof(tracerProvider));
+            TracerProvider = tracerProvider;
+        }
 
         /// <summary>
         /// Registers a new <see cref="MeterProvider"/>.
         /// This method should be called to set a custom meter provider to enable metrics collection.
         /// </summary>
         /// <param name="meterProvider">The meter provider to register.</param>
-        public abstract void RegisterMeterProvider(MeterProvider meterProvider);
+        public virtual void RegisterMeterProvider(MeterProvider meterProvider)
+        {
+            if (meterProvider == null)
+                throw new ArgumentNullException(nameof(meterProvider));
+            MeterProvider = meterProvider;
+        }
 
         /// <summary>
         /// Registers a new <see cref="TracerProvider"/>.
         /// This method should be called to set a custom tracer provider to enable tracing.
         /// </summary>
         /// <param name="tracerProvider">The tracer provider to register.</param>
-        public abstract void RegisterTracerProvider(TracerProvider tracerProvider);
+        public virtual void RegisterTracerProvider(TracerProvider tracerProvider)
+        {
+            if (tracerProvider == null)
+                throw new ArgumentNullException(nameof(tracerProvider));
+            TracerProvider = tracerProvider;
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the following metrics to the SDK:
* client.call.duration
* client.uptime
* client.call.attempts
* client.call.errors
* client.call.attempt_duration
* client.call.resolve_endpoint_duration
* client.call.serialization_duration
* client.call.deserialization_duration
* client.call.auth.signing_duration
* client.call.auth.resolve_identity_duration
* client.http.bytes_sent
* client.http.bytes_received

Switched `TelemetryProvider` properties sets to private to not allow subclasses to alter them and making the register methods the only mutable mechanism, and updated `DefaultTelemetryProvider` acordingly.


## Motivation and Context
DOTNET-7518
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
Created a hacked OTel provider, ran same requests and checked the output in the console and visualized these traces in observability tools, here are some examples of the tracked metrics from different services and actions:


<br/>
<details>
  <summary><b>Console examples:</b></summary>

```
Metric Name: client.uptime, Unit: s, Meter: AWSSDK.S3
(2024-07-09T20:51:56.0155210Z, 2024-07-09T20:52:15.4079103Z] rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 16.7116956 Count: 1 Min: 16.7116956 Max: 16.7116956
(10,25]:1


Metric Name: client.call.duration, Unit: s, Meter: AWSSDK.S3
(2024-07-09T20:51:56.0631967Z, 2024-07-09T20:52:15.4079126Z] rpc.method: ListBuckets rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.7526558 Count: 1 Min: 0.7526558 Max: 0.7526558
(0,5]:1

(2024-07-09T20:51:56.0631967Z, 2024-07-09T20:52:15.4079126Z] rpc.method: PutBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.3325341 Count: 1 Min: 0.3325341 Max: 0.3325341
(0,5]:1

(2024-07-09T20:51:56.0631967Z, 2024-07-09T20:52:15.4079126Z] rpc.method: GetACL rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0383011 Count: 1 Min: 0.0383011 Max: 0.0383011
(0,5]:1

(2024-07-09T20:51:56.0631967Z, 2024-07-09T20:52:15.4079126Z] rpc.method: ListObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0329314 Count: 1 Min: 0.0329314 Max: 0.0329314
(0,5]:1

(2024-07-09T20:51:56.0631967Z, 2024-07-09T20:52:15.4079126Z] rpc.method: PutObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 6.1348382 Count: 35 Min: 0.1319425 Max: 0.4694568
(0,5]:35

(2024-07-09T20:51:56.0631967Z, 2024-07-09T20:52:15.4079126Z] rpc.method: GetObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 7.1103559 Count: 37 Min: 0.0352235 Max: 3.5720756
(0,5]:37

(2024-07-09T20:51:56.0631967Z, 2024-07-09T20:52:15.4079126Z] rpc.method: ListVersions rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0602026 Count: 1 Min: 0.0602026 Max: 0.0602026
(0,5]:1

(2024-07-09T20:51:56.0631967Z, 2024-07-09T20:52:15.4079126Z] rpc.method: DeleteObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.4776557 Count: 1 Min: 0.4776557 Max: 0.4776557
(0,5]:1

(2024-07-09T20:51:56.0631967Z, 2024-07-09T20:52:15.4079126Z] rpc.method: DeleteBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.2283794 Count: 1 Min: 0.2283794 Max: 0.2283794
(0,5]:1


Metric Name: client.call.serialization_duration, Unit: s, Meter: AWSSDK.S3
(2024-07-09T20:51:56.0822022Z, 2024-07-09T20:52:15.4079146Z] rpc.method: ListBuckets rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0170236 Count: 1 Min: 0.0170236 Max: 0.0170236
(0,5]:1

(2024-07-09T20:51:56.0822022Z, 2024-07-09T20:52:15.4079146Z] rpc.method: PutBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0042885 Count: 1 Min: 0.0042885 Max: 0.0042885
(0,5]:1

(2024-07-09T20:51:56.0822022Z, 2024-07-09T20:52:15.4079146Z] rpc.method: GetACL rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0008517 Count: 1 Min: 0.0008517 Max: 0.0008517
(0,5]:1

(2024-07-09T20:51:56.0822022Z, 2024-07-09T20:52:15.4079146Z] rpc.method: ListObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0009378 Count: 1 Min: 0.0009378 Max: 0.0009378
(0,5]:1

(2024-07-09T20:51:56.0822022Z, 2024-07-09T20:52:15.4079146Z] rpc.method: PutObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.005508099999999999 Count: 35 Min: 2.97E-05 Max: 0.0035104
(0,5]:35

(2024-07-09T20:51:56.0822022Z, 2024-07-09T20:52:15.4079146Z] rpc.method: GetObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0036232999999999994 Count: 37 Min: 2.89E-05 Max: 0.0017374
(0,5]:37

(2024-07-09T20:51:56.0822022Z, 2024-07-09T20:52:15.4079146Z] rpc.method: ListVersions rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0008432 Count: 1 Min: 0.0008432 Max: 0.0008432
(0,5]:1

(2024-07-09T20:51:56.0822022Z, 2024-07-09T20:52:15.4079146Z] rpc.method: DeleteObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0021004 Count: 1 Min: 0.0021004 Max: 0.0021004
(0,5]:1

(2024-07-09T20:51:56.0822022Z, 2024-07-09T20:52:15.4079146Z] rpc.method: DeleteBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0004062 Count: 1 Min: 0.0004062 Max: 0.0004062
(0,5]:1


Metric Name: client.call.resolve_endpoint_duration, Unit: s, Meter: AWSSDK.S3
(2024-07-09T20:51:56.1469390Z, 2024-07-09T20:52:15.4079161Z] rpc.method: ListBuckets rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0671123 Count: 1 Min: 0.0671123 Max: 0.0671123
(0,5]:1

(2024-07-09T20:51:56.1469390Z, 2024-07-09T20:52:15.4079161Z] rpc.method: PutBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0012998 Count: 1 Min: 0.0012998 Max: 0.0012998
(0,5]:1

(2024-07-09T20:51:56.1469390Z, 2024-07-09T20:52:15.4079161Z] rpc.method: GetACL rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0001225 Count: 1 Min: 0.0001225 Max: 0.0001225
(0,5]:1

(2024-07-09T20:51:56.1469390Z, 2024-07-09T20:52:15.4079161Z] rpc.method: ListObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0002505 Count: 1 Min: 0.0002505 Max: 0.0002505
(0,5]:1

(2024-07-09T20:51:56.1469390Z, 2024-07-09T20:52:15.4079161Z] rpc.method: PutObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0065437 Count: 35 Min: 8.83E-05 Max: 0.00064
(0,5]:35

(2024-07-09T20:51:56.1469390Z, 2024-07-09T20:52:15.4079161Z] rpc.method: GetObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0061722999999999995 Count: 37 Min: 8.59E-05 Max: 0.0003003
(0,5]:37

(2024-07-09T20:51:56.1469390Z, 2024-07-09T20:52:15.4079161Z] rpc.method: ListVersions rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0001288 Count: 1 Min: 0.0001288 Max: 0.0001288
(0,5]:1

(2024-07-09T20:51:56.1469390Z, 2024-07-09T20:52:15.4079161Z] rpc.method: DeleteObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 8.92E-05 Count: 1 Min: 8.92E-05 Max: 8.92E-05
(0,5]:1

(2024-07-09T20:51:56.1469390Z, 2024-07-09T20:52:15.4079161Z] rpc.method: DeleteBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 8.92E-05 Count: 1 Min: 8.92E-05 Max: 8.92E-05
(0,5]:1


Metric Name: client.call.auth.resolve_identity_duration, Unit: s, Meter: AWSSDK.S3
(2024-07-09T20:51:56.2295096Z, 2024-07-09T20:52:15.4079180Z] rpc.method: ListBuckets rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.002077 Count: 1 Min: 0.002077 Max: 0.002077
(0,5]:1

(2024-07-09T20:51:56.2295096Z, 2024-07-09T20:52:15.4079180Z] rpc.method: PutBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 6.9E-06 Count: 1 Min: 6.9E-06 Max: 6.9E-06
(0,5]:1

(2024-07-09T20:51:56.2295096Z, 2024-07-09T20:52:15.4079180Z] rpc.method: GetACL rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 4E-06 Count: 1 Min: 4E-06 Max: 4E-06
(0,5]:1

(2024-07-09T20:51:56.2295096Z, 2024-07-09T20:52:15.4079180Z] rpc.method: ListObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 5.5E-06 Count: 1 Min: 5.5E-06 Max: 5.5E-06
(0,5]:1

(2024-07-09T20:51:56.2295096Z, 2024-07-09T20:52:15.4079180Z] rpc.method: PutObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0002614 Count: 35 Min: 2.6E-06 Max: 2.51E-05
(0,5]:35

(2024-07-09T20:51:56.2295096Z, 2024-07-09T20:52:15.4079180Z] rpc.method: GetObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.00021980000000000006 Count: 37 Min: 2.1E-06 Max: 1.32E-05
(0,5]:37

(2024-07-09T20:51:56.2295096Z, 2024-07-09T20:52:15.4079180Z] rpc.method: ListVersions rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 5E-06 Count: 1 Min: 5E-06 Max: 5E-06
(0,5]:1

(2024-07-09T20:51:56.2295096Z, 2024-07-09T20:52:15.4079180Z] rpc.method: DeleteObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 4.4E-06 Count: 1 Min: 4.4E-06 Max: 4.4E-06
(0,5]:1

(2024-07-09T20:51:56.2295096Z, 2024-07-09T20:52:15.4079180Z] rpc.method: DeleteBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 4E-06 Count: 1 Min: 4E-06 Max: 4E-06
(0,5]:1


Metric Name: client.call.auth.signing_duration, Unit: s, Meter: AWSSDK.S3
(2024-07-09T20:51:56.2412004Z, 2024-07-09T20:52:15.4079196Z] rpc.method: ListBuckets rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0859607 Count: 1 Min: 0.0859607 Max: 0.0859607
(0,5]:1

(2024-07-09T20:51:56.2412004Z, 2024-07-09T20:52:15.4079196Z] rpc.method: PutBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0006397 Count: 1 Min: 0.0006397 Max: 0.0006397
(0,5]:1

(2024-07-09T20:51:56.2412004Z, 2024-07-09T20:52:15.4079196Z] rpc.method: GetACL rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0039421 Count: 1 Min: 0.0039421 Max: 0.0039421
(0,5]:1

(2024-07-09T20:51:56.2412004Z, 2024-07-09T20:52:15.4079196Z] rpc.method: ListObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0001217 Count: 1 Min: 0.0001217 Max: 0.0001217
(0,5]:1

(2024-07-09T20:51:56.2412004Z, 2024-07-09T20:52:15.4079196Z] rpc.method: PutObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0236498 Count: 35 Min: 8.85E-05 Max: 0.0150428
(0,5]:35

(2024-07-09T20:51:56.2412004Z, 2024-07-09T20:52:15.4079196Z] rpc.method: GetObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.006673200000000001 Count: 37 Min: 7.83E-05 Max: 0.0003617
(0,5]:37

(2024-07-09T20:51:56.2412004Z, 2024-07-09T20:52:15.4079196Z] rpc.method: ListVersions rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0001037 Count: 1 Min: 0.0001037 Max: 0.0001037
(0,5]:1

(2024-07-09T20:51:56.2412004Z, 2024-07-09T20:52:15.4079196Z] rpc.method: DeleteObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 8.81E-05 Count: 1 Min: 8.81E-05 Max: 8.81E-05
(0,5]:1

(2024-07-09T20:51:56.2412004Z, 2024-07-09T20:52:15.4079196Z] rpc.method: DeleteBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 8.89E-05 Count: 1 Min: 8.89E-05 Max: 8.89E-05
(0,5]:1


Metric Name: client.call.attempt_duration, Unit: s, Meter: AWSSDK.S3
(2024-07-09T20:51:56.3794607Z, 2024-07-09T20:52:15.4079213Z] rpc.method: ListBuckets rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.3889079 Count: 1 Min: 0.3889079 Max: 0.3889079
(0,5]:1

(2024-07-09T20:51:56.3794607Z, 2024-07-09T20:52:15.4079213Z] rpc.method: PutBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.3208213 Count: 1 Min: 0.3208213 Max: 0.3208213
(0,5]:1

(2024-07-09T20:51:56.3794607Z, 2024-07-09T20:52:15.4079213Z] rpc.method: GetACL rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0286077 Count: 1 Min: 0.0286077 Max: 0.0286077
(0,5]:1

(2024-07-09T20:51:56.3794607Z, 2024-07-09T20:52:15.4079213Z] rpc.method: ListObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0262215 Count: 1 Min: 0.0262215 Max: 0.0262215
(0,5]:1

(2024-07-09T20:51:56.3794607Z, 2024-07-09T20:52:15.4079213Z] rpc.method: PutObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 6.0725575 Count: 35 Min: 0.1312982 Max: 0.4680492
(0,5]:35

(2024-07-09T20:51:56.3794607Z, 2024-07-09T20:52:15.4079213Z] rpc.method: GetObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 1.7543711000000002 Count: 37 Min: 0.0337125 Max: 0.1999691
(0,5]:37

(2024-07-09T20:51:56.3794607Z, 2024-07-09T20:52:15.4079213Z] rpc.method: ListVersions rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0402997 Count: 1 Min: 0.0402997 Max: 0.0402997
(0,5]:1

(2024-07-09T20:51:56.3794607Z, 2024-07-09T20:52:15.4079213Z] rpc.method: DeleteObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.4729442 Count: 1 Min: 0.4729442 Max: 0.4729442
(0,5]:1

(2024-07-09T20:51:56.3794607Z, 2024-07-09T20:52:15.4079213Z] rpc.method: DeleteBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.2266923 Count: 1 Min: 0.2266923 Max: 0.2266923
(0,5]:1


Metric Name: client.call.deserialization_duration, Unit: s, Meter: AWSSDK.S3
(2024-07-09T20:51:56.7941121Z, 2024-07-09T20:52:15.4079231Z] rpc.method: ListBuckets rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.018165 Count: 1 Min: 0.018165 Max: 0.018165
(0,5]:1

(2024-07-09T20:51:56.7941121Z, 2024-07-09T20:52:15.4079231Z] rpc.method: PutBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0001223 Count: 1 Min: 0.0001223 Max: 0.0001223
(0,5]:1

(2024-07-09T20:51:56.7941121Z, 2024-07-09T20:52:15.4079231Z] rpc.method: GetACL rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0037079 Count: 1 Min: 0.0037079 Max: 0.0037079
(0,5]:1

(2024-07-09T20:51:56.7941121Z, 2024-07-09T20:52:15.4079231Z] rpc.method: ListObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.00239 Count: 1 Min: 0.00239 Max: 0.00239
(0,5]:1

(2024-07-09T20:51:56.7941121Z, 2024-07-09T20:52:15.4079231Z] rpc.method: PutObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0015826000000000002 Count: 35 Min: 8.2E-06 Max: 0.0010906
(0,5]:35

(2024-07-09T20:51:56.7941121Z, 2024-07-09T20:52:15.4079231Z] rpc.method: GetObject rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.004999700000000001 Count: 35 Min: 3.01E-05 Max: 0.0030071
(0,5]:35

(2024-07-09T20:51:56.7941121Z, 2024-07-09T20:52:15.4079231Z] rpc.method: ListVersions rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0178718 Count: 1 Min: 0.0178718 Max: 0.0178718
(0,5]:1

(2024-07-09T20:51:56.7941121Z, 2024-07-09T20:52:15.4079231Z] rpc.method: DeleteObjects rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0015635 Count: 1 Min: 0.0015635 Max: 0.0015635
(0,5]:1

(2024-07-09T20:51:56.7941121Z, 2024-07-09T20:52:15.4079231Z] rpc.method: DeleteBucket rpc.service: S3 rpc.system: aws-api Histogram
Value: Sum: 0.0001717 Count: 1 Min: 0.0001717 Max: 0.0001717
(0,5]:1


Metric Name: client.http.bytes_sent, Unit: By, Meter: AWSSDK.S3
(2024-07-09T20:51:57.4209274Z, 2024-07-09T20:52:15.4079237Z] rpc.method: PutObject rpc.service: S3 rpc.system: aws-api server.address: newbucket1902445051.s3.amazonaws.com:443 LongSum
Value: 256496
(2024-07-09T20:51:57.4209274Z, 2024-07-09T20:52:15.4079237Z] rpc.method: DeleteObjects rpc.service: S3 rpc.system: aws-api server.address: newbucket1902445051.s3.amazonaws.com:443 LongSum
Value: 2537

Metric Name: client.http.bytes_received, Unit: By, Meter: AWSSDK.S3
(2024-07-09T20:51:57.4652236Z, 2024-07-09T20:52:15.4079241Z] rpc.method: GetObject rpc.service: S3 rpc.system: aws-api server.address: newbucket1902445051.s3.amazonaws.com:443 LongSum
Value: 250390

Metric Name: client.call.errors, Unit: {error}, Meter: AWSSDK.S3
(2024-07-09T20:52:08.3364408Z, 2024-07-09T20:52:15.4079246Z] exception.type: AmazonS3Exception rpc.method: GetObject rpc.service: S3 rpc.system: aws-api LongSum
Value: 2
```


</details>



<details>
  <summary><b>Examples after exporting to prometheus:</b></summary>


* client.call.duration
![image](https://github.com/aws/aws-sdk-net/assets/28155926/383009a2-9488-4df5-8481-decea1c33318)

* client.uptime (uptime is per client, thats why it doesn't show methods)
![image](https://github.com/aws/aws-sdk-net/assets/28155926/3b681cdb-dd12-4165-bd92-46741cfd9bcd)

* client.call.attempts
![image](https://github.com/aws/aws-sdk-net/assets/28155926/960add70-b27c-4111-8f99-0c07020c771b)

* client.call.errors
![image](https://github.com/aws/aws-sdk-net/assets/28155926/17730130-8fc7-48f4-8f5e-4528189b8e56)

* client.call.attempt_duration
![image](https://github.com/aws/aws-sdk-net/assets/28155926/4e4d639b-d491-482a-b06e-7c7ecb1ce70f)

* client.call.resolve_endpoint_duration
![image](https://github.com/aws/aws-sdk-net/assets/28155926/28f16847-44a9-47dd-8e93-5b8b0d13f95b)

* client.call.serialization_duration
![image](https://github.com/aws/aws-sdk-net/assets/28155926/fb4ab925-98d0-4da2-8350-b95148b71b63)

* client.call.deserialization_duration
![image](https://github.com/aws/aws-sdk-net/assets/28155926/79e96696-dabd-4e6b-a082-edea3c0ee675)

* client.call.auth.signing_duration
![image](https://github.com/aws/aws-sdk-net/assets/28155926/54cb71af-245b-47b3-b2a2-1d05f9688a44)

* client.call.auth.resolve_identity_duration
![image](https://github.com/aws/aws-sdk-net/assets/28155926/a42237d3-109b-445d-a5c8-4edbf8ff474a)

* client.http.bytes_sent
![image](https://github.com/aws/aws-sdk-net/assets/28155926/ff06f0a5-ed53-464b-8838-55da5dd33af7)

* client.http.bytes_received
![image](https://github.com/aws/aws-sdk-net/assets/28155926/f890e090-3f6a-460b-b6d9-233ea01ee0d0)

</details>


<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement