### PR TITLE
test: Ensure protected and private properties are set when deserializing in DynamoDB's object-persistence model

### DIFF
--- a/sdk/test/NetStandard/UnitTests/Services/DynamoDBTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Services/DynamoDBTests.cs
@@ -1,11 +1,12 @@
-using Xunit;
-using Amazon.DynamoDBv2.Model;
-using System.Threading.Tasks;
-using Moq;
 using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
-using System.Threading;
+using Amazon.DynamoDBv2.Model;
+using Moq;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace AWSSDK_NetStandard.UnitTests
 {

--- a/sdk/test/NetStandard/UnitTests/Services/DynamoDBTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Services/DynamoDBTests.cs
@@ -208,5 +208,52 @@ namespace AWSSDK_NetStandard.UnitTests
             Assert.Throws<InvalidOperationException>(() => Table.LoadTable(mockClient.Object, "TestTable"));
         }
         #endregion
+
+        /// <summary>
+        /// Verifies that non-public properties are set when converting a Document to a .NET object
+        /// </summary>
+        /// <remarks>
+        /// This test is duplicated for .NET Framework and .NET since we once had a 
+        /// bug where behavior differed. See https://github.com/aws/aws-sdk-net/issues/1848
+        /// </remarks>
+        [Fact]
+        [Trait("Category", "DynamoDBv2")]
+        public void FromDocument_NonPublicProperties()
+        {
+            var mockClient = new Mock<IAmazonDynamoDB>();
+            var context = new DynamoDBContext(mockClient.Object, new DynamoDBContextConfig { DisableFetchingTableMetadata = true} );
+
+            var document = new Document();
+            document["pk"] = "Primary";
+            document["private"] = "Private Value";
+            document["internal"] = "Internal Value";
+            document["protected"] = "Protected Value";
+
+            var model = context.FromDocument<DataModelWithMixedAccessibility>(document.ForceConversion(DynamoDBEntryConversion.V2));
+
+            Assert.Equal("Private Value", model.PublicAccessToPrivate);
+            Assert.Equal("Internal Value", model.Internal);
+            Assert.Equal("Protected Value", model.PublicAccessToProtected);
+        }
+
+        [DynamoDBTable("MockTable")]
+        public class DataModelWithMixedAccessibility
+        {
+            [DynamoDBHashKey("pk")]
+            public string pk { get; set; }
+
+            [DynamoDBProperty("private")]
+            private string _private { get; set; }
+
+            public string PublicAccessToPrivate => _private;
+
+            [DynamoDBProperty("internal")]
+            internal string Internal { get; set; }
+
+            [DynamoDBProperty("protected")]
+            protected string _protected { get; set; }
+
+            public string PublicAccessToProtected => _protected;
+        }
     }
 }


### PR DESCRIPTION
## Description
Previously for early versions of .NET Standard, we rolled some of our own `TypeFactory `/`TypeInfo` handling. This led to an inconsistency in how non-public members were treated in DynamoDB's object-persistence programming model.

**Before:**
* .NET Framework - only public members would be populated when loading from DynamoDB
* .NET (Standard/Core) - public and non-public members would be populated.

We inadvertently fixed this in the 3.7.300 release. As we added the .NET 8 target to the SDK, we refactored our `TypeInfo` handling. 

This PR adds tests to guard against a future regression. Both .NET Framework and .NET (Standard/Core) now deserialize both public and non-public members.

## Motivation and Context
#1848, DOTNET-5225

## Testing
```
dotnet test .\sdk\src\Services\DynamoDBv2\DynamoDBv2.sln
dotnet test .\sdk\AWSSDK.CoreAndCustomUnitTests.NetStandard.sln
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement