### PR TITLE
Add resolving basic credentials from configuration in AWSSDK.Extensions.NETCore.Setup

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
@@ -360,6 +360,13 @@ namespace Microsoft.Extensions.Configuration
                 options.ExternalId = section["ExternalId"];
             }
 
+            var accessKey = section["Credentials:AccessKey"];
+            var secretKey = section["Credentials:SecretKey"];
+            if (!string.IsNullOrEmpty(accessKey) & !string.IsNullOrEmpty(secretKey))
+            {
+                options.Credentials = new BasicAWSCredentials(accessKey, secretKey);
+            }
+
             var loggingSection = section.GetSection(LoggingKey);
             if(loggingSection != null)
             {

--- a/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
+++ b/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
@@ -271,5 +271,30 @@ namespace NETCore.SetupTests
             Assert.Equal(TimeSpan.FromMilliseconds(100), serviceConfig.TimeLength);
             Assert.Equal(TimeSpan.FromMilliseconds(200), serviceConfig.NullableTimeLength);
         }
+
+        [Fact]
+        public void GetCredentials()
+        {
+            var accessKey = Guid.NewGuid().ToString("N");
+            var secretKey = Guid.NewGuid().ToString("N");
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new KeyValuePair<string, string?>[]
+                {
+                    new KeyValuePair<string, string?>("AWS:Credentials:AccessKey", accessKey),
+                    new KeyValuePair<string, string?>("AWS:Credentials:SecretKey", secretKey),
+                })
+                .Build();
+
+            var options = config.GetAWSOptions();
+
+            Assert.NotNull(options);
+            Assert.NotNull(options.Credentials);
+            Assert.IsType<BasicAWSCredentials>(options.Credentials);
+
+            var credentials = options.Credentials.GetCredentials();
+            Assert.Equal(accessKey, credentials.AccessKey);
+            Assert.Equal(secretKey, credentials.SecretKey);
+        }
     }
 }


### PR DESCRIPTION
Closes #3480 

## Description
`Amazon.Extensions.NETCore.Setup.ClientFactory<T>.CreateCredentials(ILogger, AWSOptions)`, when no credentials or profile are provided in the `AWSOptions`, uses `Amazon.Runtime.FallbackCredentialsFactory.GetCredentials()` to resolve credentials using:

1. `AppConfigAWSCredentials` on .NET Framework
2. `AssumeRoleWithWebIdentityCredentials.FromEnvironmentVariables()`
3. From a credential profile chain
4. From environment variables: `EnvironmentVariablesAWSCredentials`
5. From EC2 environment variables

It's not uncommon that on-prem non-containerized applications use the configuration file to store all configuration.

`Microsoft.Extensions.Configuration.ConfigurationExtensions.GetAWSOptions` could resolve basic AWS credentials from the configuration.

## Motivation and Context

appssettings.json:

```json
{
  "AWS": {
    "Credentials": {
      "AccessKey": "<accessKey>",
      "SecretKey": "<secretKey>"
    }
```

```csharp
var awsOptions = configuration.GetAWSOptions();
// awsOptions.Credentials has a BasicAWSCredentials with accessKey and secretKey
```

## Testing
Unit tests added.



## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement