### PR TITLE
Perform background refresh of credentials during preempt expiry period

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -36,11 +36,7 @@ namespace Amazon.Runtime
         /// </summary>
         public class CredentialsRefreshState
         {
-            public ImmutableCredentials Credentials
-            {
-                get; 
-                set;
-            }
+            public ImmutableCredentials Credentials { get; set; }
             public DateTime Expiration { get; set; }
 
             public CredentialsRefreshState()
@@ -58,6 +54,16 @@ namespace Amazon.Runtime
                 var now = AWSSDKUtils.CorrectedUtcNow;
                 var exp = Expiration.ToUniversalTime();
                 return (now > exp - preemptExpiryTime);
+            }
+
+            internal TimeSpan GetTimeToLive(TimeSpan preemptExpiryTime)
+            {
+#pragma warning disable CS0612,CS0618 // Type or member is obsolete
+                var now = AWSSDKUtils.CorrectedUtcNow;
+#pragma warning restore CS0612,CS0618 // Type or member is obsolete
+                var exp = Expiration.ToUniversalTime();
+
+                return exp - now + preemptExpiryTime;
             }
         }
 
@@ -110,46 +116,106 @@ namespace Amazon.Runtime
         /// <returns></returns>
         public override ImmutableCredentials GetCredentials()
         {
-            _updateGeneratedCredentialsSemaphore.Wait();
-            try
+            // We save the currentState as it might be modified or cleared.
+            var tempState = currentState;
+
+            var ttl = tempState?.GetTimeToLive(PreemptExpiryTime);
+
+            if (ttl > TimeSpan.Zero)
             {
-                // We save the currentState as it might be modified or cleared.
-                var tempState = currentState;
-                // If credentials are expired or we don't have any state yet, update
-                if (ShouldUpdateState(tempState, PreemptExpiryTime))
+                if (ttl < PreemptExpiryTime)
                 {
-                    tempState = GenerateNewCredentials();
-                    UpdateToGeneratedCredentials(tempState, PreemptExpiryTime);
-                    currentState = tempState;
+                    // background refresh (fire & forget)
+                    if (_updateGeneratedCredentialsSemaphore.Wait(0))
+                    {
+                        _ = System.Threading.Tasks.Task.Run(GenerateCredentialsAndUpdateState);
+                    }
                 }
-                return tempState.Credentials.Copy();
             }
-            finally
+            else
             {
-                _updateGeneratedCredentialsSemaphore.Release();
+                // If credentials are expired, update
+                _updateGeneratedCredentialsSemaphore.Wait();
+                tempState = GenerateCredentialsAndUpdateState();
+            }
+
+            return tempState.Credentials.Copy();
+
+            CredentialsRefreshState GenerateCredentialsAndUpdateState()
+            {
+                System.Diagnostics.Debug.Assert(_updateGeneratedCredentialsSemaphore.CurrentCount == 0);
+
+                try
+                {
+                    var tempState = currentState;
+                    // double-check that the credentials still need updating
+                    // as it's possible that multiple requests were queued acquiring the semaphore
+                    if (ShouldUpdateState(tempState, PreemptExpiryTime))
+                    {
+                        tempState = GenerateNewCredentials();
+                        UpdateToGeneratedCredentials(tempState, PreemptExpiryTime);
+                        currentState = tempState;
+                    }
+
+                    return tempState;
+                }
+                finally
+                {
+                    _updateGeneratedCredentialsSemaphore.Release();
+                }
             }
         }
 
 #if AWS_ASYNC_API
         public override async System.Threading.Tasks.Task<ImmutableCredentials> GetCredentialsAsync()
         {
-            await _updateGeneratedCredentialsSemaphore.WaitAsync().ConfigureAwait(false);
-            try
+            // We save the currentState as it might be modified or cleared.
+            var tempState = currentState;
+
+            var ttl = tempState?.GetTimeToLive(PreemptExpiryTime);
+
+            if (ttl > TimeSpan.Zero)
             {
-                // We save the currentState as it might be modified or cleared.
-                var tempState = currentState;
-                // If credentials are expired, update
-                if (ShouldUpdateState(tempState, PreemptExpiryTime))
+                if (ttl < PreemptExpiryTime)
                 {
-                    tempState = await GenerateNewCredentialsAsync().ConfigureAwait(false);
-                    UpdateToGeneratedCredentials(tempState, PreemptExpiryTime);
-                    currentState = tempState;
+                    // background refresh (fire & forget)
+                    if (_updateGeneratedCredentialsSemaphore.Wait(0))
+                    {
+                        _ = GenerateCredentialsAndUpdateStateAsync();
+                    }
                 }
-                return tempState.Credentials.Copy();
             }
-            finally
+            else
             {
-                _updateGeneratedCredentialsSemaphore.Release();
+                // If credentials are expired, update
+                await _updateGeneratedCredentialsSemaphore.WaitAsync().ConfigureAwait(false);
+                tempState = await GenerateCredentialsAndUpdateStateAsync().ConfigureAwait(false);
+            }
+
+            return tempState.Credentials.Copy();
+
+            async System.Threading.Tasks.Task<CredentialsRefreshState> GenerateCredentialsAndUpdateStateAsync()
+            {
+                System.Diagnostics.Debug.Assert(_updateGeneratedCredentialsSemaphore.CurrentCount == 0);
+
+                try
+                {
+                    var tempState = currentState;
+                    // double-check that the credentials still need updating
+                    // as it's possible that multiple requests were queued acquiring the semaphore
+                    if (ShouldUpdateState(tempState, PreemptExpiryTime))
+                    {
+                        tempState = await GenerateNewCredentialsAsync().ConfigureAwait(false);
+                        UpdateToGeneratedCredentials(tempState, PreemptExpiryTime);
+                        currentState = tempState;
+                    }
+
+                    return tempState;
+                }
+                finally
+                {
+                    _updateGeneratedCredentialsSemaphore.Release();
+                }
             }
         }
 #endif
@@ -246,7 +312,7 @@ namespace Amazon.Runtime
             throw new NotImplementedException();
         }
 #if AWS_ASYNC_API
-        /// <summary>
+        /// <summary> 
         /// When overridden in a derived class, generates new credentials and new expiration date.
         /// 
         /// Called on first credentials request and when expiration date is in the past.

--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -52,14 +52,14 @@ namespace Amazon.Runtime
             internal bool IsExpiredWithin(TimeSpan preemptExpiryTime)
             {
                 var now = AWSSDKUtils.CorrectedUtcNow;
-                var exp = Expiration.ToUniversalTime();
-                return (now > exp - preemptExpiryTime);
+                var exp = Expiration;
+                return now > exp - preemptExpiryTime;
             }
 
             internal TimeSpan GetTimeToLive(TimeSpan preemptExpiryTime)
             {
                 var now = AWSSDKUtils.CorrectedUtcNow;
-                var exp = Expiration.ToUniversalTime();
+                var exp = Expiration;
 
                 return exp - now + preemptExpiryTime;
             }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -58,9 +58,7 @@ namespace Amazon.Runtime
 
             internal TimeSpan GetTimeToLive(TimeSpan preemptExpiryTime)
             {
-#pragma warning disable CS0612,CS0618 // Type or member is obsolete
                 var now = AWSSDKUtils.CorrectedUtcNow;
-#pragma warning restore CS0612,CS0618 // Type or member is obsolete
                 var exp = Expiration.ToUniversalTime();
 
                 return exp - now + preemptExpiryTime;

--- a/sdk/test/NetStandard/UnitTests/AWSSDK.UnitTests.Custom.NetStandard.csproj
+++ b/sdk/test/NetStandard/UnitTests/AWSSDK.UnitTests.Custom.NetStandard.csproj
@@ -59,7 +59,7 @@ This project file should not be used as part of a release pipeline.
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="Moq" Version="4.18.4" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" >
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 		    <PrivateAssets>all</PrivateAssets>
 		    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/sdk/test/NetStandard/UnitTests/Core/Credentials/RefreshingAWSCredentialsTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/Credentials/RefreshingAWSCredentialsTests.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Xunit;
+
+namespace UnitTests.NetStandard.Core.Credentials
+{
+    public sealed class RefreshingAWSCredentialsTests : IDisposable
+    {
+        private readonly Func<DateTime> _resetUtcNowSource;
+
+        public RefreshingAWSCredentialsTests()
+        {
+            _resetUtcNowSource = AWSConfigs.utcNowSource;
+        }
+
+        [Fact]
+        public void ConcurrentCallsToGetExpiredCrendentialsOnlyGeneratesNewCredentialsOnce()
+        {
+            var baseTimeUtc = new DateTime(1970, 1, 1).ToUniversalTime();
+            var lifetime = TimeSpan.FromMinutes(60);
+            var mockCredentials = new MockRefreshingAWSCredentials(lifetime)
+            {
+                PreemptExpiryTime = TimeSpan.FromMinutes(15),
+            };
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc;
+            var initialCreds = mockCredentials.GetCredentials();
+            
+            AWSConfigs.utcNowSource = () => baseTimeUtc + lifetime;
+
+            mockCredentials.CloseGenerateCredentialsGate(); // prevent GenerateNewCredentials from returning
+
+            var concurrentCredentialTasks = Task.WhenAll(
+                    Enumerable.Range(1, 5)
+                        .Select(i => Task.Run(() => mockCredentials.GetCredentials()))
+                    );
+
+            mockCredentials.OpenGenerateCredentialsGate(); // allow GenerateNewCredentials to complete
+
+            var allCreds = concurrentCredentialTasks.Result;
+            Assert.NotEqual(initialCreds, allCreds[0]);
+
+            Assert.Equal(2, mockCredentials.GeneratedTokenCount);
+            for (var i = 1; i < allCreds.Length; i++)
+            {
+                Assert.Equal(allCreds[0], allCreds[i]);
+            }
+        }
+
+        [Fact]
+        public void CredentialsAreRefreshedInImmediatelyWhenExpired()
+        {
+            var baseTimeUtc = new DateTime(1970, 1, 1).ToUniversalTime();
+            var lifetime = TimeSpan.FromMinutes(60);
+            var mockCredentials = new MockRefreshingAWSCredentials(lifetime)
+            {
+                PreemptExpiryTime = TimeSpan.FromMinutes(15),
+            };
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc;
+            var initialCreds = mockCredentials.GetCredentials();
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc + lifetime;
+            var credsAfterExpiration = mockCredentials.GetCredentials();
+            Assert.NotEqual(initialCreds, credsAfterExpiration);
+            Assert.Equal(2, mockCredentials.GeneratedTokenCount);
+        }
+
+        [Fact]
+        public async Task CredentialsAreRefreshedInImmediatelyWhenExpiredAsync()
+        {
+            var baseTimeUtc = new DateTime(1970, 1, 1).ToUniversalTime();
+            var lifetime = TimeSpan.FromMinutes(60);
+            var mockCredentials = new MockRefreshingAWSCredentials(lifetime)
+            {
+                PreemptExpiryTime = TimeSpan.FromMinutes(15),
+            };
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc;
+            var initialCreds = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc + lifetime;
+            var credsAfterExpiration = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
+            Assert.NotEqual(initialCreds, credsAfterExpiration);
+            Assert.Equal(2, mockCredentials.GeneratedTokenCount);
+        }
+
+        [Fact]
+        public async Task ConcurrentCallsToGetExpiredCrendentialsOnlyGeneratesNewCredentialsOnceAsync()
+        {
+            var baseTimeUtc = new DateTime(1970, 1, 1).ToUniversalTime();
+            var lifetime = TimeSpan.FromMinutes(60);
+            var mockCredentials = new MockRefreshingAWSCredentials(lifetime)
+            {
+                PreemptExpiryTime = TimeSpan.FromMinutes(15),
+            };
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc;
+            var initialCreds = mockCredentials.GetCredentials();
+            
+            AWSConfigs.utcNowSource = () => baseTimeUtc + lifetime;
+
+            mockCredentials.CloseGenerateCredentialsGate(); // prevent GenerateNewCredentials from returning
+
+            var concurrentCredentialTasks = Task.WhenAll(
+                    Enumerable.Range(1, 5)
+                        .Select(i => mockCredentials.GetCredentialsAsync())
+                    );
+
+            mockCredentials.OpenGenerateCredentialsGate(); // allow GenerateNewCredentials to complete
+
+            var allCreds = await concurrentCredentialTasks;
+
+            Assert.NotEqual(initialCreds, allCreds[0]);
+
+            Assert.Equal(2, mockCredentials.GeneratedTokenCount);
+            for (var i = 1; i < allCreds.Length; i++)
+            {
+                Assert.Equal(allCreds[0], allCreds[i]);
+            }
+        }
+
+        [Fact]
+        public void CredentialsAreRefreshedInBackgroundDuringPreemptyExpiryPeriod()
+        {
+            var baseTimeUtc = new DateTime(1970, 1, 1).ToUniversalTime();
+            var lifetime = TimeSpan.FromMinutes(60);
+            var mockCredentials = new MockRefreshingAWSCredentials(lifetime)
+            {
+                PreemptExpiryTime = TimeSpan.FromMinutes(15),
+            };
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc;
+            var initialCreds = mockCredentials.GetCredentials();
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc + TimeSpan.FromMinutes(50);
+            var previousState = mockCredentials.CurrentState;
+            var credsDuringPreemptExpiry = mockCredentials.GetCredentials();
+            Assert.Equal(initialCreds, credsDuringPreemptExpiry);
+
+            // wait for background refresh to complete
+            Assert.True(SpinWait.SpinUntil(() => !ReferenceEquals(mockCredentials.CurrentState, previousState), 1_000));
+
+            var credsAfterRefresh = mockCredentials.GetCredentials();
+            Assert.NotEqual(credsAfterRefresh, credsDuringPreemptExpiry);
+            Assert.Equal(AWSConfigs.utcNowSource() + lifetime - mockCredentials.PreemptExpiryTime, mockCredentials.CurrentState.Expiration);
+            Assert.Equal(2, mockCredentials.GeneratedTokenCount);
+        }
+
+        [Fact]
+        public async Task CredentialsAreRefreshedInBackgroundDuringPreemptyExpiryPeriodAsync()
+        {
+            var baseTimeUtc = new DateTime(1970, 1, 1).ToUniversalTime();
+            var lifetime = TimeSpan.FromMinutes(60);
+            var mockCredentials = new MockRefreshingAWSCredentials(lifetime)
+            {
+                PreemptExpiryTime = TimeSpan.FromMinutes(15),
+            };
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc;
+            var initialCreds = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
+
+            AWSConfigs.utcNowSource = () => baseTimeUtc + TimeSpan.FromMinutes(50);
+            var previousState = mockCredentials.CurrentState;
+            var credsDuringPreemptExpiry = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
+            Assert.Equal(initialCreds, credsDuringPreemptExpiry);
+
+            // wait for background refresh to complete
+            Assert.True(SpinWait.SpinUntil(() => !ReferenceEquals(mockCredentials.CurrentState, previousState), 1_000));
+
+            var credsAfterRefresh = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
+            Assert.NotEqual(credsAfterRefresh, credsDuringPreemptExpiry);
+            Assert.Equal(AWSConfigs.utcNowSource() + lifetime - mockCredentials.PreemptExpiryTime, mockCredentials.CurrentState.Expiration);
+            Assert.Equal(2, mockCredentials.GeneratedTokenCount);
+        }
+
+        public void Dispose()
+        {
+            AWSConfigs.utcNowSource = _resetUtcNowSource;
+        }
+
+        // using a hand-written mock in order to have access to the protected fields
+        private sealed class MockRefreshingAWSCredentials : RefreshingAWSCredentials
+        {
+            private readonly TimeSpan _credentialsLifetime;
+            private readonly ManualResetEventSlim _generateCredsEvent;
+            private int _tokenCounter;
+
+            public MockRefreshingAWSCredentials(TimeSpan credentialsLifetime)
+            {
+                _credentialsLifetime = credentialsLifetime;
+                _generateCredsEvent = new ManualResetEventSlim(initialState: true);
+                _tokenCounter = 0;
+            }
+
+            public CredentialsRefreshState CurrentState => base.currentState;
+
+            public int GeneratedTokenCount => _tokenCounter;
+
+            public bool IsGenerateCredentialsGateClosed => !_generateCredsEvent.IsSet;
+
+            public void OpenGenerateCredentialsGate()
+            {
+                _generateCredsEvent.Set();
+            }
+
+            public void CloseGenerateCredentialsGate()
+            {
+                _generateCredsEvent.Reset();
+            }
+
+            protected override CredentialsRefreshState GenerateNewCredentials()
+            {
+                _generateCredsEvent.Wait();
+                return new CredentialsRefreshState
+                {
+                    Credentials = new ImmutableCredentials("access_key_id", "secret_access_key", $"token_{Interlocked.Increment(ref _tokenCounter)}"),
+                    Expiration = AWSConfigs.utcNowSource() + _credentialsLifetime,
+                };
+            }
+
+            protected override Task<CredentialsRefreshState> GenerateNewCredentialsAsync()
+            {
+                return Task.Run(GenerateNewCredentials);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Enable a "background" refresh of the credentials when the current credentials state is expired but within the `PreemptExpiryTime` period.

## Description
<!--- Describe your changes in detail -->
Adds a new method `GetTimeToLive` to the `RefreshingAWSCredentials.CredentialsRefreshState` class which calculates the remaining time to live (TTL) for a credential, adjusting for the "baked-in" preempt expiry time period. Within the `GetCredentials(Async)` method,  the TTL is used to determine whether the current credentials are in one of three states: valid, expired, or valid but within the preempt expiry period. When in that last state, the current (valid, non-expired) credentials will be returned and a background refresh of the credentials will be attempted. If there is already an in-flight attempt (inline or background) to refresh the credentials, then a new background refresh will not be triggered. When in the expired state, an inline request to generate new credentials will still be triggered; however, after acquiring the mutual exclusion lock, the current credentials will be re-evaluated for whether they are still expired or not. This double-check helps to elide calls to `GenerateNewCredentials(Async)` when multiple tasks were in queue to acquire the refresh credentials lock, and preserves the existing behavior which contains the expiry check within the lock.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
We have encountered an issue in our containerized HTTP API services that talk to AWS services (such as DynamoDB) while they are under load. The root cause is _not_ an issue with the AWS SDK; however, an interesting cascading effect we have observed is "blips" in response times during an AWS credential refresh, in many cases leading to client request timeouts.

In the current implementation of the `RefreshingAWSCredentials` class, every call to `GetCredentialsAsync` will attempt to obtain exclusive access by calling `SemaphoreSlim.WaitAsync()`. When the `GenerateNewCredentialsAsync` call is delayed, then all calls to obtain credentials are blocked. In our service, since every incoming request is making at least one AWS service call, this effectively blocks all requests until it completes. This then leads to increased memory usage as all task continuation are enqueued with the `SemaphoreSlim`. If enough of these continuations are enqueued, GC pressure mounts, with the GC consuming more CPU time but unable to remove any of the rooted contexts, ultimately resulting in a negative feedback loop where the process spends most of its time in futile GC attempts. In the image below, there are over 1,000 continuations enqueued waiting for the new credentials to be generated, which consumes around 100MB.

This PR attempts to bypass any delays (and lock contention in general) with generating new credentials by attempting to perform a refresh of the credentials using a single background task.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We were able to reproduce the issue by using a custom implementation of `AssumeRoleWithWebIdentityCredentials` which allowed us to introduce a configurable amount of delay in the `GenerateNewCredentialsAsync` method. Additionally, we configured the `PreemptExpiryTime` value to be 59 minutes so that new credentials would be generated every 1 minute.

New unit tests were added to the solution to cover both existing and new functionality of the `RefreshingAWSCredentials` class.

## Screenshots (if appropriate)
![Screenshot 2024-10-10 085240](https://github.com/user-attachments/assets/6292a4e2-c154-4f51-8cdf-e8ba8a46d6eb)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement