### PR TITLE
Allow to remove TableNamePrefix on operation level

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -186,8 +186,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// Property that directs <see cref="DynamoDBContext"/> to prefix all table names
         /// with a specific string.
-        /// If property is null or empty, no prefix is used and default
-        /// table names are used.
+        /// If property is null, no prefix is used and default table names are used.
         /// </summary>
         public string TableNamePrefix { get; set; }
 
@@ -428,9 +427,7 @@ namespace Amazon.DynamoDBv2.DataModel
             bool retrieveDateTimeInUtc = operationConfig.RetrieveDateTimeInUtc ?? contextConfig.RetrieveDateTimeInUtc ?? false;
             bool isEmptyStringValueEnabled = operationConfig.IsEmptyStringValueEnabled ?? contextConfig.IsEmptyStringValueEnabled ?? false;
             DynamoDBEntryConversion conversion = operationConfig.Conversion ?? contextConfig.Conversion ?? DynamoDBEntryConversion.CurrentConversion;
-            string tableNamePrefix =
-                !string.IsNullOrEmpty(operationConfig.TableNamePrefix) ? operationConfig.TableNamePrefix :
-                !string.IsNullOrEmpty(contextConfig.TableNamePrefix) ? contextConfig.TableNamePrefix : string.Empty;
+            string tableNamePrefix = operationConfig.TableNamePrefix ?? contextConfig.TableNamePrefix ?? string.Empty;
 
             // These properties can only be set at the operation level
             bool disableFetchingTableMetadata = contextConfig.DisableFetchingTableMetadata ?? false;


### PR DESCRIPTION
Fixes #3470 

## Description
Allow to remove TableNamePrefix in operation-level configs by setting an empty string.

## Motivation and Context
In some cases I have most of the tables _with_ suffix, and one or two, which do not correspond to such convention. In this case I would like to be able to use TableNamePrefix globally, but remove it per operation.

## Testing
Added unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement