### PR TITLE
fix: Add missing NewerNoncurrentVersions to PutLifecycleConfigurationRequestMarshall

### DIFF
--- a/generator/.DevConfigs/78e0b691-e434-47d4-9e53-d63e12ae1407.json
+++ b/generator/.DevConfigs/78e0b691-e434-47d4-9e53-d63e12ae1407.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "fix: Add missing NewerNoncurrentVersions to PutLifecycleConfigurationRequestMarshall"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutLifecycleConfigurationRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutLifecycleConfigurationRequestMarshaller.cs
@@ -57,7 +57,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             request.AddSubResource("lifecycle");
 
             var stringWriter = new XMLEncodedStringWriter(System.Globalization.CultureInfo.InvariantCulture);
-            using (var xmlWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings(){Encoding = Encoding.UTF8, OmitXmlDeclaration = true, NewLineHandling = NewLineHandling.Entitize }))
+            using (var xmlWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings() { Encoding = Encoding.UTF8, OmitXmlDeclaration = true, NewLineHandling = NewLineHandling.Entitize }))
             {
                 var lifecycleConfigurationLifecycleConfiguration = putLifecycleConfigurationRequest.Configuration;
                 if (lifecycleConfigurationLifecycleConfiguration != null)
@@ -137,6 +137,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                             if (noncurrentVersionTransition != null)
                                             {
                                                 xmlWriter.WriteStartElement("NoncurrentVersionTransition");
+                                                if (noncurrentVersionTransition.IsSetNewerNoncurrentVersions())
+                                                {
+                                                    xmlWriter.WriteElementString("NewerNoncurrentVersions", S3Transforms.ToXmlStringValue(noncurrentVersionTransition.NewerNoncurrentVersions));
+                                                }
                                                 if (noncurrentVersionTransition.IsSetNoncurrentDays())
                                                 {
                                                     xmlWriter.WriteElementString("NoncurrentDays", S3Transforms.ToXmlStringValue(noncurrentVersionTransition.NoncurrentDays));

--- a/sdk/test/Services/S3/IntegrationTests/LifecycleTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/LifecycleTests.cs
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
- using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -97,9 +97,13 @@ namespace S3UnitTest
                 {
                     new LifecycleRule
                     {
-#pragma warning disable 618
-                        Prefix = "rule1-",
-#pragma warning restore 618
+                        Filter = new LifecycleFilter
+                        {
+                            LifecycleFilterPredicate = new LifecyclePrefixPredicate()
+                            {
+                                Prefix = "rule1-"
+                            }
+                        },
                         Status = LifecycleRuleStatus.Enabled,
                         Expiration = new LifecycleRuleExpiration
                         {
@@ -114,6 +118,7 @@ namespace S3UnitTest
                         NoncurrentVersionTransition = new LifecycleRuleNoncurrentVersionTransition
                         {
                             NoncurrentDays = 14,
+                            NewerNoncurrentVersions = 10,
                             StorageClass = S3StorageClass.Glacier
                         },
 #pragma warning restore 618
@@ -124,9 +129,13 @@ namespace S3UnitTest
                     },
                     new LifecycleRule
                     {
-#pragma warning disable 618
-                        Prefix = "rule2-",
-#pragma warning restore 618
+                        Filter = new LifecycleFilter
+                        {
+                            LifecycleFilterPredicate = new LifecyclePrefixPredicate()
+                            {
+                                Prefix = "rule2-"
+                            }
+                        },
                         Expiration = new LifecycleRuleExpiration
                         {
                             Days = 120
@@ -149,21 +158,27 @@ namespace S3UnitTest
                             new LifecycleRuleNoncurrentVersionTransition
                             {
                                 NoncurrentDays = 30,
+                                NewerNoncurrentVersions = 20,
                                 StorageClass = S3StorageClass.StandardInfrequentAccess
                             },
                             new LifecycleRuleNoncurrentVersionTransition
                             {
                                 NoncurrentDays = 90,
+                                NewerNoncurrentVersions = 50,
                                 StorageClass = S3StorageClass.Glacier
                             }
                         }
                     },
                     new LifecycleRule
                     {
-#pragma warning disable 618
-                        Prefix = "rule3-",
-#pragma warning restore 618
-                        Expiration = new LifecycleRuleExpiration 
+                        Filter = new LifecycleFilter
+                        {
+                            LifecycleFilterPredicate = new LifecyclePrefixPredicate()
+                            {
+                                Prefix = "rule3-"
+                            }
+                        },
+                        Expiration = new LifecycleRuleExpiration
                         {
                             ExpiredObjectDeleteMarker = true
                         },
@@ -185,11 +200,13 @@ namespace S3UnitTest
                             new LifecycleRuleNoncurrentVersionTransition
                             {
                                 NoncurrentDays = 30,
+                                NewerNoncurrentVersions = 60,
                                 StorageClass = S3StorageClass.StandardInfrequentAccess
                             },
                             new LifecycleRuleNoncurrentVersionTransition
                             {
                                 NoncurrentDays = 90,
+                                NewerNoncurrentVersions = 70,
                                 StorageClass = S3StorageClass.Glacier
                             }
                         }
@@ -202,7 +219,7 @@ namespace S3UnitTest
                 BucketName = bucketName,
                 Configuration = configuration
             });
-            
+
             s3Configuration = S3TestUtils.WaitForConsistency(() =>
             {
                 var res = Client.GetLifecycleConfiguration(bucketName);
@@ -213,7 +230,7 @@ namespace S3UnitTest
             Assert.IsNotNull(s3Configuration);
             Assert.IsNotNull(s3Configuration.Rules);
             Assert.AreEqual(configuration.Rules.Count, s3Configuration.Rules.Count);
-            for(int i=0;i<configuration.Rules.Count;i++)
+            for (int i = 0; i < configuration.Rules.Count; i++)
             {
                 var s3Rule = s3Configuration.Rules[i];
                 var rule = configuration.Rules[i];
@@ -414,7 +431,7 @@ namespace S3UnitTest
                     }
                 }
             });
-                        
+
             var actualConfig = S3TestUtils.WaitForConsistency(() =>
             {
                 var res = client.GetLifecycleConfiguration(bucketName);
@@ -475,6 +492,9 @@ namespace S3UnitTest
             {
                 Assert.AreEqual(expected.NoncurrentVersionTransition.NoncurrentDays,
                     actual.NoncurrentVersionTransition.NoncurrentDays);
+
+                Assert.AreEqual(expected.NoncurrentVersionTransition.NewerNoncurrentVersions,
+                    actual.NoncurrentVersionTransition.NewerNoncurrentVersions);
             }
 #pragma warning restore 618
         }
@@ -491,7 +511,7 @@ namespace S3UnitTest
             }
         }
 
-        private  static void AssertPredicatesAreEqual(LifecycleFilterPredicate expected, LifecycleFilterPredicate actual)
+        private static void AssertPredicatesAreEqual(LifecycleFilterPredicate expected, LifecycleFilterPredicate actual)
         {
             Assert.IsNotNull(expected);
             Assert.IsNotNull(actual);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`NewerNoncurrentVersions` wasn't added to `PutLifecycleConfigurationRequest` marshaller and isn't send to the backend, this PR adds `NewerNoncurrentVersions` to `PutLifecycleConfigurationRequestMarshall`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
https://github.com/aws/aws-sdk-net/issues/3500

## Testing
* In `LifecycleTests.LifecycleTest` added `NewerNoncurrentVersions` to `PutLifecycleConfigurationRequest` and verified that the correct value existed in `GetLifecycleConfiguration` response.
* `DRY_RUN-32036596-3ba9-4e36-b645-6882c73b2e13`
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement