### PR TITLE
Add basic <inheritdoc/> support to the API reference generator

### DIFF
--- a/docgenerator/SDKDocGeneratorLib/NDocUtilities.cs
+++ b/docgenerator/SDKDocGeneratorLib/NDocUtilities.cs
@@ -167,32 +167,32 @@ namespace SDKDocGenerator
 
             // Follow a plain <inheritdoc/> by searching the base type and interfaces.
             var inheritdocElement = element.XPathSelectElement("inheritdoc");
-            if (inheritdocElement != null)
+            if (inheritdocElement == null)
+                return element;
+
+            if (inheritdocElement.Attribute("cref") != null || inheritdocElement.Attribute("path") != null)
             {
-                if (inheritdocElement.Attribute("cref") != null || inheritdocElement.Attribute("path") != null)
+                Trace.WriteLine($"Skipping following <inheritdoc> for {signature} since cref and/or path are not supported yet.");
+                return element;
+            }
+
+            if (type.BaseType.FullName != "System.Object") // we never expect to inherit class-level docs from here
+            {
+                var baseTypeDocs = FindDocumentation(ndoc, type.BaseType);
+
+                if (baseTypeDocs != null)
                 {
-                    Trace.WriteLine($"Skipping following <inheritdoc> for {signature} since cref and/or path are not supported yet.");
-                    return element;
+                    return baseTypeDocs;
                 }
+            }
 
-                if (type.BaseType.FullName != "System.Object") // we never expect to inherit class-level docs from here
+            foreach (var baseInterface in type.GetInterfaces())
+            {
+                var interfaceDocs = FindDocumentation(ndoc, baseInterface);
+
+                if (interfaceDocs != null)
                 {
-                    var baseTypeDocs = FindDocumentation(ndoc, type.BaseType);
-
-                    if (baseTypeDocs != null)
-                    {
-                        return baseTypeDocs;
-                    }
-                }
-
-                foreach (var baseInterface in type.GetInterfaces())
-                {
-                    var interfaceDocs = FindDocumentation(ndoc, baseInterface);
-
-                    if (interfaceDocs != null)
-                    {
-                        return interfaceDocs;
-                    }
+                    return interfaceDocs;
                 }
             }
 
@@ -209,26 +209,26 @@ namespace SDKDocGenerator
 
             // Follow a plain <inheritdoc/> by searching the base type and interfaces.
             var inheritdocElement = element.XPathSelectElement("inheritdoc");
-            if (inheritdocElement != null)
+            if (inheritdocElement == null)
+                return element;
+
+            if (inheritdocElement.Attribute("cref") != null || inheritdocElement.Attribute("path") != null)
             {
-                if (inheritdocElement.Attribute("cref") != null || inheritdocElement.Attribute("path") != null)
-                {
-                    Trace.WriteLine($"Skipping following <inheritdoc> for {signature} since cref and/or path are not supported yet.");
-                    return element;
-                }
+                Trace.WriteLine($"Skipping following <inheritdoc> for {signature} since cref and/or path are not supported yet.");
+                return element;
+            }
 
-                var baseTypeMatchingProperties = info.DeclaringType.BaseType.GetProperties().Where(property => property.Name.Equals(info.Name, StringComparison.OrdinalIgnoreCase));
+            var baseTypeMatchingProperties = info.DeclaringType.BaseType.GetProperties().Where(property => property.Name.Equals(info.Name, StringComparison.OrdinalIgnoreCase));
 
-                if (baseTypeMatchingProperties.Count() == 1)
-                    return FindDocumentation(ndoc, baseTypeMatchingProperties.First());
+            if (baseTypeMatchingProperties.Count() == 1)
+                return FindDocumentation(ndoc, baseTypeMatchingProperties.First());
 
-                foreach (var baseInterface in info.DeclaringType.GetInterfaces())
-                {
-                    var interfaceMatchingProperties = baseInterface.GetProperties().Where(property => property.Name.Equals(info.Name, StringComparison.OrdinalIgnoreCase));
+            foreach (var baseInterface in info.DeclaringType.GetInterfaces())
+            {
+                var interfaceMatchingProperties = baseInterface.GetProperties().Where(property => property.Name.Equals(info.Name, StringComparison.OrdinalIgnoreCase));
 
-                    if (interfaceMatchingProperties.Count() == 1)
-                        return FindDocumentation(ndoc, interfaceMatchingProperties.First());
-                }
+                if (interfaceMatchingProperties.Count() == 1)
+                    return FindDocumentation(ndoc, interfaceMatchingProperties.First());
             }
 
             return element;
@@ -326,26 +326,26 @@ namespace SDKDocGenerator
 
             // Follow a plain < inheritdoc /> by searching the base type and interfaces.
             var inheritdocElement = element.XPathSelectElement("inheritdoc");
-            if (inheritdocElement != null)
+            if (inheritdocElement == null)
+                return element;
+
+            if (inheritdocElement.Attribute("cref") != null || inheritdocElement.Attribute("path") != null)
             {
-                if (inheritdocElement.Attribute("cref") != null || inheritdocElement.Attribute("path") != null)
-                {
-                    Trace.WriteLine($"Skipping following <inheritdoc> for {signature} since cref and/or path are not supported yet.");
-                    return element;
-                }
+                Trace.WriteLine($"Skipping following <inheritdoc> for {signature} since cref and/or path are not supported yet.");
+                return element;
+            }
 
-                var baseTypeMatchingMethods = info.DeclaringType.BaseType.GetMethodsToDocument().Where(method => method.FullName.Equals(info.FullName, StringComparison.OrdinalIgnoreCase));
+            var baseTypeMatchingMethods = info.DeclaringType.BaseType.GetMethodsToDocument().Where(method => method.FullName.Equals(info.FullName, StringComparison.OrdinalIgnoreCase));
                 
-                if (baseTypeMatchingMethods.Count() == 1)
-                    return FindDocumentation(ndoc, baseTypeMatchingMethods.First());
+            if (baseTypeMatchingMethods.Count() == 1)
+                return FindDocumentation(ndoc, baseTypeMatchingMethods.First());
 
-                foreach (var baseInterface in info.DeclaringType.GetInterfaces())
-                {
-                    var interfaceMatchingMethods = baseInterface.GetMethodsToDocument().Where(method => method.FullName.Equals(info.FullName, StringComparison.OrdinalIgnoreCase));
+            foreach (var baseInterface in info.DeclaringType.GetInterfaces())
+            {
+                var interfaceMatchingMethods = baseInterface.GetMethodsToDocument().Where(method => method.FullName.Equals(info.FullName, StringComparison.OrdinalIgnoreCase));
 
-                    if (interfaceMatchingMethods.Count() == 1)
-                        return FindDocumentation(ndoc, interfaceMatchingMethods.First());
-                }
+                if (interfaceMatchingMethods.Count() == 1)
+                    return FindDocumentation(ndoc, interfaceMatchingMethods.First());
             }
 
             return element;
@@ -456,26 +456,26 @@ namespace SDKDocGenerator
 
             // Follow a plain < inheritdoc /> by searching the base type and interfaces.
             var inheritdocElement = element.XPathSelectElement("inheritdoc");
-            if (inheritdocElement != null)
+            if (inheritdocElement == null)
+                return element;
+
+            if (inheritdocElement.Attribute("cref") != null || inheritdocElement.Attribute("path") != null)
             {
-                if (inheritdocElement.Attribute("cref") != null || inheritdocElement.Attribute("path") != null)
-                {
-                    Trace.WriteLine($"Skipping following <inheritdoc> for {signature} since cref and/or path are not supported yet.");
-                    return element;
-                }
+                Trace.WriteLine($"Skipping following <inheritdoc> for {signature} since cref and/or path are not supported yet.");
+                return element;
+            }
 
-                var baseTypeMatchingMethods = info.DeclaringType.BaseType.GetMethodsToDocument().Where(method => method.FullName.Equals(info.FullName, StringComparison.OrdinalIgnoreCase));
+            var baseTypeMatchingMethods = info.DeclaringType.BaseType.GetMethodsToDocument().Where(method => method.FullName.Equals(info.FullName, StringComparison.OrdinalIgnoreCase));
 
-                if (baseTypeMatchingMethods.Count() == 1)
-                    return FindDocumentation(ndoc, baseTypeMatchingMethods.First());
+            if (baseTypeMatchingMethods.Count() == 1)
+                return FindDocumentation(ndoc, baseTypeMatchingMethods.First());
 
-                foreach (var baseInterface in info.DeclaringType.GetInterfaces())
-                {
-                    var interfaceMatchingMethods = baseInterface.GetMethodsToDocument().Where(method => method.FullName.Equals(info.FullName, StringComparison.OrdinalIgnoreCase));
+            foreach (var baseInterface in info.DeclaringType.GetInterfaces())
+            {
+                var interfaceMatchingMethods = baseInterface.GetMethodsToDocument().Where(method => method.FullName.Equals(info.FullName, StringComparison.OrdinalIgnoreCase));
 
-                    if (interfaceMatchingMethods.Count() == 1)
-                        return FindDocumentation(ndoc, interfaceMatchingMethods.First());
-                }
+                if (interfaceMatchingMethods.Count() == 1)
+                    return FindDocumentation(ndoc, interfaceMatchingMethods.First());
             }
 
             return element;

--- a/generator/.DevConfigs/16e51295-c0ea-4e04-bc26-c9ae086a1059.json
+++ b/generator/.DevConfigs/16e51295-c0ea-4e04-bc26-c9ae086a1059.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Apply missing documentation to some classes in Amazon.Runtime"
+      ],
+      "type": "patch",
+      "updateMinimum": false
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/DefaultConfiguration.cs
+++ b/sdk/src/Core/Amazon.Runtime/DefaultConfiguration.cs
@@ -78,12 +78,8 @@ namespace Amazon.Runtime
     /// <para />
     /// All options above can be configured by users, and the overridden value will take precedence.
     /// <para />
-    /// <b>Note:</b> for any mode other than <see cref="DefaultConfigurationMode.Legacy"/>, the vended default values
-    /// might change as best practices may evolve. As a result, it is encouraged to perform testing when upgrading the SDK
-    /// if you are using a mode other than <see cref="DefaultConfigurationMode.Legacy"/>.
-    /// <para />
-    /// While the <see cref="DefaultConfigurationMode.Legacy"/> defaults mode is specific to .NET,
-    /// other modes are standardized across all of the AWS SDKs.
+    /// <b>Note:</b> the vended default values might change as best practices may evolve. As a result, it is encouraged to perform 
+    /// testing when upgrading the SDK.
     /// <para />
     /// The defaults mode can be configured:
     /// <list type="number">

--- a/sdk/src/Core/Amazon.Runtime/DefaultConfiguration.cs
+++ b/sdk/src/Core/Amazon.Runtime/DefaultConfiguration.cs
@@ -72,7 +72,26 @@ namespace Amazon.Runtime
         TimeSpan? HttpRequestTimeout { get; }
     }
 
-    /// <inheritdoc cref="IDefaultConfiguration"/>
+    /// <summary>
+    /// A defaults mode determines how certain default configuration options are resolved in the SDK. Based on the provided
+    /// mode, the SDK will vend sensible default values tailored to the specific <see cref="DefaultConfigurationMode"/>.
+    /// <para />
+    /// All options above can be configured by users, and the overridden value will take precedence.
+    /// <para />
+    /// <b>Note:</b> for any mode other than <see cref="DefaultConfigurationMode.Legacy"/>, the vended default values
+    /// might change as best practices may evolve. As a result, it is encouraged to perform testing when upgrading the SDK
+    /// if you are using a mode other than <see cref="DefaultConfigurationMode.Legacy"/>.
+    /// <para />
+    /// While the <see cref="DefaultConfigurationMode.Legacy"/> defaults mode is specific to .NET,
+    /// other modes are standardized across all of the AWS SDKs.
+    /// <para />
+    /// The defaults mode can be configured:
+    /// <list type="number">
+    /// <item>When constructing an <see cref="AmazonServiceClient"/> implementation by setting <see cref="ClientConfig.DefaultConfigurationMode"/>.</item>
+    /// <item>Globally via the "AWS_DEFAULTS_MODE" environment variable.</item>
+    /// <item>On a configuration profile via the "defaults_mode" profile file property.</item>
+    /// </list>
+    /// </summary>
     [DebuggerDisplay("{" + nameof(Name) + "}")]
     public class DefaultConfiguration : IDefaultConfiguration
     {

--- a/sdk/src/Core/Amazon.Runtime/Tokens/StaticTokenProvider.cs
+++ b/sdk/src/Core/Amazon.Runtime/Tokens/StaticTokenProvider.cs
@@ -7,7 +7,10 @@ using Amazon.Util;
 
 namespace Amazon.Runtime
 {
-    /// <inheritdoc cref="StaticTokenProvider(string, DateTime?)"/>
+    /// <summary>
+    /// An <see cref="IAWSTokenProvider"/> implementation can be assigned to
+    /// <see cref="IClientConfig.AWSTokenProvider"/> or added to a <see cref="AWSTokenProviderChain"/>.
+    /// </summary>
     public class StaticTokenProvider : IAWSTokenProvider
     {
         private readonly string _token;

--- a/sdk/src/Core/Amazon.Runtime/_bcl+netstandard/Tokens/SSOTokenProviderFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/_bcl+netstandard/Tokens/SSOTokenProviderFactory.cs
@@ -19,7 +19,9 @@ using Amazon.Runtime.Internal;
 
 namespace Amazon.Runtime
 {
-    /// <inheritdoc cref="Build"/>
+    /// <summary>
+    /// Interface for a factory that constructs new instances of <see cref="SSOTokenProvider"/>
+    /// </summary>
     public interface ISSOTokenProviderFactory
     {
         /// <summary>
@@ -28,7 +30,9 @@ namespace Amazon.Runtime
         SSOTokenProvider Build(CredentialProfile profile);
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Factory that constructs new new instances of <see cref="SSOTokenProvider"/>
+    /// </summary>
     public class SSOTokenProviderFactory : ISSOTokenProviderFactory
     {
         private readonly ISSOTokenFileCache _ssoTokenFileCache;


### PR DESCRIPTION
_7/16/24 note: Pushing up a draft before I'm out on vacation. I still need to test against the full SDK (see below for current testing), but here it is in case anybody wants to take an early look._

## Description

### Before
The [API Reference]() for the AWS SDK for .NET uses a homegrown doc generator, which does not follow `<inheritdoc/>` tags.

For example this block in `DefaultConfiguration`: https://github.com/aws/aws-sdk-net/blob/364ebb9f592dfc8b315e826430b0b9a6ad182f08/sdk/src/Core/Amazon.Runtime/DefaultConfiguration.cs#L88-L103

Results in this at https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Runtime/TDefaultConfiguration.html:
![image](https://github.com/user-attachments/assets/943ba682-bf31-4386-9f95-0256963d456d)

### After
Now the generator will follow plain `<inheritdoc/>` tags for 
1. Types
2. Properties
3. Methods

Same page from above:
![image](https://github.com/user-attachments/assets/c4fe0395-f7f6-43af-81eb-f80192819d01)

Since this was quick unplanned work, I did not add support for the following (will submit an internal backlog item):
1. Constructors
2. Fields
3. Following something like `<inheritdoc cref="..."/>` or `<inheritdoc path="...."/>`
    * Because of this, I replaced some of these more comlex `<inheritdoc>` tags in core with copied+pasted docs.

## Motivation and Context
1. We have some API ref pages today that are missing docs
2. While doing DynamoDB V4 work, we're expanding the high-level interfaces and clients, and it's nice to not paste all of the docs twice.

## Testing
1. Ran the generator locally against AWSSDK.Core and AWSSDK.DynamoDBv2 via `dotnet msbuild .\buildtools\doc-build.proj -t:doc-build`. Confirmed the following local pages now have docs that are missing in live:
    * https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/DynamoDBv2/TTableBuilder.html - methods
    * https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Runtime/TDefaultConfiguration.html - properties
2. Dry-run in progress
3. I still want to run a full generation to verify that we're not regressing or generating unintended changes for other assemblies.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement