### PR TITLE
fix: Added logic to marshall NoncurrentVersionExpiration.NewerNoncurrentVersions in PutLifecycleConfigurationRequestMarshaller.

### DIFF
--- a/generator/.DevConfigs/4c4d88f7-2745-49b9-bdd1-7a05029b0395.json
+++ b/generator/.DevConfigs/4c4d88f7-2745-49b9-bdd1-7a05029b0395.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "fix: Added logic to marshall NoncurrentVersionExpiration.NewerNoncurrentVersions in PutLifecycleConfigurationRequestMarshaller."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutLifecycleConfigurationRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutLifecycleConfigurationRequestMarshaller.cs
@@ -122,6 +122,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                                     if (noncurrentVersionExpiration != null)
                                     {
                                         xmlWriter.WriteStartElement("NoncurrentVersionExpiration");
+                                        if (noncurrentVersionExpiration.IsSetNewerNoncurrentVersions())
+                                        {
+                                            xmlWriter.WriteElementString("NewerNoncurrentVersions", S3Transforms.ToXmlStringValue(noncurrentVersionExpiration.NewerNoncurrentVersions));
+                                        }
                                         if (noncurrentVersionExpiration.IsSetNoncurrentDays())
                                         {
                                             xmlWriter.WriteElementString("NoncurrentDays", S3Transforms.ToXmlStringValue(noncurrentVersionExpiration.NoncurrentDays));

--- a/sdk/test/Services/S3/IntegrationTests/LifecycleTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/LifecycleTests.cs
@@ -109,6 +109,11 @@ namespace S3UnitTest
                         {
                             Days = 2,
                         },
+                        NoncurrentVersionExpiration = new LifecycleRuleNoncurrentVersionExpiration()
+                        {
+                            NoncurrentDays = 15, // 'NoncurrentDays' in the NoncurrentVersionExpiration action must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action.
+                            NewerNoncurrentVersions = 10,
+                        },
 #pragma warning disable 618
                         Transition = new LifecycleTransition
                         {
@@ -153,6 +158,11 @@ namespace S3UnitTest
                                 StorageClass = S3StorageClass.Glacier
                             }
                         },
+                        NoncurrentVersionExpiration = new LifecycleRuleNoncurrentVersionExpiration()
+                        {
+                            NoncurrentDays = 91, // 'NoncurrentDays' in the NoncurrentVersionExpiration action must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action.
+                            NewerNoncurrentVersions = 10,
+                        },
                         NoncurrentVersionTransitions = new List<LifecycleRuleNoncurrentVersionTransition>
                         {
                             new LifecycleRuleNoncurrentVersionTransition
@@ -194,6 +204,11 @@ namespace S3UnitTest
                                 Days = 90,
                                 StorageClass = S3StorageClass.Glacier
                             }
+                        },
+                        NoncurrentVersionExpiration = new LifecycleRuleNoncurrentVersionExpiration()
+                        {
+                            NoncurrentDays = 92, // 'NoncurrentDays' in the NoncurrentVersionExpiration action must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action.
+                            NewerNoncurrentVersions = 60
                         },
                         NoncurrentVersionTransitions = new List<LifecycleRuleNoncurrentVersionTransition>
                         {
@@ -480,6 +495,19 @@ namespace S3UnitTest
             {
                 Assert.AreEqual(expected.Expiration.Days, actual.Expiration.Days);
                 Assert.AreEqual(expected.Expiration.ExpiredObjectDeleteMarker, actual.Expiration.ExpiredObjectDeleteMarker);
+            }
+
+            if (expected.NoncurrentVersionExpiration == null)
+            {
+                Assert.IsNull(actual.NoncurrentVersionExpiration);
+            }
+            else
+            {
+                Assert.AreEqual(expected.NoncurrentVersionExpiration.NoncurrentDays,
+                    actual.NoncurrentVersionExpiration.NoncurrentDays);
+
+                Assert.AreEqual(expected.NoncurrentVersionExpiration.NewerNoncurrentVersions,
+                    actual.NoncurrentVersionExpiration.NewerNoncurrentVersions);
             }
 
 #pragma warning disable 618


### PR DESCRIPTION
Added logic to marshall `NoncurrentVersionExpiration.NewerNoncurrentVersions` in `PutLifecycleConfigurationRequestMarshaller`.

## Motivation and Context
Issue #3580 

## Testing
- Modified integration test in **sdk/test/Services/S3/IntegrationTests/LifecycleTests.cs** to set `NoncurrentVersionExpiration.NewerNoncurrentVersions` in `PutLifecycleConfigurationRequest`, submit the `LifecycleConfiguration` via `Amazons3Client.PutLifecycleConfiguration()` and validate the same when retrieved using `Amazons3Client.GetLifecycleConfiguration()`.

- Catapult dry-run completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement