### PR TITLE
Fixes issue #3479 where S3ForcePathStyle is unable to be read from a config file

### DIFF
--- a/generator/.DevConfigs/666f52b5-8ab6-4817-b54c-f42d2d41bb46.json
+++ b/generator/.DevConfigs/666f52b5-8ab6-4817-b54c-f42d2d41bb46.json
@@ -1,0 +1,18 @@
+{
+    "core": {
+        "changeLogMessages": [
+          "Add S3ForcePathStyle as a config option for credential profiles."
+        ],
+        "type": "patch",
+        "updateMinimum": true
+      },
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fixes [issue 3479](https://github.com/aws/aws-sdk-net/issues/3479) where ForcePathStyle is unable to be read from the config file"
+            ]
+        }
+    ]
+}

--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfile.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfile.cs
@@ -93,6 +93,11 @@ namespace Amazon.Runtime.CredentialManagement
         /// If true, the use of multi-region access points is disabled.
         /// </summary>
         public bool? S3DisableMultiRegionAccessPoints { get; set; }
+
+        /// <summary>
+        /// When true, S3 requests will always use path style addressing.
+        /// </summary>
+        public bool? S3ForcePathStyle { get; set; }
         
         /// <summary>
         /// The Sts Regional Endpoints Value as either legacy or regional

--- a/sdk/test/Services/S3/UnitTests/Custom/S3ForcePathStyleTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/S3ForcePathStyleTests.cs
@@ -1,0 +1,81 @@
+﻿using Amazon.S3;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using AWSSDK_DotNet.CommonTest.Utils;
+using Amazon.Runtime.CredentialManagement;
+
+namespace AWSSDK.UnitTests
+{
+    [TestClass]
+    public class S3ForcePathStyleTests
+    {
+        private static readonly string ProfileText =
+            @"[enable_force_path_style]
+                region = us-west-2
+                aws_access_key_id = default_aws_access_key_id   
+                aws_secret_access_key = default_aws_secret_access_key
+                s3_force_path_style = true
+                [disable_force_path_style]
+                region = us-west-2
+                aws_access_key_id = other_aws_access_key_id
+                aws_secret_access_key = other_aws_secret_access_key
+                s3_force_path_style = false";
+
+        private const string AWSProfileVariable = "AWS_PROFILE";
+        private string _beginningAWSProfileEnvironmentValue;
+        private string _tempCredentialsFilePath;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            // Save off current environment variable value to restore later
+            _beginningAWSProfileEnvironmentValue = Environment.GetEnvironmentVariable(AWSProfileVariable);
+
+            // Then clear the current value so every test is starting from a clean slate
+            Environment.SetEnvironmentVariable(AWSProfileVariable, "");
+
+            // set credentials file and use it to load CredentialProfileStoreChain
+            _tempCredentialsFilePath = Path.GetTempFileName();
+            File.WriteAllText(_tempCredentialsFilePath, ProfileText);
+            ReflectionHelpers.Invoke(typeof(AmazonS3Config), "credentialProfileChain", new CredentialProfileStoreChain(_tempCredentialsFilePath));
+            ReflectionHelpers.Invoke(typeof(AmazonS3Config), "_triedToResolveProfile", false);
+        }
+
+        [TestCleanup]
+        public void RestoreOriginalSettings()
+        {
+            Environment.SetEnvironmentVariable(AWSProfileVariable, _beginningAWSProfileEnvironmentValue);
+            File.Delete(_tempCredentialsFilePath);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void CredentialProfileEnable_ShouldApplyToS3Config()
+        {
+            Environment.SetEnvironmentVariable(AWSProfileVariable, "enable_force_path_style");
+            var config = new AmazonS3Config();
+            Assert.IsTrue(config.ForcePathStyle);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void UnsetForcePathStyleShouldDefaultToFalse()
+        {
+            var config = new AmazonS3Config();
+            Assert.IsFalse(config.ForcePathStyle);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void ConfigShouldOverrideProfile()
+        {
+            Environment.SetEnvironmentVariable(AWSProfileVariable, "enable_force_path_style");
+            var config = new AmazonS3Config
+            {
+                ForcePathStyle = false
+            };
+            Assert.IsFalse(config.ForcePathStyle);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A user can set ForcePathStyle on the `AmazonS3Config` object but it doesn't get read from the config file which makes it difficult to set when using something like the AWSSDK.Extensions.NetCoreSetup library, since that creates the client under the hood. This just adds the ability to read this value from the config file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes issue #3479 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Dry run in v3 passes
Added unit tests which pass.
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement