### PR TITLE
Add DSQL auth token generator

### DIFF
--- a/generator/.DevConfigs/5B1CABC0-FA39-48C5-B8BB-D4DBBFF4F45D.json
+++ b/generator/.DevConfigs/5B1CABC0-FA39-48C5-B8BB-D4DBBFF4F45D.json
@@ -1,0 +1,18 @@
+{
+    "services": [
+        {
+            "serviceName": "DSQL",
+            "type": "minor",
+            "changeLogMessages": [
+                "Add Amazon.DSQL.Util.DSQLAuthTokenGenerator for generating auth tokens for connecting to DSQL clusters."
+            ]
+        },
+        {
+            "serviceName": "RDS",
+            "type": "patch",
+            "changeLogMessages": [
+                "Update documentation for Amazon.RDS.Util.RDSAuthTokenGenerator."
+            ]
+        }		
+    ]
+}

--- a/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
+++ b/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
@@ -1,0 +1,261 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Auth;
+using Amazon.Runtime.Internal.Transform;
+using Amazon.Runtime.Internal.Util;
+using System;
+using System.Globalization;
+
+namespace Amazon.DSQL.Util
+{
+    /// <summary>
+    /// Provides authorization tokens for IAM authentication to an DSQL database.
+    /// </summary>
+    public static class DSQLAuthTokenGenerator
+    {
+        private const string DSQLServiceName = "dsql";
+        private const string HTTPGet = "GET";
+        private const string HTTPS = "https";
+        private const string URISchemeDelimiter = "://";
+        private const string ActionKey = "Action";
+        private const string DBConnectActionValue = "DbConnect";
+        private const string DBConnectAdminActionValue = "DbConnectAdmin";
+        private const string XAmzExpires = "X-Amz-Expires";
+        private const string XAmzSecurityToken = "X-Amz-Security-Token";
+        private static readonly TimeSpan FifteenMinutes = TimeSpan.FromMinutes(15);
+
+        /// <summary>
+        /// AWS4PreSignedUrlSigner is built around operation request objects.
+        /// This request type will only be used to generate the signed token.
+        /// It will never be used to make an actual request to DSQL.
+        /// </summary>
+        private class GenerateDSQLAuthTokenRequest : AmazonWebServiceRequest
+        {
+            public GenerateDSQLAuthTokenRequest()
+            {
+                ((IAmazonWebServiceRequest)this).SignatureVersion = SignatureVersion.SigV4;
+            }
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
+        /// <remarks>
+        /// The AWS region and credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static string GenerateDbConnectAuthToken(string hostname)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return GenerateDbConnectAuthToken(region, hostname);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
+        /// <remarks>
+        /// The AWS credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="region">The region of the DSQL database.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static string GenerateDbConnectAuthToken(RegionEndpoint region, string hostname)
+        {
+            AWSCredentials credentials = FallbackCredentialsFactory.GetCredentials();
+            return GenerateDbConnectAuthToken(credentials, region, hostname);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
+        /// <remarks>
+        /// The AWS region for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static string GenerateDbConnectAuthToken(AWSCredentials credentials, string hostname)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return GenerateDbConnectAuthToken(credentials, region, hostname);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="region">The region of the DSQL database.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static string GenerateDbConnectAuthToken(AWSCredentials credentials, RegionEndpoint region, string hostname)
+        {
+            if (credentials == null)
+                throw new ArgumentNullException("credentials");
+
+            var immutableCredentials = credentials.GetCredentials();
+            return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue);
+        }
+
+#if AWS_ASYNC_API
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="region">The region of the DSQL database.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateDbConnectAuthTokenAsync(AWSCredentials credentials, RegionEndpoint region, string hostname)
+        {
+            if (credentials == null)
+                throw new ArgumentNullException("credentials");
+
+            var immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue);
+        }
+#endif
+
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnectAdmin action.
+        /// <remarks>
+        /// The AWS region and credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static string GenerateDbConnectAdminAuthToken(string hostname)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return GenerateDbConnectAdminAuthToken(region, hostname);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnectAdmin action.
+        /// <remarks>
+        /// The AWS credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="region">The region of the DSQL database.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static string GenerateDbConnectAdminAuthToken(RegionEndpoint region, string hostname)
+        {
+            AWSCredentials credentials = FallbackCredentialsFactory.GetCredentials();
+            return GenerateDbConnectAdminAuthToken(credentials, region, hostname);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnectAdmin action.
+        /// <remarks>
+        /// The AWS region for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static string GenerateDbConnectAdminAuthToken(AWSCredentials credentials, string hostname)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return GenerateDbConnectAdminAuthToken(credentials, region, hostname);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnectAdmin action.
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="region">The region of the DSQL database.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static string GenerateDbConnectAdminAuthToken(AWSCredentials credentials, RegionEndpoint region, string hostname)
+        {
+            if (credentials == null)
+                throw new ArgumentNullException("credentials");
+
+            var immutableCredentials = credentials.GetCredentials();
+            return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue);
+        }
+
+#if AWS_ASYNC_API
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnectAdmin action.
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="region">The region of the DSQL database.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateDbConnectAdminAuthTokenAsync(AWSCredentials credentials, RegionEndpoint region, string hostname)
+        {
+            if (credentials == null)
+                throw new ArgumentNullException("credentials");
+
+            var immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue);
+        }
+#endif
+
+
+        private static string GenerateAuthToken(ImmutableCredentials immutableCredentials, RegionEndpoint region, string hostname, string actionValue)
+        {
+            if (immutableCredentials == null)
+                throw new ArgumentNullException("immutableCredentials");
+
+            if (region == null)
+                throw new ArgumentNullException("region");
+
+            hostname = hostname?.Trim();
+            if (string.IsNullOrEmpty(hostname))
+                throw new ArgumentException("Hostname must not be null or empty.");
+
+            GenerateDSQLAuthTokenRequest authTokenRequest = new GenerateDSQLAuthTokenRequest();
+            IRequest request = new DefaultRequest(authTokenRequest, DSQLServiceName);
+
+            request.UseQueryString = true;
+            request.HttpMethod = HTTPGet;
+            request.Parameters.Add(XAmzExpires, FifteenMinutes.TotalSeconds.ToString(CultureInfo.InvariantCulture));
+            request.Parameters.Add(ActionKey, actionValue);
+            request.Endpoint = new UriBuilder(HTTPS, hostname).Uri;
+
+            if (immutableCredentials.UseToken)
+            {
+                request.Parameters[XAmzSecurityToken] = immutableCredentials.Token;
+            }
+
+            var signingResult = AWS4PreSignedUrlSigner.SignRequest(request, null, new RequestMetrics(), immutableCredentials.AccessKey,
+                immutableCredentials.SecretKey, DSQLServiceName, region.SystemName);
+
+            var authorization = "&" + signingResult.ForQueryParameters;
+            var url = AmazonServiceClient.ComposeUrl(request);
+
+            // remove the https:// and append the authorization
+            return url.AbsoluteUri.Substring(HTTPS.Length + URISchemeDelimiter.Length) + authorization;
+        }
+    }
+}

--- a/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
+++ b/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
@@ -55,9 +55,9 @@ namespace Amazon.RDS.Util
         /// <summary>
         /// Generate a token for IAM authentication to an RDS database.
         /// <remarks>
-        /// Token generation additionally requires a RegionEndpoint and AWSCredentials.
-        /// They will be loaded from the application's default configuration,
-        /// and if unsuccessful from the Instance Profile service on an EC2 instance.
+        /// The AWS region and credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
         /// </remarks>
         /// </summary>
         /// <param name="hostname">Hostname of the RDS database.</param>
@@ -73,9 +73,9 @@ namespace Amazon.RDS.Util
         /// <summary>
         /// Generate a token for IAM authentication to an RDS database.
         /// <remarks>
-        /// Token generation additionally requires AWSCredentials.
-        /// They will be loaded from the application's default configuration,
-        /// and if unsuccessful from the Instance Profile service on an EC2 instance.
+        /// The AWS credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
         /// </remarks>
         /// </summary>
         /// <param name="region">The region of the RDS database.</param>
@@ -92,9 +92,9 @@ namespace Amazon.RDS.Util
         /// <summary>
         /// Generate a token for IAM authentication to an RDS database.
         /// <remarks>
-        /// Token generation additionally requires a RegionEndpoint.
-        /// It will be loaded from the application's default configuration,
-        /// and if unsuccessful from the Instance Profile service on an EC2 instance.
+        /// The AWS region for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
         /// </remarks>
         /// </summary>
         /// <param name="credentials">The credentials for the token.</param>

--- a/sdk/test/Services/DSQL/UnitTests/Custom/DSQLAuthTokenGeneratorTest.cs
+++ b/sdk/test/Services/DSQL/UnitTests/Custom/DSQLAuthTokenGeneratorTest.cs
@@ -1,0 +1,289 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon;
+using Amazon.DSQL;
+using Amazon.DSQL.Util;
+using Amazon.Runtime;
+using Amazon.Util;
+using AWSSDK_DotNet.IntegrationTests.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace AWSSDK.UnitTests.DSQL
+{
+    [TestClass]
+    public class DSQLAuthTokenGeneratorTest
+    {
+        private const string DBCluster = "db_cluster";
+        private const string DBConnectActionValue = "DbConnect";
+        private const string DBConnectAdminActionValue = "DbConnectAdmin";
+        private const string AccessKey = "access_key";
+        private const string SecretKey = "secret_key";
+        private const string SessionToken = "session_token";
+
+        private static readonly RegionEndpoint AWSRegion = RegionEndpoint.GetBySystemName("us-east-1");
+        private static readonly AWSCredentials BasicCredentials = new BasicAWSCredentials(AccessKey, SecretKey);
+        private static readonly AWSCredentials SessionCredentials = new SessionAWSCredentials(AccessKey, SecretKey, SessionToken);
+
+        private List<FallbackCredentialsFactory.CredentialsGenerator> originalFallbackList;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            originalFallbackList = FallbackCredentialsFactory.CredentialsGenerators;
+
+            FallbackCredentialsFactory.Reset();
+            FallbackCredentialsFactory.CredentialsGenerators = new List<FallbackCredentialsFactory.CredentialsGenerator>()
+            {
+                () => { return BasicCredentials; }
+            };
+            AWSConfigs.AWSRegion = AWSRegion.SystemName;
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            FallbackCredentialsFactory.Reset();
+            FallbackCredentialsFactory.CredentialsGenerators = originalFallbackList;
+        }
+
+        // DbConnect
+
+#if ASYNC_AWAIT
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public async System.Threading.Tasks.Task GenerateDbConnectAuthTokenBasicAsync()
+        {
+            AssertAuthToken(await DSQLAuthTokenGenerator.GenerateDbConnectAuthTokenAsync(BasicCredentials,
+                AWSRegion, DBCluster), AccessKey, AWSRegion, DBConnectActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public async System.Threading.Tasks.Task GenerateDbConnectAuthTokenSessionAsync()
+        {
+            AssertAuthToken(await DSQLAuthTokenGenerator.GenerateDbConnectAuthTokenAsync(SessionCredentials,
+                AWSRegion, DBCluster), AccessKey, AWSRegion, DBConnectActionValue, true);
+        }
+#endif
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAuthTokenBasic()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAuthToken(BasicCredentials,
+                AWSRegion, DBCluster), AccessKey, AWSRegion, DBConnectActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAuthTokenSession()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAuthToken(SessionCredentials,
+                AWSRegion, DBCluster), AccessKey, AWSRegion, DBConnectActionValue, true);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAuthTokenNoRegion()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAuthToken(BasicCredentials,
+                DBCluster), AccessKey, FallbackRegionFactory.GetRegionEndpoint(), DBConnectActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAuthTokenNoCredentials()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAuthToken(AWSRegion,
+                DBCluster), AccessKey, AWSRegion, DBConnectActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAuthTokenNoRegionNoCredentials()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAuthToken(DBCluster),
+                AccessKey, FallbackRegionFactory.GetRegionEndpoint(), DBConnectActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAuthTokenNullCredentials()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                DSQLAuthTokenGenerator.GenerateDbConnectAuthToken((AWSCredentials)null, DBCluster);
+            }, typeof(ArgumentNullException));
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAuthTokenNullRegion()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                DSQLAuthTokenGenerator.GenerateDbConnectAuthToken((RegionEndpoint)null, DBCluster);
+            }, typeof(ArgumentNullException));
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAuthTokenNullHostname()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                DSQLAuthTokenGenerator.GenerateDbConnectAuthToken(AWSRegion, null);
+            }, typeof(ArgumentException));
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAuthTokenEmptyHostname()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                DSQLAuthTokenGenerator.GenerateDbConnectAuthToken(AWSRegion, " ");
+            }, typeof(ArgumentException));
+        }
+
+        // DbConnectAdmin
+
+        #if ASYNC_AWAIT
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public async System.Threading.Tasks.Task GenerateDbConnectAdminAuthTokenBasicAsync()
+        {
+            AssertAuthToken(await DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthTokenAsync(BasicCredentials,
+                AWSRegion, DBCluster), AccessKey, AWSRegion, DBConnectAdminActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public async System.Threading.Tasks.Task GenerateDbConnectAdminAuthTokenSessionAsync()
+        {
+            AssertAuthToken(await DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthTokenAsync(SessionCredentials,
+                AWSRegion, DBCluster), AccessKey, AWSRegion, DBConnectAdminActionValue, true);
+        }
+#endif
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAdminAuthTokenBasic()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthToken(BasicCredentials,
+                AWSRegion, DBCluster), AccessKey, AWSRegion, DBConnectAdminActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAdminAuthTokenSession()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthToken(SessionCredentials,
+                AWSRegion, DBCluster), AccessKey, AWSRegion, DBConnectAdminActionValue, true);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAdminAuthTokenNoRegion()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthToken(BasicCredentials,
+                DBCluster), AccessKey, FallbackRegionFactory.GetRegionEndpoint(), DBConnectAdminActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAdminAuthTokenNoCredentials()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthToken(AWSRegion,
+                DBCluster), AccessKey, AWSRegion, DBConnectAdminActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAdminAuthTokenNoRegionNoCredentials()
+        {
+            AssertAuthToken(DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthToken(DBCluster),
+                AccessKey, FallbackRegionFactory.GetRegionEndpoint(), DBConnectAdminActionValue);
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAdminAuthTokenNullCredentials()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthToken((AWSCredentials)null, DBCluster);
+            }, typeof(ArgumentNullException));
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAdminAuthTokenNullRegion()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthToken((RegionEndpoint)null, DBCluster);
+            }, typeof(ArgumentNullException));
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAdminAuthTokenNullHostname()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthToken(AWSRegion, null);
+            }, typeof(ArgumentException));
+        }
+
+        [TestMethod]
+        [TestCategory("DSQL")]
+        public void GenerateDbConnectAdminAuthTokenEmptyHostname()
+        {
+            AssertExtensions.ExpectException(() =>
+            {
+                DSQLAuthTokenGenerator.GenerateDbConnectAdminAuthToken(AWSRegion, " ");
+            }, typeof(ArgumentException));
+        }
+
+        private void AssertAuthToken(string token, string accessKey, RegionEndpoint region, string actionValue)
+        {
+            AssertAuthToken(token, accessKey, region, actionValue, false);
+        }
+
+        private void AssertAuthToken(string token, string accessKey, RegionEndpoint region, string actionValue, bool hasSessionToken)
+        {
+            // Look for today or yesterday to cover the crazy case where the
+            // token was generated utc yesterday but we're asserting utc today.
+            DateTime utcNow = DateTime.UtcNow;
+            var todayRegex = "(" + utcNow.ToString("yyyyMMdd") + "|" + utcNow.AddDays(-1).ToString("yyyyMMdd") + ")";
+
+            var sessionTokenPart = hasSessionToken ? "X-Amz-Security-Token=" + AWSSDKUtils.UrlEncode(SessionToken, false) + "&" : "";
+            var regex = Regex.Escape(string.Format(CultureInfo.InvariantCulture,
+                "{0}/?Action={1}&X-Amz-Expires=900&{2}X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=" +
+                "{3}%2FTODAYREGEX%2F{4}%2Fdsql%2Faws4_request&X-Amz-Date=TODAYREGEXTTIMEREGEXZ&X-Amz-SignedHeaders=host&X-Amz-Signature=SIGNATUREREGEX",
+                DBCluster, actionValue, sessionTokenPart, accessKey, region.SystemName));
+            regex = regex.Replace("TIMEREGEX", "[0-9]{6}").Replace("SIGNATUREREGEX", "[0-9a-f]{64}").Replace("TODAYREGEX", todayRegex);
+
+            Assert.IsTrue(Regex.IsMatch(token, regex), token + " doesn't match regex " + regex);
+        }
+
+    }
+}


### PR DESCRIPTION
## Description
Add utility code for generating auth token used for connect to the new DSQL service. This code is very similar to the RDS auth token generator feature already in the SDK. https://github.com/aws/aws-sdk-net/blob/main/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs#L29

Well adding this I fixed up the documentation in the RDS auth generator to match what I was saying in the DSQL version. Not sure why the RDS implied it would only search for credentials through EC2 instance metadata.


## Motivation and Context
Make it easier to generate the DSQL auth token for .NET users.

## Testing
Added new unit tests and ran a successful dry run. I also created a DSQL cluster and confirmed I was able to generate an auth token and connect to the cluster with the auth token.

