### PR TITLE
Update SQS test to handle null collections

### DIFF
--- a/sdk/test/NetStandard/IntegrationTests/SQSTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/SQSTests.cs
@@ -18,7 +18,11 @@ namespace Amazon.DNXCore.IntegrationTests
             var request = new ListQueuesRequest();
             var response = await Client.ListQueuesAsync(request);
             Assert.NotNull(response.ResponseMetadata.Metadata);
-            Assert.NotNull(response.QueueUrls);
+
+            if (AWSConfigs.InitializeCollections)
+            {
+                Assert.NotNull(response.QueueUrls);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
## Description
Updates SQS integration test to handle nullable collection (test can fail when run on an account without any queues _and_ the `AWSConfigs.InitializeCollections` property is false - which is the default for V4).

## Testing
Dry-run: `da80b35c-381c-4ae8-9d3c-20d3d577c0ba`

## Checklist
- [X] My code follows the code style of this project
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license