### PR TITLE
Revert "Ignore integration tests for S3 Select"

### DIFF
--- a/sdk/test/Services/S3/IntegrationTests/SelectObjectContentTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/SelectObjectContentTests.cs
@@ -35,7 +35,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 {
     [TestClass]
-    [Ignore("S3 Select is not available to new customers so these tests cannot run on new accounts")]
     public class SelectObjectContentTests : TestBase<AmazonS3Client>
     {
         private static readonly string TestFileKey = "selectobjectcontent_content.txt";


### PR DESCRIPTION
This reverts commit 679eff58394cb01b970bab9da12857224899339c.

## Description
S3 has allow-listed our accounts to keep using S3 Select, so this PR re-enables the tests that failed during the preview 2 release.

## Testing
- Ran tests locally using the testing account credentials.

## License
- [X] I confirm that this pull request can be released under the Apache 2 license