### PR TITLE
Fix #3173 trim warning for Constant Class

### DIFF
--- a/generator/.DevConfigs/c96f3a9d-eeff-4b56-9f52-353e52dad6cc.json
+++ b/generator/.DevConfigs/c96f3a9d-eeff-4b56-9f52-353e52dad6cc.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Fix #3173. Add DynamicallyAccessedMembers to ConstantClass in Net8 to remove trim warnings."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/ConstantClass.cs
+++ b/sdk/src/Core/Amazon.Runtime/ConstantClass.cs
@@ -33,6 +33,9 @@ namespace Amazon.Runtime
     /// <summary>
     /// Base class for constant class that holds the value that will be sent to AWS for the static constants.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+#endif
     public class ConstantClass
     {
         static readonly object staticFieldsLock = new object();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
[ConstantClass's Intern method](https://github.com/aws/aws-sdk-net/blob/4aa0c67e587fb8e0b408dfd2d160be45e9888510/sdk/src/Core/Amazon.Runtime/ConstantClass.cs#L84) is not trim compatible because we cannot guarantee that the object returned by `GetType()` will have its public fields untrimmed, which `LoadFields` expects. Since we cannot directly annotate `System.GetType()`, we have to apply the `DynamicallyAccessedMembers` attribute to `ConstantClass` itself to guarantee that `LoadFields` will receive an object with its public fields untrimmed.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes #3173.
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
DRY_RUN successful
I created a simple console app with trimming enable and then ran `dotnet publish --sc -f net8.0` and the warning went away.
```
using Amazon;
using Amazon.SimpleSystemsManagement;
using Amazon.SimpleSystemsManagement.Model;

using (var simpleSystemsManagementClient = new AmazonSimpleSystemsManagementClient(RegionEndpoint.USWest2))
{
    var putResponse = await simpleSystemsManagementClient.PutParameterAsync(new PutParameterRequest()
    {
        Name = "something",
        Value = "something",
        Type = ParameterType.String,
        Overwrite = true,
    }).ConfigureAwait(false);
    var getParameterRequest = new GetParameterRequest()
    {
        Name = "something",
        WithDecryption = true,
    };
    var getParameterResponse = await simpleSystemsManagementClient.GetParameterAsync(getParameterRequest).ConfigureAwait(false);
}

```
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement