### PR TITLE
Check for null collections in AmazonEC2ResponseHandler

### DIFF
--- a/sdk/src/Services/EC2/Custom/Internal/AmazonEC2ResponseHandler.cs
+++ b/sdk/src/Services/EC2/Custom/Internal/AmazonEC2ResponseHandler.cs
@@ -204,12 +204,18 @@ namespace Amazon.EC2.Internal
         {
             foreach (var ipPermission in ipPermissions)
             {
+                if (ipPermission.Ipv4Ranges == null)
+                {
+                    continue;
+                }
+
 #pragma warning disable CS0612,CS0618
                 ipPermission.IpRanges = ipPermission.Ipv4Ranges.Select(i => i.CidrIp).ToList();
 #pragma warning restore CS0612,CS0618
                 ipPermission.CopyIpv4RangesToInternalCollection(ipPermission.Ipv4Ranges);
             }
         }
+
         /// <summary>
         /// The original values used by the customer in the Ipv4Ranges property on the request 
         /// object is restored. This is done when the customer is using the deprecated IpRanges property.
@@ -219,39 +225,42 @@ namespace Amazon.EC2.Internal
         {
             foreach (var ipPermission in IpPermissions)
             {
-                if(ipPermission.RestoreOldIpV4Range)
+                if (ipPermission.RestoreOldIpV4Range)
                 {
                     ipPermission.Ipv4Ranges = ipPermission.PreIpv4Ranges;
                     ipPermission.RestoreOldIpV4Range = false;
                 }
-                    
             }
         }
 
         private static void PopulateLaunchSpecificationSecurityGroupNames(LaunchSpecification launchSpecification)
         {
-            if (launchSpecification != null)
+            if (launchSpecification == null || launchSpecification.AllSecurityGroups == null)
             {
-                var groupNames = new List<string>();
-                foreach (GroupIdentifier group in launchSpecification.AllSecurityGroups)
-                {
-                    groupNames.Add(group.GroupName);
-                }
-                launchSpecification.SecurityGroups = groupNames;
+                return;
             }
+
+            var groupNames = new List<string>();
+            foreach (GroupIdentifier group in launchSpecification.AllSecurityGroups)
+            {
+                groupNames.Add(group.GroupName);
+            }
+            launchSpecification.SecurityGroups = groupNames;
         }
 
         private static void PopulateReservationSecurityGroupNames(Reservation reservation)
         {
-            if (reservation != null)
+            if (reservation == null || reservation.Groups == null)
             {
-                var groupNames = new List<string>();
-                foreach (GroupIdentifier group in reservation.Groups)
-                {
-                    groupNames.Add(group.GroupName);
-                }
-                reservation.GroupNames = groupNames;
+                return;
             }
+
+            var groupNames = new List<string>();
+            foreach (GroupIdentifier group in reservation.Groups)
+            {
+                groupNames.Add(group.GroupName);
+            }
+            reservation.GroupNames = groupNames;
         }
     }
 }


### PR DESCRIPTION
## Description
Updates the `AmazonEC2ResponseHandler` class to handle null collections when populating legacy fields (e.g. `Ipv4Ranges` to `IpRanges`). As discussed internally, we can even remove these before GA, but that'll be addressed in a separate task / PR.

## Testing
- Dry-run: `DRY_RUN-efd5cd23-acb5-41cb-b31e-1f99acde78b2`
- Ran example and confirmed exception is not thrown:
```csharp
var request = new DescribeSecurityGroupsRequest();
var client = new AmazonEC2Client(RegionEndpoint.USEast1);
var groups = await client.Paginators
    .DescribeSecurityGroups(request)
    .SecurityGroups
    .ToListAsync();
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
