### PR TITLE
Remove abstract Sign override that uses access and secret key.

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -107,44 +107,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// <param name="metrics">
         /// Metrics for the request
         /// </param>
-        /// <param name="awsAccessKeyId">
-        /// The AWS public key for the account making the service call.
-        /// </param>
-        /// <param name="awsSecretAccessKey">
-        /// The AWS secret key for the account making the call, in clear text.
-        /// </param>
-        /// <exception cref="Amazon.Runtime.SignatureException">
-        /// If any problems are encountered while signing the request.
-        /// </exception>
-        public override void Sign(IRequest request, 
-                                  IClientConfig clientConfig, 
-                                  RequestMetrics metrics, 
-                                  string awsAccessKeyId, 
-                                  string awsSecretAccessKey)
-        {
-            var signingResult = SignRequest(request, clientConfig, metrics, awsAccessKeyId, awsSecretAccessKey);
-            request.Headers[HeaderKeys.AuthorizationHeader] = signingResult.ForAuthorizationHeader;
-        }
-
-        /// <summary>
-        /// Calculates and signs the specified request using the AWS4 signing protocol by using the
-        /// AWS account credentials given in the method parameters. The resulting signature is added
-        /// to the request headers as 'Authorization'. Parameters supplied in the request, either in
-        /// the resource path as a query string or in the Parameters collection must not have been
-        /// uri encoded. If they have, use the SignRequest method to obtain a signature.
-        /// </summary>
-        /// <param name="request">
-        /// The request to compute the signature for. Additional headers mandated by the AWS4 protocol 
-        /// ('host' and 'x-amz-date') will be added to the request before signing.
-        /// </param>
-        /// <param name="clientConfig">
-        /// Client configuration data encompassing the service call (notably authentication
-        /// region, endpoint and service name).
-        /// </param>
-        /// <param name="metrics">
-        /// Metrics for the request
-        /// </param>
-        /// <param name="baseIdentity">
+        /// <param name="identity">
         /// The AWS credentials for the account making the service call.
         /// </param>
         /// <exception cref="Amazon.Runtime.SignatureException">
@@ -153,11 +116,18 @@ namespace Amazon.Runtime.Internal.Auth
         public override void Sign(IRequest request, 
                                   IClientConfig clientConfig, 
                                   RequestMetrics metrics,
-                                  BaseIdentity baseIdentity)
+                                  BaseIdentity identity)
         {
-            var credentials = baseIdentity as AWSCredentials;
+            var credentials = identity as AWSCredentials;
+            if (credentials is null)
+            {
+                throw new AmazonClientException($"The identity parameter must be of type AWSCredentials for the signer {nameof(AWS4Signer)}.");
+            }
+
             var immutableCredentials = credentials.GetCredentials();
-            Sign(request, clientConfig, metrics, immutableCredentials.AccessKey, immutableCredentials.SecretKey);
+
+            var signingResult = SignRequest(request, clientConfig, metrics, immutableCredentials.AccessKey, immutableCredentials.SecretKey);
+            request.Headers[HeaderKeys.AuthorizationHeader] = signingResult.ForAuthorizationHeader;            
         }
 
         /// <summary>
@@ -1071,39 +1041,6 @@ namespace Amazon.Runtime.Internal.Auth
             "s3express"
         };
 
-        /// <summary>
-        /// Calculates and signs the specified request using the AWS4 signing protocol by using the
-        /// AWS account credentials given in the method parameters. The resulting signature is added
-        /// to the request headers as 'Authorization'.
-        /// </summary>
-        /// <param name="request">
-        /// The request to compute the signature for. Additional headers mandated by the AWS4 protocol 
-        /// ('host' and 'x-amz-date') will be added to the request before signing.
-        /// </param>
-        /// <param name="clientConfig">
-        /// Adding supporting data for the service call required by the signer (notably authentication
-        /// region, endpoint and service name).
-        /// </param>
-        /// <param name="metrics">
-        /// Metrics for the request
-        /// </param>
-        /// <param name="awsAccessKeyId">
-        /// The AWS public key for the account making the service call.
-        /// </param>
-        /// <param name="awsSecretAccessKey">
-        /// The AWS secret key for the account making the call, in clear text
-        /// </param>
-        /// <exception cref="Amazon.Runtime.SignatureException">
-        /// If any problems are encountered while signing the request.
-        /// </exception>
-        public override void Sign(IRequest request,
-                                  IClientConfig clientConfig,
-                                  RequestMetrics metrics,
-                                  string awsAccessKeyId,
-                                  string awsSecretAccessKey)
-        {
-            throw new InvalidOperationException("PreSignedUrl signature computation is not supported by this method; use SignRequest instead.");
-        }
 
         /// <summary>
         /// Calculates and signs the specified request using the AWS4 signing protocol by using the
@@ -1121,7 +1058,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// <param name="metrics">
         /// Metrics for the request
         /// </param>
-        /// <param name="baseIdentity">
+        /// <param name="identity">
         /// The AWS credentials for the account making the service call.
         /// </param>
         /// <exception cref="Amazon.Runtime.SignatureException">
@@ -1130,7 +1067,7 @@ namespace Amazon.Runtime.Internal.Auth
         public override void Sign(IRequest request,
                                   IClientConfig clientConfig,
                                   RequestMetrics metrics,
-                                  BaseIdentity baseIdentity)
+                                  BaseIdentity identity)
         {
             throw new InvalidOperationException("PreSignedUrl signature computation is not supported by this method; use SignRequest instead.");
         }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
@@ -117,19 +117,14 @@ namespace Amazon.Runtime.Internal.Auth
         /// <param name="metrics">
         /// Metrics for the request
         /// </param>
-        /// <param name="baseIdentity">
+        /// <param name="identity">
         /// The AWS credentials for the account making the service call.
         /// </param>
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity baseIdentity)
+        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity identity)
         {
-            var credentials = baseIdentity as AWSCredentials;
+            var credentials = identity as AWSCredentials;
             var immutableCredentials = credentials.GetCredentials();
             _awsSigV4AProvider.Sign(request, clientConfig, metrics, immutableCredentials);
-        }
-
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey)
-        {
-            throw new AWSCommonRuntimeException("SigV4a signing with only an access key and secret is not supported. Call the Sign override with ImmutableCredentials instead.");
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWSEndpointAuthSchemeSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWSEndpointAuthSchemeSigner.cs
@@ -30,12 +30,7 @@ namespace Amazon.Runtime.Internal.Auth
             get { return ClientProtocol.RestProtocol; }
         }
 
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey)
-        {
-            Sign(request, clientConfig, metrics, new BasicAWSCredentials(awsAccessKeyId, awsSecretAccessKey));
-        }
-
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity baseIdentity)
+        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity identity)
         {
             var useSigV4 = request.SignatureVersion == SignatureVersion.SigV4;
             var signer = SelectSigner(this, useSigV4, request, clientConfig);
@@ -43,7 +38,12 @@ namespace Amazon.Runtime.Internal.Auth
             var aws4Signer = signer as AWS4Signer;
             var useV4a = aws4aSigner != null;
             var useV4 = aws4Signer != null;
-            var credentials = baseIdentity as AWSCredentials;
+            var credentials = identity as AWSCredentials;
+            if (credentials is null)
+            {
+                throw new AmazonClientException($"The identity parameter must be of type AWSCredentials for the signer {nameof(AWSEndpointAuthSchemeSigner)}.");
+            }
+
             var immutableCredentials = credentials.GetCredentials();
 
             AWSSigningResultBase signingResult;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AbstractAWSSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AbstractAWSSigner.cs
@@ -108,26 +108,18 @@ namespace Amazon.Runtime.Internal.Auth
                 throw new Amazon.Runtime.SignatureException("Failed to generate signature: " + e.Message, e);
             }
         }
-        public abstract void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey);
 
-        public virtual void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity baseIdentity)
-        {
-            if (baseIdentity is AWSCredentials credentials)
-            {
-                var immutableCredentials = credentials.GetCredentials();
-                Sign(request, clientConfig, metrics, immutableCredentials?.AccessKey, immutableCredentials?.SecretKey);
-            }
-        }
+        public abstract void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity identity);
 
 #if AWS_ASYNC_API
         public virtual System.Threading.Tasks.Task SignAsync(
             IRequest request, 
             IClientConfig clientConfig,
             RequestMetrics metrics,
-            BaseIdentity baseIdentity,
+            BaseIdentity identity,
             CancellationToken token = default)
         {
-            Sign(request, clientConfig, metrics, baseIdentity);
+            Sign(request, clientConfig, metrics, identity);
 #if NETSTANDARD
             return Task.CompletedTask;
 #else

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/BearerTokenSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/BearerTokenSigner.cs
@@ -28,23 +28,7 @@ namespace Amazon.Runtime.Internal.Auth
         public override bool RequiresCredentials { get; } = false;
         public override ClientProtocol Protocol { get; } = ClientProtocol.Unknown;
 
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey) 
-            => InternalSign(request, baseIdentity: null);
-
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity baseIdentity)
-        {
-            InternalSign(request, baseIdentity);
-        }
-
-#if AWS_ASYNC_API
-        public override Task SignAsync(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity baseIdentity, CancellationToken token = default)
-        {
-            InternalSign(request, baseIdentity);
-            return Task.CompletedTask;
-        }
-#endif
-
-        private void InternalSign(IRequest request, BaseIdentity baseIdentity)
+        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity identity)
         {
             if (request.Endpoint.Scheme == "http")
             {
@@ -53,9 +37,9 @@ namespace Amazon.Runtime.Internal.Auth
                     "Endpoint must not use 'http'.");
             }
 
-            if (baseIdentity is not AWSToken awsToken || string.IsNullOrEmpty(awsToken.Token))
+            if (identity is not AWSToken awsToken || string.IsNullOrEmpty(awsToken.Token))
             {
-                throw new AmazonClientException("No Token found.  Operation requires a Bearer token.");
+                throw new AmazonClientException("No Token found. Operation requires a Bearer token.");
             }
 
             request.Headers["Authorization"] = $"Bearer {awsToken.Token}";

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
@@ -33,9 +33,16 @@ namespace Amazon.Runtime.Internal.Auth
             get { return ClientProtocol.RestProtocol; }
         }
 
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey)
+        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity identity)
         {
-            if (String.IsNullOrEmpty(awsAccessKeyId))
+            var credentials = identity as AWSCredentials;
+            if (credentials is null)
+            {
+                throw new AmazonClientException($"The identity parameter must be of type AWSCredentials for the signer {nameof(CloudFrontSigner)}.");
+            }
+
+            var immutableCredentials = credentials.GetCredentials();
+            if (String.IsNullOrEmpty(immutableCredentials.AccessKey))
             {
                 throw new ArgumentOutOfRangeException("awsAccessKeyId", "The AWS Access Key ID cannot be NULL or a Zero length string");
             }
@@ -45,16 +52,9 @@ namespace Amazon.Runtime.Internal.Auth
             string dateTimeString = dateTime.ToString(AWSSDKUtils.RFC822DateFormat, CultureInfo.InvariantCulture);
             request.Headers.Add(HeaderKeys.XAmzDateHeader, dateTimeString);
 
-            string signature = ComputeHash(dateTimeString, awsSecretAccessKey, SigningAlgorithm.HmacSHA1);
+            string signature = ComputeHash(dateTimeString, immutableCredentials.SecretKey, SigningAlgorithm.HmacSHA1);
 
-            request.Headers.Add(HeaderKeys.AuthorizationHeader, "AWS " + awsAccessKeyId + ":" + signature);
-        }
-
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity baseIdentity)
-        {
-            var credentials = baseIdentity as AWSCredentials;
-            var immutableCredentials = credentials.GetCredentials();
-            Sign(request, clientConfig, metrics, immutableCredentials.AccessKey, immutableCredentials.SecretKey);
+            request.Headers.Add(HeaderKeys.AuthorizationHeader, "AWS " + immutableCredentials.AccessKey + ":" + signature);
         }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/EventBridgeSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/EventBridgeSigner.cs
@@ -32,12 +32,7 @@ namespace Amazon.Runtime.Internal.Auth
             get { return ClientProtocol.RestProtocol; }
         }
 
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey)
-        {
-            Sign(request, clientConfig, metrics, new BasicAWSCredentials(awsAccessKeyId, awsSecretAccessKey));
-        }
-
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity baseIdentity)
+        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity identity)
         {
             var useSigV4 = request.SignatureVersion == SignatureVersion.SigV4;
             var signer = SelectSigner(this, useSigV4, request, clientConfig);
@@ -45,7 +40,12 @@ namespace Amazon.Runtime.Internal.Auth
             var aws4Signer = signer as AWS4Signer;
             var useV4a = aws4aSigner != null;
             var useV4 = aws4Signer != null;
-            var credentials = baseIdentity as AWSCredentials;
+
+            var credentials = identity as AWSCredentials;
+            if (credentials is null)
+            {
+                throw new AmazonClientException($"The identity parameter must be of type AWSCredentials for the signer {nameof(EventBridgeSigner)}.");
+            }
             var immutableCredentials = credentials.GetCredentials();
 
             AWSSigningResultBase signingResult;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/NullSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/NullSigner.cs
@@ -26,13 +26,8 @@ namespace Amazon.Runtime.Internal.Auth
     /// </summary>
     public class NullSigner : AbstractAWSSigner
     {
-        public override void Sign(IRequest request, IClientConfig clientConfig, Util.RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey)
-        {
-            // This is a null signer which a does no-op
-            return;
-        }
 
-        public override void Sign(IRequest request, IClientConfig clientConfig, Util.RequestMetrics metrics, BaseIdentity baseIdentity)
+        public override void Sign(IRequest request, IClientConfig clientConfig, Util.RequestMetrics metrics, BaseIdentity identity)
         {
             // This is a null signer which does no-op
             return;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/S3Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/S3Signer.cs
@@ -54,19 +54,19 @@ namespace Amazon.Runtime.Internal.Auth
             get { return ClientProtocol.RestProtocol; }
         }
 
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey)
-        {
-            Sign(request, clientConfig, metrics, new BasicAWSCredentials(awsAccessKeyId, awsSecretAccessKey));
-        }
-
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity baseIdentity)
+        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity identity)
         {
             var signer = SelectSigner(this, _useSigV4, request, clientConfig);
             var aws4Signer = signer as AWS4Signer;
             var aws4aSigner = signer as AWS4aSignerCRTWrapper;
             var useV4 = aws4Signer != null;
             var useV4a = aws4aSigner != null;
-            var credentials = baseIdentity as AWSCredentials;
+            var credentials = identity as AWSCredentials;
+            if (credentials is null)
+            {
+                throw new AmazonClientException($"The identity parameter must be of type AWSCredentials for the signer {nameof(S3Signer)}.");
+            }
+
             var immutableCredentials = credentials.GetCredentials();
 
             if (useV4a)

--- a/sdk/src/Services/S3/Custom/Internal/S3Signer.cs
+++ b/sdk/src/Services/S3/Custom/Internal/S3Signer.cs
@@ -44,14 +44,9 @@ namespace Amazon.S3.Internal
             get { return _s3Signer.Protocol; }
         }
 
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey)
+        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity identity)
         {
-            Sign(request, clientConfig, metrics, new BasicAWSCredentials(awsAccessKeyId, awsSecretAccessKey));
-        }
-
-        public override void Sign(IRequest request, IClientConfig clientConfig, RequestMetrics metrics, BaseIdentity credentials)
-        {
-            _s3Signer.Sign(request, clientConfig, metrics, credentials);
+            _s3Signer.Sign(request, clientConfig, metrics, identity);
         }
 
         internal static void SignRequest(IRequest request, RequestMetrics metrics, string awsAccessKeyId, string awsSecretAccessKey)

--- a/sdk/test/Services/S3/UnitTests/Custom/IntegrityCheckTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/IntegrityCheckTests.cs
@@ -153,7 +153,7 @@ namespace AWSSDK.UnitTests
                 RegionEndpoint = RegionEndpoint.USWest1
             };
 
-            signer.Sign(request, config, new RequestMetrics(), "ACCESS", "SECRET");
+            signer.Sign(request, config, new RequestMetrics(), new BasicAWSCredentials("ACCESS", "SECRET"));
             return request;
         }
 

--- a/sdk/test/Services/S3/UnitTests/Custom/S3ObjectLambdaTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/S3ObjectLambdaTests.cs
@@ -230,7 +230,7 @@ namespace AWSSDK.UnitTests
                 RegionEndpoint = RegionEndpoint.USEast1
             };
             var iRequest = S3ArnTestUtils.RunMockRequest(request, GetObjectRequestMarshaller.Instance, config);
-            signer.Sign(iRequest, config, new RequestMetrics(), "ACCESS", "SECRET");
+            signer.Sign(iRequest, config, new RequestMetrics(), new BasicAWSCredentials("ACCESS", "SECRET"));
 
             Assert.IsTrue(iRequest.Headers.ContainsKey(HeaderKeys.AuthorizationHeader));
             Assert.IsTrue((iRequest.Headers["Authorization"]).Contains("s3-object-lambda"));
@@ -299,7 +299,7 @@ namespace AWSSDK.UnitTests
             };
 
             var iRequest = S3ArnTestUtils.RunMockRequest(request, WriteGetObjectResponseRequestMarshaller.Instance, config);
-            signer.Sign(iRequest, config, new RequestMetrics(), "ACCESS", "SECRET");
+            signer.Sign(iRequest, config, new RequestMetrics(), new BasicAWSCredentials("ACCESS", "SECRET"));
 
             Assert.IsTrue(iRequest.Headers.ContainsKey(HeaderKeys.AuthorizationHeader));
             Assert.IsTrue((iRequest.Headers["Authorization"]).Contains("s3-object-lambda"));

--- a/sdk/test/Services/S3/UnitTests/Custom/SignatureVersionTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/SignatureVersionTests.cs
@@ -60,7 +60,7 @@ namespace AWSSDK.UnitTests
                 RegionEndpoint = RegionEndpoint.USWest2
             };
             var iRequest = S3ArnTestUtils.RunMockRequest(putObjectRequest, PutObjectRequestMarshaller.Instance, config);
-            signer.Sign(iRequest, config, new RequestMetrics(), "ACCESS", "SECRET");
+            signer.Sign(iRequest, config, new RequestMetrics(), new BasicAWSCredentials("ACCESS", "SECRET"));
 
             Assert.IsTrue(iRequest.Headers.ContainsKey(HeaderKeys.AuthorizationHeader));
             Assert.IsTrue((iRequest.Headers["Authorization"]).Contains("s3-outposts"));
@@ -115,7 +115,7 @@ namespace AWSSDK.UnitTests
                     RegionEndpoint = RegionEndpoint.USWest1
                 };
 
-                signer.Sign(iRequest, config, new RequestMetrics(), "ACCESS", "SECRET");
+                signer.Sign(iRequest, config, new RequestMetrics(), new BasicAWSCredentials("ACCESS", "SECRET"));
 
                 Assert.IsTrue(iRequest.Headers.ContainsKey(HeaderKeys.AuthorizationHeader));
 

--- a/sdk/test/Services/S3Control/UnitTests/Custom/S3OutpostsSigningTests.cs
+++ b/sdk/test/Services/S3Control/UnitTests/Custom/S3OutpostsSigningTests.cs
@@ -51,7 +51,7 @@ namespace AWSSDK.UnitTests
             };
             var originalAuthService = config.AuthenticationServiceName;
             var iRequest = S3ControlArnTestUtils.RunMockRequest(getAccessPointRequest, GetAccessPointRequestMarshaller.Instance, config);
-            signer.Sign(iRequest, config, new RequestMetrics(), "ACCESS", "SECRET");
+            signer.Sign(iRequest, config, new RequestMetrics(), new BasicAWSCredentials("ACCESS", "SECRET"));
             Assert.IsTrue(iRequest.Headers.ContainsKey(HeaderKeys.AuthorizationHeader));
             Assert.IsTrue((iRequest.Headers["Authorization"]).Contains("s3-outposts"));
             Assert.IsTrue(config.AuthenticationServiceName == originalAuthService);
@@ -75,7 +75,7 @@ namespace AWSSDK.UnitTests
             };
             var originalAuthService = config.AuthenticationServiceName;
             var iRequest = S3ControlArnTestUtils.RunMockRequest(getBucketRequest, GetBucketRequestMarshaller.Instance, config);
-            signer.Sign(iRequest, config, new RequestMetrics(), "ACCESS", "SECRET");
+            signer.Sign(iRequest, config, new RequestMetrics(), new BasicAWSCredentials("ACCESS", "SECRET"));
             Assert.IsTrue(iRequest.Headers.ContainsKey(HeaderKeys.AuthorizationHeader));
             Assert.IsTrue((iRequest.Headers["Authorization"]).Contains("s3-outposts"));
             Assert.IsTrue(config.AuthenticationServiceName == originalAuthService);
@@ -100,7 +100,7 @@ namespace AWSSDK.UnitTests
             };
             var originalAuthService = config.AuthenticationServiceName;
             var iRequest = S3ControlArnTestUtils.RunMockRequest(createBucketRequest, CreateBucketRequestMarshaller.Instance, config);            
-            signer.Sign(iRequest, config, new RequestMetrics(), "ACCESS", "SECRET");
+            signer.Sign(iRequest, config, new RequestMetrics(), new BasicAWSCredentials("ACCESS", "SECRET"));
             Assert.IsTrue(iRequest.Headers.ContainsKey(HeaderKeys.AuthorizationHeader));
             Assert.IsTrue((iRequest.Headers["Authorization"]).Contains("s3-outposts"));
             Assert.IsTrue(config.AuthenticationServiceName == originalAuthService);
@@ -123,7 +123,7 @@ namespace AWSSDK.UnitTests
             };
             var originalAuthService = config.AuthenticationServiceName;
             var iRequest = S3ControlArnTestUtils.RunMockRequest(createAccessPointRequest, CreateAccessPointRequestMarshaller.Instance, config);            
-            signer.Sign(iRequest, config, new RequestMetrics(), "ACCESS", "SECRET");
+            signer.Sign(iRequest, config, new RequestMetrics(), new BasicAWSCredentials("ACCESS", "SECRET"));
 
             Assert.IsTrue(iRequest.Headers.ContainsKey(HeaderKeys.AuthorizationHeader));
             Assert.IsTrue((iRequest.Headers["Authorization"]).Contains("s3-outposts"));

--- a/sdk/test/UnitTests/Custom/Runtime/BearerTokenSignerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/BearerTokenSignerTests.cs
@@ -52,7 +52,7 @@ namespace AWSSDK.UnitTests.Runtime
                     mockRequest.Object,
                     clientConfig: null,
                     metrics: null,
-                    baseIdentity: null);
+                    identity: null);
             }
             catch (Exception e)
             {
@@ -86,7 +86,7 @@ namespace AWSSDK.UnitTests.Runtime
                     mockRequest.Object,
                     clientConfig: null,
                     metrics: null,
-                    baseIdentity: null);
+                    identity: null);
             }
             catch (Exception e)
             {
@@ -252,7 +252,7 @@ namespace AWSSDK.UnitTests.Runtime
 
             Assert.IsNotNull(exception);
             Assert.IsInstanceOfType(exception, typeof(AmazonClientException));
-            Assert.AreEqual(exception.Message, "No Token found.  Operation requires a Bearer token.");
+            Assert.AreEqual(exception.Message, "No Token found. Operation requires a Bearer token.");
         }
 
 #if AWS_ASYNC_API
@@ -282,7 +282,7 @@ namespace AWSSDK.UnitTests.Runtime
 
             Assert.IsNotNull(exception);
             Assert.IsInstanceOfType(exception, typeof(AmazonClientException));
-            Assert.AreEqual(exception.Message, "No Token found.  Operation requires a Bearer token.");
+            Assert.AreEqual(exception.Message, "No Token found. Operation requires a Bearer token.");
         }
 #endif
 

--- a/sdk/test/UnitTests/Custom/Runtime/RuntimePipelineTestBase.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RuntimePipelineTestBase.cs
@@ -148,15 +148,6 @@ namespace AWSSDK.UnitTests
         public override void Sign(IRequest request, 
             IClientConfig clientConfig, 
             RequestMetrics metrics,
-            string awsAccessKeyId,
-            string awsSecretAccessKey)
-        {
-             this.SignCount++;
-        }
-
-        public override void Sign(IRequest request, 
-            IClientConfig clientConfig, 
-            RequestMetrics metrics,
             BaseIdentity credentials)
         {
             this.SignCount++;


### PR DESCRIPTION
An addendum to @dscpinheiro PR https://github.com/aws/aws-sdk-net/pull/3562 that removes the abstract `Sign` method that uses access and secret key parameters in the `AbstractAWSSigner` and makes the Sign method that uses `BaseIdentity` abstract. This allows us to remove any overrides in signers that don't use access keys and forces them to implement the version that uses `BaseIdentity`.

I also added checks in the signer that the instance of `BaseIdentity` was the correct type for that signer.

Running a dry run now to confirm changes are good.