### PR TITLE
ServiceClientGenerator: DefaultConfiguration.cs shouldn't use comma

### DIFF
--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/DefaultConfiguration.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/DefaultConfiguration.cs
@@ -12,6 +12,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     using System.Linq;
     using System.Text;
     using System.Collections.Generic;
+    using System.Globalization;
     using ServiceClientGenerator.DefaultConfiguration;
     using System;
     
@@ -33,7 +34,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("\r\n");
             this.Write("\r\n");
             
-            #line 10 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 11 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
     AddLicenseHeader();
 
@@ -43,21 +44,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("\r\n\r\nusing System;\r\nusing System.Collections.Generic;\r\nusing System.Collections.Ob" +
                     "jectModel;\r\n\r\nusing Amazon.Runtime;\r\n\r\nnamespace ");
             
-            #line 21 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 22 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(base.Config.Namespace));
             
             #line default
             #line hidden
             this.Write("\r\n{\r\n    /// <summary>\r\n    /// Configuration for accessing Amazon ");
             
-            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 25 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(base.Config.ClassName));
             
             #line default
             #line hidden
             this.Write(" service\r\n    /// </summary>\r\n    public static class Amazon");
             
-            #line 26 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 27 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(base.Config.ClassName));
             
             #line default
@@ -65,7 +66,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("DefaultConfiguration\r\n    {\r\n        /// <summary>\r\n        /// Collection of all" +
                     " <see cref=\"DefaultConfiguration\"/>s supported by\r\n        /// ");
             
-            #line 30 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 31 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(base.Config.ClassName));
             
             #line default
@@ -75,14 +76,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "ction<IDefaultConfiguration>(new List<IDefaultConfiguration>\r\n            {\r\n   " +
                     "             ");
             
-            #line 36 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 37 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(string.Join(",\r\n                ", base.DefaultConfigurationModel.Modes.Select(x => x.Name).ToArray())));
             
             #line default
             #line hidden
             this.Write("\r\n            });\r\n        }\r\n\r\n");
             
-            #line 40 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 41 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
     foreach (var mode in base.DefaultConfigurationModel.Modes)
     {
@@ -92,14 +93,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        /// <summary>\r\n        /// ");
             
-            #line 45 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 46 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.Documentation));
             
             #line default
             #line hidden
             this.Write("\r\n        /// </summary>\r\n        public static IDefaultConfiguration ");
             
-            #line 47 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.Name));
             
             #line default
@@ -107,56 +108,56 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write(" {get;} = new DefaultConfiguration\r\n        {\r\n            Name = DefaultConfigur" +
                     "ationMode.");
             
-            #line 49 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 50 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.Name));
             
             #line default
             #line hidden
             this.Write(",\r\n            RetryMode = ");
             
-            #line 50 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 51 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(nameof(RequestRetryMode)));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 50 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 51 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.RetryMode));
             
             #line default
             #line hidden
             this.Write(",\r\n            StsRegionalEndpoints = ");
             
-            #line 51 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 52 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(nameof(StsRegionalEndpointsValue)));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 51 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 52 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.StsRegionalEndpoints));
             
             #line default
             #line hidden
             this.Write(",\r\n            S3UsEast1RegionalEndpoint = ");
             
-            #line 52 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 53 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(nameof(S3UsEast1RegionalEndpointValue)));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 52 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 53 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.S3UsEast1RegionalEndpoint));
             
             #line default
             #line hidden
             this.Write(",\r\n");
             
-            #line 53 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 54 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
             if (mode.ConnectTimeout.HasValue)
             {
@@ -166,21 +167,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            // ");
             
-            #line 57 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(mode.ConnectTimeout.Value.ToString("g")));
+            #line 58 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(mode.ConnectTimeout.Value.ToString("g", CultureInfo.InvariantCulture)));
             
             #line default
             #line hidden
             this.Write("\r\n            ConnectTimeout = TimeSpan.FromMilliseconds(");
             
-            #line 58 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 59 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.ConnectTimeout.Value.TotalMilliseconds));
             
             #line default
             #line hidden
             this.Write("L),\r\n");
             
-            #line 59 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 60 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
             }
             else
@@ -191,8 +192,8 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            ConnectTimeout = null,\r\n");
             
-            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
- 
+            #line 66 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+
             }
 
             if (mode.TlsNegotiationTimeout.HasValue)
@@ -203,21 +204,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            // ");
             
-            #line 71 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(mode.TlsNegotiationTimeout.Value.ToString("g")));
+            #line 72 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(mode.TlsNegotiationTimeout.Value.ToString("g", CultureInfo.InvariantCulture)));
             
             #line default
             #line hidden
             this.Write("\r\n            TlsNegotiationTimeout = TimeSpan.FromMilliseconds(");
             
-            #line 72 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 73 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.TlsNegotiationTimeout.Value.TotalMilliseconds));
             
             #line default
             #line hidden
             this.Write("L),\r\n");
             
-            #line 73 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 74 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
             }
             else
@@ -228,8 +229,8 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            TlsNegotiationTimeout = null,\r\n");
             
-            #line 79 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
- 
+            #line 80 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+
             }
 
             if (mode.TimeToFirstByteTimeout.HasValue)
@@ -240,21 +241,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            // ");
             
-            #line 85 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(mode.TimeToFirstByteTimeout.Value.ToString("g")));
+            #line 86 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(mode.TimeToFirstByteTimeout.Value.ToString("g", CultureInfo.InvariantCulture)));
             
             #line default
             #line hidden
             this.Write("\r\n            TimeToFirstByteTimeout = TimeSpan.FromMilliseconds(");
             
-            #line 86 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 87 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.TimeToFirstByteTimeout.Value.TotalMilliseconds));
             
             #line default
             #line hidden
             this.Write("L),\r\n");
             
-            #line 87 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 88 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
             }
             else
@@ -265,7 +266,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            TimeToFirstByteTimeout = null,\r\n");
             
-            #line 93 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 94 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
             }
 
@@ -277,21 +278,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            // ");
             
-            #line 99 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(mode.HttpRequestTimeout.Value.ToString("g")));
+            #line 100 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(mode.HttpRequestTimeout.Value.ToString("g", CultureInfo.InvariantCulture)));
             
             #line default
             #line hidden
             this.Write("\r\n            HttpRequestTimeout = TimeSpan.FromMilliseconds(");
             
-            #line 100 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 101 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mode.HttpRequestTimeout.Value.TotalMilliseconds));
             
             #line default
             #line hidden
             this.Write("L)\r\n");
             
-            #line 101 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 102 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
             }
             else
@@ -302,7 +303,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            HttpRequestTimeout = null\r\n");
             
-            #line 107 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 108 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
             }
 
@@ -311,7 +312,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        };\r\n");
             
-            #line 111 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
+            #line 112 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\DefaultConfiguration.tt"
 
     }
 

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/DefaultConfiguration.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/DefaultConfiguration.tt
@@ -4,6 +4,7 @@
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.Globalization" #>
 
 <#@ import namespace="ServiceClientGenerator.DefaultConfiguration" #>
 
@@ -54,7 +55,7 @@ namespace <#= base.Config.Namespace#>
             if (mode.ConnectTimeout.HasValue)
             {
 #>
-            // <#= mode.ConnectTimeout.Value.ToString("g") #>
+            // <#= mode.ConnectTimeout.Value.ToString("g", CultureInfo.InvariantCulture) #>
             ConnectTimeout = TimeSpan.FromMilliseconds(<#= mode.ConnectTimeout.Value.TotalMilliseconds #>L),
 <#
             }
@@ -62,13 +63,13 @@ namespace <#= base.Config.Namespace#>
             {
 #>
             ConnectTimeout = null,
-<# 
+<#
             }
 
             if (mode.TlsNegotiationTimeout.HasValue)
             {
 #>
-            // <#= mode.TlsNegotiationTimeout.Value.ToString("g") #>
+            // <#= mode.TlsNegotiationTimeout.Value.ToString("g", CultureInfo.InvariantCulture) #>
             TlsNegotiationTimeout = TimeSpan.FromMilliseconds(<#= mode.TlsNegotiationTimeout.Value.TotalMilliseconds #>L),
 <#
             }
@@ -76,13 +77,13 @@ namespace <#= base.Config.Namespace#>
             {
 #>
             TlsNegotiationTimeout = null,
-<# 
+<#
             }
 
             if (mode.TimeToFirstByteTimeout.HasValue)
             {
 #>
-            // <#= mode.TimeToFirstByteTimeout.Value.ToString("g") #>
+            // <#= mode.TimeToFirstByteTimeout.Value.ToString("g", CultureInfo.InvariantCulture) #>
             TimeToFirstByteTimeout = TimeSpan.FromMilliseconds(<#= mode.TimeToFirstByteTimeout.Value.TotalMilliseconds #>L),
 <#
             }
@@ -96,7 +97,7 @@ namespace <#= base.Config.Namespace#>
             if (mode.HttpRequestTimeout.HasValue)
             {
 #>
-            // <#= mode.HttpRequestTimeout.Value.ToString("g") #>
+            // <#= mode.HttpRequestTimeout.Value.ToString("g", CultureInfo.InvariantCulture) #>
             HttpRequestTimeout = TimeSpan.FromMilliseconds(<#= mode.HttpRequestTimeout.Value.TotalMilliseconds #>L)
 <#
             }


### PR DESCRIPTION
ServiceClientGenerator outputs different `***DefaultConfiguration.cs` files when current culture (fr-FR) uses comma as a decimal separator. This PR fixes it by using `InvariantCulture` when printing `TimeSpan` values in the comment lines.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In `generator/ServiceClientGeneratorLib/Generators/SourceFiles/DefaultConfiguration.tt` template I replaced `TimeSpan.ToString("g")` with `TimeSpan.ToString("g", CultureInfo.InvariantCulture)`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

`ServiceClientGenerator` output should result in the same generated output regardless of the current culture.
This PR is similar to PR https://github.com/aws/aws-sdk-net/pull/3527.

Generator output for invariant (or en-US) culture is below. [Example](https://github.com/aws/aws-sdk-net/blob/main/sdk/src/Services/Lambda/Generated/AmazonLambdaDefaultConfiguration.cs#L60).

```csharp
    public static IDefaultConfiguration Standard {get;} = new DefaultConfiguration
    {
        Name = DefaultConfigurationMode.Standard,
        RetryMode = RequestRetryMode.Standard,
        StsRegionalEndpoints = StsRegionalEndpointsValue.Regional,
        S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Regional,
        // 0:00:03.1
        ConnectTimeout = TimeSpan.FromMilliseconds(3100L),
        // 0:00:03.1
        TlsNegotiationTimeout = TimeSpan.FromMilliseconds(3100L),
```

Generator output when current culture uses comma (',', "fr-FR") as a decimal separator is below. Notice a comma instead of a dot in the comment lines. 410 files, `sdk/src/Services/***/Generated/Amazon***DefaultConfiguration.cs`, are affected.

```csharp
    public static IDefaultConfiguration Standard {get;} = new DefaultConfiguration
    {
        Name = DefaultConfigurationMode.Standard,
        RetryMode = RequestRetryMode.Standard,
        StsRegionalEndpoints = StsRegionalEndpointsValue.Regional,
        S3UsEast1RegionalEndpoint = S3UsEast1RegionalEndpointValue.Regional,
        // 0:00:03,1
        ConnectTimeout = TimeSpan.FromMilliseconds(3100L),
        // 0:00:03,1
        TlsNegotiationTimeout = TimeSpan.FromMilliseconds(3100L),
```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Apply the fix. Build `AWSSDKGenerator.sln`. Run the generator, `aws-sdk-net\generator\ServiceClientGenerator\bin\Release\ServiceClientGenerator.exe` . Observe `git diff`. When current culture uses comma as a decimal separator, the generated output is now the same as when using invariant (or en-US) culture.

<!--- ## Screenshots (if appropriate) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement