### PR TITLE
Support decimal precision for Document.FromJson and ToJson by using System.Text.Json instead of LitJson

### DIFF
--- a/generator/.DevConfigs/f4c592db-5554-4e25-9d2d-8efbe169b757.json
+++ b/generator/.DevConfigs/f4c592db-5554-4e25-9d2d-8efbe169b757.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "feature",
+            "changeLogMessages": [
+                "Switch Document.FromJson and ToJson to use System.Text.Json instead of LitJson. This supports additional precision for decimal values."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text;
-using ThirdParty.Json.LitJson;
+using System.Text.Json;
 
 namespace Amazon.DynamoDBv2.DocumentModel
 {
@@ -59,11 +59,12 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         private static string SerializeEnumerable(IEnumerable<Document> documents, bool prettyPrint)
         {
-            var sb = new StringBuilder();
-            var writer = new JsonWriter(sb);
-            writer.PrettyPrint = prettyPrint;
+            using var stream = new MemoryStream();
+            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { 
+                Indented = prettyPrint 
+            });
 
-            writer.WriteArrayStart();
+            writer.WriteStartArray();
             if (documents != null)
             {
                 foreach (var document in documents)
@@ -74,10 +75,10 @@ namespace Amazon.DynamoDBv2.DocumentModel
                     }
                 }
             }
-            writer.WriteArrayEnd();
+            writer.WriteEndArray();
 
-            var jsonText = sb.ToString();
-            return jsonText;
+            writer.Flush();
+            return Encoding.UTF8.GetString(stream.ToArray());
         }
     }
 }

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/DynamoDB/JSONTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/DynamoDB/JSONTests.cs
@@ -1,28 +1,21 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using System.Linq;
-
-using Amazon.DynamoDBv2;
-using Amazon.DynamoDBv2.Model;
-using Amazon;
-using Amazon.DynamoDBv2.DataModel;
+﻿using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DocumentModel;
-using ThirdParty.Json.LitJson;
+using System;
+using System.Collections.Generic;
 using System.IO;
-
+using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Amazon.DNXCore.IntegrationTests.DynamoDB
 {
     public partial class DynamoDBTests : IClassFixture<DynamoDBTestsFixture>
     {
-        const string sampleJson = @"{
+        const string _sampleJson = @"{
 ""Name"" : ""Alan"" ,
 ""Age"" : 31,
 ""CompanyName"" : ""Big River"" ,
-""CurrentStatus"" : ""Active""
+""CurrentStatus"" : ""Active"",
 ""CompanyInfo"" : {
     ""Name"" : ""Big River"" ,
     ""Year Founded"" : 1998,
@@ -32,19 +25,10 @@ namespace Amazon.DNXCore.IntegrationTests.DynamoDB
 ""IsActive"" : true,
 ""RetirementInfo"" : null
 }";
-        
+
         [Fact]
         [Trait(CategoryAttribute, "DynamoDB")]
-        public async Task TestJSON()
-        {
-            TestJsonConversions();
-
-            TestBinaryDecoding();
-
-            await TestPutGet();
-        }
-
-        private async Task TestPutGet()
+        public async Task TestDocumentPutGet()
         {
             // Clear tables
             await SharedTestFixture.CleanupTables();
@@ -56,13 +40,13 @@ namespace Amazon.DNXCore.IntegrationTests.DynamoDB
             LoadTables(DynamoDBEntryConversion.V2, out hashTable, out hashRangeTable);
 
             // JSON as top-level data
-            var doc = Document.FromJson(sampleJson);
+            var doc = Document.FromJson(_sampleJson);
             await hashRangeTable.PutItemAsync(doc);
             var retrievedDoc = await hashRangeTable.GetItemAsync("Alan", 31);
             Assert.True(doc.Equals(retrievedDoc));
 
             // JSON as nested data
-            var nestedDoc = Document.FromJson(sampleJson);
+            var nestedDoc = Document.FromJson(_sampleJson);
             doc = new Document();
             doc["Name"] = "Jim";
             doc["Age"] = 29;
@@ -72,13 +56,15 @@ namespace Amazon.DNXCore.IntegrationTests.DynamoDB
             Assert.True(doc.ForceConversion(DynamoDBEntryConversion.V2).Equals(retrievedDoc));
         }
 
-        private static void TestJsonConversions()
+        [Fact]
+        [Trait(CategoryAttribute, "DynamoDB")]
+        public static void TestDocumentJsonConversions()
         {
             // Create Document from JSON
-            var doc = Document.FromJson(sampleJson);
+            var doc = Document.FromJson(_sampleJson);
 
             // Verify types
-            Assert.True(doc["Name"] is Primitive);            
+            Assert.True(doc["Name"] is Primitive);
             Assert.True(doc["CompanyInfo"] is Document);
             Assert.True(doc["Aliases"] is DynamoDBList);
             Assert.True(doc["IsActive"] is DynamoDBBool);
@@ -86,13 +72,15 @@ namespace Amazon.DNXCore.IntegrationTests.DynamoDB
 
             // Verify conversions produce identical JSON
             var json = doc.ToJson();
-            CompareJson(sampleJson, json);
+            CompareJson(_sampleJson, json);
             var prettyJson = doc.ToJsonPretty();
-            CompareJson(sampleJson, prettyJson);
+            CompareJson(_sampleJson, prettyJson);
             CompareJson(json, prettyJson);
         }
 
-        private static void TestBinaryDecoding()
+        [Fact]
+        [Trait(CategoryAttribute, "DynamoDB")]
+        public static void TestDocumentBinaryDecoding()
         {
             // Test data
             var data = "Hello world!";
@@ -223,16 +211,26 @@ namespace Amazon.DNXCore.IntegrationTests.DynamoDB
             AssertExtensions.ExpectException(() => rt.DecodeBase64Attributes("FakeBinaryData"));
         }
 
-        // Compares two JSON strings by converting text->JSON->text and comparing the final forms
+        /// <summary>
+        /// Compares two JSON strings by converting text->JSON->text and comparing the final forms
+        /// </summary>
         private static void CompareJson(string jsonA, string jsonB)
         {
-            var a = JsonMapper.ToObject(jsonA);
-            var b = JsonMapper.ToObject(jsonB);
+            var a = JsonDocument.Parse(jsonA);
+            var b = JsonDocument.Parse(jsonB);
 
-            var aRt = a.ToJson();
-            var bRt = b.ToJson();
+            var streamA = new MemoryStream();
+            var writerA = new Utf8JsonWriter(streamA);
+            a.WriteTo(writerA);
 
-            Assert.Equal(aRt, bRt);
+            var streamB = new MemoryStream();
+            var writerB = new Utf8JsonWriter(streamA);
+            b.WriteTo(writerB);
+
+            var aRt = Encoding.UTF8.GetString(streamA.ToArray());
+            var bRt = Encoding.UTF8.GetString(streamB.ToArray());
+
+            Assert.AreEqual(aRt, bRt);
         }
     }
 }

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/JSONTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/JSONTests.cs
@@ -6,23 +6,20 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using AWSSDK_DotNet.IntegrationTests.Utils;
 using Amazon.DynamoDBv2;
-using Amazon.DynamoDBv2.Model;
-using Amazon;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
-using ThirdParty.Json.LitJson;
 using System.IO;
-
+using System.Text.Json;
 
 namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 {
     public partial class DynamoDBTests : TestBase<AmazonDynamoDBClient>
     {
-        const string sampleJson = @"{
+        const string _sampleJson = @"{
 ""Name"" : ""Alan"" ,
 ""Age"" : 31,
 ""CompanyName"" : ""Big River"" ,
-""CurrentStatus"" : ""Active""
+""CurrentStatus"" : ""Active"",
 ""CompanyInfo"" : {
     ""Name"" : ""Big River"" ,
     ""Year Founded"" : 1998,
@@ -33,11 +30,11 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 ""RetirementInfo"" : null
 }";
 
-        const string sampleJsonArray = @"[{
+        const string _sampleJsonArray = @"[{
 ""Name"" : ""Alan"" ,
 ""Age"" : 31,
 ""CompanyName"" : ""Big River"" ,
-""CurrentStatus"" : ""Active""
+""CurrentStatus"" : ""Active"",
 ""CompanyInfo"" : {
     ""Name"" : ""Big River"" ,
     ""Year Founded"" : 1998,
@@ -65,23 +62,9 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
     }
 }]";
 
-        
         [TestMethod]
         [TestCategory("DynamoDBv2")]
-        public void TestJSON()
-        {
-            TestJsonConversions();
-
-            TestBinaryDecoding();
-
-            TestPutGet();
-
-            TestArrayMethods();
-
-            TestFromJsonCanHandleAllDataTypes();
-        }
-
-        private void TestPutGet()
+        public void TestDocumentPutGet()
         {
             // Clear tables
             CleanupTables();
@@ -94,13 +77,13 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             LoadTables(DynamoDBEntryConversion.V2, out hashTable, out hashRangeTable, out numericHashRangeTable);
 
             // JSON as top-level data
-            var doc = Document.FromJson(sampleJson);
+            var doc = Document.FromJson(_sampleJson);
             hashRangeTable.PutItem(doc);
             var retrievedDoc = hashRangeTable.GetItem("Alan", 31);
             Assert.IsTrue(doc.Equals(retrievedDoc));
 
             // JSON as nested data
-            var nestedDoc = Document.FromJson(sampleJson);
+            var nestedDoc = Document.FromJson(_sampleJson);
             doc = new Document();
             doc["Name"] = "Jim";
             doc["Age"] = 29;
@@ -110,13 +93,15 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.IsTrue(doc.ForceConversion(DynamoDBEntryConversion.V2).Equals(retrievedDoc));
         }
 
-        private static void TestJsonConversions()
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public static void TestDocumentJsonConversions()
         {
             // Create Document from JSON
-            var doc = Document.FromJson(sampleJson);
+            var doc = Document.FromJson(_sampleJson);
 
             // Verify types
-            Assert.IsTrue(doc["Name"] is Primitive);            
+            Assert.IsTrue(doc["Name"] is Primitive);
             Assert.IsTrue(doc["CompanyInfo"] is Document);
             Assert.IsTrue(doc["Aliases"] is DynamoDBList);
             Assert.IsTrue(doc["IsActive"] is DynamoDBBool);
@@ -124,13 +109,15 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
             // Verify conversions produce identical JSON
             var json = doc.ToJson();
-            CompareJson(sampleJson, json);
+            CompareJson(_sampleJson, json);
             var prettyJson = doc.ToJsonPretty();
-            CompareJson(sampleJson, prettyJson);
+            CompareJson(_sampleJson, prettyJson);
             CompareJson(json, prettyJson);
         }
 
-        private static void TestBinaryDecoding()
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public static void TestDocumentBinaryDecoding()
         {
             // Test data
             var data = "Hello world!";
@@ -261,36 +248,38 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             AssertExtensions.ExpectException(() => rt.DecodeBase64Attributes("FakeBinaryData"));
         }
 
-        private static void TestArrayMethods()
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public static void TestJsonArrayMethods()
         {
-            var docs = TestArrayRoundTrip(sampleJsonArray);
+            var docs = TestArrayRoundTrip(_sampleJsonArray);
             TestArrayRoundTrip(docs.ToJsonPretty());
         }
 
         private static IEnumerable<Document> TestArrayRoundTrip(string jsonArray) {
-            var docs = Document.FromJsonArray(jsonArray) as IEnumerable<Document>;
+            var docs = Document.FromJsonArray(jsonArray);
             
             Assert.IsNotNull(docs);
             Assert.AreEqual(2, docs.Count());
             var first = docs.First();
             // Verify types
-            Assert.IsTrue(first["Name"] is Primitive);            
-            Assert.IsTrue(first["Age"] is Primitive);            
+            Assert.IsTrue(first["Name"] is Primitive);
+            Assert.IsTrue(first["Age"] is Primitive);
             Assert.IsTrue(first["CompanyInfo"] is Document);
             Assert.IsTrue(first["Aliases"] is DynamoDBList);
             Assert.IsTrue(first["IsActive"] is DynamoDBBool);
             Assert.IsTrue(first["RetirementInfo"] is DynamoDBNull);
             // Value tests
             Assert.AreEqual("Alan", (string)first["Name"]);
-            Assert.AreEqual(31, (int)first["Age"]);       
+            Assert.AreEqual(31, (int)first["Age"]);
             Assert.IsNotNull(first["CompanyInfo"] as Document);
             Assert.AreEqual("Big River", (string)first["CompanyInfo"].AsDocument()["Name"]);
             Assert.IsTrue((bool)first["IsActive"]);
             Assert.IsNull(first["RetirementInfo"].AsDocument());
 
             var second = docs.Skip(1).First();
-            Assert.IsTrue(second["Name"] is Primitive);     
-            Assert.IsTrue(second["Age"] is Primitive);            
+            Assert.IsTrue(second["Name"] is Primitive);
+            Assert.IsTrue(second["Age"] is Primitive);
             Assert.IsTrue(second["CompanyInfo"] is Document);
             Assert.IsTrue(second["Aliases"] is DynamoDBList);
             Assert.IsTrue(second["IsActive"] is DynamoDBBool);
@@ -299,36 +288,48 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.IsTrue(second["RetirementInfo"].AsDocument()["Status"] is Primitive);
             // Value tests
             Assert.AreEqual("George P. Burdell", (string)second["Name"]);
-            Assert.AreEqual(87, (int)second["Age"]);       
+            Assert.AreEqual(87, (int)second["Age"]);
             Assert.IsNotNull(second["CompanyInfo"].AsDocument());
             Assert.AreEqual("Georgia Tech", (string)(second["CompanyInfo"] as Document)["Name"]);
             Assert.IsTrue((bool)second["IsActive"]);
             Assert.IsNotNull(second["RetirementInfo"].AsDocument());
-            Assert.AreEqual(1987, (int)second["RetirementInfo"].AsDocument()["Year"]);       
-            Assert.AreEqual("Graduated", (string)second["RetirementInfo"].AsDocument()["Status"]);     
+            Assert.AreEqual(1987, (int)second["RetirementInfo"].AsDocument()["Year"]);
+            Assert.AreEqual("Graduated", (string)second["RetirementInfo"].AsDocument()["Status"]);
 
             // Test round-tripping
             string json = docs.ToJson();
-            CompareJson(jsonArray, json);  
+            CompareJson(jsonArray, json);
             string prettyJson = docs.ToJsonPretty();
             CompareJson(jsonArray, prettyJson);
 
             return docs;
         }
 
-        // Compares two JSON strings by converting text->JSON->text and comparing the final forms
+        /// <summary>
+        /// Compares two JSON strings by converting text->JSON->text and comparing the final forms
+        /// </summary>
         private static void CompareJson(string jsonA, string jsonB)
         {
-            var a = JsonMapper.ToObject(jsonA);
-            var b = JsonMapper.ToObject(jsonB);
+            var a = JsonDocument.Parse(jsonA);
+            var b = JsonDocument.Parse(jsonB);
 
-            var aRt = a.ToJson();
-            var bRt = b.ToJson();
+            var streamA = new MemoryStream();
+            var writerA = new Utf8JsonWriter(streamA);
+            a.WriteTo(writerA);
+
+            var streamB = new MemoryStream();
+            var writerB = new Utf8JsonWriter(streamA);
+            b.WriteTo(writerB);
+
+            var aRt = Encoding.UTF8.GetString(streamA.ToArray());
+            var bRt = Encoding.UTF8.GetString(streamB.ToArray());
 
             Assert.AreEqual(aRt, bRt);
         }
 
-        private static void TestFromJsonCanHandleAllDataTypes()
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public static void TestFromJsonCanHandleAllDataTypes()
         {
             var json = @"
                 {

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DocumentJsonTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DocumentJsonTests.cs
@@ -1,0 +1,164 @@
+﻿using Amazon.DynamoDBv2.DocumentModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSSDK_DotNet.UnitTests
+{
+    [TestClass]
+    public class DocumentJsonTests
+    {
+        [TestMethod]
+        public void FromJson_Decimal()
+        {
+            var json = $@"
+            {{
+                ""min"": {decimal.MinValue},
+                ""max"": {decimal.MaxValue},
+                ""zero"": {decimal.Zero},
+                ""one"": {decimal.One},
+                ""17digits"": 1584097275961.1234
+            }}";
+            
+            var doc = Document.FromJson(json);
+
+            Assert.AreEqual(decimal.MinValue, doc["min"].AsDecimal());
+            Assert.AreEqual(decimal.MaxValue, doc["max"].AsDecimal());
+            Assert.AreEqual(decimal.Zero, doc["zero"].AsDecimal());
+            Assert.AreEqual(decimal.One, doc["one"].AsDecimal());
+            Assert.AreEqual(1584097275961.1234m, doc["17digits"].AsDecimal());
+        }
+
+        [TestMethod]
+        public void ToJson_Decimal()
+        {
+            var document = new Document();
+            document["min"] = decimal.MinValue;
+            document["max"] = decimal.MaxValue;
+            document["zero"] = decimal.Zero;
+            document["one"] = decimal.One;
+            document["17digits"] = 1584097275961.1234m;
+
+            var json = document.ToJsonPretty();
+
+            var expectedJson = $@"{{
+  ""min"": {decimal.MinValue},
+  ""max"": {decimal.MaxValue},
+  ""zero"": {decimal.Zero},
+  ""one"": {decimal.One},
+  ""17digits"": 1584097275961.1234
+}}";
+
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [TestMethod]
+        public void FromJson_Double()
+        {
+            var json = $@"
+            {{
+                ""min"": {double.MinValue.ToString("G17")},
+                ""max"": {double.MaxValue.ToString("G17")},
+                ""zero"": 0,
+                ""one"": 1.0,
+                ""17digits"": 1584097275961.1234
+            }}";
+
+            var doc = Document.FromJson(json);
+
+            Assert.AreEqual(double.MinValue, doc["min"].AsDouble());
+            Assert.AreEqual(double.MaxValue, doc["max"].AsDouble());
+            Assert.AreEqual(0.0, doc["zero"].AsDouble());
+            Assert.AreEqual(1.0, doc["one"].AsDouble());
+            Assert.AreEqual(1584097275961.1234d, doc["17digits"].AsDouble());
+        }
+
+        [TestMethod]
+        public void ToJson_Double()
+        {
+            var document = new Document();
+            document["min"] = double.MinValue;
+            document["max"] = double.MaxValue;
+            document["zero"] = 0.0;
+            document["one"] = 1.0;
+            document["17digits"] = 1584097275961.1234d; // because we're forcing this to a double, we're expecting it to lose precision
+
+            var json = document.ToJsonPretty();
+
+            var expectedJson = $@"{{
+  ""min"": {double.MinValue.ToString("G17")},
+  ""max"": {double.MaxValue.ToString("G17")},
+  ""zero"": 0,
+  ""one"": 1,
+  ""17digits"": 1584097275961.1233
+}}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+            [TestMethod]
+        public void FromJson_Int()
+        {
+            var json = $@"
+            {{
+                ""min"": {int.MinValue:G17},
+                ""max"": {int.MaxValue.ToString("G17")},
+                ""zero"": 0,
+                ""one"": 1
+            }}";
+
+            var doc = Document.FromJson(json);
+
+            Assert.AreEqual(int.MinValue, doc["min"].AsInt());
+            Assert.AreEqual(int.MaxValue, doc["max"].AsInt());
+            Assert.AreEqual(0, doc["zero"].AsInt());
+            Assert.AreEqual(1, doc["one"].AsInt());
+        }
+
+        [TestMethod]
+        public void ToJson_Int()
+        {
+            var document = new Document();
+            document["min"] = int.MinValue;
+            document["max"] = int.MaxValue;
+            document["zero"] = 0;
+            document["one"] = 1;
+
+            var json = document.ToJsonPretty();
+
+            var expectedJson = $@"{{
+  ""min"": {int.MinValue.ToString("G17")},
+  ""max"": {int.MaxValue.ToString("G17")},
+  ""zero"": 0,
+  ""one"": 1
+}}";
+
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [TestMethod]
+        public void FromJson_Long()
+        {
+            var json = $@"
+            {{
+                ""key"": 9223372036854775806
+            }}";
+
+            var doc = Document.FromJson(json);
+
+            Assert.AreEqual(9223372036854775806, (long)doc["key"]);
+        }
+
+        [TestMethod]
+        public void ToJson_Long()
+        {
+            var document = new Document();
+            document["key"] = 9223372036854775806L;
+
+            var json = document.ToJsonPretty();
+
+            var expectedJson = $@"{{
+  ""key"": 9223372036854775806
+}}";
+
+            Assert.AreEqual(expectedJson, json);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

### Before
Currently, `Document.FromJson` and `Document.ToJson` in DynamoDBv2 use LitJson for JSON handling.

This does not support `decimal`, as the first numeric type it matches to here is `double`.

https://github.com/aws/aws-sdk-net/blob/c88243bd458afadccab6282e97675141d94047ed/sdk/src/Core/ThirdParty/Json/JsonReader.cs#L132-L144

This is leading to a loss of precision for decimal values, see the linked issues.

### After
This proposes to address this by replacing LitJson in these code paths with System.TextJson.
* We want to do this anyway as long term we'd like to remove the embedded copy of LitJson from AWSSDK.Core.

While this addresses the reported issue, we still need to look at:
* Is this causing a regression for any other numeric values or types, or even non-numeric types?
* Is it handling comments, malformed JSON, etc. the same way?

## Motivation and Context
#1555 , #1039 

## Testing
* Ran DynamoDBv2 sln tests locally
* PENDING dry-run

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement