### PR TITLE
Ignore S3 Select tests

### DIFF
--- a/sdk/test/Services/S3/IntegrationTests/SelectObjectContentTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/SelectObjectContentTests.cs
@@ -35,6 +35,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 {
     [TestClass]
+    [Ignore("S3 Select is not available to new customers so these tests cannot run on new accounts")]
     public class SelectObjectContentTests : TestBase<AmazonS3Client>
     {
         private static readonly string TestFileKey = "selectobjectcontent_content.txt";


### PR DESCRIPTION
## Description
S3 Select is not available for new customers (https://x.com/jeffbarr/status/1818488419347317217), so these integration tests can fail on accounts that haven't used it before.

## Testing
Built S3 solution locally and confirmed tests were skipped.

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
