### PR TITLE
Docs: [API Ref] Support More Complicated <inheritdoc/> Syntax

### DIFF
--- a/docgenerator/SDKDocGeneratorLib/Writers/BaseWriter.cs
+++ b/docgenerator/SDKDocGeneratorLib/Writers/BaseWriter.cs
@@ -517,10 +517,10 @@ namespace SDKDocGenerator.Writers
         {
             AddSectionHeader(writer, "Version Information");
             
-            var docs472 = NDocUtilities.FindDocumentation(Artifacts.NDocForPlatform("net472"), wrapper);
-            var docsCore20 = NDocUtilities.FindDocumentation(Artifacts.NDocForPlatform("netstandard2.0"), wrapper);
-            var docsNetCoreApp31 = NDocUtilities.FindDocumentation(Artifacts.NDocForPlatform("netcoreapp3.1"), wrapper);
-            var docsNet80 = NDocUtilities.FindDocumentation(Artifacts.NDocForPlatform("net8.0"), wrapper);
+            var docs472 = NDocUtilities.FindDocumentation(Artifacts.NDocForPlatform("net472"), wrapper, TypeProvider);
+            var docsCore20 = NDocUtilities.FindDocumentation(Artifacts.NDocForPlatform("netstandard2.0"), wrapper, TypeProvider);
+            var docsNetCoreApp31 = NDocUtilities.FindDocumentation(Artifacts.NDocForPlatform("netcoreapp3.1"), wrapper, TypeProvider);
+            var docsNet80 = NDocUtilities.FindDocumentation(Artifacts.NDocForPlatform("net8.0"), wrapper, TypeProvider);
 
             // If there is no documentation then assume it is available for all platforms.
             var boolNoDocs = docs472 == null && docsCore20 == null && docsNetCoreApp31 == null

--- a/docgenerator/SDKDocGeneratorLib/Writers/ClassWriter.cs
+++ b/docgenerator/SDKDocGeneratorLib/Writers/ClassWriter.cs
@@ -83,7 +83,7 @@ namespace SDKDocGenerator.Writers
 
         protected override XElement GetSummaryDocumentation()
         {
-            var element = NDocUtilities.FindDocumentation(this._versionType);
+            var element = NDocUtilities.FindDocumentation(this._versionType, TypeProvider);
             return element;
         }
 
@@ -155,7 +155,7 @@ namespace SDKDocGenerator.Writers
 
             writer.WriteLine("<td>");
 
-            var docs = NDocUtilities.FindDocumentation(info);
+            var docs = NDocUtilities.FindDocumentation(info, TypeProvider);
             var html = NDocUtilities.TransformDocumentationToHTML(docs, "summary", this.Artifacts.ManifestAssemblyContext.SdkAssembly, this._version);
 
             writer.WriteLine(html);
@@ -206,7 +206,7 @@ namespace SDKDocGenerator.Writers
                 html = string.Format("Inherited from {0}.{1}.", propertyInfo.DeclaringType.Namespace, propertyInfo.DeclaringType.Name);
             }
             else {
-                var docs = NDocUtilities.FindDocumentation(propertyInfo);
+                var docs = NDocUtilities.FindDocumentation(propertyInfo, TypeProvider);
                 html = NDocUtilities.TransformDocumentationToHTML(docs, "summary", Artifacts.ManifestAssemblyContext.SdkAssembly, this._version);
             }
 
@@ -262,7 +262,7 @@ namespace SDKDocGenerator.Writers
                 html = string.Format("Inherited from {0}.{1}.", info.DeclaringType.Namespace, info.DeclaringType.Name);
             }
             else {
-                var docs = NDocUtilities.FindDocumentation(info);
+                var docs = NDocUtilities.FindDocumentation(info, TypeProvider);
                 html = NDocUtilities.TransformDocumentationToHTML(docs, "summary", Artifacts.ManifestAssemblyContext.SdkAssembly, this._version);
             }
             writer.WriteLine(html);
@@ -310,7 +310,7 @@ namespace SDKDocGenerator.Writers
                 html = string.Format("Inherited from {0}.{1}.", info.DeclaringType.Namespace, info.DeclaringType.Name);
             }
             else {
-                var docs = NDocUtilities.FindDocumentation(info);
+                var docs = NDocUtilities.FindDocumentation(info, TypeProvider);
                 html = NDocUtilities.TransformDocumentationToHTML(docs, "summary", Artifacts.ManifestAssemblyContext.SdkAssembly, this._version);
             }
 
@@ -360,7 +360,7 @@ namespace SDKDocGenerator.Writers
                 html = string.Format("Inherited from {0}.{1}.", info.DeclaringType.Namespace, info.DeclaringType.Name);
             }
             else {
-                var docs = NDocUtilities.FindDocumentation(info);
+                var docs = NDocUtilities.FindDocumentation(info, TypeProvider);
                 html = NDocUtilities.TransformDocumentationToHTML(docs, "summary", Artifacts.ManifestAssemblyContext.SdkAssembly, this._version);
             }
 

--- a/docgenerator/SDKDocGeneratorLib/Writers/ConstructorWriter.cs
+++ b/docgenerator/SDKDocGeneratorLib/Writers/ConstructorWriter.cs
@@ -59,7 +59,7 @@ namespace SDKDocGenerator.Writers
 
         protected override XElement GetSummaryDocumentation()
         {
-            var element = NDocUtilities.FindDocumentation(this._constructorInfo);
+            var element = NDocUtilities.FindDocumentation(this._constructorInfo, TypeProvider);
             return element;
         }
 

--- a/docgenerator/SDKDocGeneratorLib/Writers/EventWriter.cs
+++ b/docgenerator/SDKDocGeneratorLib/Writers/EventWriter.cs
@@ -49,7 +49,7 @@ namespace SDKDocGenerator.Writers
 
         protected override XElement GetSummaryDocumentation()
         {
-            var element = NDocUtilities.FindDocumentation(this._eventInfo);
+            var element = NDocUtilities.FindDocumentation(this._eventInfo, TypeProvider);
             return element;
         }
 

--- a/docgenerator/SDKDocGeneratorLib/Writers/FieldWriter.cs
+++ b/docgenerator/SDKDocGeneratorLib/Writers/FieldWriter.cs
@@ -49,7 +49,7 @@ namespace SDKDocGenerator.Writers
 
         protected override XElement GetSummaryDocumentation()
         {
-            var element = NDocUtilities.FindDocumentation(this._fieldInfo);
+            var element = NDocUtilities.FindDocumentation(this._fieldInfo, TypeProvider);
             return element;
         }
 

--- a/docgenerator/SDKDocGeneratorLib/Writers/MethodWriter.cs
+++ b/docgenerator/SDKDocGeneratorLib/Writers/MethodWriter.cs
@@ -29,7 +29,7 @@ namespace SDKDocGenerator.Writers
             if (_isFakeAsync || !this._methodInfo.Name.EndsWith("Async", StringComparison.Ordinal))
             {
                 //This is not an Async method. Lookup if an Async version exists for .NET Core.                
-                this._hasAsyncVersion = NDocUtilities.FindDocumentationAsync(Artifacts.NDocForPlatform("netcoreapp3.1"), methodInfo) != null;
+                this._hasAsyncVersion = NDocUtilities.FindDocumentationAsync(Artifacts.NDocForPlatform("netcoreapp3.1"), methodInfo, TypeProvider) != null;
             }                
         }
 
@@ -69,7 +69,7 @@ namespace SDKDocGenerator.Writers
 
         protected override XElement GetSummaryDocumentation()
         {
-            var element = NDocUtilities.FindDocumentation(this._methodInfo);
+            var element = NDocUtilities.FindDocumentation(this._methodInfo, TypeProvider);
             return element;
         }
 

--- a/docgenerator/SDKDocGeneratorLib/Writers/NamespaceWriter.cs
+++ b/docgenerator/SDKDocGeneratorLib/Writers/NamespaceWriter.cs
@@ -130,7 +130,7 @@ namespace SDKDocGenerator.Writers
 
                 writer.WriteLine("<td>");
 
-                    var docs = NDocUtilities.FindDocumentation(NDocUtilities.GetDocumentationInstance(info.DocId), info);
+                    var docs = NDocUtilities.FindDocumentation(NDocUtilities.GetDocumentationInstance(info.DocId), info, TypeProvider);
                     var html = NDocUtilities.TransformDocumentationToHTML(docs, "summary", Artifacts.ManifestAssemblyContext.SdkAssembly, this._version);
 
                     writer.WriteLine(html);

--- a/docgenerator/SDKDocGeneratorLib/Writers/PropertyWriter.cs
+++ b/docgenerator/SDKDocGeneratorLib/Writers/PropertyWriter.cs
@@ -49,7 +49,7 @@ namespace SDKDocGenerator.Writers
 
         protected override XElement GetSummaryDocumentation()
         {
-            var element = NDocUtilities.FindDocumentation(this._propertyInfo);
+            var element = NDocUtilities.FindDocumentation(this._propertyInfo, TypeProvider);
             return element;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support cref and path attributes in inheritdoc tags.

## Motivation and Context
`DOTNET-7684` In .NET's XML comments, you can apply `<inheritdoc/>` to a class/method/property to inherit the comments from the interface or base class which was supported in [a previous PR](https://github.com/aws/aws-sdk-net/pull/3390).
This PR adds support for the cref and path in inheritdoc tags.

## Testing
Built the full docs and compared them to the docs repo, and here are the differences
![image](https://github.com/user-attachments/assets/f6ff44c7-7379-4f21-9b10-d2874167ab30)

Related to this `cref` attribute in the code
![image](https://github.com/user-attachments/assets/33f30096-e075-4fde-b1f7-531752cfa028)

* Before
![image](https://github.com/user-attachments/assets/19403e03-e20e-4cd1-aa1c-8f20615173ec)
![image](https://github.com/user-attachments/assets/b8d8587d-d018-46e2-9760-12e035e08cad)

* After
![image](https://github.com/user-attachments/assets/2df72064-995e-4af0-847f-4f824839a311)
![image](https://github.com/user-attachments/assets/178a5d59-1c74-42e1-adc8-63a528628acf)



Adding unit tests to test this feature will require allot of setup that I'm not sure is justified only to test this change. So instead I added this class while testing to cover all the cref and path cases since we don't have all of these cases in our code yet.
![image](https://github.com/user-attachments/assets/61239d86-3a34-4661-a8bd-574b145a2538)
![image](https://github.com/user-attachments/assets/880d2abf-b7ba-45b8-9c9c-ac927994e483)

And here are the cases that was tested and how this reflected in the generated documentation:
* `inheritdoc` with `path` tag for class definition.
![image](https://github.com/user-attachments/assets/31e83967-abb4-4be2-a4f0-35dcc36be1a4)

* `inheritdoc` with `cref` and `path` attributes, and multiple level inheritance. 
![image](https://github.com/user-attachments/assets/6877e9be-ad1d-4970-81e4-9203cfd6caa0)

* `inheritdoc` without any attributes for methods.
![image](https://github.com/user-attachments/assets/bd95955c-28a4-452f-8305-55abd927b119)

* `inheritdoc` with `path` attribute for methods.
![image](https://github.com/user-attachments/assets/1a4332c8-9c13-4145-b62e-fa6a8a508745)

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement