### PR TITLE
fix: Update DownloadDirectoryCommand to handle non existent directories gracefully

### DIFF
--- a/sdk/src/Core/Amazon.Util/PaginatedResourceFactory.cs
+++ b/sdk/src/Core/Amazon.Util/PaginatedResourceFactory.cs
@@ -70,6 +70,9 @@ namespace Amazon.Util
                     nextToken = GetPropertyValueFromPath<string>(nextSet, tokenResponsePropertyPath);
                     currentItems = GetPropertyValueFromPath<List<ItemType>>(nextSet, itemListPropertyPath);
 
+                    if (currentItems == null)
+                        currentItems = new List<ItemType>();
+
                     return new Marker<ItemType>(currentItems, nextToken);
                 };
             return new PaginatedResource<ItemType>(fetcher);

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
@@ -127,12 +127,16 @@ namespace Amazon.S3.Transfer.Internal
             {
                 ListObjectsResponse listResponse = await this._s3Client.ListObjectsAsync(listRequest, cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);
-                foreach (S3Object s3o in listResponse.S3Objects)
+
+                if (listResponse.S3Objects != null) 
                 {
-                    if (ShouldDownload(s3o))
+                    foreach (S3Object s3o in listResponse.S3Objects)
                     {
-                        this._totalBytes += s3o.Size.GetValueOrDefault();
-                        objs.Add(s3o);
+                        if (ShouldDownload(s3o))
+                        {
+                            this._totalBytes += s3o.Size.GetValueOrDefault();
+                            objs.Add(s3o);
+                        }
                     }
                 }
                 listRequest.Marker = listResponse.NextMarker;
@@ -147,12 +151,16 @@ namespace Amazon.S3.Transfer.Internal
             {
                 ListObjectsV2Response listResponse = await this._s3Client.ListObjectsV2Async(listRequestV2, cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);
-                foreach (S3Object s3o in listResponse.S3Objects)
+
+                if (listResponse.S3Objects != null)
                 {
-                    if (ShouldDownload(s3o))
+                    foreach (S3Object s3o in listResponse.S3Objects)
                     {
-                        this._totalBytes += s3o.Size.GetValueOrDefault();
-                        objs.Add(s3o);
+                        if (ShouldDownload(s3o))
+                        {
+                            this._totalBytes += s3o.Size.GetValueOrDefault();
+                            objs.Add(s3o);
+                        }
                     }
                 }
                 listRequestV2.ContinuationToken = listResponse.NextContinuationToken;

--- a/sdk/src/Services/S3/Custom/_async/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/_async/AmazonS3Client.Extensions.cs
@@ -45,7 +45,9 @@ namespace Amazon.S3
                 InternalSDKUtils.ApplyValues(request, additionalProperties);
 
                 var listResponse = await this.ListObjectsAsync(request).ConfigureAwait(false);
-                keys.AddRange(listResponse.S3Objects?.Select(o => o.Key));
+                if (listResponse.S3Objects != null)
+                    keys.AddRange(listResponse.S3Objects.Select(o => o.Key));
+
                 marker = listResponse.NextMarker;
             } while (!string.IsNullOrEmpty(marker));
 

--- a/sdk/src/Services/S3/Custom/_bcl/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/_bcl/AmazonS3Client.Extensions.cs
@@ -44,7 +44,9 @@ namespace Amazon.S3
                 InternalSDKUtils.ApplyValues(request, additionalProperties);
 
                 var listResponse = this.ListObjects(request);
-                keys.AddRange(listResponse.S3Objects?.Select(o => o.Key));
+                if (listResponse.S3Objects != null)
+                    keys.AddRange(listResponse.S3Objects.Select(o => o.Key));
+
                 marker = listResponse.NextMarker;
             } while (!string.IsNullOrEmpty(marker));
 

--- a/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
@@ -129,7 +129,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 TestDownloadedFile(downloadPath);
 
                 // empty out file, except for 1 byte
-                File.WriteAllText(downloadPath, testContent.Substring(0,1));
+                File.WriteAllText(downloadPath, testContent.Substring(0, 1));
                 Assert.IsTrue(File.Exists(downloadPath));
                 tu.Download(downloadRequest);
                 TestDownloadedFile(downloadPath);
@@ -146,7 +146,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             var fileSize = 20 * MEG_SIZE;
             UtilityMethods.GenerateFile(path, fileSize);
             //take the generated file and turn it into an unseekable stream
-            
+
             var stream = GenerateUnseekableStreamFromFile(path);
             using (var tu = new Amazon.S3.Transfer.TransferUtility(client))
             {
@@ -475,7 +475,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         [TestCategory("S3")]
         public void SimpleUploadWithSSE_C_LargeFile()
         {
-            UploadWithSSE_C(16 * MEG_SIZE, @"SimpleUploadTest\LargeFile");            
+            UploadWithSSE_C(16 * MEG_SIZE, @"SimpleUploadTest\LargeFile");
         }
 
         [TestMethod]
@@ -528,7 +528,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             var downloadedFiles = Directory.EnumerateFiles(downloadPath, "*", SearchOption.AllDirectories).ToList();
 
             Assert.AreEqual(sourceFiles.Count, downloadedFiles.Count);
-            
+
             sourceFiles.Sort();
             downloadedFiles.Sort();
             for (var i = 0; i < sourceFiles.Count(); i++)
@@ -609,7 +609,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             }
         }
 
-        void Upload(string fileName, long size, 
+        void Upload(string fileName, long size,
             TransferProgressValidator<UploadProgressArgs> progressValidator, AmazonS3Client client = null)
         {
             var key = fileName;
@@ -712,20 +712,40 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             return directory;
         }
 
-         [TestMethod]
-         [TestCategory("S3")]
-         public void DownloadDirectoryProgressTest()
-         {
-             // disable clock skew testing, this is a multithreaded test
-             using (RetryUtilities.DisableClockSkewCorrection())
-             {
-                 var progressValidator = new DirectoryProgressValidator<DownloadDirectoryProgressArgs>();
-                 ConfigureProgressValidator(progressValidator);
+        [TestMethod]
+        [TestCategory("S3")]
+        public void DownloadNonExistentS3Directory()
+        {
+            var client = Client;
+            var downloadPath = GenerateDirectoryPath();
 
-                 DownloadDirectory(progressValidator);
-                 progressValidator.AssertOnCompletion();
-             }
-         }
+            var transferUtility = new TransferUtility(Client);
+
+            transferUtility.DownloadDirectory(new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = "NonExistentS3Directory",
+                LocalDirectory = downloadPath,
+            });
+
+            var downloadedFiles = Directory.EnumerateFiles(downloadPath, "*", SearchOption.AllDirectories).ToList();
+            Assert.AreEqual(0, downloadedFiles.Count);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void DownloadDirectoryProgressTest()
+        {
+            // disable clock skew testing, this is a multithreaded test
+            using (RetryUtilities.DisableClockSkewCorrection())
+            {
+                var progressValidator = new DirectoryProgressValidator<DownloadDirectoryProgressArgs>();
+                ConfigureProgressValidator(progressValidator);
+
+                DownloadDirectory(progressValidator);
+                progressValidator.AssertOnCompletion();
+            }
+        }
 
         void DownloadDirectory(DirectoryProgressValidator<DownloadDirectoryProgressArgs> progressValidator, bool concurrent = true)
         {
@@ -1278,11 +1298,11 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             private readonly bool _setZeroLengthStream;
 
             public UnseekableStream(byte[] buffer) : base(buffer) { }
-            public UnseekableStream(bool setZeroLengthStream): base()
+            public UnseekableStream(bool setZeroLengthStream) : base()
             {
                 _setZeroLengthStream = setZeroLengthStream;
             }
-            public UnseekableStream(): base() { }
+            public UnseekableStream() : base() { }
 
             public override bool CanSeek
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update `DownloadDirectoryCommand` to handle non existent directories gracefully

With the V4 change of no initializing the collections by default, `DownloadDirectoryCommand` throws null reference exception when trying to download a non existent directory since `listResponse.S3Objects` collection is set to null.
This PR fixes that by checking if `listResponse.S3Objects` is not null before enumeration.
<!--- Describe your changes in detail -->

## Motivation and Context
#DOTNET-7682
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
* Ran S3 unit and integration tests locally.
* Added `DownloadNonExistentS3Directory` test to validate this fix.
* `DRY_RUN-97fefe47-1e53-4477-bcdb-33d5013e92d3`
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement