### PR TITLE
Do not trim leading slashes for copy object and copy part operations

### DIFF
--- a/generator/.DevConfigs/2869e4ae-e992-4bb7-938e-fed27e1b1d47.json
+++ b/generator/.DevConfigs/2869e4ae-e992-4bb7-938e-fed27e1b1d47.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Remove the DisableTrimmingLeadingSlash flag for CopyObject and CopyPart operations. The SDK will no longer trim leading slashes."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyObjectRequest.cs
@@ -245,7 +245,6 @@ namespace Amazon.S3.Model
         private string copySourceServerSideEncryptionCustomerProvidedKeyMD5;
         private TaggingDirective taggingDirective;
 
-        private bool disableTrimmingLeadingSlash = false;
 
         /// <summary>
         /// A canned access control list (CACL) to apply to the object.
@@ -1187,16 +1186,6 @@ namespace Amazon.S3.Model
         internal bool IsSetChecksumAlgorithm()
         {
             return this._checksumAlgorithm != null;
-        }
-
-        /// <summary>
-        /// If this is set to true then the Amazon S3 client will not remove leading slashes from <see cref="SourceKey"/> and <see cref="DestinationKey"/>. 
-        /// The default value is false.
-        /// </summary>
-        public bool DisableTrimmingLeadingSlash
-        {
-            get { return this.disableTrimmingLeadingSlash; }
-            set { this.disableTrimmingLeadingSlash = value; }
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CopyPartRequest.cs
@@ -246,7 +246,6 @@ namespace Amazon.S3.Model
         private string copySourceServerSideEncryptionCustomerProvidedKey;
         private string copySourceServerSideEncryptionCustomerProvidedKeyMD5;
 
-        private bool disableTrimmingLeadingSlash = false;
 
         /// <summary>
         /// The name of the bucket containing the object to copy.
@@ -823,14 +822,5 @@ namespace Amazon.S3.Model
             return requestPayer != null;
         }
 
-        /// <summary>
-        /// If this is set to true then the Amazon S3 client will not remove leading slashes from <see cref="SourceKey"/> and <see cref="DestinationKey"/>. 
-        /// The default value is false.
-        /// </summary>
-        public bool DisableTrimmingLeadingSlash
-        {
-            get { return this.disableTrimmingLeadingSlash; }
-            set { this.disableTrimmingLeadingSlash = value; }
-        }
     }
 }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
@@ -36,15 +36,9 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
         public IRequest Marshall(CopyObjectRequest copyObjectRequest)
         {
-            var sourceKey = 
-                copyObjectRequest.DisableTrimmingLeadingSlash || string.IsNullOrEmpty(copyObjectRequest.SourceKey) ?
-                copyObjectRequest.SourceKey :
-                AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.SourceKey);
+            var sourceKey = copyObjectRequest.SourceKey;
 
-            var destinationKey = 
-                copyObjectRequest.DisableTrimmingLeadingSlash || string.IsNullOrEmpty(copyObjectRequest.DestinationKey) ?
-                copyObjectRequest.DestinationKey:
-                AmazonS3Util.RemoveLeadingSlash(copyObjectRequest.DestinationKey);
+            var destinationKey = copyObjectRequest.DestinationKey;
             
             IRequest request = new DefaultRequest(copyObjectRequest, "AmazonS3");
 

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
@@ -38,15 +38,9 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         {
             IRequest request = new DefaultRequest(copyPartRequest, "AmazonS3");
 
-            var sourceKey =
-                copyPartRequest.DisableTrimmingLeadingSlash ?
-                copyPartRequest.SourceKey :
-                AmazonS3Util.RemoveLeadingSlash(copyPartRequest.SourceKey);
+            var sourceKey = copyPartRequest.SourceKey;
 
-            var destinationKey =
-                copyPartRequest.DisableTrimmingLeadingSlash ?
-                copyPartRequest.DestinationKey :
-                AmazonS3Util.RemoveLeadingSlash(copyPartRequest.DestinationKey);
+            var destinationKey = copyPartRequest.DestinationKey;
 
             request.HttpMethod = "PUT";
 

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/CopyObjectTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/CopyObjectTests.cs
@@ -42,11 +42,11 @@ namespace Amazon.DNXCore.IntegrationTests.S3
         }
 
         [Theory]
-        [InlineData(false, testKey, "/destinationTestKey1.txt", "destinationTestKey1.txt")]
-        [InlineData(true, testKeyWithSlash, "/destinationTestKey2.txt", "/destinationTestKey2.txt")]
-        [InlineData(true, testKeyWithSlash, "/", "/")]
+        [InlineData(testKey, "/destinationTestKey1.txt", "/destinationTestKey1.txt")]
+        [InlineData(testKeyWithSlash, "/destinationTestKey2.txt", "/destinationTestKey2.txt")]
+        [InlineData(testKeyWithSlash, "/", "/")]
         [Trait(CategoryAttribute, "S3")]
-        public async Task CopyObjectTestWithLeadingSlash(bool disableTrimmingLeadingSlash, string sourceKey, string destinationKey, string expectedKey)
+        public async Task CopyObjectTestWithLeadingSlash(string sourceKey, string destinationKey, string expectedKey)
         {
             var copyResponse = await Client.CopyObjectAsync(new CopyObjectRequest
             {
@@ -55,8 +55,6 @@ namespace Amazon.DNXCore.IntegrationTests.S3
 
                 DestinationBucket = bucketName,
                 DestinationKey = destinationKey,
-
-                DisableTrimmingLeadingSlash = disableTrimmingLeadingSlash
             });
             Assert.Equal(HttpStatusCode.OK, copyResponse.HttpStatusCode);
 

--- a/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
@@ -157,12 +157,12 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             Assert.IsTrue(taggingMetadata.Tagging.Any(tag => tag.Key == "newtag1" && tag.Value == "1"));
         }
 
-        [DataRow(false, testKey, "/destinationTestKey1.txt", "destinationTestKey1.txt")]
-        [DataRow(true, testKeyWithSlash, "/destinationTestKey2.txt", "/destinationTestKey2.txt")]
-        [DataRow(true, testKeyWithSlash, "/", "/")]
+        [DataRow(testKey, "/destinationTestKey1.txt", "/destinationTestKey1.txt")]
+        [DataRow(testKeyWithSlash, "/destinationTestKey2.txt", "/destinationTestKey2.txt")]
+        [DataRow(testKeyWithSlash, "/", "/")]
         [DataTestMethod]
         [TestCategory("S3")]
-        public void TestCopyObjectWithLeadingSlash(bool disableTrimmingLeadingSlash, string sourceKey, string destinationKey, string expectedKey)
+        public void TestCopyObjectWithLeadingSlash(string sourceKey, string destinationKey, string expectedKey)
         {
             var copyObjectResponse = usEastClient.CopyObject(new CopyObjectRequest
             {
@@ -172,7 +172,6 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 DestinationBucket = westBucketName,
                 DestinationKey = destinationKey,
 
-                DisableTrimmingLeadingSlash = disableTrimmingLeadingSlash
             });
             Assert.AreEqual(HttpStatusCode.OK, copyObjectResponse.HttpStatusCode);
 

--- a/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
@@ -157,7 +157,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             Assert.IsTrue(taggingMetadata.Tagging.Any(tag => tag.Key == "newtag1" && tag.Value == "1"));
         }
 
-        [DataRow(testKey, "/destinationTestKey1.txt", "/destinationTestKey1.txt")]
+        [DataRow(testKey, "destinationTestKey1.txt", "destinationTestKey1.txt")]
         [DataRow(testKeyWithSlash, "/destinationTestKey2.txt", "/destinationTestKey2.txt")]
         [DataRow(testKeyWithSlash, "/", "/")]
         [DataTestMethod]

--- a/sdk/test/Services/S3/IntegrationTests/CopyPartTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyPartTests.cs
@@ -63,7 +63,6 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                     UploadId = uploadId,
                     PartNumber = 1,
 
-                    DisableTrimmingLeadingSlash = true
                 });
                 Assert.IsNotNull(copyPartResponse.ETag);
                 Assert.IsTrue(copyPartResponse.ETag != null && copyPartResponse.ETag.Length > 0);


### PR DESCRIPTION
…perations

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The .NET SDK trims leading slashes on copy object and copy part operations. This behavior can be turned off by setting `DisableTrimmingLeadingSlash` to true. This change removes that flag so that the .NET SDK will not trim leading slashes.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
This is something we can only fix in v4
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
dry run in v4 passes.


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement