### PR TITLE
Add ToString methods for better enum string conversion

### DIFF
--- a/sdk/src/Core/Amazon.Auth/AccessControlPolicy/ConditionFactory.cs
+++ b/sdk/src/Core/Amazon.Auth/AccessControlPolicy/ConditionFactory.cs
@@ -102,7 +102,7 @@ namespace Amazon.Auth.AccessControlPolicy
         /// <summary>
         /// Enumeration of the supported ways an ARN comparison can be evaluated.
         /// </summary>
-        public enum ArnComparisonType 
+        public enum ArnComparisonType
         {
             /// <summary>Exact matching</summary>
             ArnEquals,
@@ -177,7 +177,7 @@ namespace Amazon.Auth.AccessControlPolicy
         /// <summary>
         /// Enumeration of the supported ways a string comparison can be evaluated.
         /// </summary>
-        public enum StringComparisonType 
+        public enum StringComparisonType
         {
             /// <summary>
             /// Case-sensitive exact string matching
@@ -220,9 +220,9 @@ namespace Amazon.Auth.AccessControlPolicy
         /// <param name="type">The type of comparison to perform.</param>
         /// <param name="value">The second ARN to compare against. When using ArnLike or ArnNotLike this may contain the
         ///     multi-character wildcard (*) or the single-character wildcard</param>
-        public static Condition NewCondition(ArnComparisonType type, string key, string value) 
+        public static Condition NewCondition(ArnComparisonType type, string key, string value)
         {
-            return new Condition(type.ToString(), key, value);
+            return new Condition(ToString(type), key, value);
         }
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace Amazon.Auth.AccessControlPolicy
         /// <param name="value">The boolean to compare against.</param>
         public static Condition NewCondition(string key, bool value)
         {
-            return new Condition("Bool", key, value.ToString().ToLowerInvariant());
+            return new Condition("Bool", key, value ? "true" : "false");
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace Amazon.Auth.AccessControlPolicy
         [Obsolete("Invoking this method results in non-UTC DateTimes not being marshalled correctly. Use NewConditionUtc instead.", false)]
         public static Condition NewCondition(DateComparisonType type, DateTime date)
         {
-            return new Condition(type.ToString(), CURRENT_TIME_CONDITION_KEY, date.ToString(AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture));
+            return new Condition(ToString(type), CURRENT_TIME_CONDITION_KEY, date.ToString(AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -265,7 +265,7 @@ namespace Amazon.Auth.AccessControlPolicy
         /// <param name="date">The date to compare against.</param>
         public static Condition NewConditionUtc(DateComparisonType type, DateTime date)
         {
-            return new Condition(type.ToString(), CURRENT_TIME_CONDITION_KEY, date.ToUniversalTime().ToString(AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture));
+            return new Condition(ToString(type), CURRENT_TIME_CONDITION_KEY, date.ToUniversalTime().ToString(AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -298,7 +298,7 @@ namespace Amazon.Auth.AccessControlPolicy
         /// <param name="ipAddressRange">The CIDR IP range involved in the policy condition.</param>
         public static Condition NewCondition(IpAddressComparisonType type, string ipAddressRange)
         {
-            return new Condition(type.ToString(), SOURCE_IP_CONDITION_KEY, ipAddressRange);
+            return new Condition(ToString(type), SOURCE_IP_CONDITION_KEY, ipAddressRange);
         }
 
         /// <summary>
@@ -310,7 +310,7 @@ namespace Amazon.Auth.AccessControlPolicy
         /// <param name="value">The second number to compare against.</param>
         public static Condition NewCondition(NumericComparisonType type, string key, string value)
         {
-            return new Condition(type.ToString(), key, value);
+            return new Condition(ToString(type), key, value);
         }
 
         /// <summary>
@@ -329,7 +329,7 @@ namespace Amazon.Auth.AccessControlPolicy
         /// </param>
         public static Condition NewCondition(StringComparisonType type, string key, string value)
         {
-            return new Condition(type.ToString(), key, value);
+            return new Condition(ToString(type), key, value);
         }
 
         /// <summary>
@@ -375,6 +375,99 @@ namespace Amazon.Auth.AccessControlPolicy
         public static Condition NewSecureTransportCondition()
         {
             return NewCondition(SECURE_TRANSPORT_CONDITION_KEY, true);
+        }
+
+        private static string ToString(ArnComparisonType type)
+        {
+            switch (type)
+            {
+                case ArnComparisonType.ArnEquals:
+                    return nameof(ArnComparisonType.ArnEquals);
+                case ArnComparisonType.ArnLike:
+                    return nameof(ArnComparisonType.ArnLike);
+                case ArnComparisonType.ArnNotEquals:
+                    return nameof(ArnComparisonType.ArnNotEquals);
+                case ArnComparisonType.ArnNotLike:
+                    return nameof(ArnComparisonType.ArnNotLike);
+                default:
+                    return type.ToString();
+            }
+        }
+
+        private static string ToString(DateComparisonType type)
+        {
+            switch (type)
+            {
+                case DateComparisonType.DateEquals:
+                    return nameof(DateComparisonType.DateEquals);
+                case DateComparisonType.DateGreaterThan:
+                    return nameof(DateComparisonType.DateGreaterThan);
+                case DateComparisonType.DateGreaterThanEquals:
+                    return nameof(DateComparisonType.DateGreaterThanEquals);
+                case DateComparisonType.DateLessThan:
+                    return nameof(DateComparisonType.DateLessThan);
+                case DateComparisonType.DateLessThanEquals:
+                    return nameof(DateComparisonType.DateLessThanEquals);
+                case DateComparisonType.DateNotEquals:
+                    return nameof(DateComparisonType.DateNotEquals);
+                default:
+                    return type.ToString();
+            }
+        }
+
+        private static string ToString(IpAddressComparisonType type)
+        {
+            switch (type)
+            {
+                case IpAddressComparisonType.IpAddress:
+                    return nameof(IpAddressComparisonType.IpAddress);
+                case IpAddressComparisonType.NotIpAddress:
+                    return nameof(IpAddressComparisonType.NotIpAddress);
+                default:
+                    return type.ToString();
+            }
+        }
+
+        private static string ToString(NumericComparisonType type)
+        {
+            switch (type)
+            {
+                case NumericComparisonType.NumericEquals:
+                    return nameof(NumericComparisonType.NumericEquals);
+                case NumericComparisonType.NumericGreaterThan:
+                    return nameof(NumericComparisonType.NumericGreaterThan);
+                case NumericComparisonType.NumericGreaterThanEquals:
+                    return nameof(NumericComparisonType.NumericGreaterThanEquals);
+                case NumericComparisonType.NumericLessThan:
+                    return nameof(NumericComparisonType.NumericLessThan);
+                case NumericComparisonType.NumericLessThanEquals:
+                    return nameof(NumericComparisonType.NumericLessThanEquals);
+                case NumericComparisonType.NumericNotEquals:
+                    return nameof(NumericComparisonType.NumericNotEquals);
+                default:
+                    return type.ToString();
+            }
+        }
+
+        private static string ToString(StringComparisonType type)
+        {
+            switch (type)
+            {
+                case StringComparisonType.StringEquals:
+                    return nameof(StringComparisonType.StringEquals);
+                case StringComparisonType.StringEqualsIgnoreCase:
+                    return nameof(StringComparisonType.StringEqualsIgnoreCase);
+                case StringComparisonType.StringLike:
+                    return nameof(StringComparisonType.StringLike);
+                case StringComparisonType.StringNotEquals:
+                    return nameof(StringComparisonType.StringNotEquals);
+                case StringComparisonType.StringNotEqualsIgnoreCase:
+                    return nameof(StringComparisonType.StringNotEqualsIgnoreCase);
+                case StringComparisonType.StringNotLike:
+                    return nameof(StringComparisonType.StringNotLike);
+                default:
+                    return type.ToString();
+            }
         }
     }
 }

--- a/sdk/test/UnitTests/Custom/PolicyTests.cs
+++ b/sdk/test/UnitTests/Custom/PolicyTests.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Amazon.Auth.AccessControlPolicy;
+using AWSSDK_DotNet.IntegrationTests.Utils;
+using static Amazon.Auth.AccessControlPolicy.ConditionFactory;
 
 namespace AWSSDK_DotNet.UnitTests
 {
@@ -101,6 +103,56 @@ namespace AWSSDK_DotNet.UnitTests
             var result = policy.CheckIfStatementExists(statementToCheck);
 
             Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void LookForArnComparisonTypeChanges()
+        {
+            var expectedHash = "93F200C066AF797AE2A923313D16DD1737AB26D8041C03F68E2BC9FAB03F464A";
+            AssertExtensions.AssertEnumUnchanged(
+                typeof(ArnComparisonType),
+                expectedHash,
+                "The Amazon.Auth.AccessControlPolicy.ConditionFactory.ToString(ArnComparisonType) method implementation may need to be updated.");
+        }
+
+        [TestMethod]
+        public void LookForDateComparisonTypeChanges()
+        {
+            var expectedHash = "929F27F8B4A0619A30D90F35429690BE334B14D4881EF47311FDEB5696D27DEF";
+            AssertExtensions.AssertEnumUnchanged(
+                typeof(DateComparisonType),
+                expectedHash,
+                "The Amazon.Auth.AccessControlPolicy.ConditionFactory.ToString(DateComparisonType) method implementation may need to be updated.");
+        }
+
+        [TestMethod]
+        public void LookForIpAddressComparisonTypeChanges()
+        {
+            var expectedHash = "440711FCA8408753BAEC4D1ECA39F813477A43DCA988924E0260A28359F53B78";
+            AssertExtensions.AssertEnumUnchanged(
+                typeof(IpAddressComparisonType),
+                expectedHash,
+                "The Amazon.Auth.AccessControlPolicy.ConditionFactory.ToString(DateComparisonType) method implementation may need to be updated.");
+        }
+
+        [TestMethod]
+        public void LookForNumericComparisonTypeChanges()
+        {
+            var expectedHash = "15808022DE81B0A1C62DBB9238EA542B891EDE6840278508C1FBFC4A6ACC829D";
+            AssertExtensions.AssertEnumUnchanged(
+                typeof(NumericComparisonType),
+                expectedHash,
+                "The Amazon.Auth.AccessControlPolicy.ConditionFactory.ToString(DateComparisonType) method implementation may need to be updated.");
+        }
+
+        [TestMethod]
+        public void LookForStringComparisonTypeChanges()
+        {
+            var expectedHash = "8466438D83763A3ADE2161964A9C3A68E247BC576A40956D5295382C74D8FB22";
+            AssertExtensions.AssertEnumUnchanged(
+                typeof(StringComparisonType),
+                expectedHash,
+                "The Amazon.Auth.AccessControlPolicy.ConditionFactory.ToString(DateComparisonType) method implementation may need to be updated.");
         }
     }
 }


### PR DESCRIPTION
## Description

- Added private `ToString` methods for various comparison `enum`s in `ConditionFactory.cs` to improve readability and maintainability.
- Updated `NewCondition` methods to use these new `ToString` methods for consistent string representation.
- Optimized `boolean` conversion to `string` using a ternary operator.

## Motivation and Context

The result of invoking `ToString` on an `enum` is cached in a limited space and there's no guarantee that the value will be cached for the same value in consecutive invocations.

Having code that returns compile-time generated static `string`s will guarantee that that `string` is always available and easy to access.

Invoking `ToString` in `bool` will return the `string`literals `"True"` or `"False"`, depending on its value. However, invoking `ToLowerInvariant()` on those `String`s will incur in the generation/allocation of a new `string` every time.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement