### PR TITLE
Refactor User-Agent construction in Marshaller.cs

### DIFF
--- a/generator/.DevConfigs/aabf4e64-a7dd-4ee3-95a7-c8466c22a7e3.json
+++ b/generator/.DevConfigs/aabf4e64-a7dd-4ee3-95a7-c8466c22a7e3.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Improve user agent string construction in Marshaller.cs"
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Amazon.Runtime.Telemetry;
@@ -114,11 +115,13 @@ namespace Amazon.Runtime.Internal
             if (!string.IsNullOrEmpty(clientAppId))
                 sb.Append(" app/").Append(InternalSDKUtils.ReplaceInvalidUserAgentCharacters(clientAppId));
 
-            sb.Append(" cfg/retry-mode#}").Append(ToUserAgentHeaderString(requestContext.ClientConfig.RetryMode));
+            var retryMode = ToUserAgentHeaderString(requestContext.ClientConfig.RetryMode);
+            Debug.Assert(retryMode != requestContext.ClientConfig.RetryMode.ToString().ToLower(), "Invalid RetryMode string.");
+            sb.Append(" cfg/retry-mode#}").Append(retryMode);
 
-            sb.Append(" md/").Append(IsAsync ? "ClientAsync" : "ClientSync");
+            sb.Append(" md/").Append(requestContext.IsAsync ? "ClientAsync" : "ClientSync");
 
-            sb.Append(" cfg/init-coll#").Append(InitializeCollections ? '1' : '0');
+            sb.Append(" cfg/init-coll#").Append(AWSConfigs.InitializeCollections ? '1' : '0');
 
             var userAgentAddition = requestContext.OriginalRequest.UserAgentAddition;
             if (!string.IsNullOrEmpty(userAgentAddition))

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
@@ -115,9 +115,7 @@ namespace Amazon.Runtime.Internal
             if (!string.IsNullOrEmpty(clientAppId))
                 sb.Append(" app/").Append(InternalSDKUtils.ReplaceInvalidUserAgentCharacters(clientAppId));
 
-            var retryMode = ToUserAgentHeaderString(requestContext.ClientConfig.RetryMode);
-            Debug.Assert(retryMode != requestContext.ClientConfig.RetryMode.ToString().ToLower(), "Invalid RetryMode string.");
-            sb.Append(" cfg/retry-mode#}").Append(retryMode);
+            sb.Append(" cfg/retry-mode#}").Append(ToUserAgentHeaderString(requestContext.ClientConfig.RetryMode));
 
             sb.Append(" md/").Append(requestContext.IsAsync ? "ClientAsync" : "ClientSync");
 
@@ -143,10 +141,15 @@ namespace Amazon.Runtime.Internal
 
         private static string ToUserAgentHeaderString(RequestRetryMode requestRetryMode)
         {
-            if (requestRetryMode == RequestRetryMode.Adaptive)
-                return "adaptive";
-            else
-                return "standard";
+            switch (requestRetryMode)
+            {
+                case RequestRetryMode.Standard:
+                    return "standard";
+                case RequestRetryMode.Adaptive:
+                    return "adaptive";
+                default:
+                    return requestRetryMode.ToString().ToLowerInvariant();
+            }
         }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
@@ -106,28 +106,27 @@ namespace Amazon.Runtime.Internal
 
         private static void SetUserAgentHeader(IRequestContext requestContext)
         {
-            var sb = new StringBuilder(requestContext.ClientConfig.UserAgent);
+            var sb = new StringBuilder(256);
+
+            sb.Append(InternalSDKUtils.ReplaceInvalidUserAgentCharacters(requestContext.ClientConfig.UserAgent));
 
             var clientAppId = requestContext.ClientConfig.ClientAppId;
             if (!string.IsNullOrEmpty(clientAppId))
-                sb.AppendFormat(" app/{0}", clientAppId);
+                sb.Append(" app/").Append(InternalSDKUtils.ReplaceInvalidUserAgentCharacters(clientAppId));
 
-            var retryMode = requestContext.ClientConfig.RetryMode.ToString().ToLower();
-            sb.AppendFormat(" cfg/retry-mode#{0}", retryMode);
+            sb.Append(" cfg/retry-mode#}").Append(ToUserAgentHeaderString(requestContext.ClientConfig.RetryMode));
 
-            sb.AppendFormat(" md/{0}", requestContext.IsAsync ? "ClientAsync" : "ClientSync");
+            sb.Append(" md/").Append(IsAsync ? "ClientAsync" : "ClientSync");
 
-            sb.AppendFormat(" cfg/init-coll#{0}", AWSConfigs.InitializeCollections ? "1" : "0");
+            sb.Append(" cfg/init-coll#").Append(InitializeCollections ? '1' : '0');
 
             var userAgentAddition = requestContext.OriginalRequest.UserAgentAddition;
             if (!string.IsNullOrEmpty(userAgentAddition))
             {
-                sb.AppendFormat(" {0}", userAgentAddition);
+                sb.Append(' ').Append(InternalSDKUtils.ReplaceInvalidUserAgentCharacters(userAgentAddition));
             }
 
             var userAgent = sb.ToString();
-
-            userAgent = InternalSDKUtils.ReplaceInvalidUserAgentCharacters(userAgent);
 
             if (requestContext.ClientConfig.UseAlternateUserAgentHeader)
             {
@@ -137,6 +136,14 @@ namespace Amazon.Runtime.Internal
             {
                 requestContext.Request.Headers[HeaderKeys.UserAgentHeader] = userAgent;
             }
+        }
+
+        private static string ToUserAgentHeaderString(RequestRetryMode requestRetryMode)
+        {
+            if (requestRetryMode == RequestRetryMode.Adaptive)
+                return "adaptive";
+            else
+                return "standard";
         }
     }
 }

--- a/sdk/src/Core/GlobalSuppressions.cs
+++ b/sdk/src/Core/GlobalSuppressions.cs
@@ -191,9 +191,9 @@ using System.Diagnostics.CodeAnalysis;
 [module: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Amazon.Runtime.Internal.Auth.AWS4Signer.#CanonicalizeHeaders(System.Collections.Generic.ICollection`1<System.Collections.Generic.KeyValuePair`2<System.String,System.String>>)")]
 [module: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Amazon.Runtime.Internal.Auth.S3Signer.#BuildCanonicalizedHeaders(System.Collections.Generic.IDictionary`2<System.String,System.String>)")]
 [module: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Amazon.Runtime.Internal.Auth.AWS4Signer.#DetermineSigningRegion(Amazon.Runtime.IClientConfig,System.String,Amazon.RegionEndpoint,Amazon.Runtime.Internal.IRequest)")]
-
 [module: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Amazon.Runtime.Internal.Auth.AWS4Signer.#CanonicalizeHeaders(System.Collections.Generic.IDictionary`2<System.String,System.String>)")]
 [module: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Amazon.Runtime.Internal.Auth.AWS4Signer.#CanonicalizeHeaderNames(System.Collections.Generic.IDictionary`2<System.String,System.String>)")]
+[module: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Amazon.Runtime.Internal.Marshaller.#ToUserAgentHeaderString(Amazon.Runtime.RequestRetryMode)")]
 
 // Types names matching namespaces
 [module: SuppressMessage("Microsoft.Naming", "CA1724:TypeNamesShouldNotMatchNamespaces", Scope = "type", Target = "Amazon.Auth.AccessControlPolicy.Policy")]

--- a/sdk/test/Services/SecurityToken/UnitTests/Custom/StaticCheckTests.cs
+++ b/sdk/test/Services/SecurityToken/UnitTests/Custom/StaticCheckTests.cs
@@ -83,5 +83,15 @@ namespace AWSSDK.UnitTests
             // the properties are used at least once.
             Assert.IsTrue(profileOptionsProperties.SetEquals(referencedProfileOptionsProperties));
         }
+
+        [TestMethod]
+        public void LookForRequestRetryModeChanges()
+        {
+            var expectedHash = "2FC699DB6A4284C5D53F3B7FA4E64165576FD1F6AE458BC737AE503F06DFBE4C";
+            AssertExtensions.AssertEnumUnchanged(
+                typeof(RequestRetryMode),
+                expectedHash,
+                "The Amazon.Runtime.Internal.Marshaller.ToUserAgentHeaderString method implementation may need to be updated.");
+        }
     }
 }


### PR DESCRIPTION
Updated `SetUserAgentHeader` to improve User-Agent string construction:
- Initialize `StringBuilder` with a capacity of 256.
- Append `UserAgent` after replacing invalid characters.
- Append `ClientAppId` after replacing invalid characters.
- Use `ToUserAgentHeaderString` for retry mode conversion.
- Append `IsAsync` and initialization config directly.
- Append `UserAgentAddition` after replacing invalid characters.
- Removed redundant call to `ReplaceInvalidUserAgentCharacters`.
- Added `ToUserAgentHeaderString` method for `RequestRetryMode`.

## Description
See #3412

## Motivation and Context
See #3412

## Testing
There should be no changes to the result.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement