### PR TITLE
Update versioning for preview 4

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AWSSDK.Extensions.CloudFront.Signers.nuspec
+++ b/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AWSSDK.Extensions.CloudFront.Signers.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.CloudFront.Signers</id>
     <title>AWSSDK - Extensions for AWS CloudFront</title>
-    <version>4.0.0.0-preview.3</version>
+    <version>4.0.0.0-preview.4</version>
     <authors>Amazon Web Services</authors>
 	<description>This package contains extension methods for creating signed URLs for Amazon CloudFront distributions and for creating signed cookies for Amazon CloudFront distributions using canned or custom policies.</description>
     <language>en-US</language>
@@ -13,23 +13,23 @@
     <icon>images\AWSLogo.png</icon>
     <dependencies>
       <group targetFramework="net472">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
-        <dependency id="AWSSDK.CloudFront" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
+        <dependency id="AWSSDK.CloudFront" version="4.0.0.0-preview.4" />
         <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
-        <dependency id="AWSSDK.CloudFront" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
+        <dependency id="AWSSDK.CloudFront" version="4.0.0.0-preview.4" />
         <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
-        <dependency id="AWSSDK.CloudFront" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
+        <dependency id="AWSSDK.CloudFront" version="4.0.0.0-preview.4" />
         <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
-        <dependency id="AWSSDK.CloudFront" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
+        <dependency id="AWSSDK.CloudFront" version="4.0.0.0-preview.4" />
         <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
     </dependencies>

--- a/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
+++ b/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.CrtIntegration</id>
     <title>AWSSDK - Extensions for AWS Common Runtime Integration</title>
-    <version>4.0.0.0-preview.3</version>
+    <version>4.0.0.0-preview.4</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with the AWS Common Runtime</description>
     <language>en-US</language>
@@ -13,22 +13,22 @@
     <icon>images\AWSLogo.png</icon>
     <dependencies>
       <group targetFramework="net472">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
         <dependency id="AWSCRT-AUTH" version="0.4.4" />
         <dependency id="AWSCRT-CHECKSUMS" version="0.4.4" />
       </group>

--- a/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/AWSSDK.Extensions.EC2.DecryptPassword.nuspec
+++ b/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/AWSSDK.Extensions.EC2.DecryptPassword.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.EC2.DecryptPassword</id>
     <title>AWSSDK - Extensions for AWS EC2</title>
-    <version>4.0.0.0-preview.3</version>
+    <version>4.0.0.0-preview.4</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS EC2 to get the decrypted password for an EC2 instance.</description>
     <language>en-US</language>
@@ -13,23 +13,23 @@
     <icon>images\AWSLogo.png</icon>
     <dependencies>
       <group targetFramework="net472">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
-        <dependency id="AWSSDK.EC2" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
+        <dependency id="AWSSDK.EC2" version="4.0.0.0-preview.4" />
 		<dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
-        <dependency id="AWSSDK.EC2" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
+        <dependency id="AWSSDK.EC2" version="4.0.0.0-preview.4" />
 		<dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
-        <dependency id="AWSSDK.EC2" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
+        <dependency id="AWSSDK.EC2" version="4.0.0.0-preview.4" />
 		<dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
-        <dependency id="AWSSDK.EC2" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
+        <dependency id="AWSSDK.EC2" version="4.0.0.0-preview.4" />
 		<dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
     </dependencies>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.NETCore.Setup</id>
     <title>AWSSDK - Extensions for NETCore Setup</title>
-    <version>4.0.0.0-preview.3</version>
+    <version>4.0.0.0-preview.4</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with .NET Core configuration and dependency injection frameworks.</description>
     <language>en-US</language>
@@ -14,19 +14,19 @@
 	
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.0-preview.4" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />

--- a/generator/.DevConfigs/3b852981-2872-4c6d-bbc4-ccfc1d01b6cc.json
+++ b/generator/.DevConfigs/3b852981-2872-4c6d-bbc4-ccfc1d01b6cc.json
@@ -1,9 +1,10 @@
 {
-    "core": {
-      "changeLogMessages": [
-        "fix: re-populate request property when instantiating WebServiceRequestEventArgs"
-      ],
-      "type": "patch",
-      "updateMinimum": true
-    }
-  }
+  "core": {
+    "changeLogMessages": [
+      "Re-populate request property when instantiating `WebServiceRequestEventArgs`",
+      "Update `System.Text.Json` dependency to version `8.0.5`"
+    ],
+    "updateMinimum": true
+  },
+  "overrideVersion": "4.0.0.0"
+}

--- a/generator/ServiceModels/_sdk-versions.json
+++ b/generator/ServiceModels/_sdk-versions.json
@@ -5,7 +5,7 @@
     "CoreVersion"       : "4.0.0.0",
     "OverrideCoreVersion" : "4.0",
     "DefaultToPreview"    : true,
-    "PreviewLabel"        : "preview.3",
+    "PreviewLabel"        : "preview.4",
     "ServiceVersions"     : {
         "CloudHSM" : {
             "Version" : "4.0.0.0",


### PR DESCRIPTION
## Description
Updates the SDK versioning for the next V4 preview (note: this preview intentionally does not contain any service changes, it's needed to unblock the PowerShell V5 preview - https://aws.amazon.com/blogs/developer/notice-of-upcoming-major-version-5-of-aws-tools-for-powershell/).

## Testing
- Dry-run: `DRY_RUN-5d28c516-f471-40fd-85a9-f2446138c1b0`

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
