### PR TITLE
fix #3125. allow x-amz-tagging-directive to be set on copy object req…

### DIFF
--- a/generator/.DevConfigs/a200f517-2b4f-49fb-bf87-ef5e8c37b371.json
+++ b/generator/.DevConfigs/a200f517-2b4f-49fb-bf87-ef5e8c37b371.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fix #3125. Expose TaggingDirective, which controls x-amz-tagging-directive as a property on CopyObjectRequest."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
@@ -243,6 +243,7 @@ namespace Amazon.S3.Model
         private ServerSideEncryptionCustomerMethod copySourceServerSideCustomerEncryption;
         private string copySourceServerSideEncryptionCustomerProvidedKey;
         private string copySourceServerSideEncryptionCustomerProvidedKeyMD5;
+        private TaggingDirective taggingDirective = TaggingDirective.COPY;
 
         private bool disableTrimmingLeadingSlash = false;
 
@@ -1089,6 +1090,29 @@ namespace Amazon.S3.Model
         {
             get { return this.disableTrimmingLeadingSlash; }
             set { this.disableTrimmingLeadingSlash = value; }
+        }
+
+        /// <summary>
+        /// Specifies whether the object tag-set is copied from the source object or replaced with the tag-set that's provided in the request.
+        /// <para>
+        /// The default value is COPY. You can change the value and decide not to send this header at all if you are working with a service that doesn't 
+        /// have an implementation for this header yet.
+        /// </para>
+        /// <para>
+        /// For directory buckets in a CopyObject operation, only the empty tag-set is supported. 
+        /// Any requests that attempt to write non-empty tags into directory buckets will receive a 501 Not Implemented status code.
+        /// </para>
+        /// </summary>
+        public TaggingDirective TaggingDirective
+        {
+            get { return this.taggingDirective; }
+            set { this.taggingDirective = value; }
+        }
+        
+        // Check to see if TaggingDirective property is set
+        internal bool IsSetTaggingDirective()
+        {
+            return this.taggingDirective != null; 
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
@@ -243,7 +243,7 @@ namespace Amazon.S3.Model
         private ServerSideEncryptionCustomerMethod copySourceServerSideCustomerEncryption;
         private string copySourceServerSideEncryptionCustomerProvidedKey;
         private string copySourceServerSideEncryptionCustomerProvidedKeyMD5;
-        private TaggingDirective taggingDirective = TaggingDirective.COPY;
+        private TaggingDirective taggingDirective;
 
         private bool disableTrimmingLeadingSlash = false;
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
@@ -73,15 +73,17 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             if (copyObjectRequest.IsSetUnmodifiedSinceDateUtc())
                 request.Headers.Add(HeaderKeys.XAmzCopySourceIfUnmodifiedSinceHeader, S3Transforms.ToStringValue(copyObjectRequest.UnmodifiedSinceDateUtc.Value));
-
-            if (copyObjectRequest.IsSetTagSet())
+            
+            if (copyObjectRequest.IsSetTaggingDirective())
             {
-                request.Headers.Add(S3Constants.AmzHeaderTagging, AmazonS3Util.TagSetToQueryString(copyObjectRequest.TagSet));
-                request.Headers.Add(S3Constants.AmzHeaderTaggingDirective, TaggingDirective.REPLACE.Value);
-            }
-            else
-            {
-                request.Headers.Add(S3Constants.AmzHeaderTaggingDirective, TaggingDirective.COPY.Value);
+                if (copyObjectRequest.TaggingDirective == TaggingDirective.REPLACE)
+                {
+                    if (copyObjectRequest.IsSetTagSet())
+                        request.Headers.Add(S3Constants.AmzHeaderTagging, AmazonS3Util.TagSetToQueryString(copyObjectRequest.TagSet));
+                    request.Headers.Add(S3Constants.AmzHeaderTaggingDirective, TaggingDirective.REPLACE.Value);
+                }
+                else if (copyObjectRequest.TaggingDirective == TaggingDirective.COPY)
+                    request.Headers.Add(S3Constants.AmzHeaderTaggingDirective, TaggingDirective.COPY.Value);
             }
 
             request.Headers.Add(HeaderKeys.XAmzMetadataDirectiveHeader, S3Transforms.ToStringValue(copyObjectRequest.MetadataDirective.ToString()));

--- a/sdk/src/Services/S3/Custom/S3Enumerations.cs
+++ b/sdk/src/Services/S3/Custom/S3Enumerations.cs
@@ -1703,7 +1703,7 @@ namespace Amazon.S3
     /// <summary>
     /// Specifies whether the object tag-set are copied from the source object or replaced with tag-set provided in the request.
     /// </summary>
-    internal sealed class TaggingDirective : ConstantClass
+    public sealed class TaggingDirective : ConstantClass
     {
         /// <summary>
         /// The object tag-set is copied from the source object.


### PR DESCRIPTION
…uests

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 According to the docs, `TaggingDirective` is a property that the user should be able to set on a copy object request. This PR exposes that property. Even though the default value is COPY as noted in [the docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html), we also allow a user to set it as null in case they are using an s3-compatible api.

`TaggingDirective` and the `TagSet` are designed to be used together according to [this description](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_RequestSyntax) of `x-amz-tagging`. 

This PR 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
DOTNET-7535
Addresses #3125.
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
DRY_RUN passes
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement