### PR TITLE
Revert skip flaky S3Express test

### DIFF
--- a/sdk/test/Services/S3/IntegrationTests/S3ExpressTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/S3ExpressTests.cs
@@ -213,7 +213,6 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 
         [TestMethod]
         [TestCategory("S3")]
-        [Ignore("Excluding flaky S3Express test")]
         public void Test_CopyObject_BetweenRegularBucket_And_S3ExpressBucket()
         {
             var oldObjectKey = "Test Object 123";


### PR DESCRIPTION
Revert skipping the test `Test_CopyObject_BetweenRegularBucket_And_S3ExpressBucket` since S3 Express is now back to normal.