### PR TITLE
fix: update AWS_S3_USE_ARN_REGION to take precedence over value set i…

### DIFF
--- a/generator/.DevConfigs/83d75756-74fc-4a10-98a6-96c5c71bda8b.json
+++ b/generator/.DevConfigs/83d75756-74fc-4a10-98a6-96c5c71bda8b.json
@@ -4,7 +4,7 @@
             "serviceName": "S3",
             "type": "patch",
             "changeLogMessages": [
-                "Fix: Fix AmazonS3Config so that AWS_S3_USE_ARN_REGION takes precedence over s3_use_arn_region set in config file."
+                "Update `AWS_S3_USE_ARN_REGION` environment variable to take precedence over `s3_use_arn_region` option in the config file."
             ]
         }
     ]

--- a/generator/.DevConfigs/83d75756-74fc-4a10-98a6-96c5c71bda8b.json
+++ b/generator/.DevConfigs/83d75756-74fc-4a10-98a6-96c5c71bda8b.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fix: Fix AmazonS3Config so that AWS_S3_USE_ARN_REGION takes precedence over s3_use_arn_region set in config file."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/S3/Custom/AmazonS3Config.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Config.cs
@@ -35,13 +35,14 @@ namespace Amazon.S3
         private const string DefaultProfileName = "default";
         private const string AwsS3UsEast1RegionalEndpointsEnvironmentVariable = "AWS_S3_US_EAST_1_REGIONAL_ENDPOINT";
         private const string DisableMRAPEnvName = "AWS_S3_DISABLE_MULTIREGION_ACCESS_POINTS";
+        private const string AwsConfigFileEnvName = "AWS_CONFIG_FILE";
 
         private bool forcePathStyle = false;
         private bool useAccelerateEndpoint = false;
         private S3UsEast1RegionalEndpointValue? s3UsEast1RegionalEndpointValue;
         private readonly string legacyUSEast1GlobalRegionSystemName = RegionEndpoint.USEast1.SystemName;
 
-        private static CredentialProfileStoreChain credentialProfileChain = new CredentialProfileStoreChain();
+        private static CredentialProfileStoreChain credentialProfileChain = new CredentialProfileStoreChain(Environment.GetEnvironmentVariable(AwsConfigFileEnvName));
 
         // we cache this per execution process to avoid excessive file I/O
         private static CredentialProfile _profile;
@@ -114,14 +115,17 @@ namespace Amazon.S3
                         return _useArnRegion.Value;
                     }
 
-                    _useArnRegion = _profile?.S3UseArnRegion;
-
-                    if (!_useArnRegion.HasValue && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(UseArnRegionEnvName)))
+                    if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(UseArnRegionEnvName)))
                     {
                         if (bool.TryParse(Environment.GetEnvironmentVariable(UseArnRegionEnvName), out var value))
                         {
                             _useArnRegion = value;
                         }
+                    }
+
+                    if (!_useArnRegion.HasValue)
+                    {
+                        _useArnRegion = _profile?.S3UseArnRegion;
                     }
 
                     if (!_useArnRegion.HasValue)

--- a/sdk/src/Services/S3/Custom/AmazonS3Config.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Config.cs
@@ -42,7 +42,7 @@ namespace Amazon.S3
         private S3UsEast1RegionalEndpointValue? s3UsEast1RegionalEndpointValue;
         private readonly string legacyUSEast1GlobalRegionSystemName = RegionEndpoint.USEast1.SystemName;
 
-        private static CredentialProfileStoreChain credentialProfileChain = new CredentialProfileStoreChain(Environment.GetEnvironmentVariable(AwsConfigFileEnvName));
+        private static CredentialProfileStoreChain credentialProfileChain = new CredentialProfileStoreChain();
 
         // we cache this per execution process to avoid excessive file I/O
         private static CredentialProfile _profile;

--- a/sdk/src/Services/S3/Custom/AmazonS3Config.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Config.cs
@@ -35,7 +35,6 @@ namespace Amazon.S3
         private const string DefaultProfileName = "default";
         private const string AwsS3UsEast1RegionalEndpointsEnvironmentVariable = "AWS_S3_US_EAST_1_REGIONAL_ENDPOINT";
         private const string DisableMRAPEnvName = "AWS_S3_DISABLE_MULTIREGION_ACCESS_POINTS";
-        private const string AwsConfigFileEnvName = "AWS_CONFIG_FILE";
 
         private bool forcePathStyle = false;
         private bool useAccelerateEndpoint = false;

--- a/sdk/test/Services/S3/UnitTests/Custom/UseArnRegionTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/UseArnRegionTests.cs
@@ -68,7 +68,6 @@ namespace AWSSDK.UnitTests
             Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "");
             // set credentials file and use it to load CredentialProfileStoreChain
 
-            // set credentials file and use it to load CredentialProfileStoreChain
             _tempCredentialsFilePath = Path.GetTempFileName();
             File.WriteAllText(_tempCredentialsFilePath, ProfileText);
             ReflectionHelpers.Invoke(typeof(AmazonS3Config), "credentialProfileChain", new CredentialProfileStoreChain(_tempCredentialsFilePath));
@@ -99,117 +98,69 @@ namespace AWSSDK.UnitTests
         [TestCategory("S3")]
         public void EnvironmentVariableEnable()
         {
-            var beginningS3UseArnRegionEnvValue = Environment.GetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE);
-            try
-            {
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, "true");
+            Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, "true");
 
-                var config = new AmazonS3Config
-                {
-                };
-
-                Assert.IsTrue(config.UseArnRegion);
-            }
-            finally
+            var config = new AmazonS3Config
             {
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, beginningS3UseArnRegionEnvValue);
-            }
+            };
+
+            Assert.IsTrue(config.UseArnRegion);
         }
 
         [TestMethod]
         [TestCategory("S3")]
         public void ExplicitDisableOverridesEnvironmentVariable()
         {
-            var beginningS3UseArnRegionEnvValue = Environment.GetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE);
-            try
+            Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, "true");
+
+            var config = new AmazonS3Config
             {
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, "true");
+                UseArnRegion = false
+            };
 
-                var config = new AmazonS3Config
-                {
-                    UseArnRegion = false
-                };
-
-                Assert.IsFalse(config.UseArnRegion);
-            }
-
-            finally
-            {
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, beginningS3UseArnRegionEnvValue);
-            }
-
+            Assert.IsFalse(config.UseArnRegion);
         }
 
         [TestMethod]
         [TestCategory("S3")]
         public void ProfileValueIsUsedIfSet()
         {
-            var beginningS3UseArnRegionEnvValue = Environment.GetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE);
-            try
+            Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "use-arn-region-enabled");
+
+            var config = new AmazonS3Config
             {
-                Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "use-arn-region-enabled");
+            };
 
-                var config = new AmazonS3Config
-                {
-                };
-
-                Assert.IsTrue(config.UseArnRegion);
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, beginningS3UseArnRegionEnvValue);
-            }
-
+            Assert.IsTrue(config.UseArnRegion);
         }
 
         [TestMethod]
         [TestCategory("S3")]
         public void EnvironmentVariableTakesPrecedenceOverProfileValue()
         {
-            var beginningAwsProfileEnvValue = Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
-            var beginningS3UseArnRegionEnvValue = Environment.GetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE);
+            Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "use-arn-region-enabled");
+            Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, "false");
 
-            try
+            var config = new AmazonS3Config
             {
-                Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "use-arn-region-enabled");
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, "false");
+            };
 
-                var config = new AmazonS3Config
-                {
-                };
-
-                Assert.IsFalse(config.UseArnRegion);
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, "");
-            }
-            finally
-            {
-
-                Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, beginningAwsProfileEnvValue);
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, beginningS3UseArnRegionEnvValue);
-            }
+            Assert.IsFalse(config.UseArnRegion);
         }
 
         [TestMethod]
         [TestCategory("S3")]
         public void ConfigValueTakesPrecedenceOverAllValues()
         {
-            var beginningAwsProfileEnvValue = Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
-            var beginningS3UseArnRegionEnvValue = Environment.GetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE);
-            try
+            Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "use-arn-region-disabled");
+            Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, "false");
+            var config = new AmazonS3Config
             {
-                Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "use-arn-region-disabled");
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, "false");
-                var config = new AmazonS3Config
-                {
-                    UseArnRegion = true
-                };
-                Assert.IsTrue(config.UseArnRegion);
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, beginningAwsProfileEnvValue);
-                Environment.SetEnvironmentVariable(AWS_S3_USE_ARN_REGION_ENVIRONMENT_VARIABLE, beginningS3UseArnRegionEnvValue);
-            }
+                UseArnRegion = true
+            };
+
+            Assert.IsTrue(config.UseArnRegion);
+            
         }
     }
 }


### PR DESCRIPTION
…n config file

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This updates AmazonS3Config use-arn-region to take the value set in environment variable over that set in the ~/.aws/config file. This follows other env var + config file precedence.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
dotnet-7073
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
dry run in v4 passes
Added unit tests
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement