### PR TITLE
Adds TryAddDefaultAWSOptions to AWSSDK.Extensions.NETCore.Setup

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
@@ -64,6 +64,38 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Adds the AWSOptions object to the dependency injection framework providing information
+        /// that will be used to construct Amazon service clients if they haven't already been registered.
+        /// </summary>
+        /// <param name="collection"></param>
+        /// <param name="options">The default AWS options used to construct AWS service clients with.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection TryAddDefaultAWSOptions(this IServiceCollection collection, AWSOptions options)
+        {
+            collection.TryAdd(new ServiceDescriptor(typeof(AWSOptions), options));
+            return collection;
+        }
+
+        /// <summary>
+        /// Adds the AWSOptions object to the dependency injection framework providing information
+        /// that will be used to construct Amazon service clients if they haven't already been registered.
+        /// </summary>
+        /// <param name="collection"></param>
+        /// <param name="implementationFactory">The factory that creates the default AWS options.
+        /// The AWS options will be used to construct AWS service clients
+        /// </param>
+        /// <param name="lifetime">The lifetime of the AWSOptions. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection TryAddDefaultAWSOptions(
+            this IServiceCollection collection, 
+            Func<IServiceProvider, AWSOptions> implementationFactory, 
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        {
+            collection.TryAdd(new ServiceDescriptor(typeof(AWSOptions), implementationFactory, lifetime));
+            return collection;
+        }
+
+        /// <summary>
         /// Adds the Amazon service client to the dependency injection framework. The Amazon service client is not
         /// created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
         /// instance will be reused for the lifetime of the process and the object should not be disposed.

--- a/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
+++ b/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
@@ -14,6 +14,48 @@ namespace DependencyInjectionTests
     public class DependencyInjectionTests
     {
         [Fact]
+        public void TryAddDefaultConfigDontOverrideWhenAlreadySetup()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+
+            var mockOptions = Mock.Of<AWSOptions>();
+
+            services.AddDefaultAWSOptions(mockOptions);
+            services.TryAddDefaultAWSOptions(config.GetAWSOptions());
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var options = serviceProvider.GetService<AWSOptions>();
+            Assert.True(object.ReferenceEquals(options, mockOptions));
+        }
+
+        [Fact]
+        public void TryAddDefaultConfigWithFunctionDontOverrideWhenAlreadySetup()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+
+            var mockOptions = Mock.Of<AWSOptions>();
+
+            services.AddDefaultAWSOptions(mockOptions);
+            services.TryAddDefaultAWSOptions(s => config.GetAWSOptions());
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var options = serviceProvider.GetService<AWSOptions>();
+            Assert.True(object.ReferenceEquals(options, mockOptions));
+        }
+
+        [Fact]
         public void InjectS3ClientWithDefaultConfig()
         {
             var builder = new ConfigurationBuilder();


### PR DESCRIPTION
Closes #3481 

## Description
`Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddDefaultAWSOptions` always registers `AWSOptions` even if there was a previous registration.

## Motivation and Context
Code using does not need to worry if the options have already been registered.

## Testing
Unit tests added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement