### PR TITLE
Optimize `Metrics.IncrementCounter()` for .NET 8+

### DIFF
--- a/sdk/test/NetStandard/UnitTests/MetricsTests.cs
+++ b/sdk/test/NetStandard/UnitTests/MetricsTests.cs
@@ -1,0 +1,37 @@
+﻿using Amazon.Runtime;
+using Amazon.Runtime.Internal.Util;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UnitTests.NetStandard
+{
+    [Trait("Category", "Core")]
+    public class MetricsTests
+    {
+        [Fact]
+        public void IncrementCounter()
+        {
+            var metrics = new RequestMetrics() { IsEnabled = true };
+
+            for (var i = 0; i < 1000; i++)
+            {
+                metrics.IncrementCounter(Metric.AttemptCount);
+            }
+
+            Assert.Equal(1000, metrics.Counters[Metric.AttemptCount]);
+        }
+
+        [Fact]
+        public void IncrementCounterConcurrently()
+        {
+            var metrics = new RequestMetrics() { IsEnabled = true };
+
+            Parallel.For(0, 1000, (i) =>
+            {
+                metrics.IncrementCounter(Metric.AttemptCount);
+            });
+
+            Assert.Equal(1000, metrics.Counters[Metric.AttemptCount]);
+        }
+    }
+}

--- a/sdk/test/UnitTests/Custom/Util/MetricsTests.cs
+++ b/sdk/test/UnitTests/Custom/Util/MetricsTests.cs
@@ -1,0 +1,39 @@
+﻿using Amazon.Runtime;
+using Amazon.Runtime.Internal.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+
+namespace AWSSDK.UnitTests.Custom.NetFramework.Custom.Util
+{
+    [TestClass]
+    [TestCategory("UnitTest")]
+    [TestCategory("Util")]
+    public class MetricsTests
+    {
+        [TestMethod]
+        public void IncrementCounter()
+        {
+            var metrics = new RequestMetrics() { IsEnabled = true };
+
+            for (var i = 0; i < 1000; i++)
+            {
+                metrics.IncrementCounter(Metric.AttemptCount);
+            }
+
+            Assert.AreEqual(1000, metrics.Counters[Metric.AttemptCount]);
+        }
+
+        [TestMethod]
+        public void IncrementCounterConcurrently()
+        {
+            var metrics = new RequestMetrics() { IsEnabled = true };
+
+            Parallel.For(0, 1000, (i) =>
+            {
+                metrics.IncrementCounter(Metric.AttemptCount);
+            });
+
+            Assert.AreEqual(1000, metrics.Counters[Metric.AttemptCount]);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Optimize the performance of `Metrics.IncrementCounter()` on .NET 8+ by using the ref-returning `CollectionsMarshal.GetValueRefOrAddDefault()`. To my knowledge, the `lock` statement is still needed owing to the [following remark in the documentation](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.collectionsmarshal.getvaluereforadddefault?view=net-8.0)

> Items should not be added to or removed from the [Dictionary<TKey,TValue>](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2?view=net-8.0) while the ref TValue is in use.

## Motivation and Context
Metrics counters tend to be called a lot. The optimized version is also less code.

## Testing
Unit tests covering both sequential and concurrent scenarios.

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/0a2c2a56-c08a-459f-9be3-d09409a59ede)

## Benchmarks

<details>
  <summary>Benchmark Code</summary>
  
  ```csharp
public class DictionaryIncrement
{
    private object metricsLock = new object();
    private readonly Dictionary<string,long> Counters = new Dictionary<string,long>();
    private string metric;

    [GlobalSetup]
    public void Setup()
    {
        metric = "foo";
    }

    [Benchmark(Baseline = true)]
    public void Original()
    {
        lock (metricsLock)
        {
            long value;
            if (!Counters.TryGetValue(metric, out value))
            {
                value = 1;
            }
            else
            {
                value++;
            }
            Counters[metric] = value;
        }
    }

    [Benchmark]
    public void Optimized()
    {
        lock (metricsLock)
        {
            ref long value = ref CollectionsMarshal.GetValueRefOrAddDefault(Counters, metric, out _);
            value++;
        }
    }
}
  ```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement