### PR TITLE
Added support for RequestPayer property in TransferUtility Upload request/commands.

### DIFF
--- a/generator/.DevConfigs/7ae6d22d-5331-411e-bfe0-fc94909de4d7.json
+++ b/generator/.DevConfigs/7ae6d22d-5331-411e-bfe0-fc94909de4d7.json
@@ -1,0 +1,9 @@
+{
+    "services": [
+      {
+        "serviceName": "S3",
+        "type": "patch",
+        "changeLogMessages": [ "Added support for RequestPayer property in TransferUtility Upload request/commands." ]
+      }
+    ]
+  }

--- a/sdk/src/Services/S3/Custom/Transfer/BaseUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/BaseUploadRequest.cs
@@ -29,6 +29,8 @@ namespace Amazon.S3.Transfer
     /// </summary>
     public abstract class BaseUploadRequest
     {
+        private RequestPayer requestPayer;
+
 #if (BCL && !BCL45)
         private TimeSpan? timeout = null;
 
@@ -59,5 +61,15 @@ namespace Amazon.S3.Transfer
             }
         }
 #endif
+
+        /// <summary>
+        /// Confirms that the requester knows that they will be charged for the request. 
+        /// Bucket owners need not specify this parameter in their requests.
+        /// </summary>
+        public RequestPayer RequestPayer
+        {
+            get { return this.requestPayer; }
+            set { this.requestPayer = value; }
+        }
     }
 }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
@@ -101,6 +101,7 @@ namespace Amazon.S3.Transfer.Internal
             downloadRequest.ServerSideEncryptionCustomerMethod = this._request.ServerSideEncryptionCustomerMethod;
             downloadRequest.ServerSideEncryptionCustomerProvidedKey = this._request.ServerSideEncryptionCustomerProvidedKey;
             downloadRequest.ServerSideEncryptionCustomerProvidedKeyMD5 = this._request.ServerSideEncryptionCustomerProvidedKeyMD5;
+            downloadRequest.RequestPayer = this._request.RequestPayer;
 
             //Ensure the target file is a rooted within LocalDirectory. Otherwise error.
             if(!InternalSDKUtils.IsFilePathRootedWithDirectoryPath(downloadRequest.FilePath, _request.LocalDirectory))
@@ -135,6 +136,8 @@ namespace Amazon.S3.Transfer.Internal
                     listRequestV2.Prefix = listRequestV2.Prefix.Substring(1);
             }
 
+            listRequestV2.RequestPayer = this._request.RequestPayer;
+
             return listRequestV2;
         }
 
@@ -159,6 +162,8 @@ namespace Amazon.S3.Transfer.Internal
                 else
                     listRequest.Prefix = listRequest.Prefix.Substring(1);
             }
+
+            listRequest.RequestPayer = this._request.RequestPayer;
 
             return listRequest;
         }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
@@ -173,7 +173,8 @@ namespace Amazon.S3.Transfer.Internal
                 BucketName = this._fileTransporterRequest.BucketName,
                 Key = this._fileTransporterRequest.Key,
                 UploadId = initResponse.UploadId,
-                IfNoneMatch = this._fileTransporterRequest.IfNoneMatch                
+                IfNoneMatch = this._fileTransporterRequest.IfNoneMatch,
+                RequestPayer = this._fileTransporterRequest.RequestPayer
             };
 
             if(this._fileTransporterRequest.ServerSideEncryptionCustomerMethod != null 
@@ -243,7 +244,8 @@ namespace Amazon.S3.Transfer.Internal
                 DisableDefaultChecksumValidation = this._fileTransporterRequest.DisableDefaultChecksumValidation,
                 DisablePayloadSigning = this._fileTransporterRequest.DisablePayloadSigning,
                 ChecksumAlgorithm = this._fileTransporterRequest.ChecksumAlgorithm,
-                CalculateContentMD5Header = this._fileTransporterRequest.CalculateContentMD5Header
+                CalculateContentMD5Header = this._fileTransporterRequest.CalculateContentMD5Header,
+                RequestPayer = this._fileTransporterRequest.RequestPayer
             };
 
             // If the InitiateMultipartUploadResponse indicates that this upload is using KMS, force SigV4 for each UploadPart request
@@ -296,7 +298,8 @@ namespace Amazon.S3.Transfer.Internal
                 TagSet = this._fileTransporterRequest.TagSet,
                 ChecksumAlgorithm = this._fileTransporterRequest.ChecksumAlgorithm,
                 ObjectLockLegalHoldStatus = this._fileTransporterRequest.ObjectLockLegalHoldStatus,
-                ObjectLockMode = this._fileTransporterRequest.ObjectLockMode
+                ObjectLockMode = this._fileTransporterRequest.ObjectLockMode,
+                RequestPayer = this._fileTransporterRequest.RequestPayer
             };
 
             if (this._fileTransporterRequest.IsSetObjectLockRetainUntilDate())

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/SimpleUploadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/SimpleUploadCommand.cs
@@ -74,7 +74,8 @@ namespace Amazon.S3.Transfer.Internal
 #endif
                 DisableDefaultChecksumValidation = this._fileTransporterRequest.DisableDefaultChecksumValidation,
                 DisablePayloadSigning = this._fileTransporterRequest.DisablePayloadSigning,
-                ChecksumAlgorithm = this._fileTransporterRequest.ChecksumAlgorithm
+                ChecksumAlgorithm = this._fileTransporterRequest.ChecksumAlgorithm,
+                RequestPayer = this._fileTransporterRequest.RequestPayer
             };
 
             // Avoid setting ContentType to null, as that may clear

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/UploadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/UploadDirectoryCommand.cs
@@ -77,6 +77,7 @@ namespace Amazon.S3.Transfer.Internal
                 ObjectLockLegalHoldStatus = this._request.ObjectLockLegalHoldStatus,
                 ObjectLockMode = this._request.ObjectLockMode,
                 DisablePayloadSigning = this._request.DisablePayloadSigning,
+                RequestPayer = this._request.RequestPayer,
 #if (BCL && !BCL45)
                 Timeout = ClientConfig.GetTimeoutValue(this._config.DefaultTimeout, this._request.Timeout)
 #endif

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/MultipartUploadCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/MultipartUploadCommand.async.cs
@@ -183,6 +183,7 @@ namespace Amazon.S3.Transfer.Internal
                 {
                     BucketName = this._fileTransporterRequest.BucketName,
                     Key = this._fileTransporterRequest.Key,
+                    RequestPayer = this._fileTransporterRequest.RequestPayer,
                     UploadId = uploadId
                 }).Wait();
             }
@@ -293,6 +294,7 @@ namespace Amazon.S3.Transfer.Internal
                 {
                     BucketName = request.BucketName,
                     Key = request.Key,
+                    RequestPayer = request.RequestPayer,
                     UploadId = initiateResponse.UploadId
                 }).ConfigureAwait(false);
                 Logger.Error(ex, ex.Message);

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl35/MultipartUploadCommand.bcl35.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl35/MultipartUploadCommand.bcl35.cs
@@ -198,7 +198,8 @@ namespace Amazon.S3.Transfer.Internal
                 {
                     BucketName = request.BucketName,
                     Key = request.Key,
-                    UploadId = initiateResponse.UploadId
+                    UploadId = initiateResponse.UploadId,
+                    RequestPayer = request.RequestPayer
                 });
                 Logger.Error(ex, ex.Message);
                 throw;

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryRequest.cs
@@ -52,6 +52,8 @@ namespace Amazon.S3.Transfer
         private string serverSideEncryptionCustomerProvidedKey;
         private string serverSideEncryptionCustomerProvidedKeyMD5;
 
+        private RequestPayer requestPayer;
+
         /// <summary>
         /// 	Gets or sets the name of the bucket.
         /// </summary>
@@ -299,6 +301,16 @@ namespace Amazon.S3.Transfer
         {
             get { return this.serverSideEncryptionCustomerProvidedKeyMD5; }
             set { this.serverSideEncryptionCustomerProvidedKeyMD5 = value; }
+        }
+
+        /// <summary>
+        /// Confirms that the requester knows that they will be charged for the request. 
+        /// Bucket owners need not specify this parameter in their requests.
+        /// </summary>
+        public RequestPayer RequestPayer
+        {
+            get { return this.requestPayer; }
+            set { this.requestPayer = value; }
         }
 
         /// <summary>

--- a/sdk/test/Services/S3/IntegrationTests/TransferUtilityRequesterPaysTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/TransferUtilityRequesterPaysTests.cs
@@ -1,0 +1,562 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Transfer;
+using Amazon.S3.Util;
+using AWSSDK_DotNet.IntegrationTests.Utils;
+using System.Drawing;
+using Amazon.SimpleNotificationService.Model;
+
+namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
+{
+    [TestClass]
+    public class TransferUtilityRequestorPaysTests : TestBase<AmazonS3Client>
+    {
+        public static readonly long MEG_SIZE = (int)Math.Pow(2, 20);
+        public static readonly long KILO_SIZE = (int)Math.Pow(2, 10);
+        public static readonly string BasePath = @"c:\temp\test\transferutility\";
+
+        private static string bucketName;
+        private static string octetStreamContentType = "application/octet-stream";
+        private static string plainTextContentType = "text/plain";
+
+        [ClassInitialize()]
+        public static void ClassInitialize(TestContext a)
+        {
+            // Create standard bucket for operations
+            bucketName = S3TestUtils.CreateBucketWithWait(Client);
+
+            Client.PutBucketRequestPayment(new PutBucketRequestPaymentRequest
+            {
+                BucketName = bucketName,
+                RequestPaymentConfiguration = new RequestPaymentConfiguration()
+                { 
+                    Payer = "Requester" // Valid Values: Requester | BucketOwner. We cannot use RequestPayer.Requester, which is a constant class for specifying x-amz-request-payer header
+                }
+            });
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            AmazonS3Util.DeleteS3BucketWithObjects(Client, bucketName);
+            
+            BaseClean();
+            if (Directory.Exists(BasePath))
+            {
+                Directory.Delete(BasePath, true);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void SimpleUploadTest()
+        {
+            var fileName = UtilityMethods.GenerateName(@"SimpleUploadTest\SmallFile");
+            Upload(fileName, 10 * MEG_SIZE, null);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void UploadUnSeekableStreamTest()
+        {
+            var client = Client;
+            var fileName = UtilityMethods.GenerateName(@"SimpleUploadTest\SmallFile");
+            var path = Path.Combine(BasePath, fileName);
+            var fileSize = 20 * MEG_SIZE;
+            UtilityMethods.GenerateFile(path, fileSize);
+            //take the generated file and turn it into an unseekable stream
+            
+            var stream = GenerateUnseekableStreamFromFile(path);
+            using (var tu = new Amazon.S3.Transfer.TransferUtility(client))
+            {
+                var transferUtilityUploadRequest = new TransferUtilityUploadRequest()
+                {
+                    BucketName = bucketName,
+                    InputStream = stream,
+                    Key = fileName,
+                    RequestPayer = RequestPayer.Requester
+                };
+
+                tu.Upload(transferUtilityUploadRequest);
+
+                var metadata = Client.GetObjectMetadata(new GetObjectMetadataRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName,
+                    RequestPayer= RequestPayer.Requester
+                });
+                Assert.AreEqual(fileSize, metadata.ContentLength);
+
+                //Download the file and validate content of downloaded file is equal.
+                var downloadPath = path + ".download";
+                var downloadRequest = new TransferUtilityDownloadRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName,
+                    FilePath = downloadPath,
+                    RequestPayer = RequestPayer.Requester
+                };
+                tu.Download(downloadRequest);
+                UtilityMethods.CompareFiles(path, downloadPath);
+            }
+        }
+
+        private UnseekableStream GenerateUnseekableStreamFromFile(string filePath)
+        {
+            try
+            {
+                byte[] fileBytes = File.ReadAllBytes(filePath);
+                UnseekableStream unseekableStream = new UnseekableStream(fileBytes);
+                unseekableStream.Position = 0;
+
+                return unseekableStream;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An error occurred while generating the stream: {ex.Message}");
+                throw;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void MultipartUploadProgressTest()
+        {
+            // disable clock skew testing, this is a multithreaded test
+            using (RetryUtilities.DisableClockSkewCorrection())
+            {
+                var fileName = UtilityMethods.GenerateName(@"MultipartUploadTest\File");
+                var progressValidator = new TransferProgressValidator<UploadProgressArgs>
+                {
+                    ValidateProgressInterval = false,
+                    Validate = (p) =>
+                    {
+                        Assert.AreEqual(p.FilePath, Path.Combine(BasePath, fileName));
+                    }
+                };
+                Upload(fileName, 20 * MEG_SIZE, progressValidator);
+                progressValidator.AssertOnCompletion();
+            }
+        }
+
+        void Upload(string fileName, long size, TransferProgressValidator<UploadProgressArgs> progressValidator, AmazonS3Client client = null)
+        {
+            var key = fileName;
+            Client.DeleteObject(new DeleteObjectRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                RequestPayer = RequestPayer.Requester
+            });
+
+            var path = Path.Combine(BasePath, fileName);
+            UtilityMethods.GenerateFile(path, size);
+
+            var config = new TransferUtilityConfig();
+            var transferUtility = client != null ? new TransferUtility(client, config)
+                : new TransferUtility(Client, config);
+            var request = new TransferUtilityUploadRequest
+            {
+                BucketName = bucketName,
+                FilePath = path,
+                Key = key,
+                ContentType = octetStreamContentType,
+                RequestPayer = RequestPayer.Requester
+            };
+
+            if (progressValidator != null)
+            {
+                request.UploadProgressEvent += progressValidator.OnProgressEvent;
+            }
+
+            transferUtility.Upload(request);
+
+            var metadata = Client.GetObjectMetadata(new GetObjectMetadataRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                RequestPayer  = RequestPayer.Requester
+            });
+            Console.WriteLine("Expected Size: {0} , Actual Size {1}", size, metadata.ContentLength);
+            Assert.AreEqual(octetStreamContentType, metadata.Headers.ContentType);
+            Assert.AreEqual(size, metadata.ContentLength);
+            ValidateFileContents(Client, bucketName, key, path);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void UploadDirectoryWithProgressTracker()
+        {
+            var progressValidator = new DirectoryProgressValidator<UploadDirectoryProgressArgs>();
+            ConfigureProgressValidator(progressValidator);
+
+            UploadDirectory(10 * MEG_SIZE, progressValidator, true);
+            progressValidator.AssertOnCompletion();
+        }
+
+        DirectoryInfo UploadDirectory(long size, DirectoryProgressValidator<UploadDirectoryProgressArgs> progressValidator, bool validate = true)
+        {
+            var numberOfTestFiles = 5;
+            var directory = CreateTestDirectory(size, numberOfTestFiles);
+            var keyPrefix = directory.Name;
+            var directoryPath = directory.FullName;
+
+            var config = new TransferUtilityConfig
+            {
+                ConcurrentServiceRequests = 10,
+            };
+            var transferUtility = new TransferUtility(Client, config);
+            var request = new TransferUtilityUploadDirectoryRequest
+            {
+                BucketName = bucketName,
+                Directory = directoryPath,
+                KeyPrefix = keyPrefix,
+                ContentType = plainTextContentType,
+                SearchPattern = "*",
+                SearchOption = SearchOption.AllDirectories,
+                RequestPayer = RequestPayer.Requester
+            };
+
+            if (progressValidator != null)
+            {
+                request.UploadDirectoryProgressEvent += progressValidator.OnProgressEvent;
+            }
+
+            HashSet<string> files = new HashSet<string>();
+            request.UploadDirectoryProgressEvent += (s, e) =>
+            {
+                files.Add(e.CurrentFile);
+                Console.WriteLine("Progress callback = " + e.ToString());
+            };
+
+            transferUtility.UploadDirectory(request);
+
+            Assert.AreEqual(numberOfTestFiles, files.Count);
+
+            if (validate)
+                ValidateDirectoryContents(Client, bucketName, keyPrefix, directory, plainTextContentType);
+
+            return directory;
+        }
+
+         [TestMethod]
+         [TestCategory("S3")]
+         public void DownloadDirectoryProgressTest()
+         {
+             // disable clock skew testing, this is a multithreaded test
+             using (RetryUtilities.DisableClockSkewCorrection())
+             {
+                 var progressValidator = new DirectoryProgressValidator<DownloadDirectoryProgressArgs>();
+                 ConfigureProgressValidator(progressValidator);
+
+                 DownloadDirectory(progressValidator);
+                 progressValidator.AssertOnCompletion();
+             }
+         }
+
+        void DownloadDirectory(DirectoryProgressValidator<DownloadDirectoryProgressArgs> progressValidator, bool concurrent = true)
+        {
+            var directory = UploadDirectory(20 * MEG_SIZE, null, false);
+            var directoryPath = directory.FullName;
+            var keyPrefix = directory.Name;
+            Directory.Delete(directoryPath, true);
+
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                LocalDirectory = directoryPath,
+                S3Directory = keyPrefix,
+                RequestPayer = RequestPayer.Requester
+            };
+
+            if (progressValidator != null)
+                request.DownloadedDirectoryProgressEvent += progressValidator.OnProgressEvent;
+
+            transferUtility.DownloadDirectory(request);
+            ValidateDirectoryContents(Client, bucketName, keyPrefix, directory);
+        }
+
+       
+        public static void ConfigureProgressValidator(DirectoryProgressValidator<DownloadDirectoryProgressArgs> progressValidator)
+        {
+            progressValidator.Validate = (progress, lastProgress) =>
+            {
+                if (lastProgress != null)
+                {
+                    Assert.IsTrue(progress.NumberOfFilesDownloaded >= lastProgress.NumberOfFilesDownloaded);
+                    Assert.IsTrue(progress.TransferredBytes >= lastProgress.TransferredBytes);
+                    if (progress.NumberOfFilesDownloaded == lastProgress.NumberOfFilesDownloaded)
+                    {
+                        Assert.IsTrue(progress.TransferredBytes - lastProgress.TransferredBytes >= 100 * KILO_SIZE);
+                    }
+                }
+
+                if (progress.NumberOfFilesDownloaded == progress.TotalNumberOfFiles)
+                {
+                    Assert.AreEqual(progress.TransferredBytes, progress.TotalBytes);
+                    progressValidator.IsProgressEventComplete = true;
+                }
+
+                Console.WriteLine(progress.ToString());
+            };
+        }
+
+        public static void ConfigureProgressValidator(DirectoryProgressValidator<UploadDirectoryProgressArgs> progressValidator)
+        {
+            progressValidator.Validate = (progress, lastProgress) =>
+            {
+                // Skip validation if testing clock skew correction
+                if (RetryUtilities.TestClockSkewCorrection)
+                    return;
+
+                Assert.IsFalse(string.IsNullOrEmpty(progress.CurrentFile));
+                Assert.IsTrue(progress.TotalNumberOfBytesForCurrentFile > 0);
+                Assert.IsTrue(progress.TransferredBytesForCurrentFile > 0);
+
+                if (lastProgress != null)
+                {
+                    Assert.IsTrue(progress.NumberOfFilesUploaded >= lastProgress.NumberOfFilesUploaded);
+                    Assert.IsTrue(progress.TransferredBytes > lastProgress.TransferredBytes);
+                    if (progress.NumberOfFilesUploaded == lastProgress.NumberOfFilesUploaded)
+                    {
+                        Assert.IsTrue(progress.TransferredBytes - lastProgress.TransferredBytes >= 100 * KILO_SIZE);
+                    }
+                    else
+                    {
+                        Assert.AreEqual(progress.TransferredBytesForCurrentFile, progress.TotalNumberOfBytesForCurrentFile);
+                    }
+                }
+
+                if (progress.NumberOfFilesUploaded == progress.TotalNumberOfFiles)
+                {
+                    Assert.AreEqual(progress.TransferredBytes, progress.TotalBytes);
+                    progressValidator.IsProgressEventComplete = true;
+                }
+
+                Console.Write("\t{0} : {1}/{2}\t", progress.CurrentFile,
+                    progress.TransferredBytesForCurrentFile, progress.TotalNumberOfBytesForCurrentFile);
+                Console.WriteLine(progress.ToString());
+            };
+        }
+
+        public static void ValidateFileContents(IAmazonS3 s3client, string bucketName, string key, string path)
+        {
+            // test assumes we used a known extension and added it to the file key
+            var ext = Path.GetExtension(key);
+            ValidateFileContents(s3client, bucketName, key, path, AmazonS3Util.MimeTypeFromExtension(ext));
+        }
+
+        public static void ValidateFileContents(IAmazonS3 s3client, string bucketName, string key, string path, string contentType)
+        {
+            var downloadPath = path + ".chk";
+            var request = new GetObjectRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                RequestPayer = RequestPayer.Requester
+            };
+
+            UtilityMethods.WaitUntil(() =>
+            {
+                using (var response = s3client.GetObject(request))
+                {
+                    if (!string.IsNullOrEmpty(contentType))
+                    {
+                        Assert.AreEqual(contentType, response.Headers.ContentType);
+                    }
+                    response.WriteResponseStreamToFile(downloadPath);
+                }
+                return true;
+            }, sleepSeconds: 2, maxWaitSeconds: 10);
+            UtilityMethods.CompareFiles(path, downloadPath);
+        }
+
+        public static void ValidateDirectoryContents(IAmazonS3 s3client, string bucketName, string keyPrefix, DirectoryInfo sourceDirectory)
+        {
+            ValidateDirectoryContents(s3client, bucketName, keyPrefix, sourceDirectory, null);
+        }
+
+        public static void ValidateDirectoryContents(IAmazonS3 s3client, string bucketName, string keyPrefix, DirectoryInfo sourceDirectory, string contentType)
+        {
+            var directoryPath = sourceDirectory.FullName;
+            var files = sourceDirectory.GetFiles("*", SearchOption.AllDirectories);
+            foreach (var file in files)
+            {
+                var filePath = file.FullName;
+                var key = filePath.Substring(directoryPath.Length + 1);
+                key = (!string.IsNullOrEmpty(keyPrefix) ? keyPrefix + "/" : string.Empty) + key.Replace("\\", "/");
+                ValidateFileContents(s3client, bucketName, key, filePath, contentType);
+            }
+        }
+
+        public static DirectoryInfo CreateTestDirectory(long size = 0, int numberOfTestFiles = 5)
+        {
+            if (size == 0)
+                size = 1 * MEG_SIZE;
+
+            var directoryPath = GenerateDirectoryPath();
+            for (int i = 0; i < numberOfTestFiles; i++)
+            {
+                var filePath = Path.Combine(Path.Combine(directoryPath, i.ToString()), "file.txt");
+                UtilityMethods.GenerateFile(filePath, size);
+            }
+
+            return new DirectoryInfo(directoryPath);
+        }
+
+        public static string GenerateDirectoryPath(string baseName = "DirectoryTest")
+        {
+            var directoryName = UtilityMethods.GenerateName(baseName);
+            var directoryPath = Path.Combine(BasePath, directoryName);
+            return directoryPath;
+        }
+
+        public abstract class ProgressValidator<T>
+        {
+            public T LastProgressEventValue { get; set; }
+
+            public bool IsProgressEventComplete { get; set; }
+
+            public Exception ProgressEventException { get; set; }
+
+            public void AssertOnCompletion()
+            {
+                // Skip validation if testing clock skew correction
+                if (RetryUtilities.TestClockSkewCorrection)
+                    return;
+
+                if (this.ProgressEventException != null)
+                    throw this.ProgressEventException;
+
+                // Add some time for the background thread to finish before checking the complete
+                for (int retries = 1; retries < 5 && !this.IsProgressEventComplete; retries++)
+                {
+                    Thread.Sleep(1000 * retries);
+                }
+                Assert.IsTrue(this.IsProgressEventComplete, "IsProgressEventComplete is false");
+            }
+        }
+
+        class TransferProgressValidator<T> : ProgressValidator<T> where T : TransferProgressArgs
+        {
+            //private MethodInfo memberInfo = null;
+
+            public Action<T> Validate { get; set; }
+
+            public bool ValidateProgressInterval { get; set; }
+
+            public TransferProgressValidator()
+            {
+                this.ValidateProgressInterval = true;
+            }
+
+            public void OnProgressEvent(object sender, T progress)
+            {
+                try
+                {
+                    Console.WriteLine("Progress Event : {0}%\t{1}/{2}", progress.PercentDone, progress.TransferredBytes, progress.TotalBytes);
+                    Assert.IsFalse(progress.PercentDone > 100, "Progress percent done cannot be greater than 100%");
+                    if (this.IsProgressEventComplete)
+                        Assert.Fail("A progress event was received after completion.");
+
+                    if (progress.TransferredBytes == progress.TotalBytes)
+                    {
+                        Assert.AreEqual(progress.PercentDone, 100);
+                        this.IsProgressEventComplete = true;
+                    }
+
+                    if (this.LastProgressEventValue != null)
+                    {
+                        if (progress.PercentDone < this.LastProgressEventValue.PercentDone)
+                            Console.WriteLine("Progress Event : --------------------------");
+
+                        Assert.IsTrue(progress.PercentDone >= this.LastProgressEventValue.PercentDone);
+                        Assert.IsTrue(progress.TransferredBytes > this.LastProgressEventValue.TransferredBytes);
+
+                        if (progress.TransferredBytes < progress.TotalBytes)
+                        {
+                            if (progress.TransferredBytes - this.LastProgressEventValue.TransferredBytes < 100 * KILO_SIZE)
+                                Console.WriteLine("Progress Event : *******Part Uploaded********");
+
+                            if (this.ValidateProgressInterval)
+                            {
+                                // When TransferUtility uploads using multipart upload, the TransferredBytes
+                                // will be less than the interval for last chunk of each upload part request.
+                                Assert.IsTrue(progress.TransferredBytes - this.LastProgressEventValue.TransferredBytes >= 100 * KILO_SIZE);
+                            }
+                        }
+                    }
+
+                    Validate(progress);
+                    this.LastProgressEventValue = progress;
+                }
+                catch (Exception ex)
+                {
+                    this.ProgressEventException = ex;
+                    Console.WriteLine("Exception caught: {0}", ex.Message);
+                    throw;
+                }
+            }
+        }
+
+        public class DirectoryProgressValidator<T> : ProgressValidator<T>
+        {
+            public Action<T, T> Validate { get; set; }
+
+            public void OnProgressEvent(object sender, T progress)
+            {
+                try
+                {
+                    Validate(progress, this.LastProgressEventValue);
+                }
+                catch (Exception ex)
+                {
+                    this.ProgressEventException = ex;
+                    Console.WriteLine("Exception caught: {0}", ex.Message);
+                    throw;
+                }
+                finally
+                {
+                    this.LastProgressEventValue = progress;
+                }
+            }
+        }
+
+        private class UnseekableStream : MemoryStream
+        {
+            private readonly bool _setZeroLengthStream;
+
+            public UnseekableStream(byte[] buffer) : base(buffer) { }
+            public UnseekableStream(bool setZeroLengthStream): base()
+            {
+                _setZeroLengthStream = setZeroLengthStream;
+            }
+            public UnseekableStream(): base() { }
+
+            public override bool CanSeek
+            {
+                get => false;
+            }
+            public override long Length
+            {
+                get
+                {
+                    if (_setZeroLengthStream)
+                    {
+                        return 0;
+                    }
+                    else { throw new NotSupportedException(); }
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Description
Added support for `RequestPayer` property in `TransferUtility` Upload request/commands.

## Motivation and Context
Internal ticket to add `RequestPayer` in S3 CmdLets. Before support for `RequestPayer` could be added in PowerShell CmdLets, this property needs to be supported in AWS SDK .NET `TransferUtility` upload request/commands.

As a note for PowerShell CmdLets:
- [Get-S3Object](https://docs.aws.amazon.com/powershell/latest/reference/items/Get-S3Object.html) already supports `-RequestPayer` parameter.
- `Write-S3Object` doesn't expose `-RequestPayer` parameter. It uses:
  - `UploadFileToS3()` > `TransferUtilityUploadRequest` > `TransferUtility.Upload()`: [TransferUtilityUploadRequest](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/TTransferUtilityUploadRequest.html) doesn't expose `RequestPayer` property. **So change in .NET SDK is required.**
  - `UploadTextToS3()` > `PutObjectRequest` > `PutObject[Async]()`: [PutObjectRequest](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/TPutObjectRequest.html) already exposes `RequestPayer` property, so no change in .NET SDK.
  - `UploadFolderToS3()` > `TransferUtilityUploadDirectoryRequest` > `TransferUtility.UploadDirectory()`: [TransferUtilityUploadDirectoryRequest](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/TTransferUtilityUploadDirectoryRequest.html) doesn't expose `RequestPayer` property. **So change in .NET SDK is required.**
  
  Both `TransferUtilityUploadRequest` and `TransferUtilityUploadDirectoryRequest` inherit from [BaseUploadRequest](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/TBaseUploadRequest.html) abstract class. So perhaps, we should add `RequestPayer` property in `BaseUploadRequest` class (similar to PR https://github.com/aws/aws-sdk-net/pull/3309 for `BaseDownloadRequest`).

- `Copy-S3Object` doesn't expose `-RequestPayer` parameter. It uses:
  - `CopyS3ObjectToLocalFile` > `TransferUtilityDownloadRequest` > `TransferUtility.Download()`: `TransferUtilityDownloadRequest` exposes `RequestPayer` (this was made available in [PR](https://github.com/aws/aws-sdk-net/pull/3309)). So no change in .NET SDK.
  - `CopyS3ObjectsToLocalFolder` > `TransferUtilityDownloadDirectoryRequest` > `TransferUtility.DownloadDirectory()`: `TransferUtilityDownloadDirectoryRequest` doesn't expose `RequestPayer` property. **So change in .NET SDK is required.**
  - `GetSourceObjectData` > `GetObjectMetadata` > [GetObjectMetadataRequest](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/TGetObjectMetadataRequest.html): `GetObjectMetadataRequest` already exposes `RequestPayer` property, so no change in .NET SDK.
  - `MultipartCopyS3ObjectToS3` >
    - `InitiateMultipartUploadRequest`: This exposes `RequestPayer` property, so no change in .NET SDK.
    - `MultiPartObjectCopyController` >
      - `PartitionIntoParts`(*) > `PartDetail`
      - `Run()` > `UploadPartCopyThreadWorker` > `CopyPartRequest`: [CopyPartRequest](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/TCopyPartRequest.html) exposes `RequestPayer` property, so no change in .NET SDK.
    - `CompleteMultipartUploadRequest`: This exposes `RequestPayer` property, so no change in .NET SDK.

  - `CopyS3ObjectToS3` > `CopyObjectRequest`: [CopyObjectRequest](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/TCopyObjectRequest.html) exposes `RequestPayer` property, so no change in .NET SDK.
- `Remove-S3Object` doesn't expose `-RequestPayer` parameter. It uses:
  - `DeleteSingleS3Object` > `DeleteObjectRequest`: `DeleteObjectRequest` exposes `RequestPayer` property, so no change in .NET SDK.
  - `DeleteMultiS3Object` > `DeleteObjectsRequest`: `DeleteObjectRequest` exposes `RequestPayer` property, so no change in .NET SDK.

## Testing
- Added integration tests for testing `RequestPayer` with `TransferUtility`. However, `RequestPayer` scenario is best tested with 2 accounts (refer https://github.com/aws/aws-sdk-net/issues/1526#issuecomment-870950276 for example steps).
- 1st Dry run completed successfully.
- 2nd Dry run (after adding integration tests) completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement