### PR TITLE
chore: updated the documentation for TransferUtilityDownloadDirectoryRequest.LocalDirectory mentioning that it is case-sensitive.

### DIFF
--- a/generator/.DevConfigs/5a43ed01-13a4-4f03-afb5-209de16e31c3.json
+++ b/generator/.DevConfigs/5a43ed01-13a4-4f03-afb5-209de16e31c3.json
@@ -1,0 +1,9 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [ "Updated the documentation for TransferUtilityDownloadDirectoryRequest.LocalDirectory mentioning that it is case-sensitive." ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryRequest.cs
@@ -82,6 +82,7 @@ namespace Amazon.S3.Transfer
         /// <summary>
         /// 	Gets or sets the local directory where objects from Amazon S3 will be downloaded.  
 		/// 	If the directory doesn't exist, it will be created.
+        /// 	For some platforms like Linux, the file system is case-sensitive. The correct casing to the actual path must be used.
         /// </summary>
         /// <value>
         /// 	The local directory where objects from Amazon S3 will be downloaded.


### PR DESCRIPTION
## Description
Updated the documentation for `TransferUtilityDownloadDirectoryRequest.LocalDirectory` mentioning that it is case-sensitive.

## Motivation and Context
Issue #3017

**Repro Steps:**
- In S3 bucket, create a folder named `DownloadDirectory-Windows83-Test`.
- Upload 2 text files named `basic.txt` and `vc~ended.txt` (this one has Windows 8:3 name) to the above folder.
- Using code below, try to download file to where actual directory on Windows file system is `D:\temp`.
  ```
  TransferUtility directoryTransferUtility = new TransferUtility(amazonS3Client);
  TransferUtilityDownloadDirectoryRequest request = new TransferUtilityDownloadDirectoryRequest
  {
      BucketName = bucketName,
      S3Directory = "DownloadDirectory-Windows83-Test",
      LocalDirectory = @"D:\TEMP\abc\Imports\01_4791\Job52",
      DownloadFilesConcurrently = true,
  };
  await directoryTransferUtility.DownloadDirectoryAsync(request).ConfigureAwait(false);
  ```

**Findings:**
The issue appears to be with `System.IO.FileInfo` at [InternalSDKUtils.IsFilePathRootedWithDirectoryPath()](https://github.com/aws/aws-sdk-net/blob/ddb9b60e8b804f561ffb5415eb729ecc3ca2582a/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs#L240) where:
- For normal file (e.g. Somefile.txt), it returns `C:\Windows\TEMP\SomeDirectory\Somefile.txt` in `FullName` property.
- For file containing `~` character (e.g. `vc~ended.caf`), it returns `C:\Windows\Temp\SomeDirectory\vc~ended.caf` in `FullName` property (the `OriginalPath` property of `FileInfo` object has casing supplied by user).

We should not use `StringComparison.InvariantCultureIgnoreCase` (as proposed in issue description) since on Linux, the file system is case sensitive, and we would want to match the exact directory name.

We cannot access `OriginalPath` property since it is `protected` in base [FileSystemInfo](https://learn.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.originalpath?view=netframework-4.8.1#system-io-filesysteminfo-originalpath) class.

On Windows, there is a registry setting which when set, makes file system case-sensitive (just like Linux). Refer [Enabling Case Sensitivity on Windows 10](https://www.ortussolutions.com/blog/how-to-make-windows-folders-case-sensitive) for example, which has example command `fsutil.exe file SetCaseSensitiveInfo C:\folder\path enable`.

So it's better to update API documentation for `TransferUtilityDownloadDirectoryRequest.LocalDirectory` mentioning that it is case-sensitive for certain platforms/scenerios.


## Testing
Refer repro steps above. No dry-run is necessary for API doc only change.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement