### PR TITLE
Code samples generator: fix culture-specific printing of doubles

### DIFF
--- a/generator/ServiceClientGeneratorLib/Example.cs
+++ b/generator/ServiceClientGeneratorLib/Example.cs
@@ -42,7 +42,7 @@ namespace ServiceClientGenerator
         /// The example id taken from the model.
         /// </summary>
         /// <remarks>
-        /// This unique id is used for the region in the emitted code sample 
+        /// This unique id is used for the region in the emitted code sample
         /// that will be parsed to include the code in the documentation.
         /// </remarks>
         public string Id
@@ -201,7 +201,7 @@ namespace ServiceClientGenerator
 
             return result;
         }
-        
+
 
         /// <summary>
         /// Given a member and sample data, build a literal/instantation for the
@@ -227,9 +227,15 @@ namespace ServiceClientGenerator
             if (shape.IsString && data.IsString)
                 cb.AppendQuote(data.ToString());
             else if (shape.IsBoolean)
-                cb.Append(data.ToString().ToLower());
+                cb.Append(data.ToString().ToLowerInvariant());
+
             else if (shape.IsFloat || shape.IsInt || shape.IsDouble || shape.IsLong)
-                cb.Append(data.ToString());
+            {
+                if (data.IsDouble)
+                    cb.Append(((double)data).ToString(CultureInfo.InvariantCulture));
+                else
+                    cb.Append(data.ToString());
+            }
 
             else if (shape.IsList && data.IsArray)
             {
@@ -285,7 +291,7 @@ namespace ServiceClientGenerator
                 foreach (var field in data.PropertyNames)
                 {
                     var property = shape.Members.GetMemberByName(field);
- 
+
                     if (null == property)
                         continue;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use invariant culture for printing floats and doubles in `generator/ServiceClientGeneratorLib/Example.cs`. This makes sure the generated content does not depend on the current culture (dot/comma as a decimal separator).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
When running `generator/ServiceClientGenerator/bin/Release/ServiceClientGenerator.exe` and the current culture uses comma as a decimal separator (e.g. French, fr-FR), the generated file `docgenerator/AWSSDKDocSamples/Lambda/Lambda.GeneratedSamples.cs`
becomes invalid, `0,7` is printed instead of `0.7`. This is the only file that is affected by this issue.

Valid output:
```csharp
RoutingConfig = new AliasRoutingConfiguration { AdditionalVersionWeights = new Dictionary<string, double> {
    { "1", 0.7 }
} }
```
Invalid output:
```csharp
RoutingConfig = new AliasRoutingConfiguration { AdditionalVersionWeights = new Dictionary<string, double> {
    { "1", 0,7 }
} }
```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a unit test to `generator/ServiceClientGeneratorTests/UnitTests.cs`.

<!--- ## Screenshots (if appropriate) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement