### PR TITLE
Add base class for upcoming object persistence operation-specific config objects

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
@@ -23,6 +23,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// anything operation-specific should be added to derived classes.
     /// </remarks>
 #if NET8_0_OR_GREATER
+    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
 #endif
     public abstract class BaseOperationConfig
@@ -41,9 +42,9 @@ namespace Amazon.DynamoDBv2.DataModel
         public string TableNamePrefix { get; set; }
 
         /// <summary>
-        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
-        /// requests. This controls how the cache key is derived, which influences when the SDK will call
-        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
+        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to 
+        /// construct and validate  requests. This controls how the cache key is derived, which influences 
+        /// when the SDK will call DescribeTable internally to populate the cache.
         /// </summary>
         /// <remarks>
         /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
@@ -58,8 +59,8 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <remarks>
         /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
-        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
-        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
+        /// DescribeTable calls that are used to populate the SDK's cache of table metadata. 
+        /// It requires that the table's index schema be accurately described via the above methods, 
         /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
         /// </remarks>
         public bool? DisableFetchingTableMetadata { get; set; }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
@@ -1,0 +1,100 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.DynamoDBv2.DataModel
+{
+    /// <summary>
+    /// Base class for operation-specific configurations for DynamoDB object persistence operations.
+    /// </summary>
+    /// <remarks>
+    /// This should only contain members that are relevant to all object persistence operations, 
+    /// anything operation-specific should be added to derived classes.
+    /// </remarks>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+#endif
+    public abstract class BaseOperationConfig
+    {
+        /// <summary>
+        /// Indicates which DynamoDB table to use. This overrides the table specified 
+        /// by the <see cref="DynamoDBTableAttribute"/> on the .NET objects that you're saving or loading.
+        /// </summary>
+        public string OverrideTableName { get; set; }
+
+        /// <summary>
+        /// Directs <see cref="DynamoDBContext"/> to prefix all table names
+        /// with a specific string. If this is null or empty, no prefix is used 
+        /// and default table names are used.
+        /// </summary>
+        public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call
+        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
+        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
+        /// </remarks>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
+
+        /// <summary>
+        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
+        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
+        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
+        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
+        /// </remarks>
+        public bool? DisableFetchingTableMetadata { get; set; }
+
+        /// <summary>
+        /// Specification which controls the conversion between .NET and DynamoDB types.
+        /// </summary>
+        public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <summary>
+        /// Contorls how <see cref="DynamoDBContext"/> interprets emptry string values.
+        /// If the property is false (or not set), empty string values will be
+        /// interpreted as null values.
+        /// </summary>
+        public bool? IsEmptyStringValueEnabled { get; set; }
+
+        /// <summary>
+        /// Converts this to the shared <see cref="DynamoDBOperationConfig"/>
+        /// </summary>
+        /// <remarks>
+        /// Users should interact with the new, operation-specific configs, but we
+        /// convert to the internal shared config for the internal code paths.
+        /// </remarks>
+        /// <returns>A new <see cref="DynamoDBOperationConfig"/> with settings copied from the operation-specific config</returns>
+        internal virtual DynamoDBOperationConfig ToDynamoDBOperationConfig()
+        {
+            return new DynamoDBOperationConfig()
+            {
+                OverrideTableName = OverrideTableName,
+                TableNamePrefix = TableNamePrefix,
+                MetadataCachingMode = MetadataCachingMode,
+                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
+                Conversion = Conversion,
+                IsEmptyStringValueEnabled = IsEmptyStringValueEnabled
+            };
+        }
+    }
+}

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
@@ -1,0 +1,22 @@
+﻿using Amazon.DynamoDBv2.DataModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSSDK_DotNet.UnitTests
+{
+    /// <summary>
+    /// These tests serve as a reminder to developers and reviewers to 
+    /// ensure that new DynamoDB operation-specific properties are plumbed
+    /// into the internal code paths correctly
+    /// </summary>
+    [TestClass]
+    public class DataModelOperationSpecificConfigTests
+    {
+        [TestMethod]
+        public void BaseOperationConfig()
+        {
+            // If this fails because you've added a property, be sure to add it to
+            // `ToDynamoDBOperationConfig` before updating this unit test
+            Assert.AreEqual(6, typeof(BaseOperationConfig).GetProperties().Length);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This is adding a base class to use for the new set of operation-specific config objects for the object persistence APIs.

## Motivation and Context
See #3376 for the full context for this change, this PR came from https://github.com/aws/aws-sdk-net/pull/3376#issuecomment-2220525789. I'd rather merge this into the feature branch quickly, then rebase the PRs that are introducing the derived classes on top of it.

## Testing
Existing DynamoDBv2 sln tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement