### PR TITLE
Fix bug with AWSSDK.Core's nuspec

### DIFF
--- a/generator/ServiceClientGeneratorLib/Generators/NuGet/CoreNuspec.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/NuGet/CoreNuspec.cs
@@ -15,7 +15,7 @@ namespace ServiceClientGenerator.Generators.NuGet
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\NuGet\CoreNuspec.tt"
+    #line 1 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\NuGet\CoreNuspec.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class CoreNuspec : CoreNuspecBase
     {
@@ -28,13 +28,13 @@ namespace ServiceClientGenerator.Generators.NuGet
             this.Write("\r\n<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<package> \r\n  <metadata> \r\n    <id>AWSS" +
                     "DK.Core</id>\r\n    <title>AWSSDK - Core Runtime</title>\r\n    <version>");
             
-            #line 9 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\NuGet\CoreNuspec.tt"
+            #line 9 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\NuGet\CoreNuspec.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Session["FileVersion"]));
             
             #line default
             #line hidden
             
-            #line 9 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\NuGet\CoreNuspec.tt"
+            #line 9 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\NuGet\CoreNuspec.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Session["NuGetPreviewFlag"]));
             
             #line default
@@ -48,7 +48,7 @@ namespace ServiceClientGenerator.Generators.NuGet
                     "n=\"4.5.1\" />\r\n        <dependency id=\"System.Memory\" version=\"4.5.5\" />\r\n       " +
                     " <dependency id=\"System.Text.Json\" version=\"8.0.4\" />\r\n      </group>\r\n      <gr" +
                     "oup targetFramework=\"netstandard2.0\">\r\n        <dependency id=\"Microsoft.Bcl.Asy" +
-                    "ncInterfaces\" version=\"1.1.0\" />\r\n        <dependency id=\"System.Buffers\" versio" +
+                    "ncInterfaces\" version=\"8.0.0\" />\r\n        <dependency id=\"System.Buffers\" versio" +
                     "n=\"4.5.1\" />\r\n        <dependency id=\"System.Memory\" version=\"4.5.5\" />\r\n       " +
                     " <dependency id=\"System.Text.Json\" version=\"8.0.4\" />\r\n      </group>\r\n      <gr" +
                     "oup targetFramework=\"netcoreapp3.1\">\r\n      </group>\r\n      <group targetFramewo" +

--- a/generator/ServiceClientGeneratorLib/Generators/NuGet/CoreNuspec.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/NuGet/CoreNuspec.tt
@@ -21,7 +21,7 @@
         <dependency id="System.Text.Json" version="8.0.4" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" />
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Memory" version="4.5.5" />
         <dependency id="System.Text.Json" version="8.0.4" />


### PR DESCRIPTION
## Description
In previous change for V4 the AWSSDK.Core project file was updated to reference version 8.0.0 of `Microsoft.Bcl.AsyncInterfaces` but the nuspec wasn't update and is still referencing version `1.1.0`. This causes downgrade compilation errors forcing applications to add the specific dependency of `Microsoft.Bcl.AsyncInterfaces`. 