### PR TITLE
Add missing AssemblyInfo files for new extensions

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AWSSDK.Extensions.CloudFront.Signers.NetFramework.csproj
+++ b/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AWSSDK.Extensions.CloudFront.Signers.NetFramework.csproj
@@ -1,10 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
 	<AssemblyName>AWSSDK.Extensions.CloudFront.Signers</AssemblyName>
 	<PackageId>AWSSDK.Extensions.CloudFront.Signers</PackageId>
-	<Version>4.0.1.0-preview</Version>
-	<Title>AWSSDK.Extensions.Cloudfront.Signers</Title>
 	<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
 	<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 	<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AWSSDK.Extensions.CloudFront.Signers.NetStandard.csproj
+++ b/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AWSSDK.Extensions.CloudFront.Signers.NetStandard.csproj
@@ -3,9 +3,7 @@
 	<TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
 	<AssemblyName>AWSSDK.Extensions.CloudFront.Signers</AssemblyName>
 	<PackageId>AWSSDK.Extensions.CloudFront.Signers</PackageId>
-	<Version>4.0.1.0-preview</Version>
-	<Title>AWSSDK.Extensions.Cloudfront.Signers</Title>
-	 <DefineConstants>$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
+	<DefineConstants>$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
 	<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
 	<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 	<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AWSSDK.Extensions.CloudFront.Signers.nuspec
+++ b/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AWSSDK.Extensions.CloudFront.Signers.nuspec
@@ -5,10 +5,7 @@
     <title>AWSSDK - Extensions for AWS CloudFront</title>
     <version>4.0.1.0-preview</version>
     <authors>Amazon Web Services</authors>
-		<description>
-			This package contains extension methods for creating signed URLs for Amazon CloudFront distributions and
-			for creating signed cookies for Amazon CloudFront distributions using canned or custom policies.
-		</description>
+	<description>This package contains extension methods for creating signed URLs for Amazon CloudFront distributions and for creating signed cookies for Amazon CloudFront distributions using canned or custom policies.</description>
     <language>en-US</language>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/aws/aws-sdk-net/</projectUrl>
@@ -36,7 +33,6 @@
         <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
     </dependencies>
-
   </metadata> 
   <files>
     <file src="..\..\..\sdk\nuget-content\AWSLogo.png" target="images\" />

--- a/extensions/src/AWSSDK.Extensions.CloudFront.Signers/Properties/AssemblyInfo.cs
+++ b/extensions/src/AWSSDK.Extensions.CloudFront.Signers/Properties/AssemblyInfo.cs
@@ -2,11 +2,11 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("AWSSDK.Extensions.CrtIntegration")]
+[assembly: AssemblyTitle("AWSSDK.Extensions.Cloudfront.Signers")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Amazon.com, Inc")]
-[assembly: AssemblyProduct("Amazon Web Services Common Runtime integration with the AWS .NET SDK")]
-[assembly: AssemblyDescription("Amazon Web Services Common Runtime integration with the AWS .NET SDK")]
+[assembly: AssemblyProduct("AWS SDK for .NET extensions for Amazon CloudFront")]
+[assembly: AssemblyDescription("AWS SDK for .NET extensions for Amazon CloudFront")]
 [assembly: AssemblyCopyright("Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.")]
 [assembly: AssemblyTrademark("")]
 
@@ -14,7 +14,6 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
 
 #if NETFRAMEWORK
 [assembly: AssemblyVersion("4.0")]

--- a/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
+++ b/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.CrtIntegration</id>
     <title>AWSSDK - Extensions for AWS Common Runtime Integration</title>
-    <version>4.0.0-preview</version>
+    <version>4.0.1.0-preview</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with the AWS Common Runtime</description>
     <language>en-US</language>
@@ -13,27 +13,26 @@
     <icon>images\AWSLogo.png</icon>
     <dependencies>
       <group targetFramework="net472">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview" />
+        <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0-preview" />
+        <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="AWSSDK.Core" version="4.0.0-preview" />
+        <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0-preview" />
+        <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>
     </dependencies>
-
   </metadata> 
   <files>
     <file src="..\..\..\sdk\nuget-content\AWSLogo.png" target="images\" />

--- a/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/AWSSDK.Extensions.EC2.DecryptPassword.NetFramework.csproj
+++ b/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/AWSSDK.Extensions.EC2.DecryptPassword.NetFramework.csproj
@@ -1,10 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
 	<AssemblyName>AWSSDK.Extensions.EC2.DecryptPassword</AssemblyName>
 	<PackageId>AWSSDK.Extensions.EC2.DecryptPassword</PackageId>
-	<Version>4.0.1.0-preview</Version>
-	<Title>AWSSDK.Extensions.EC2.DecryptPassword</Title>
 	<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
 	<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 	<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/AWSSDK.Extensions.EC2.DecryptPassword.NetStandard.csproj
+++ b/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/AWSSDK.Extensions.EC2.DecryptPassword.NetStandard.csproj
@@ -1,10 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	<TargetFrameworks>netstandard2.0;netcoreapp3.1;net8.0</TargetFrameworks>
 	<AssemblyName>AWSSDK.Extensions.EC2.DecryptPassword</AssemblyName>
 	<PackageId>AWSSDK.Extensions.EC2.DecryptPassword</PackageId>
-	<Version>4.0.1.0-preview</Version>
-	<Title>AWSSDK.Extensions.EC2.DecryptPassword</Title>
 	<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
 	<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 	<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/AWSSDK.Extensions.EC2.DecryptPassword.nuspec
+++ b/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/AWSSDK.Extensions.EC2.DecryptPassword.nuspec
@@ -15,25 +15,24 @@
       <group targetFramework="net472">
         <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="AWSSDK.EC2" version="4.0.1.0-preview" />
-		    <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
+		<dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="AWSSDK.EC2" version="4.0.1.0-preview" />
-		    <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
+		<dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="AWSSDK.EC2" version="4.0.1.0-preview" />
-		    <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
+		<dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="AWSSDK.EC2" version="4.0.1.0-preview" />
-		    <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
+		<dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
     </dependencies>
-
   </metadata> 
   <files>
     <file src="..\..\..\sdk\nuget-content\AWSLogo.png" target="images\" />

--- a/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/Properties/AssemblyInfo.cs
+++ b/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/Properties/AssemblyInfo.cs
@@ -2,11 +2,11 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("AWSSDK.Extensions.CrtIntegration")]
+[assembly: AssemblyTitle("AWSSDK.Extensions.EC2.DecryptPassword")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Amazon.com, Inc")]
-[assembly: AssemblyProduct("Amazon Web Services Common Runtime integration with the AWS .NET SDK")]
-[assembly: AssemblyDescription("Amazon Web Services Common Runtime integration with the AWS .NET SDK")]
+[assembly: AssemblyProduct("AWS SDK for .NET extensions for Amazon EC2")]
+[assembly: AssemblyDescription("AWS SDK for .NET extensions for Amazon EC2")]
 [assembly: AssemblyCopyright("Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.")]
 [assembly: AssemblyTrademark("")]
 
@@ -14,7 +14,6 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
 
 #if NETFRAMEWORK
 [assembly: AssemblyVersion("4.0")]

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.NETCore.Setup</id>
     <title>AWSSDK - Extensions for NETCore Setup</title>
-    <version>4.0.0.0-preview</version>
+    <version>4.0.1.0-preview</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with .NET Core configuration and dependency injection frameworks.</description>
     <language>en-US</language>
@@ -14,19 +14,19 @@
 	
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview" />
+        <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview" />
+        <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview" />
+        <dependency id="AWSSDK.Core" version="4.0.1.0-preview" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/Properties/AssemblyInfo.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/Properties/AssemblyInfo.cs
@@ -16,5 +16,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 
-[assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.0.0")]
+[assembly: AssemblyVersion("4.0.1.0")]
+[assembly: AssemblyFileVersion("4.0.1.0")]


### PR DESCRIPTION
## Description
* Add missing `Properties/AssemblyInfo.cs` files for new extensions
* Bump existing extension packages to version `4.0.1.0-preview` as well

## Testing
- Dry-run (in progress): `DRY_RUN-6a470772-f650-4f0c-b415-cd0695738f34`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
