### PR TITLE
Fixes issue #3463 where repeated retries were happening for error cod…

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
+++ b/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.CrtIntegration</id>
     <title>AWSSDK - Extensions for AWS Common Runtime Integration</title>
-    <version>3.7.300.1</version>
+    <version>3.7.300.2</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with the AWS Common Runtime</description>
     <language>en-US</language>

--- a/extensions/src/AWSSDK.Extensions.CrtIntegration/CrtAWS4aSigner.cs
+++ b/extensions/src/AWSSDK.Extensions.CrtIntegration/CrtAWS4aSigner.cs
@@ -102,7 +102,8 @@ namespace Amazon.Extensions.CrtIntegration
                                               ImmutableCredentials credentials)
         {
             var signedAt = AWS4Signer.InitializeHeaders(request.Headers, request.Endpoint);
-            
+            request.SignedAt = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString());
+
             var serviceSigningName = !string.IsNullOrEmpty(request.OverrideSigningServiceName) ? request.OverrideSigningServiceName : AWS4Signer.DetermineService(clientConfig);
             if (serviceSigningName == "s3")
             {
@@ -187,6 +188,7 @@ namespace Amazon.Extensions.CrtIntegration
             }
 
             var signedAt = AWS4Signer.InitializeHeaders(request.Headers, request.Endpoint);
+            request.SignedAt = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString());
             var regionSet = overrideSigningRegion ?? AWS4Signer.DetermineSigningRegion(clientConfig, clientConfig.RegionEndpointServiceName, request.AlternateEndpoint, request);
 
             var signingConfig = PrepareCRTSigningConfig(

--- a/generator/.DevConfigs/ccbd00c0-53e2-478f-87bc-c4cdda3c41e7.json
+++ b/generator/.DevConfigs/ccbd00c0-53e2-478f-87bc-c4cdda3c41e7.json
@@ -1,0 +1,12 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Fixes #3463 where repeated retries were happening on error codes that weren't necessarily clockskew related."
+      ],
+      "type": "patch",
+      "updateMinimum": true,
+      "backwardIncompatibilitiesToIgnore": [ 
+        "Amazon.Runtime.Internal.IRequest/MethodAbstractMethodAdded"
+      ]
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -1229,6 +1229,7 @@ namespace Amazon.Runtime.Internal.Auth
             }
 
             var signedAt = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString());
+            request.SignedAt = signedAt;
             var region = overrideSigningRegion ?? DetermineSigningRegion(clientConfig, clientConfig.RegionEndpointServiceName, request.AlternateEndpoint, request);
 
             // AWS4 presigned urls got S3 are expected to contain a 'UNSIGNED-PAYLOAD' magic string

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
@@ -39,11 +39,12 @@ namespace Amazon.Runtime.Internal.Auth
                 throw new ArgumentOutOfRangeException("awsAccessKeyId", "The AWS Access Key ID cannot be NULL or a Zero length string");
             }
 
-            string dateTime = AWSSDKUtils.GetFormattedTimestampRFC822(0);
-            request.SignedAt = AWSSDKUtils.CorrectedUtcNow;
-            request.Headers.Add(HeaderKeys.XAmzDateHeader, dateTime);
+            DateTime dateTime = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString());
+            request.SignedAt = dateTime;
+            string dateTimeString = dateTime.ToString(AWSSDKUtils.RFC822DateFormat, CultureInfo.InvariantCulture);
+            request.Headers.Add(HeaderKeys.XAmzDateHeader, dateTimeString);
 
-            string signature = ComputeHash(dateTime, awsSecretAccessKey, SigningAlgorithm.HmacSHA1);
+            string signature = ComputeHash(dateTimeString, awsSecretAccessKey, SigningAlgorithm.HmacSHA1);
 
             request.Headers.Add(HeaderKeys.AuthorizationHeader, "AWS " + awsAccessKeyId + ":" + signature);
         }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
@@ -40,6 +40,7 @@ namespace Amazon.Runtime.Internal.Auth
             }
 
             string dateTime = AWSSDKUtils.GetFormattedTimestampRFC822(0);
+            request.SignedAt = AWSSDKUtils.CorrectedUtcNow;
             request.Headers.Add(HeaderKeys.XAmzDateHeader, dateTime);
 
             string signature = ComputeHash(dateTime, awsSecretAccessKey, SigningAlgorithm.HmacSHA1);

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/QueryStringSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/QueryStringSigner.cs
@@ -57,7 +57,7 @@ namespace Amazon.Runtime.Internal.Auth
             request.Parameters["SignatureVersion"] = SignatureVersion2;
             request.Parameters["SignatureMethod"] = clientConfig.SignatureMethod.ToString();
             request.Parameters["Timestamp"] = AWSSDKUtils.GetFormattedTimestampISO8601(clientConfig);
-            request.SignedAt = clientConfig.CorrectedUtcNow;
+            request.SignedAt = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString());
             // remove Signature parameter, in case this is a retry
             request.Parameters.Remove("Signature");
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/QueryStringSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/QueryStringSigner.cs
@@ -57,6 +57,7 @@ namespace Amazon.Runtime.Internal.Auth
             request.Parameters["SignatureVersion"] = SignatureVersion2;
             request.Parameters["SignatureMethod"] = clientConfig.SignatureMethod.ToString();
             request.Parameters["Timestamp"] = AWSSDKUtils.GetFormattedTimestampISO8601(clientConfig);
+            request.SignedAt = clientConfig.CorrectedUtcNow;
             // remove Signature parameter, in case this is a retry
             request.Parameters.Remove("Signature");
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/S3Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/S3Signer.cs
@@ -91,7 +91,7 @@ namespace Amazon.Runtime.Internal.Auth
         public static void SignRequest(IRequest request, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey)
         {
             request.Headers[HeaderKeys.XAmzDateHeader] = AWSSDKUtils.FormattedCurrentTimestampRFC822;
-
+            request.SignedAt = AWSSDKUtils.CorrectedUtcNow;
             var stringToSign = BuildStringToSign(request);
             metrics.AddProperty(Metric.StringToSign, stringToSign);
             var auth = CryptoUtilFactory.CryptoInstance.HMACSign(stringToSign, awsSecretAccessKey, SigningAlgorithm.HmacSHA1);

--- a/sdk/src/Core/Amazon.Runtime/Internal/DefaultRequest.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/DefaultRequest.cs
@@ -56,7 +56,7 @@ namespace Amazon.Runtime.Internal
         RegionEndpoint alternateRegion;
         long originalStreamLength;
         int marshallerVersion = 2; //2 is the default version and must be used whenever a version is not specified in the marshaller.
-
+        DateTime? signedAt;
         /// <summary>
         /// Constructs a new DefaultRequest with the specified service name and the
         /// original, user facing request object.
@@ -80,7 +80,20 @@ namespace Amazon.Runtime.Internal
             parametersCollection = new ParameterCollection();
             parametersFacade = new ParametersDictionaryFacade(parametersCollection);
         }
-
+        /// <summary>
+        /// The time which the request was signed at.
+        /// </summary>
+        public DateTime? SignedAt
+        {
+            get
+            {
+                return signedAt;
+            }
+            set
+            {
+                this.signedAt = value;
+            }
+        }
 
         /// <summary>
         /// The name of the request

--- a/sdk/src/Core/Amazon.Runtime/Internal/IRequest.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/IRequest.cs
@@ -396,5 +396,10 @@ namespace Amazon.Runtime.Internal
         /// Checksum data to calculate checksum after optionally compressing the request payload
         /// </summary>
         ChecksumData ChecksumData { get; set; }
+
+        /// <summary>
+        /// The time which the request was signed at.
+        /// </summary>
+        DateTime? SignedAt { get; set; }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
@@ -66,7 +66,7 @@ namespace Amazon.Runtime.Internal
             try
             {
                 SetMetrics(executionContext.RequestContext);
-                IRequest wrappedRequest = executionContext.RequestContext.Request; 
+                IRequest wrappedRequest = executionContext.RequestContext.Request;
                 httpRequest = CreateWebRequest(executionContext.RequestContext);
                 httpRequest.SetRequestHeaders(wrappedRequest.Headers);
 

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
@@ -425,6 +425,7 @@ namespace Amazon.Runtime
             var isHead =
                 executionContext.RequestContext.Request != null &&
                 string.Equals(executionContext.RequestContext.Request.HttpMethod, "HEAD", StringComparison.Ordinal);
+            // ase.ErrorCode == null represents the case where it is a head request and there is no error code on the exception
             var isPossibleClockSkewErrorCode =
                 ase != null &&
                 (ase.ErrorCode == null || possibleClockSkewErrorCodes.Contains(ase.ErrorCode));


### PR DESCRIPTION
…es that weren't always clockskew related.

<!--- Provide a general summary of your changes in the Title above -->

In a previous PR to fix a clockskew related threading issue, we updated the list of error codes to retry on. This list was too exhaustive and included error codes such as `AuthFailure` which are not always clockskew related. To not break the previous threading related fix, I added a new property called `SignedAt` to the `IRequest` class. Whenever a request is signed, this value is also populated. 

This way we store the original time that the request was signed at, instead of calling `GetCorrectedUtcNowForEndpoint` inside the `IsClockSkew` method. The previous threading issue revolved around the fact that one thread may update the datetime returned by `GetCorrectedUtcNowForEndpoint` if 2 threads enter `IsClockSkew` simultaneously, leading to the request not being retried on one of the threads. By keeping track of the original time the request was signed at, we ensure that when we calculate the diff, we are using the time which that request was signed at and not one that was overwritten by a separate request in a separate thread.

The second change I made was to separate the `IsClockSkewErrorCode` into 2 lists, where one is guaranteed to be a clockskew error and another which might be a clockskew error. If it is a definite clockskew error we adjust the clockskew and retry. If it is a possible clockskew error we check the difference in `request.SignedAt` and the server time to determine if it is indeed clockskew related and only retry and update the clockskew in that scenario.

**Note**: When updating the clockskew we use the `servertime - correctedUtcNow()` because at this point we want to use the latest time, regardless of which thread we're on.



## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes issue #3463 
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've added unit tests for the exact scenario the user reports in the issue.
DRY_RUN PASSED
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement