### PR TITLE
[V4] Address Native AOT warnings for DynamoDB's Document Model library

### DIFF
--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -20,6 +20,8 @@ using System.Globalization;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.Util.Internal;
+using System.Diagnostics.CodeAnalysis;
+
 
 #if NETSTANDARD
 using Amazon.Runtime.Internal.Util;
@@ -71,9 +73,6 @@ namespace Amazon.DynamoDBv2
     /// A collection of converters capable of converting between
     /// .NET and DynamoDB objects.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class DynamoDBEntryConversion
     {
         #region Static members
@@ -252,7 +251,11 @@ namespace Amazon.DynamoDBv2
         /// <typeparam name="TOutput"></typeparam>
         /// <param name="entry"></param>
         /// <returns></returns>
+#if NET8_0_OR_GREATER
+        public TOutput ConvertFromEntry<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] TOutput>(DynamoDBEntry entry)
+#else
         public TOutput ConvertFromEntry<TOutput>(DynamoDBEntry entry)
+#endif
         {
             TOutput output;
             if (TryConvertFromEntry<TOutput>(entry, out output))
@@ -269,7 +272,11 @@ namespace Amazon.DynamoDBv2
         /// <param name="entry"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
+#if NET8_0_OR_GREATER
+        public object ConvertFromEntry([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type outputType, DynamoDBEntry entry)
+#else
         public object ConvertFromEntry(Type outputType, DynamoDBEntry entry)
+#endif
         {
             if (outputType == null) throw new ArgumentNullException("outputType");
             if (entry == null) throw new ArgumentNullException("entry");
@@ -287,7 +294,11 @@ namespace Amazon.DynamoDBv2
         /// <param name="entry"></param>
         /// <param name="output"></param>
         /// <returns>True if successfully converted, otherwise false.</returns>
+#if NET8_0_OR_GREATER
+        public bool TryConvertFromEntry<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] TOutput>(DynamoDBEntry entry, out TOutput output)
+#else
         public bool TryConvertFromEntry<TOutput>(DynamoDBEntry entry, out TOutput output)
+#endif
         {
             output = default(TOutput);
 
@@ -313,7 +324,11 @@ namespace Amazon.DynamoDBv2
         /// <param name="value"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
+#if NET8_0_OR_GREATER
+        public bool TryConvertFromEntry([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type outputType, DynamoDBEntry entry, out object value)
+#else
         public bool TryConvertFromEntry(Type outputType, DynamoDBEntry entry, out object value)
+#endif
         {
             if (outputType == null) throw new ArgumentNullException("outputType");
             if (entry == null) throw new ArgumentNullException("entry");
@@ -322,7 +337,7 @@ namespace Amazon.DynamoDBv2
             return converter.TryFromEntry(entry, outputType, out value);
         }
 
-        #endregion
+#endregion
 
         #region Internal members
 
@@ -360,7 +375,12 @@ namespace Amazon.DynamoDBv2
             //foreach (var value in values)
             //    yield return ConvertToEntry(value);
         }
+
+#if NET8_0_OR_GREATER
+        internal IEnumerable<object> ConvertFromEntries([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type elementType, IEnumerable<DynamoDBEntry> entries)
+#else
         internal IEnumerable<object> ConvertFromEntries(Type elementType, IEnumerable<DynamoDBEntry> entries)
+#endif
         {
             if (entries == null) throw new ArgumentNullException("entries");
 
@@ -377,7 +397,7 @@ namespace Amazon.DynamoDBv2
             return pl;
         }
 
-        #endregion
+#endregion
 
         #region Private members
 
@@ -539,7 +559,12 @@ namespace Amazon.DynamoDBv2
             entry = null;
             return false;
         }
+
+#if NET8_0_OR_GREATER
+        public object FromEntry(DynamoDBEntry entry, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType)
+#else
         public object FromEntry(DynamoDBEntry entry, Type targetType)
+#endif
         {
             if (entry == null) throw new ArgumentNullException("entry");
             if (targetType == null) throw new ArgumentNullException("targetType");
@@ -551,7 +576,12 @@ namespace Amazon.DynamoDBv2
             throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
                 "Unable to convert [{0}] of type {1} to {2}", entry, entry.GetType().FullName, targetType.FullName));
         }
+
+#if NET8_0_OR_GREATER
+        public bool TryFromEntry(DynamoDBEntry entry, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object value)
+#else
         public bool TryFromEntry(DynamoDBEntry entry, Type targetType, out object value)
+#endif
         {
             var p = entry as Primitive;
 
@@ -627,17 +657,32 @@ namespace Amazon.DynamoDBv2
             result = null;
             return false;
         }
+
+#if NET8_0_OR_GREATER
+        public virtual bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
+#else
         public virtual bool TryFrom(Primitive p, Type targetType, out object result)
+#endif
         {
             result = null;
             return false;
         }
+
+#if NET8_0_OR_GREATER
+        public virtual bool TryFrom(PrimitiveList pl, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
+#else
         public virtual bool TryFrom(PrimitiveList pl, Type targetType, out object result)
+#endif
         {
             result = null;
             return false;
         }
+
+#if NET8_0_OR_GREATER
+        public virtual bool TryFrom(DynamoDBList l, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
+#else
         public virtual bool TryFrom(DynamoDBList l, Type targetType, out object result)
+#endif
         {
             result = null;
             return false;
@@ -651,19 +696,6 @@ namespace Amazon.DynamoDBv2
 
     internal abstract class Converter<T> : Converter
     {
-        public override IEnumerable<Type> GetTargetTypes()
-        {
-            var type = typeof(T);
-            yield return type;
-
-            if (type.IsValueType)
-            {
-                //yield return typeof(Nullable<T>);
-                var nullableType = typeof(Nullable<>).MakeGenericType(type);
-                yield return nullableType;
-            }
-        }
-
         public override bool TryTo(object value, out DynamoDBBool b)
         {
             return TryTo((T)value, out b);
@@ -718,21 +750,36 @@ namespace Amazon.DynamoDBv2
             result = t;
             return output;
         }
+
+#if NET8_0_OR_GREATER
+        public override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
+#else
         public override bool TryFrom(Primitive p, Type targetType, out object result)
+#endif
         {
             T t;
             var output = TryFrom(p, targetType, out t);
             result = t;
             return output;
         }
+
+#if NET8_0_OR_GREATER
+        public override bool TryFrom(PrimitiveList pl, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
+#else
         public override bool TryFrom(PrimitiveList pl, Type targetType, out object result)
+#endif
         {
             T t;
             var output = TryFrom(pl, targetType, out t);
             result = t;
             return output;
         }
+
+#if NET8_0_OR_GREATER
+        public override bool TryFrom(DynamoDBList l, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
+#else
         public override bool TryFrom(DynamoDBList l, Type targetType, out object result)
+#endif
         {
             T t;
             var output = TryFrom(l, targetType, out t);
@@ -752,7 +799,12 @@ namespace Amazon.DynamoDBv2
             result = default(T);
             return false;
         }
+
+#if NET8_0_OR_GREATER
+        protected virtual bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out T result)
+#else
         protected virtual bool TryFrom(Primitive p, Type targetType, out T result)
+#endif
         {
             result = default(T);
             return false;

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
@@ -20,6 +20,7 @@ using Amazon.Util;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -30,227 +31,323 @@ namespace Amazon.DynamoDBv2
 {
     #region Basic converters
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class ByteConverterV1 : Converter<byte>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(byte), typeof(Nullable<byte>) }; 
+        }
+
         protected override bool TryTo(byte value, out Primitive p)
         {
             p = new Primitive(value.ToString("d", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out byte result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out byte result)
+#endif
         {
             return byte.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class SByteConverterV1 : Converter<SByte>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(SByte), typeof(Nullable<SByte>) };
+        }
+
         protected override bool TryTo(sbyte value, out Primitive p)
         {
             p = new Primitive(value.ToString("d", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out sbyte result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out sbyte result)
+#endif
         {
             return SByte.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class UInt16ConverterV1 : Converter<UInt16>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(UInt16), typeof(Nullable<UInt16>) };
+        }
+
         protected override bool TryTo(ushort value, out Primitive p)
         {
             p = new Primitive(value.ToString("d", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out ushort result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out ushort result)
+#endif
         {
             return UInt16.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class Int16ConverterV1 : Converter<Int16>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(Int16), typeof(Nullable<Int16>) };
+        }
+
         protected override bool TryTo(short value, out Primitive p)
         {
             p = new Primitive(value.ToString("d", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out short result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out short result)
+#endif
         {
             return Int16.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class UInt32ConverterV1 : Converter<UInt32>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(UInt32), typeof(Nullable<UInt32>) };
+        }
+
         protected override bool TryTo(uint value, out Primitive p)
         {
             p = new Primitive(value.ToString("d", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out uint result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out uint result)
+#endif
         {
             return UInt32.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class Int32ConverterV1 : Converter<Int32>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(Int32), typeof(Nullable<Int32>) };
+        }
+
         protected override bool TryTo(int value, out Primitive p)
         {
             p = new Primitive(value.ToString("d", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out int result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out int result)
+#endif
         {
             return Int32.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class UInt64ConverterV1 : Converter<UInt64>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(UInt64), typeof(Nullable<UInt64>) };
+        }
+
         protected override bool TryTo(ulong value, out Primitive p)
         {
             p = new Primitive(value.ToString("d", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out ulong result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out ulong result)
+#endif
         {
             return UInt64.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class Int64ConverterV1 : Converter<Int64>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(Int64), typeof(Nullable<Int64>) };
+        }
+
         protected override bool TryTo(long value, out Primitive p)
         {
             p = new Primitive(value.ToString("d", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out long result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out long result)
+#endif
         {
             return Int64.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class SingleConverterV1 : Converter<Single>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(Single), typeof(Nullable<Single>) };
+        }
+
         protected override bool TryTo(float value, out Primitive p)
         {
             p = new Primitive(value.ToString("r", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out float result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out float result)
+#endif
         {
             return Single.TryParse(p.StringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DoubleConverterV1 : Converter<Double>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(Double), typeof(Nullable<Double>) };
+        }
+
         protected override bool TryTo(double value, out Primitive p)
         {
             p = new Primitive(value.ToString("r", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out double result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out double result)
+#endif
         {
             return Double.TryParse(p.StringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DecimalConverterV1 : Converter<Decimal>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(Decimal), typeof(Nullable<Decimal>) };
+        }
+
         protected override bool TryTo(decimal value, out Primitive p)
         {
             p = new Primitive(value.ToString("g", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out decimal result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out decimal result)
+#endif
         {
             return Decimal.TryParse(p.StringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class CharConverterV1 : Converter<Char>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(Char), typeof(Nullable<Char>) };
+        }
+
         protected override bool TryTo(char value, out Primitive p)
         {
             p = new Primitive(value.ToString(), DynamoDBEntryType.String);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out char result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out char result)
+#endif
         {
             return Char.TryParse(p.StringValue, out result);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class StringConverterV1 : Converter<String>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(String) };
+        }
+
         protected override bool TryTo(string value, out Primitive p)
         {
             p = new Primitive(value, DynamoDBEntryType.String);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out string result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out string result)
+#endif
         {
             result = p.StringValue;
             return (result != null);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DateTimeConverterV1 : Converter<DateTime>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(DateTime), typeof(Nullable<DateTime>) };
+        }
+
         protected override bool TryTo(DateTime value, out Primitive p)
         {
             DateTime utc = value.ToUniversalTime();
             p = new Primitive(utc.ToString(AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture), DynamoDBEntryType.String);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out DateTime result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out DateTime result)
+#endif
         {
             if (DateTime.TryParseExact(p.StringValue, AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out result))
             {
@@ -260,51 +357,72 @@ namespace Amazon.DynamoDBv2
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class GuidConverterV1 : Converter<Guid>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(Guid), typeof(Nullable<Guid>) };
+        }
+
         protected override bool TryTo(Guid value, out Primitive p)
         {
             p = new Primitive(value.ToString("D"), DynamoDBEntryType.String);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out Guid result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out Guid result)
+#endif
         {
             result = new Guid(p.StringValue);
             return true;
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class BytesConverterV1 : Converter<byte[]>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(byte[]) };
+        }
+
         protected override bool TryTo(byte[] value, out Primitive p)
         {
             p = new Primitive(value);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out byte[] result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out byte[] result)
+#endif
         {
             result = p.Value as byte[];
             return (result != null);
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class MemoryStreamConverterV1 : Converter<MemoryStream>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(MemoryStream) };
+        }
+
         protected override bool TryTo(MemoryStream value, out Primitive p)
         {
             p = new Primitive(value);
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out MemoryStream result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out MemoryStream result)
+#endif
         {
             var bytes = p.Value as byte[];
             if (bytes == null)
@@ -318,11 +436,13 @@ namespace Amazon.DynamoDBv2
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class EnumConverterV1 : Converter<Enum>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(Enum) };
+        }
+
         protected override bool TryTo(Enum value, out Primitive p)
         {
             p = null;
@@ -344,7 +464,12 @@ namespace Amazon.DynamoDBv2
             var succeeded = (p != null);
             return succeeded;
         }
+
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out Enum result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out Enum result)
+#endif
         {
             result = null;
 
@@ -364,14 +489,15 @@ namespace Amazon.DynamoDBv2
             return succeeded;
         }
 
+#if NET8_0_OR_GREATER
+        private Enum ConvertEnum(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType)
+#else
         private Enum ConvertEnum(Primitive p, Type targetType)
+#endif
         {
-            // get numeric type underlying enum (int, byte, etc.)
-            var enumUnderlyingType = Enum.GetUnderlyingType(targetType);
-
             object numerical;
             // convert Primitive to numeric type, using current conversion
-            if (Conversion.TryConvertFromEntry(enumUnderlyingType, p, out numerical))
+            if (Conversion.TryConvertFromEntry(typeof(int), p, out numerical))
             {
                 // convert numeric to target enum
                 return Enum.ToObject(targetType, numerical) as Enum;
@@ -393,7 +519,7 @@ namespace Amazon.DynamoDBv2
         }
     }
 
-    #endregion
+#endregion
 
     #region Converters supporting reading V2 DDB items, but writing V1 items
 
@@ -401,11 +527,13 @@ namespace Amazon.DynamoDBv2
     /// A boolean converter which reads booleans as N or BOOL types,
     /// but writes out N type (1 if true, 0 if false).
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class BoolConverterV1 : Converter<bool>
     {
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(bool), typeof(Nullable<bool>) };
+        }
+
         protected override bool TryTo(bool value, out Primitive p)
         {
             p = new Primitive(value ? "1" : "0", DynamoDBEntryType.Numeric);
@@ -416,48 +544,25 @@ namespace Amazon.DynamoDBv2
             result = b.Value;
             return true;
         }
+#if NET8_0_OR_GREATER
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out bool result)
+#else
         protected override bool TryFrom(Primitive p, Type targetType, out bool result)
+#endif
         {
             result = !p.StringValue.Equals("0", StringComparison.OrdinalIgnoreCase);
             return true;
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal abstract class CollectionConverter : Converter
     {
-        private IEnumerable<Type> targetTypes;
-        private static IEnumerable<Type> GetTargetTypes(IEnumerable<Type> memberTypes)
-        {
-            var listType = typeof(List<>);
-            var setType = typeof(HashSet<>);
 
-            foreach (var pt in memberTypes)
-            {
-                // typeof(T[]),
-                if (pt != typeof(byte))
-                {
-                    yield return pt.MakeArrayType();
-                }
-                // typeof(List<T>),
-                yield return listType.MakeGenericType(pt);
-                // typeof(HashSet<T>),
-                yield return setType.MakeGenericType(pt);
-            }
-        }
-        public CollectionConverter(IEnumerable<Type> memberTypes)
-        {
-            targetTypes = GetTargetTypes(memberTypes);
-        }
-
-        public override IEnumerable<Type> GetTargetTypes()
-        {
-            return targetTypes;
-        }
-
+#if NET8_0_OR_GREATER
+        protected bool EntriesToCollection([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type elementType, IEnumerable<DynamoDBEntry> entries, out object result)
+#else
         protected bool EntriesToCollection(Type targetType, Type elementType, IEnumerable<DynamoDBEntry> entries, out object result)
+#endif
         {
             var items = Conversion.ConvertFromEntries(elementType, entries);
             return Utils.ItemsToCollection(targetType, items, out result);
@@ -468,15 +573,17 @@ namespace Amazon.DynamoDBv2
     /// A collection converter which reads both sets of collections (sets and lists)
     /// and writes out sets (NS, SS, BS)
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class PrimitiveCollectionConverterV1 : CollectionConverter
     {
         public PrimitiveCollectionConverterV1()
-            : base(Utils.PrimitiveTypes)
+            : base()
         { }
-        
+
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return Utils.PrimitiveTypesCollectionsAndArray;
+        }
+
         public override bool TryTo(object value, out PrimitiveList pl)
         {
             var items = value as IEnumerable;
@@ -490,13 +597,22 @@ namespace Amazon.DynamoDBv2
             return false;
         }
 
+#if NET8_0_OR_GREATER
+        public override bool TryFrom(PrimitiveList pl, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
+#else
         public override bool TryFrom(PrimitiveList pl, Type targetType, out object result)
+#endif
         {
             var elementType = Utils.GetPrimitiveElementType(targetType);
             var primitives = pl.Entries;
             return EntriesToCollection(targetType, elementType, pl.Entries.Cast<DynamoDBEntry>(), out result);
         }
+
+#if NET8_0_OR_GREATER
+        public override bool TryFrom(DynamoDBList l, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
+#else
         public override bool TryFrom(DynamoDBList l, Type targetType, out object result)
+#endif
         {
             var elementType = Utils.GetPrimitiveElementType(targetType);
             var entries = l.Entries;
@@ -509,9 +625,6 @@ namespace Amazon.DynamoDBv2
     /// Converts from Dictionary{string,object} to DynamoDBEntry.
     /// Does NOT convert from DynamoDBEntry to Dictionary{string,object}.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DictionaryConverterV1 : Converter
     {
         public override IEnumerable<Type> GetTargetTypes()
@@ -547,5 +660,5 @@ namespace Amazon.DynamoDBv2
         }
     }
 
-    #endregion
+#endregion
 }

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
@@ -19,6 +19,7 @@ using Amazon.Util.Internal;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -27,117 +28,60 @@ namespace Amazon.DynamoDBv2
 {
     #region Same converter behavior as V1
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class ByteConverterV2 : ByteConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class SByteConverterV2 : SByteConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class UInt16ConverterV2 : UInt16ConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class Int16ConverterV2 : Int16ConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class UInt32ConverterV2 : UInt32ConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class Int32ConverterV2 : Int32ConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class UInt64ConverterV2 : UInt64ConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class Int64ConverterV2 : Int64ConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class SingleConverterV2 : SingleConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DoubleConverterV2 : DoubleConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DecimalConverterV2 : DecimalConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class CharConverterV2 : CharConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class StringConverterV2 : StringConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DateTimeConverterV2 : DateTimeConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class GuidConverterV2 : GuidConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class BytesConverterV2 : BytesConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class MemoryStreamConverterV2 : MemoryStreamConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DictionaryConverterV2 : DictionaryConverterV1
     { }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class EnumConverterV2 : EnumConverterV1
     { }
 
@@ -147,10 +91,6 @@ namespace Amazon.DynamoDBv2
     /// A boolean converter which reads booleans as N or BOOL types,
     /// but writes out BOOL type.
     /// </summary>
-
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class BoolConverterV2 : BoolConverterV1
     {
         protected override bool TryTo(bool value, out DynamoDBBool b)
@@ -171,9 +111,6 @@ namespace Amazon.DynamoDBv2
     /// HashSet input - converts to a DynamoDB set (NS, SS, BS)
     /// Any other IEnumerable input - converts to a DynamoDB list (L)
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class CollectionConverterV2 : PrimitiveCollectionConverterV1
     {
         private static Type setTypeInfo = typeof(HashSet<>);
@@ -214,7 +151,7 @@ namespace Amazon.DynamoDBv2
         {
             var inputType = value.GetType();
 
-            if (DataModel.Utils.ImplementsInterface(inputType, enumerableType))
+            if ((value is IEnumerable && inputType.GenericTypeArguments.Length > 0) || inputType.IsArray)
             {
                 var elementType = Utils.GetElementType(inputType);
                 var entries = Conversion.ConvertToEntries(elementType, value as IEnumerable);
@@ -227,17 +164,18 @@ namespace Amazon.DynamoDBv2
         }
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DynamoDBListConverter : CollectionConverter
     {
         public DynamoDBListConverter()
             : this(Utils.PrimitiveTypes)
         { }
         public DynamoDBListConverter(IEnumerable<Type> memberTypes)
-            : base(memberTypes)
         { }
+
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return Utils.PrimitiveTypesCollectionsAndArray;
+        }
 
         public override bool TryTo(object value, out DynamoDBList l)
         {
@@ -258,7 +196,11 @@ namespace Amazon.DynamoDBv2
             return false;
         }
 
+#if NET8_0_OR_GREATER
+        public override bool TryFrom(DynamoDBList l, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
+#else
         public override bool TryFrom(DynamoDBList l, Type targetType, out object result)
+#endif
         {
             var elementType = Utils.GetElementType(targetType);
             var entries = l.Entries;

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/V1PropertyConverters.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/V1PropertyConverters.cs
@@ -24,6 +24,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Amazon.DynamoDBv2
 {
@@ -38,20 +39,29 @@ namespace Amazon.DynamoDBv2
     /// to use a different conversion scheme for converting individual elements.
     /// The default value for this field is the standard V1 conversion.
     /// </summary>
+
 #if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
+    public class SetPropertyConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] TCollection, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] TElement> : IPropertyConverter
+        where TCollection : ICollection<TElement>, new()
+#else
     public class SetPropertyConverter<TCollection, TElement> : IPropertyConverter
         where TCollection : ICollection<TElement>, new()
+#endif
     {
         /// <summary>
         /// Reference to the type object for the TCollection generic.
         /// </summary>
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
         protected static readonly Type collectionType = typeof(TCollection);
 
         /// <summary>
         /// Reference to the type object for the TElement generic.
         /// </summary>
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
         protected static readonly Type elementType = typeof(TElement);
 
         /// <summary>
@@ -140,11 +150,11 @@ namespace Amazon.DynamoDBv2
     /// The default value for this field is the standard V1 conversion.
     /// </summary>
     /// <typeparam name="TElement"></typeparam>
-
+    public class ListToSetPropertyConverter<
 #if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)]
 #endif
-    public class ListToSetPropertyConverter<TElement> : SetPropertyConverter<List<TElement>, TElement>
+    TElement> : SetPropertyConverter<List<TElement>, TElement>
     { }
 
     /// <summary>
@@ -154,13 +164,9 @@ namespace Amazon.DynamoDBv2
     /// Use this converter to bypass the default schema behavior for a particular
     /// property.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class BoolAsNConverter : IPropertyConverter
     {
         private static BoolConverterV1 v1Converter = new BoolConverterV1();
-        private static Type boolType = typeof(bool);
 
         /// <summary>
         /// Converts object to DynamoDBEntry
@@ -179,7 +185,7 @@ namespace Amazon.DynamoDBv2
         /// <returns></returns>
         public object FromEntry(DynamoDBEntry entry)
         {
-            return v1Converter.FromEntry(entry, boolType);
+            return v1Converter.FromEntry(entry, typeof(bool));
         }
     }
 }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -18,6 +18,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -48,6 +49,10 @@ namespace Amazon.DynamoDBv2.DataModel
         // MemberInfo of the property
         public MemberInfo Member { get; protected set; }
         // Type of the property
+
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
         public Type MemberType { get; protected set; }
         // Converter type, if one is present
         public Type ConverterType { get; set; }

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
@@ -29,9 +29,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// A collection of attribute key-value pairs that defines
     /// an item in DynamoDB.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class Document : DynamoDBEntry, IDictionary<string, DynamoDBEntry>
     {
         #region Private/internal members

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
@@ -8,9 +8,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Extensions methods Document type.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public static class DocumentExtensions
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentTransactWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentTransactWrite.cs
@@ -205,9 +205,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// Class for condition checking, putting, updating and/or deleting
     /// multiple items in a single DynamoDB table in a transaction.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public partial class DocumentTransactWrite : IDocumentTransactWrite
     {
         #region Internal properties
@@ -983,9 +980,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
         #endregion
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class ToUpdateWithExpressionTransactWriteRequestItem : ToUpdateTransactWriteRequestItemBase
     {
         #region Properties

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBBool.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBBool.cs
@@ -27,14 +27,10 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// A DynamoDBEntry that represents a DynamoDB bool (BOOL) type.
     /// </summary>
-    
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class DynamoDBBool : DynamoDBEntry
     {
         /// <summary>
-        /// Construct an instance of DynamnDBBool
+        /// Construct an instance of DynamoDBBool
         /// </summary>
         /// <param name="value"></param>
         public DynamoDBBool(bool value)

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBEntry.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBEntry.cs
@@ -29,9 +29,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Abstract class representing an arbitrary DynamoDB attribute value
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public abstract class DynamoDBEntry : ICloneable
     {
         internal class AttributeConversionConfig
@@ -1059,10 +1056,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// The entry is converted to a converted DynamoDBEntry either by the
     /// consuming Document or Table.
     /// </summary>
-
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class UnconvertedDynamoDBEntry : DynamoDBEntry
     {
         private object Value;

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBList.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBList.cs
@@ -26,9 +26,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// A DynamoDBEntry that represents a DynamoDB list (L) type.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class DynamoDBList : DynamoDBEntry
     {
         private static DynamoDBEntryConversion conversion = CreateConversion();

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBNull.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DynamoDBNull.cs
@@ -27,10 +27,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// A DynamoDBEntry that represents a DynamoDB null (NULL) type.
     /// </summary>
-
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class DynamoDBNull : DynamoDBEntry
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpectedState.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpectedState.cs
@@ -27,9 +27,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// Expected state of an attribute in DynamoDB.
     /// Exists cannot be set at the same time as Comparison and Values.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class ExpectedValue
     {
         /// <summary>
@@ -133,9 +130,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Expected state of an item in DynamoDB.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class ExpectedState
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
@@ -26,9 +26,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Expressions are used for conditional deletes and filtering for query and scan operations.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class Expression
     {
         private Dictionary<string, string> _expressionAttributeNames = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Filter.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Filter.cs
@@ -25,9 +25,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Filter for use with scan and query operations
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class Filter
     {
         #region Private members
@@ -35,9 +32,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <summary>
         /// Filter conditions
         /// </summary>
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
         protected class FilterCondition
         {
             /// <summary>
@@ -338,9 +332,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Scan filter.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class ScanFilter : Filter
     {
         /// <summary>
@@ -383,9 +374,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Query filter.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class QueryFilter : Filter
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
@@ -25,9 +25,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Utility methods to handle conversion from/to JSON
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal static class JsonUtils
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Primitive.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Primitive.cs
@@ -46,9 +46,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// A DynamoDBEntry that represents a scalar DynamoDB type
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class Primitive : DynamoDBEntry, IEquatable<Primitive>
     {
         #region Private members
@@ -662,8 +659,15 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <returns>byte[] value of this object</returns>
         public override byte[] AsByteArray()
         {
-            return V1Conversion.ConvertFromEntry<byte[]>(this);
+            // For Native AOT support this directly uses the cast to byte[] instead of the 
+            // normal "V1Conversion.ConvertFromEntry<byte[]>(this);" because the Native AOT
+            // compiler generated a warning about System.Array.CreateInstance(Type,Int32) usage.
+            // There is no actual use of "System.Array.CreateInstance(Type,Int32)" at least in the SDK
+            // code and suspect the warning is erroneous but we need the warning to go away
+            // for Native AOT users.
+            return this.Value as byte[];
         }
+
         /// <summary>
         /// Implicitly convert byte[] to Primitive
         /// </summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/PrimitiveList.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/PrimitiveList.cs
@@ -27,9 +27,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// A DynamoDBEntry that represents a primitive list DynamoDB type
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class PrimitiveList : DynamoDBEntry, IEquatable<PrimitiveList>
     {
         private static DynamoDBEntryConversion V1Conversion = DynamoDBEntryConversion.V1;

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Search.cs
@@ -177,9 +177,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Search response object
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public partial class Search : ISearch
     {
         #region Internal constructors

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
@@ -250,9 +250,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// The Table class is the starting object when using the Document API. It is used to Get documents from the DynamoDB table
     /// and write documents back to the DynamoDB table.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public partial class Table : ITable
     {
         #region Private/internal members

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableBuilder.cs
@@ -21,9 +21,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Builder that constructs a <see cref="Table"/>
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class TableBuilder : ITableBuilder
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableConfig.cs
@@ -21,9 +21,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Configuration for the Table.PutItem operation
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class TableConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableOperationConfigs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/TableOperationConfigs.cs
@@ -146,9 +146,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Configuration for the Table.Scan operation
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class ScanOperationConfig
     {
         /// <summary>
@@ -269,9 +266,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// <summary>
     /// Configuration for the Table.Query operation
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class QueryOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/Internal/InternalConstants.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Internal/InternalConstants.cs
@@ -17,6 +17,6 @@ namespace Amazon.DynamoDBv2.Custom.Internal
 {
     internal static class InternalConstants
     {
-        internal const string RequiresUnreferencedCodeMessage = "The Amazon DynamoDB high level libraries in the DocumentModel and DataModel namespace have not been updated to support Native AOT.";
+        internal const string RequiresUnreferencedCodeMessage = "The Amazon DynamoDB high level libraries in the DataModel namespace have not been updated to support Native AOT.";
     }
 }


### PR DESCRIPTION
## Description
**Note: This is just the Document Model. Not the DataModel (aka Object Persistence Model). The DataModel builds on top of the Document Model so getting the Document Model library Native AOT complaint is the prerequisite**

This PR removes the `RequiresUnreferencedCode` from the DocumentModel library and adds the appropriate `DynamicallyAccessedMembers` attributes and code adjustments to make Native AOT trim warnings go away when using the DocumentModel library with Native AOT.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3475
Add support for using the Document Model library using Native AOT. Using Native AOT for the following Lambda function reduced the cold start time from approximately 1,500 ms to 500 ms.

```csharp
public class Function
{
    static IAmazonDynamoDB _ddbClient;
    static Table _table;

    private static async Task Main()
    {
        _ddbClient = new AmazonDynamoDBClient(RegionEndpoint.USWest2);

        _table = new TableBuilder(_ddbClient, "ZipCodes")
                            .AddHashKey("Code", DynamoDBEntryType.String)
                            .Build();


        Func<string, ILambdaContext, Task<string>> handler = FunctionHandler;
        await LambdaBootstrapBuilder.Create(handler, new SourceGeneratorLambdaJsonSerializer<LambdaFunctionJsonSerializerContext>())
            .Build()
            .RunAsync();
    }


    public static async Task<string> FunctionHandler(string input, ILambdaContext context)
    {
        var document = await _table.GetItemAsync(input);
        if (document == null)
        {
            return $"No zip code found for {input}";
        }

        return $"{document["City"].AsString()}, {document["State"].AsString()}";
    }
}


[JsonSerializable(typeof(string))]
public partial class LambdaFunctionJsonSerializerContext : JsonSerializerContext
{
}
``` 

## Testing
Successful dry run
Build Native AOT Lambda function using Native AOT to ensure no trim warnings were produced.
Built a standalone console application that exercised more API then the Lambda function compiled and executed locally using Native AOT for Windows.

When I do Native AOT compile on Windows I do still get the following trim warning but it doesn't come from the AWS SDK and the warning does not happen when targeting Linux.
```
> dotnet publish -r win-x64 /p:PublishAot=true
Restore complete (1.0s)
  DynamoDBDocumentAotTest succeeded with 1 warning(s) (28.0s) → bin\Release\net8.0\win-x64\publish\
    /_/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs(90): warning IL3000: System.Net.Quic.MsQuicApi..cctor(): 'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.
```
