### PR TITLE
Remove the Context/Operation Config Hierarchy, and Remove Table-level Configurations from DynamoDBOperationConfig

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
@@ -42,30 +42,6 @@ namespace Amazon.DynamoDBv2.DataModel
         public string TableNamePrefix { get; set; }
 
         /// <summary>
-        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to 
-        /// construct and validate  requests. This controls how the cache key is derived, which influences 
-        /// when the SDK will call DescribeTable internally to populate the cache.
-        /// </summary>
-        /// <remarks>
-        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
-        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
-        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
-        /// </remarks>
-        public MetadataCachingMode? MetadataCachingMode { get; set; }
-
-        /// <summary>
-        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
-        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
-        /// </summary>
-        /// <remarks>
-        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
-        /// DescribeTable calls that are used to populate the SDK's cache of table metadata. 
-        /// It requires that the table's index schema be accurately described via the above methods, 
-        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
-        /// </remarks>
-        public bool? DisableFetchingTableMetadata { get; set; }
-
-        /// <summary>
         /// Specification which controls the conversion between .NET and DynamoDB types.
         /// </summary>
         public DynamoDBEntryConversion Conversion { get; set; }
@@ -91,8 +67,6 @@ namespace Amazon.DynamoDBv2.DataModel
             {
                 OverrideTableName = OverrideTableName,
                 TableNamePrefix = TableNamePrefix,
-                MetadataCachingMode = MetadataCachingMode,
-                DisableFetchingTableMetadata = DisableFetchingTableMetadata,
                 Conversion = Conversion,
                 IsEmptyStringValueEnabled = IsEmptyStringValueEnabled
             };

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -13,13 +13,10 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.DynamoDBv2.DocumentModel;
+using Amazon.Util;
 using System;
 using System.Collections.Generic;
-
-using Amazon.DynamoDBv2.DocumentModel;
-using Amazon.DynamoDBv2.Model;
-using System.Globalization;
-using Amazon.Util;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -69,30 +66,24 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <summary>
-        /// Property that directs DynamoDBContext to use consistent reads.
+        /// Property that directs <see cref="DynamoDBContext"/> to use consistent reads.
         /// If property is not set, behavior defaults to non-consistent reads.
         /// </summary>
+        /// <remarks>
+        /// Refer to the <see href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html">
+        /// Read Consistency</see> topic in the DynamoDB Developer Guide for more information.
+        /// </remarks>
         public bool? ConsistentRead { get; set; }
 
         /// <summary>
-        /// Property that directs DynamoDBContext to skip version checks
+        /// Property that directs <see cref="DynamoDBContext"/> to skip version checks
         /// when saving or deleting an object with a version attribute.
         /// If property is not set, version checks are performed.
         /// </summary>
         public bool? SkipVersionCheck { get; set; }
 
         /// <summary>
-        /// Indicates which DynamoDB table to use. This overrides the table specified 
-        /// by the <see cref="DynamoDBTableAttribute"/> on the .NET objects that you're saving or loading.
-        /// </summary>
-        /// <remarks>
-        /// If you specify this on <see cref="DynamoDBContextConfig"/>, then it will apply to all 
-        /// objects/tables used with that <see cref="DynamoDBContext"/> object unless overriden by an operation-specific config.
-        /// </remarks>
-        public string OverrideTableName { get; set; }
-
-        /// <summary>
-        /// Property that directs DynamoDBContext to prefix all table names
+        /// Property that directs <see cref="DynamoDBContext"/> to prefix all table names
         /// with a specific string.
         /// If property is null or empty, no prefix is used and default
         /// table names are used.
@@ -112,7 +103,7 @@ namespace Amazon.DynamoDBv2.DataModel
         public MetadataCachingMode? MetadataCachingMode { get; set; }
 
         /// <summary>
-        /// Property that directs DynamoDBContext to ignore null values
+        /// Property that directs <see cref="DynamoDBContext"/> to ignore null values
         /// on attributes during a Save operation.
         /// If the property is false (or not set), null values will be
         /// interpreted as directives to delete the specific attribute.
@@ -120,7 +111,7 @@ namespace Amazon.DynamoDBv2.DataModel
         public bool? IgnoreNullValues { get; set; }
 
         /// <summary>
-        /// Property that directs DynamoDBContext to enable empty string values
+        /// Property that directs <see cref="DynamoDBContext"/> to enable empty string values
         /// on attributes during a Save operation.
         /// If the property is false (or not set), empty string values will be
         /// interpreted as null values.
@@ -148,7 +139,9 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
         /// </summary>
-        /// <remarks>This setting is only applicable to the high-level library. Service calls made via <see cref="AmazonDynamoDBClient"/> will always return <see cref="DateTime"/> attributes in UTC.</remarks>
+        /// <remarks>This setting is only applicable to the high-level library. 
+        /// Service calls made via <see cref="AmazonDynamoDBClient"/> will always return 
+        /// <see cref="DateTime"/> attributes in UTC.</remarks>
         public bool? RetrieveDateTimeInUtc { get; set; }
     }
 
@@ -160,11 +153,101 @@ namespace Amazon.DynamoDBv2.DataModel
 #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
 #endif
-    public class DynamoDBOperationConfig : DynamoDBContextConfig
+    public class DynamoDBOperationConfig
     {
         /// <summary>
-        /// Property that indicates a query should traverse the index backward.
-        /// If the property is false (or not set), traversal shall be forward.
+        /// Property that directs <see cref="DynamoDBContext"/> to use consistent reads.
+        /// If property is not set, behavior defaults to non-consistent reads.
+        /// </summary>
+        /// <remarks>
+        /// Refer to the <see href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html">
+        /// Read Consistency</see> topic in the DynamoDB Developer Guide for more information.
+        /// </remarks>
+        public bool? ConsistentRead { get; set; }
+
+        /// <summary>
+        /// Property that directs <see cref="DynamoDBContext"/> to skip version checks
+        /// when saving or deleting an object with a version attribute.
+        /// If property is not set, version checks are performed.
+        /// </summary>
+        public bool? SkipVersionCheck { get; set; }
+
+        /// <summary>
+        /// Indicates which DynamoDB table to use. This overrides the table specified 
+        /// by the <see cref="DynamoDBTableAttribute"/> on the .NET objects that you're saving or loading.
+        /// </summary>
+        /// <remarks>
+        /// If you want to specify this globally instead of for each operation, you can use 
+        /// the <see cref="TableAlias"/> or <see cref="TypeMapping"/> collections 
+        /// on <see cref="AWSConfigsDynamoDB.Context"/>.
+        /// </remarks>
+        public string OverrideTableName { get; set; }
+
+        /// <summary>
+        /// Property that directs <see cref="DynamoDBContext"/> to prefix all table names
+        /// with a specific string.
+        /// If property is null or empty, no prefix is used and default
+        /// table names are used.
+        /// </summary>
+        public string TableNamePrefix { get; set; }
+
+        /// <summary>
+        /// The object persistence model API relies on an internal cache of the DynamoDB table's metadata to construct and validate 
+        /// requests. This controls how the cache key is derived, which influences when the SDK will call 
+        /// IAmazonDynamoDB.DescribeTable(string) internally to populate the cache.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="MetadataCachingMode.Default"/> the cache key will be a combination of the table name, credentials, region and service URL. 
+        /// For <see cref="MetadataCachingMode.TableNameOnly"/> the cache key will only consist of the table name. This reduces cache misses in contexts
+        /// where you are accessing tables with identical structure but using different credentials or endpoints (such as a multi-tenant application).
+        /// </remarks>
+        public MetadataCachingMode? MetadataCachingMode { get; set; }
+
+        /// <summary>
+        /// Property that directs  <see cref="DynamoDBContext"/> to ignore null values
+        /// on attributes during a Save operation.
+        /// If the property is false (or not set), null values will be
+        /// interpreted as directives to delete the specific attribute.
+        /// </summary>
+        public bool? IgnoreNullValues { get; set; }
+
+        /// <summary>
+        /// Property that directs  <see cref="DynamoDBContext"/> to enable empty string values
+        /// on attributes during a Save operation.
+        /// If the property is false (or not set), empty string values will be
+        /// interpreted as null values.
+        /// </summary>
+        public bool? IsEmptyStringValueEnabled { get; set; }
+
+        /// <summary>
+        /// Conversion specification which controls how conversion between
+        /// .NET and DynamoDB types happens.
+        /// </summary>
+        public DynamoDBEntryConversion Conversion { get; set; }
+
+        /// <summary>
+        /// If true disables fetching table metadata automatically from DynamoDB. Table metadata must be 
+        /// defined by <see cref="DynamoDBAttribute"/> attributes and/or in <see cref = "AWSConfigsDynamoDB"/>.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true can avoid latency and thread starvation due to blocking asynchronous 
+        /// IAmazonDynamoDB.DescribeTable(string) calls that are used to populate the SDK's cache of 
+        /// table metadata. It requires that the table's index schema be accurately described via the above methods, 
+        /// otherwise exceptions may be thrown and/or the results of certain DynamoDB operations may change.
+        /// </remarks>
+        public bool? DisableFetchingTableMetadata { get; set; }
+
+        /// <summary>
+        /// If true, all <see cref="DateTime"/> properties are retrieved in UTC timezone while reading data from DynamoDB. Else, the local timezone is used.
+        /// </summary>
+        /// <remarks>This setting is only applicable to the high-level library. 
+        /// Service calls made via <see cref="AmazonDynamoDBClient"/> will always return 
+        /// <see cref="DateTime"/> attributes in UTC.</remarks>
+        public bool? RetrieveDateTimeInUtc { get; set; }
+
+        /// <summary>
+        /// Indicates whether a query should traverse the index backwards in descending order by range key value.
+        /// If the property is false (or not set), traversal shall be in ascending order.
         /// </summary>
         public bool? BackwardQuery { get; set; }
 
@@ -175,20 +258,31 @@ namespace Amazon.DynamoDBv2.DataModel
         public string IndexName { get; set; }
 
         /// <summary>
-        /// A logical operator to apply to the filter conditions:
-        /// AND - If all of the conditions evaluate to true, then the entire filter evaluates to true.
-        /// OR - If at least one of the conditions evaluate to true, then the entire filter evaluates to true.
-        /// 
-        /// Default value is AND.
+        /// The logical operator to apply to the filter conditions.
         /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term><see cref="ConditionalOperatorValues.And" /></term>
+        ///         <definition>If all of the conditions evaluate to true, then the entire filter evaluates to true.</definition>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="ConditionalOperatorValues.Or" /></term>
+        ///         <definition>If at least one of the conditions evaluate to true, then the entire filter evaluates to true.</definition>
+        ///     </item>
+        /// </list>
+        /// The default value is <see cref="ConditionalOperatorValues.And" />.
+        /// </remarks>
         public ConditionalOperatorValues ConditionalOperator { get; set; }
 
         /// <summary>
-        /// Query filter for the Query operation operation. Evaluates the query results and returns only
+        /// Query filter for the Query operation. Evaluates the query results and returns only
         /// the matching values. If you specify more than one condition, then by default all of the
-        /// conditions must evaluate to true. To match only some conditions, set ConditionalOperator to Or.
-        /// Note: Conditions must be against non-key properties.
+        /// conditions must evaluate to true. To match only some conditions, set <see cref="ConditionalOperator"/> to <see cref="ConditionalOperatorValues.Or" />.
         /// </summary>
+        /// <remarks>
+        /// Note: Conditions must be against non-key properties.
+        /// </remarks>
         public List<ScanCondition> QueryFilter { get; set; }
 
         /// <summary>
@@ -199,7 +293,9 @@ namespace Amazon.DynamoDBv2.DataModel
             QueryFilter = new List<ScanCondition>();
         }
 
-        // Checks if the IndexName is set on the config
+        /// <summary>
+        /// Checks if the IndexName is set on the config
+        /// </summary>
         internal bool IsIndexOperation { get { return !string.IsNullOrEmpty(IndexName); } }
     }
 
@@ -360,14 +456,14 @@ namespace Amazon.DynamoDBv2.DataModel
             DynamoDBEntryConversion conversion = operationConfig.Conversion ?? contextConfig.Conversion ?? DynamoDBEntryConversion.CurrentConversion;
             MetadataCachingMode metadataCachingMode = operationConfig.MetadataCachingMode ?? contextConfig.MetadataCachingMode ?? DynamoDBv2.MetadataCachingMode.Default;
 
-            string overrideTableName =
-                !string.IsNullOrEmpty(operationConfig.OverrideTableName) ? operationConfig.OverrideTableName : 
-                !string.IsNullOrEmpty(contextConfig.OverrideTableName) ? contextConfig.OverrideTableName : string.Empty;
             string tableNamePrefix =
                 !string.IsNullOrEmpty(operationConfig.TableNamePrefix) ? operationConfig.TableNamePrefix :
                 !string.IsNullOrEmpty(contextConfig.TableNamePrefix) ? contextConfig.TableNamePrefix : string.Empty;
 
-            // These properties can only be set at the operation level, and are related to querying or scanning
+            // These properties can only be set at the operation level, most are related to querying or scanning.
+            // We don't support overriding the table name at the context level, since a context object can be used with multiple tables.
+            string overrideTableName =
+                !string.IsNullOrEmpty(operationConfig.OverrideTableName) ? operationConfig.OverrideTableName : string.Empty;
             bool backwardQuery = operationConfig.BackwardQuery ?? false;
             string indexName =
                 !string.IsNullOrEmpty(operationConfig.IndexName) ? operationConfig.IndexName : DefaultIndexName;

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
@@ -21,7 +21,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(6, typeof(BaseOperationConfig).GetProperties().Length);
+            Assert.AreEqual(4, typeof(BaseOperationConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -29,7 +29,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(8, typeof(BatchGetConfig).GetProperties().Length);
+            Assert.AreEqual(6, typeof(BatchGetConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -62,7 +62,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(8, typeof(BatchWriteConfig).GetProperties().Length);
+            Assert.AreEqual(6, typeof(BatchWriteConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -95,7 +95,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(7, typeof(TransactGetConfig).GetProperties().Length);
+            Assert.AreEqual(5, typeof(TransactGetConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -128,7 +128,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(7, typeof(TransactWriteConfig).GetProperties().Length);
+            Assert.AreEqual(5, typeof(TransactWriteConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -161,7 +161,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(12, typeof(QueryConfig).GetProperties().Length);
+            Assert.AreEqual(10, typeof(QueryConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -193,7 +193,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(7, typeof(FromQueryConfig).GetProperties().Length);
+            Assert.AreEqual(5, typeof(FromQueryConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -230,7 +230,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(11, typeof(ScanConfig).GetProperties().Length);
+            Assert.AreEqual(9, typeof(ScanConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -262,7 +262,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(7, typeof(FromScanConfig).GetProperties().Length);
+            Assert.AreEqual(5, typeof(FromScanConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -294,7 +294,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(7, typeof(DeleteConfig).GetProperties().Length);
+            Assert.AreEqual(5, typeof(DeleteConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -325,7 +325,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(8, typeof(SaveConfig).GetProperties().Length);
+            Assert.AreEqual(6, typeof(SaveConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -356,7 +356,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(8, typeof(LoadConfig).GetProperties().Length);
+            Assert.AreEqual(6, typeof(LoadConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -387,7 +387,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(7, typeof(ToDocumentConfig).GetProperties().Length);
+            Assert.AreEqual(5, typeof(ToDocumentConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -395,7 +395,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(7, typeof(FromDocumentConfig).GetProperties().Length);
+            Assert.AreEqual(5, typeof(FromDocumentConfig).GetProperties().Length);
         }
 
         [TestMethod]
@@ -403,7 +403,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(6, typeof(GetTargetTableConfig).GetProperties().Length);
+            Assert.AreEqual(4, typeof(GetTargetTableConfig).GetProperties().Length);
         }
 
         [DynamoDBTable("TableName")]

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -451,17 +451,16 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void DisableFetchingTableMetadata_QueryWithMissingRangeKey_ThrowsException()
         {
-            // For variety, use the operation-level override
-            var config = new DynamoDBOperationConfig()
+            var config = new DynamoDBContextConfig()
             {
                 DisableFetchingTableMetadata = true
             };
 
-            var context = new DynamoDBContext(new Mock<IAmazonDynamoDB>().Object);
+            var context = new DynamoDBContext(new Mock<IAmazonDynamoDB>().Object, config);
 
             // This is the table's range key, which is not attributed
             Assert.ThrowsException<InvalidOperationException>(() => 
-            context.Query<EmployeeMissingRangeKeys>("123", QueryOperator.GreaterThan, 5, config));
+            context.Query<EmployeeMissingRangeKeys>("123", QueryOperator.GreaterThan, 5));
             
             // This is a GSI's range key, which is not attributed
             Assert.ThrowsException<InvalidOperationException>(() =>
@@ -754,45 +753,6 @@ namespace AWSSDK_DotNet.UnitTests
             protected string _protected { get; set; }
 
             public string PublicAccessToProtected => _protected;
-        }
-
-        /// <summary>
-        /// Verifies that specifing an TableName on the operation-level config overrides 
-        /// the table name from the data model
-        /// </summary>
-        [TestMethod]
-        public void OperationConfig_CanOverrideTableName()
-        {
-            var client = new Mock<IAmazonDynamoDB>();
-            client.Setup(client => client.DescribeTable(It.IsAny<DescribeTableRequest>()))
-                .Returns(new DescribeTableResponse { Table = new TableDescription
-                {
-                    KeySchema = new List<KeySchemaElement>
-                    {
-                        new KeySchemaElement("Name", KeyType.HASH),
-                        new KeySchemaElement("Age", KeyType.RANGE)
-                    },
-                    AttributeDefinitions = new List<AttributeDefinition>()
-                    {
-                        new AttributeDefinition("Name", ScalarAttributeType.S),
-                        new AttributeDefinition("Age", ScalarAttributeType.S)
-                    }
-                }});
-            client.Setup(client => client.Query(It.IsAny<QueryRequest>())).Returns(new QueryResponse { Items = new() });
-
-            var config = new DynamoDBOperationConfig
-            {
-                OverrideTableName = "OverrideTableName"
-            };
-
-            var context = new DynamoDBContext(client.Object, config);
-
-            var query = context.Query<Employee>("123", config);
-            var objects =  query.ToList();
-
-            client.Verify(client => client.DescribeTable(It.Is<DescribeTableRequest>(request => request.TableName == "OverrideTableName")), Times.Once());
-            client.Verify(client => client.Query(It.Is<QueryRequest>(request => request.TableName == "OverrideTableName")), Times.Once());
-            client.VerifyNoOtherCalls();
         }
     }
 }


### PR DESCRIPTION
## Description
1. ~This allows users to set `OverrideTableName` on the `DynamoDBContextConfig`, not just the `DynamoDBOperationConfig`~
   * During review we decided against this. 
3. ~While I was here I noticed that I didn't follow the hierarchy when adding `DisableFetchingTableMetadata` last year, so backfilled that too.~

New changes after PR feedback:

1. Separate the hierarchy between `DynamoDBContextConfig` and `DynamoDBOperationConfig`, to remove the appearance that you can pass an _operation config_ into the _context_. This came up several times with `OverrideTableName`.
2. Removed two table-level configurations from `DynamoDBOperationConfig` (and thus all of the new operation-specific config objects). These control how the context object caches table metadata, and should be specified there instead of at the operation level.

## Motivation and Context
We've gotten a few requests over the years for the ability to override the DynamoDB table name via the object-persistence context config, instead of needing to do so on every operation config.
* #1421 
*  #1448 
*  #1218

This is complicated by the fact that `DynamoDBOperationConfig` inherits from `DynamoDBContextConfig`. One could be passing an _operation_ config into the _context_ constructor, thinking that `OverrideTableName` would apply.
https://github.com/aws/aws-sdk-net/blob/2b0190e05c1787d2530d4c1a94beb3208b2b9f8e/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs#L153


## Testing
1. Ran unit and integration tests in DynamoDBv2 sln locally.
3. Dry-run in progress.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement