### PR TITLE
Fix: Handle missing ResponseMetadata gracefully in MetricsHandler

### DIFF
--- a/generator/.DevConfigs/add8bc2d-45f6-476a-8506-1ee6acc55d37.json
+++ b/generator/.DevConfigs/add8bc2d-45f6-476a-8506-1ee6acc55d37.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Fix NullReferenceException in MetricsHandler when ResponseMetadata is null"
+    ],
+    "type": "patch",
+    "updateMinimum": false
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/MetricsHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/MetricsHandler.cs
@@ -42,16 +42,18 @@ namespace Amazon.Runtime.Internal
             var spanName = $"{executionContext.RequestContext.ServiceMetaData.ServiceId}.{operationName}";
             var span = TracingUtilities.CreateSpan(executionContext.RequestContext, spanName, null, SpanKind.CLIENT);
             IDisposable callDurationMetricsMeasurer = null;
-            
+
             try
             {
                 callDurationMetricsMeasurer = MetricsUtilities.MeasureDuration(executionContext.RequestContext, TelemetryConstants.CallDurationMetricName);
                 executionContext.RequestContext.Metrics.StartEvent(Metric.ClientExecuteTime);
                 base.InvokeSync(executionContext);
 
-                span.SetAttribute(TelemetryConstants.RequestIdAttributeKey, executionContext.ResponseContext.Response.ResponseMetadata.RequestId);
+                var requestId = executionContext.ResponseContext.Response.ResponseMetadata?.RequestId;
+                if (requestId != null)
+                    span.SetAttribute(TelemetryConstants.RequestIdAttributeKey, requestId);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 span.CaptureException(ex);
                 MetricsUtilities.RecordError(executionContext.RequestContext, ex);
@@ -91,7 +93,10 @@ namespace Amazon.Runtime.Internal
                 executionContext.RequestContext.Metrics.StartEvent(Metric.ClientExecuteTime);
                 var response = await base.InvokeAsync<T>(executionContext).ConfigureAwait(false);
 
-                span.SetAttribute(TelemetryConstants.RequestIdAttributeKey, executionContext.ResponseContext.Response.ResponseMetadata.RequestId);
+                var requestId = executionContext.ResponseContext.Response.ResponseMetadata?.RequestId;
+                if (requestId != null)
+                    span.SetAttribute(TelemetryConstants.RequestIdAttributeKey, requestId);
+
                 return response;
             }
             catch (Exception ex)


### PR DESCRIPTION
## Description
Fix: Handle missing ResponseMetadata gracefully in MetricsHandler

## Motivation and Context
Resolves [#3493](https://github.com/aws/aws-sdk-net/issues/3493), where certain HTTP client interception libraries could cause `ResponseMetadata` to be omitted from the response.
This fix ensures that the `MetricsHandler` will silently continue operations even if `ResponseMetadata` is missing since it is only used for adding a span attribute which can be omitted if necessary.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`DRY_RUN-917a1f99-d457-4cab-8a80-59d167cb83dd`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement