### PR TITLE
Fixed a bug in orphaned shape cleanup not cleaning up service shapes.

### DIFF
--- a/generator/ServiceClientGenerator/Program.cs
+++ b/generator/ServiceClientGenerator/Program.cs
@@ -113,7 +113,7 @@ namespace ServiceClientGenerator
                     // Skip orphan clean for DynamoDB because of the complex nature of DynamoDB and DynamoDB Streams
                     if (!serviceConfig.ClassName.StartsWith("DynamoDB") && !options.SkipRemoveOrphanCleanup)
                     {
-                        GeneratorDriver.RemoveOrphanedShapes(driver.FilesWrittenToGeneratorFolder, null, driver.GeneratedFilesRoot);
+                        GeneratorDriver.RemoveOrphanedShapes(driver.FilesWrittenToGeneratorFolder, driver.GeneratedFilesRoot);
                     }
                 }
             }

--- a/generator/ServiceClientGeneratorLib/GeneratorDriver.cs
+++ b/generator/ServiceClientGeneratorLib/GeneratorDriver.cs
@@ -1423,17 +1423,17 @@ namespace ServiceClientGenerator
             command.Execute(CodeAnalysisRoot, this.Configuration);
         }
 
-        public static void RemoveOrphanedShapesAndServices(HashSet<string> generatedFiles, HashSet<string> generatedTestFolders, string sdkRootFolder)
+        public static void RemoveOrphanedShapesAndServices(HashSet<string> generatedFiles, HashSet<string> generatedTestFiles, string sdkRootFolder)
         {
             var codeGeneratedServiceList = codeGeneratedServiceNames.Distinct();
 
             // Cleanup services within the main sdk/services folder
             var srcFolder = Utils.PathCombineAlt(sdkRootFolder, SourceSubFoldername, ServicesSubFoldername);
-            RemoveOrphanedShapes(generatedFiles, null, srcFolder);
+            RemoveOrphanedShapes(generatedFiles, srcFolder);
 
-            // Cleanup services within the sdk/test folder where it is a generated test service
+            // Cleanup services within the sdk/test/services folder where it is a generated test service
             var testSrcFolder = Utils.PathCombineAlt(sdkRootFolder, TestsSubFoldername, ServicesSubFoldername);
-            RemoveOrphanedShapes(generatedFiles, generatedTestFolders, testSrcFolder);
+            RemoveOrphanedShapes(generatedFiles, generatedTestFiles, testSrcFolder);
                         
             // Cleanup orphaned Service src artifacts. This is encountered when the service identifier is modified.
             RemoveOrphanedServices(srcFolder, codeGeneratedServiceList);
@@ -1442,18 +1442,52 @@ namespace ServiceClientGenerator
             // Cleanup orphaned Service code analysis artifacts. This is encountered when the service identifier is modified.
             RemoveOrphanedServices(Utils.PathCombineAlt(sdkRootFolder, CodeAnalysisFoldername, ServicesAnalysisSubFolderName), codeGeneratedServiceList);
         }
-        public static void RemoveOrphanedShapes(HashSet<string> generatedFiles, HashSet<string> generatedTestFolders, string srcFolder)
+
+        /// <summary>
+        /// Removes orphaned */generated/* files from specified srcFolder. This can be encountered when a model 
+        /// removes an operation or shape and the sub shapes are no longer needed. The file will be deleted if
+        /// the file contains */generated/* as part of the path and is not a file from a current run generated 
+        /// service (generatedFiles).
+        /// </summary>
+        /// <param name="generatedFiles">Lookup of all files that have been generated.</param>
+        /// <param name="srcFolder">The path to the sdk/services folder containing generated services and manual source code.</param>
+        public static void RemoveOrphanedShapes(HashSet<string> generatedFiles, string srcFolder)
         {
-            // Remove orphaned shapes. Most likely due to taking in a model that was still under development.
             foreach (var file in Directory.GetFiles(srcFolder, "*.cs", SearchOption.AllDirectories).OrderBy(f => f))
             {
                 var fullPath = Utils.ConvertPathAlt(Path.GetFullPath(file));
                 if (fullPath.IndexOf($"/{GeneratedCodeFoldername}/", StringComparison.OrdinalIgnoreCase) < 0)
                     continue;
 
-                if (!generatedFiles.Contains(fullPath) && generatedTestFolders?.Contains(fullPath) == false)
+                if (!generatedFiles.Contains(fullPath))
                 {
                     Console.Error.WriteLine("**** Warning: Removing orphaned generated code " + Path.GetFileName(file));
+                    File.Delete(file);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes orphaned */generated/* files from specified srcFolder. This can be encountered when a test service model 
+        /// removes an operation or shape and the sub shapes are no longer needed. Special care must be taken within the 
+        /// sdk/test/services folder because there is a mix of generated tests and test services. The file will be deleted if
+        /// the file contains */generated/* as part of the path, is not a file from a current run generated test service (generatedFiles),
+        /// and is not a file from a current run generated test (generatedTestFiles).
+        /// </summary>
+        /// <param name="generatedFiles">Lookup of all files that have been generated.</param>
+        /// <param name="generatedTestFiles">Lookup of all the generated test files.</param>
+        /// <param name="srcFolder">The path to the sdk/test/services folder containing generated tests and test services.</param>
+        public static void RemoveOrphanedShapes(HashSet<string> generatedFiles, HashSet<string> generatedTestFiles, string srcFolder)
+        {
+            foreach (var file in Directory.GetFiles(srcFolder, "*.cs", SearchOption.AllDirectories).OrderBy(f => f))
+            {
+                var fullPath = Utils.ConvertPathAlt(Path.GetFullPath(file));
+                if (fullPath.IndexOf($"/{GeneratedCodeFoldername}/", StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                if (!generatedFiles.Contains(fullPath) && !generatedTestFiles.Contains(fullPath))
+                {
+                    Console.Error.WriteLine("**** Warning: Removing orphaned generated test code " + Path.GetFileName(file));
                     File.Delete(file);
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes a bug where the generated service shapes were not cleaned up for breaking changes automatically because the test files list was null making the condition always false. This changed in this PR: https://github.com/aws/aws-sdk-net/pull/3242

`RemoveOrphanedShapesAndServices`

Added `null` to the `RemoveOrphanedShapes` call. 

`RemoveOrphanedShapes(generatedFiles, null, srcFolder);`

Condition that would not longer be true:

```
if (!generatedFiles.Contains(fullPath) && generatedTestFolders?.Contains(fullPath) == false)
```

This change splits the extra cross referencing of generated tests into another method to more isolate the functionality instead of the simpler fix of checking for null and doing a OR check. Documentation has also been added to `RemoveOrphanedShapes` for both overloads to make the behavior clear.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

Automatic cleanup of breaking changes isn't automatic and requires manual cleanup. This restores the automatic functionality. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Built and ran generator. No files updated.
* Using the previous generator version confirmed all files were not cleaned up when a breaking change is introduced.
* Build and ran generator along with breaking changes. Example output:

```
**** Warning: Removing orphaned generated code ApplyGuardrailRequest.cs
**** Warning: Removing orphaned generated code ApplyGuardrailResponse.cs
**** Warning: Removing orphaned generated code GuardrailContentBlock.cs
**** Warning: Removing orphaned generated code GuardrailContextualGroundingFilter.cs
**** Warning: Removing orphaned generated code GuardrailContextualGroundingPolicyAssessment.cs
**** Warning: Removing orphaned generated code GuardrailOutputContent.cs
**** Warning: Removing orphaned generated code GuardrailTextBlock.cs
**** Warning: Removing orphaned generated code GuardrailUsage.cs
**** Warning: Removing orphaned generated code ApplyGuardrailRequestMarshaller.cs
**** Warning: Removing orphaned generated code ApplyGuardrailResponseUnmarshaller.cs
**** Warning: Removing orphaned generated code GuardrailContentBlockMarshaller.cs
**** Warning: Removing orphaned generated code GuardrailContextualGroundingFilterUnmarshaller.cs
**** Warning: Removing orphaned generated code GuardrailContextualGroundingPolicyAssessmentUnmarshaller.cs
**** Warning: Removing orphaned generated code GuardrailOutputContentUnmarshaller.cs
**** Warning: Removing orphaned generated code GuardrailTextBlockMarshaller.cs
**** Warning: Removing orphaned generated code GuardrailUsageUnmarshaller.cs
**** Warning: Removing orphaned generated code S3Enumerations.cs
Updating unit test project files.
Updating solution files.
Updating solution files in ******\aws-sdk-net\sdk
Updating code analysis solution file.
Generating DefaultConfigurationMode Enum...
Generating endpoints constants...
Generating S3 enumerations constants...
...created/updated S3Enumerations.cs
```

* Made a operation removal to the `restjson-test-client`

```
"AllQueryStringTypes":{
  "name":"AllQueryStringTypes",
  "http":{
    "method":"GET",
    "requestUri":"/AllQueryStringTypesInput",
    "responseCode":200
  },
  "input":{"shape":"AllQueryStringTypesInput"},
  "documentation":"<p>This example uses all query string types.</p>"
},
```

Ensured the test service code was removed:

```
**** Warning: Removing orphaned generated code S3Enumerations.cs
**** Warning: Removing orphaned generated test code AllQueryStringTypesRequest.cs
**** Warning: Removing orphaned generated test code AllQueryStringTypesResponse.cs
**** Warning: Removing orphaned generated test code AllQueryStringTypesRequestMarshaller.cs
**** Warning: Removing orphaned generated test code AllQueryStringTypesResponseUnmarshaller.cs
Updating unit test project files.
Updating solution files.
Updating solution files in C:\Dev\repos\aws-sdk-net\sdk
Updating code analysis solution file.
Generating DefaultConfigurationMode Enum...
Generating endpoints constants...
Generating S3 enumerations constants...
...created/updated S3Enumerations.cs
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement