### PR TITLE
Add System.Numerics.Vectors to NoticeForZips file

### DIFF
--- a/buildtools/NoticeForZips.txt
+++ b/buildtools/NoticeForZips.txt
@@ -102,6 +102,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ----------------
 
+** System.Numerics.Vectors
+
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+----------------
+
 ** System.Text.Json
 
 The MIT License (MIT)

--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -523,15 +523,16 @@
 
     <Target Name="copy-license-and-notice" DependsOnTargets="$(copy-license-and-notice-DependsOnTargets)">
         <Message Text="Copying License.txt and Notice.txt to the assembly zips" />
+        <!-- net472 and netstandard2.0 need modified Notice with additional 3rd party dependencies -->
         <Copy
-            SourceFiles="../Notice.txt;../License.txt"
+            SourceFiles="./NoticeForZips.txt;../License.txt"
             DestinationFiles="../Deployment/assemblies/net472/Notice.txt;../Deployment/assemblies/net472/License.txt"
         />
-        <!-- netstandard2.0 needs modified Notice with additional 3rd party dependencies -->
         <Copy
             SourceFiles="./NoticeForZips.txt;../License.txt"
             DestinationFiles="../Deployment/assemblies/netstandard2.0/Notice.txt;../Deployment/assemblies/netstandard2.0/License.txt"
         />
+
         <Copy
             SourceFiles="../Notice.txt;../License.txt"
             DestinationFiles="../Deployment/assemblies/netcoreapp3.1/Notice.txt;../Deployment/assemblies/netcoreapp3.1/License.txt"


### PR DESCRIPTION
## Description
Updates the `buildtools/NoticeForZips.txt` file to include `System.Numerics.Vectors` (which is a dependency of `System.Memory` that needs to be included in the SDK zip files).

## Motivation and Context
Internal issue: `DOTNET-7832`

## License
- [X] I confirm that this pull request can be released under the Apache 2 license