### PR TITLE
fix: update S3 mock request to call composeUrl

### DIFF
--- a/sdk/test/Services/S3/UnitTests/Custom/S3ArnTestUtils.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/S3ArnTestUtils.cs
@@ -72,6 +72,10 @@ namespace AWSSDK.UnitTests
 
             pipeline.InvokeSync(executionContext);
 
+            // Since resource path substituation happens in the ComposeUrl method, which exists in the HttpHandler
+            // we need to call ComposeUrl here to ensure the resource path is set correctly.
+            // For an actual API call, it will always go through the HttpHandler so we need not worry about this.
+            requestContext.Request.ResourcePath = AmazonServiceClient.ComposeUrl(requestContext.Request).AbsolutePath;
             return requestContext.Request;
         }
         public class NoopPipelineHandler : IPipelineHandler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This updates `RunMockRequest` to call the `ComposeUrl` method. [This PR ](https://github.com/aws/aws-sdk-net/pull/3373) updated S3 to use the resource path dictionaries and to do path substitution for anything that is a label. Previously we were taking the actual key value and replacing it in the marshaller, which worked for a mock request because there was no label substitution. Now that we are doing label substitution in the `HttpHandler` and since the `HttpHandler` is not part of the mock request pipeline. We need to call `ComposeUrl` ourselves to get the correct resource path. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Unblocks v4 pipeline
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all the S3.sln unit tests
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement