### PR TITLE
Sync the assembly file version and the nuspec version for AWSSDK.Extensions.CrtIntegration

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
+++ b/extensions/src/AWSSDK.Extensions.CrtIntegration/AWSSDK.Extensions.CrtIntegration.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.CrtIntegration</id>
     <title>AWSSDK - Extensions for AWS Common Runtime Integration</title>
-    <version>3.7.300.2</version>
+    <version>3.7.300.3</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with the AWS Common Runtime</description>
     <language>en-US</language>

--- a/extensions/src/AWSSDK.Extensions.CrtIntegration/Properties/AssemblyInfo.cs
+++ b/extensions/src/AWSSDK.Extensions.CrtIntegration/Properties/AssemblyInfo.cs
@@ -17,4 +17,4 @@ using System.Runtime.InteropServices;
 
 
 [assembly: AssemblyVersion("3.3")]
-[assembly: AssemblyFileVersion("3.7.0.0")]
+[assembly: AssemblyFileVersion("3.7.300.3")]


### PR DESCRIPTION
## Description
The assembly file version hasn't been updated when the nuspec file version has updated. This PR simply gets the numbers in sync. Out of scope but something we should do is figure out how to automate the versioning of the extension packages.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3181

