### PR TITLE
[SRA] Add identity resolver for bearer authentication scheme

### DIFF
--- a/extensions/src/Smithy.Identity.Abstractions/Identity/IIdentityResolver.cs
+++ b/extensions/src/Smithy.Identity.Abstractions/Identity/IIdentityResolver.cs
@@ -1,4 +1,7 @@
-﻿namespace Smithy.Identity.Abstractions
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smithy.Identity.Abstractions
 {
     /// <summary>
     /// An identity resolver is a component that is able to resolve a customer's <see cref="BaseIdentity"/>.
@@ -17,5 +20,11 @@
         /// If the identity cannot be resolved an exception will be thrown.
         /// </summary>
         BaseIdentity ResolveIdentity();
+
+        /// <summary>
+        /// Loads the customer's identity for this resolver. 
+        /// If the identity cannot be resolved an exception will be thrown.
+        /// </summary>
+        Task<BaseIdentity> ResolveIdentityAsync(CancellationToken cancellationToken);
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/BearerAuthScheme.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/BearerAuthScheme.cs
@@ -1,0 +1,37 @@
+﻿/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+using Smithy.Identity.Abstractions;
+
+namespace Amazon.Runtime.Credentials.Internal
+{
+    /// <summary>
+    /// The HTTP Bearer authentication scheme (which uses token credentials and its corresponding signer).
+    /// </summary>
+    public class BearerAuthScheme : IAuthScheme<AWSToken>
+    {
+        private static readonly ISigner _signer = new BearerTokenSigner();
+
+        /// <inheritdoc/>
+        public string SchemeId => AuthSchemeOption.Bearer;
+
+        /// <inheritdoc/>
+        public IIdentityResolver GetIdentityResolver(IIdentityResolverConfiguration configuration)
+            => configuration.GetIdentityResolver<AWSToken>();
+
+        /// <inheritdoc/>
+        public ISigner Signer() => _signer;
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/IdentityResolvers/AnonymousIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/IdentityResolvers/AnonymousIdentityResolver.cs
@@ -14,6 +14,8 @@
  */
 
 using Smithy.Identity.Abstractions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Amazon.Runtime.Credentials.Internal.IdentityResolvers
 {
@@ -22,12 +24,17 @@ namespace Amazon.Runtime.Credentials.Internal.IdentityResolvers
     /// </summary>
     public class AnonymousIdentityResolver : IIdentityResolver
     {
+        private readonly AnonymousAWSCredentials _credentials = new();
+
         /// <summary>
         /// Resolves the identity by returning an instance of <see cref="AnonymousAWSCredentials"/>.
         /// </summary>
-        public BaseIdentity ResolveIdentity()
-        {
-            return new AnonymousAWSCredentials();
-        }
+        public BaseIdentity ResolveIdentity() => _credentials;
+
+        /// <summary>
+        /// Resolves the identity by returning an instance of <see cref="AnonymousAWSCredentials"/>.
+        /// </summary>
+        public Task<BaseIdentity> ResolveIdentityAsync(CancellationToken cancellationToken)
+            => Task.FromResult<BaseIdentity>(_credentials);
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/IdentityResolvers/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/IdentityResolvers/DefaultAWSCredentialsIdentityResolver.cs
@@ -22,6 +22,7 @@ using System.Globalization;
 using System.IO;
 using System.Security;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Amazon.Runtime.Credentials.Internal.IdentityResolvers
 {
@@ -48,7 +49,7 @@ namespace Amazon.Runtime.Credentials.Internal.IdentityResolvers
                 _credentialsGenerators = new List<CredentialsGenerator>
                 {
 #if BCL
-                () => new AppConfigAWSCredentials(), // Test explicit keys/profile name first.
+                    () => new AppConfigAWSCredentials(), // Test explicit keys/profile name first.
 #endif
                     () => AssumeRoleWithWebIdentityCredentials.FromEnvironmentVariables(),
                     () => new EnvironmentVariablesAWSCredentials(), // Look for credentials set in environment vars.
@@ -136,7 +137,11 @@ namespace Amazon.Runtime.Credentials.Internal.IdentityResolvers
             {
                 _cachedCredentialsLock.ExitWriteLock();
             }
+        }
 
+        public async Task<BaseIdentity> ResolveIdentityAsync(CancellationToken cancellationToken)
+        {
+            return await Task.Run(() => ResolveIdentity(), cancellationToken).ConfigureAwait(false);
         }
 
         private static AWSCredentials GetAWSCredentials(ICredentialProfileSource source)

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/IdentityResolvers/DefaultAWSTokenIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/IdentityResolvers/DefaultAWSTokenIdentityResolver.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Smithy.Identity.Abstractions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Amazon.Runtime.Credentials.Internal.IdentityResolvers
+{
+    /// <summary>
+    /// A resolver that provides a bearer token identity.
+    /// </summary>
+    public class DefaultAWSTokenIdentityResolver : IIdentityResolver
+    {
+        private readonly IAWSTokenProvider _tokenProvider;
+
+        public DefaultAWSTokenIdentityResolver() : this(null) { }
+
+        public DefaultAWSTokenIdentityResolver(string profileName)
+            => _tokenProvider = new AWSTokenProviderChain(new ProfileTokenProvider(profileName));
+
+        /// <inheritdoc/>
+        public BaseIdentity ResolveIdentity()
+        {
+#if NETFRAMEWORK
+            if (_tokenProvider.TryResolveToken(out var token))
+            {
+                return token;
+            }
+
+            throw new AmazonClientException($"Failed to resolve bearer token in {nameof(DefaultAWSTokenIdentityResolver)}");
+#else
+            throw new System.NotSupportedException($"{nameof(ResolveIdentityAsync)} must be used in cross-platform .NET");
+#endif
+        }
+
+        /// <inheritdoc/>
+        public async Task<BaseIdentity> ResolveIdentityAsync(CancellationToken cancellationToken)
+        {
+            var tokenResponse = await _tokenProvider.TryResolveTokenAsync(cancellationToken).ConfigureAwait(false);
+            if (tokenResponse.Success)
+            {
+                return tokenResponse.Value;
+            }
+
+            throw new AmazonClientException($"Failed to resolve bearer token in {nameof(DefaultAWSTokenIdentityResolver)}");
+        }
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/IdentityResolvers/IdentityResolverConfiguration.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/IdentityResolvers/IdentityResolverConfiguration.cs
@@ -23,17 +23,20 @@ namespace Amazon.Runtime.Credentials.Internal.IdentityResolvers
     public class DefaultIdentityResolverConfiguration : IIdentityResolverConfiguration
     {
         public static readonly IIdentityResolverConfiguration Instance = new DefaultIdentityResolverConfiguration();
-        private static readonly Dictionary<Type, IIdentityResolver> identityResolvers = new Dictionary<Type, IIdentityResolver>()
-            {
-                { typeof(AnonymousAWSCredentials), new AnonymousIdentityResolver() },
-                { typeof(AWSCredentials), new DefaultAWSCredentialsIdentityResolver() },
-            };
+        private static readonly Dictionary<Type, IIdentityResolver> identityResolvers = new()
+        {
+            { typeof(AnonymousAWSCredentials), new AnonymousIdentityResolver() },
+            { typeof(AWSCredentials), new DefaultAWSCredentialsIdentityResolver() },
+            { typeof(AWSToken), new DefaultAWSTokenIdentityResolver() },
+        };
 
         /// <inheritdoc/>
         public IIdentityResolver GetIdentityResolver<T>() where T : BaseIdentity
         {
-            if(identityResolvers.TryGetValue(typeof(T), out var identityResolver))
+            if (identityResolvers.TryGetValue(typeof(T), out var identityResolver))
+            {
                 return identityResolver;
+            }
 
             throw new NotImplementedException($"{typeof(T).Name} is not supported");
         }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Signer.cs
@@ -106,7 +106,19 @@ namespace Amazon.Runtime.Internal
 
             // credentials would be null in the case of anonymous users getting public resources from S3
             if (immutableCredentials == null && requestContext.Signer.RequiresCredentials)
+            {
                 return;
+            }
+
+            // The signer interface expects immutable credentials, which does not match the AWSToken structure.
+            // We'll manually set a property so that the bearer token still works as expected.
+            if (requestContext.Signer is BearerTokenSigner tokenSigner)
+            {
+                if (requestContext.Identity is AWSToken resolvedToken)
+                {
+                    tokenSigner.ResolvedToken = resolvedToken.Token;
+                }
+            }
 
             using (requestContext.Metrics.StartEvent(Metric.RequestSigningTime))
             using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.AuthSigningDurationMetricName))
@@ -143,7 +155,19 @@ namespace Amazon.Runtime.Internal
 
             // credentials would be null in the case of anonymous users getting public resources from S3
             if (immutableCredentials == null && requestContext.Signer.RequiresCredentials)
+            {
                 return;
+            }
+
+            // The signer interface expects immutable credentials, which does not match the AWSToken structure.
+            // We'll manually set a property so that the bearer token still works as expected.
+            if (requestContext.Signer is BearerTokenSigner tokenSigner)
+            {
+                if (requestContext.Identity is AWSToken resolvedToken)
+                {
+                    tokenSigner.ResolvedToken = resolvedToken.Token;
+                }
+            }
 
             using (requestContext.Metrics.StartEvent(Metric.RequestSigningTime))
             using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.AuthSigningDurationMetricName))

--- a/sdk/src/Core/Amazon.Runtime/Tokens/AWSToken.cs
+++ b/sdk/src/Core/Amazon.Runtime/Tokens/AWSToken.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using Smithy.Identity.Abstractions;
 using System;
 using System.Diagnostics;
 
@@ -26,11 +27,19 @@ namespace Amazon.Runtime
     /// This class is the focused public projection of the internal class
     /// Amazon.Runtime.Credentials.Internal.SsoToken
     /// </remarks>
-    [DebuggerDisplay("{"+ nameof(Token) + "}")]
-    public class AWSToken
+    [DebuggerDisplay("{" + nameof(Token) + "}")]
+    public class AWSToken : BaseIdentity
     {
         public string Token { get; set; }
-        public DateTime? ExpiresAt { get; set; }
+
+        [Obsolete("This property is deprecated in favor of Expiration.")]
+        public DateTime? ExpiresAt
+        {
+            get { return Expiration; }
+            set { this.Expiration = value; }
+        }
+
+        public override DateTime? Expiration { get; set; }
 
         public override string ToString()
         {

--- a/sdk/src/Core/Amazon.Runtime/Tokens/DefaultAWSTokenProviderChain.cs
+++ b/sdk/src/Core/Amazon.Runtime/Tokens/DefaultAWSTokenProviderChain.cs
@@ -28,7 +28,6 @@ namespace Amazon.Runtime
     /// <example>
     /// Example below demonstrates how to build a custom <see cref="DefaultAWSTokenProviderChain"/> in a
     /// <see cref="ClientConfig.AWSTokenProvider"/>.
-    /// NOTE: The below example requires .NET 4.5 or above.
     /// <code>
     /// <![CDATA[
     /// var exampleServiceClientConfig = new ExampleServiceClientConfig

--- a/sdk/src/Core/Amazon.Runtime/Tokens/StaticTokenProvider.cs
+++ b/sdk/src/Core/Amazon.Runtime/Tokens/StaticTokenProvider.cs
@@ -39,7 +39,12 @@ namespace Amazon.Runtime
         {
             if (IsTokenUnexpired())
             {
-                token = new AWSToken {Token = _token};
+                token = new AWSToken 
+                { 
+                    Token = _token,
+                    Expiration = _expiration,
+                };
+
                 return true;
             }
             else
@@ -59,7 +64,7 @@ namespace Amazon.Runtime
                 new TryResponse<AWSToken>
                 {
                     Success = isTokenUnexpired,
-                    Value = isTokenUnexpired ? new AWSToken { Token = _token } : null
+                    Value = isTokenUnexpired ? new AWSToken { Token = _token, Expiration = _expiration } : null
                 });
         }
 #endif

--- a/sdk/src/Core/Amazon.Runtime/_bcl+netstandard/Tokens/SSOTokenProvider.cs
+++ b/sdk/src/Core/Amazon.Runtime/_bcl+netstandard/Tokens/SSOTokenProvider.cs
@@ -137,7 +137,7 @@ namespace Amazon.Runtime
             return new AWSToken
             {
                 Token = token.AccessToken,
-                ExpiresAt = token.ExpiresAt
+                Expiration = token.ExpiresAt
             };
         }
     }

--- a/sdk/test/UnitTests/Custom/Runtime/_bcl/BearerTokenServiceTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/_bcl/BearerTokenServiceTests.cs
@@ -58,7 +58,6 @@ namespace AWSSDK.UnitTests.Runtime
         [TestMethod]
         [TestCategory("UnitTest")]
         [TestCategory("Runtime")]
-        [Ignore("This test is pending 'smithy.api#httpBearerAuth' schemeId implementation")]
         public void ServiceUsingBearerTokenCorrectlySetsAuthorizationHeader()
         {
             // ARRANGE
@@ -95,7 +94,6 @@ namespace AWSSDK.UnitTests.Runtime
         [TestMethod]
         [TestCategory("UnitTest")]
         [TestCategory("Runtime")]
-        [Ignore("This test is pending 'smithy.api#httpBearerAuth' schemeId implementation")]
         public void ServiceUsingBearerTokenAllowsCustomizingTokenProvider()
         {
             // ARRANGE

--- a/sdk/test/UnitTests/Custom/Runtime/_bcl/Tokens/SSOTokenProviderTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/_bcl/Tokens/SSOTokenProviderTests.cs
@@ -70,7 +70,7 @@ namespace AWSSDK.UnitTests.Runtime
                         x.RefreshToken(It.Is<GetSsoTokenResponse>(r => testCase.MockSSOOIDCCLientRefreshDetails.RefreshRequestMatchCriteria(r))))
                     .Returns(responseFactory);
             }
-            
+
             var mockFileSystem = new MockFileSystem();
             mockFileSystem.WriteAllText(
                 Path.Combine(testCacheFolder, cacheFile),
@@ -168,7 +168,7 @@ namespace AWSSDK.UnitTests.Runtime
                         RegistrationExpiresAt = req.RegistrationExpiresAt,
                         StartUrl = req.StartUrl
                     }));
-                
+
                 mockSSOOIDCClient
                     .Setup(x =>
                         x.RefreshTokenAsync(It.Is<GetSsoTokenResponse>(r => testCase.MockSSOOIDCCLientRefreshDetails.RefreshRequestMatchCriteria(r))))
@@ -264,10 +264,10 @@ namespace AWSSDK.UnitTests.Runtime
                 AssertOnAWSToken = token =>
                 {
                     Assert.AreEqual("cachedtoken", token.Token);
-                    Assert.AreEqual(DateTime.Parse("2021-12-25T21:30:00Z").ToUniversalTime(), token.ExpiresAt);
+                    Assert.AreEqual(DateTime.Parse("2021-12-25T21:30:00Z").ToUniversalTime(), token.Expiration);
                 }
             }};
-            
+
             // Minimal valid cached token
             yield return new object[] {new TestCase
             {
@@ -280,10 +280,10 @@ namespace AWSSDK.UnitTests.Runtime
                 AssertOnAWSToken = token =>
                 {
                     Assert.AreEqual("cachedtoken", token.Token);
-                    Assert.AreEqual(DateTime.Parse("2021-12-25T21:30:00Z").ToUniversalTime(), token.ExpiresAt);
+                    Assert.AreEqual(DateTime.Parse("2021-12-25T21:30:00Z").ToUniversalTime(), token.Expiration);
                 }
             }};
-            
+
             // Minimal expired cached token
             yield return new object[] {new TestCase
             {
@@ -377,7 +377,7 @@ namespace AWSSDK.UnitTests.Runtime
                 AssertOnAWSToken = token =>
                 {
                     Assert.AreEqual("newtoken", token.Token);
-                    Assert.AreEqual(DateTime.Parse("2021-12-25T21:30:00Z").ToUniversalTime(), token.ExpiresAt);
+                    Assert.AreEqual(DateTime.Parse("2021-12-25T21:30:00Z").ToUniversalTime(), token.Expiration);
                 }
             }};
 
@@ -426,7 +426,7 @@ namespace AWSSDK.UnitTests.Runtime
                 AssertOnAWSToken = token =>
                 {
                     Assert.AreEqual("newtoken", token.Token);
-                    Assert.AreEqual(DateTime.Parse("2021-12-25T21:30:00Z").ToUniversalTime(), token.ExpiresAt);
+                    Assert.AreEqual(DateTime.Parse("2021-12-25T21:30:00Z").ToUniversalTime(), token.Expiration);
                 }
             }};
 
@@ -446,7 +446,7 @@ namespace AWSSDK.UnitTests.Runtime
                     ""registrationExpiresAt"": ""2022-12-25T13:30:00Z"",
                     ""refreshToken"": ""cachedrefreshtoken""
                 }",
-                AssertException = e => 
+                AssertException = e =>
                 {
                     Assert.IsInstanceOfType(e, typeof(AmazonClientException));
                     Assert.IsTrue(e.Message.StartsWith("SSO Token has expired and failed to refresh"), e.Message);


### PR DESCRIPTION
## Description
Updates the `IdentityResolverConfiguration` to resolve the bearer authentication scheme (i.e. the `smithy.api#httpBearerAuth` trait). I also had to modify other existing components (such as the bearer token signer) since their implementation is different than SigV4 / SigV4A credentials.

## Motivation and Context
`DOTNET-7652`

## Testing
- Dry-run: `DRY_RUN-23d6c74a-9d68-484f-b185-acd1787f844f`
- Ran a local application specifying a profile using SSO (note: while testing I noticed we're not including the Smithy project DLL in the Core `.nupkg` file - will address that in a separate PR).

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license