### PR TITLE
[SRA] Invalidate credentials caching when environment variables change

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfileStoreChain.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfileStoreChain.cs
@@ -14,16 +14,14 @@
  */
 
 using System.Collections.Generic;
-using Amazon.Util.Internal;
 using Amazon.Runtime.Internal.Settings;
-using System.Linq;
+using System;
 
 namespace Amazon.Runtime.CredentialManagement
 {
     /// <summary>
     /// Class to abstract the combined use of NetSDKCredentialsFile and SharedCredentialsFile where possible.
     /// </summary>
-    /// <returns></returns>
     public class CredentialProfileStoreChain : ICredentialProfileSource
     {
         /// <summary>
@@ -212,5 +210,32 @@ namespace Amazon.Runtime.CredentialManagement
                 profile.CredentialProfileStore.UnregisterProfile(profileName);
             }
         }
+    }
+
+    /// <summary>
+    /// Exception thrown when a custom profile (i.e. specified via the <c>AWS_PROFILE</c> environment variable and
+    /// different than <c>default</c>) does not exist. 
+    /// </summary>
+    /// <remarks>
+    /// This will be surfaced to the user instead of moving on to the next credential provider.
+    /// </remarks>
+#if !NETSTANDARD
+    [Serializable]
+#endif
+    public class ProfileNotFoundException : AmazonClientException
+    {
+        public ProfileNotFoundException(string message) : base(message) { }
+
+        public ProfileNotFoundException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+#if !NETSTANDARD
+        protected ProfileNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -34,11 +34,12 @@ namespace Amazon.Runtime.Credentials
         private const string AWS_PROFILE_ENVIRONMENT_VARIABLE = "AWS_PROFILE";
         private const string DEFAULT_PROFILE_NAME = "default";
 
-        private static ReaderWriterLockSlim _cachedCredentialsLock = new ReaderWriterLockSlim();
+        private static readonly ReaderWriterLockSlim _cachedCredentialsLock = new();
         private delegate AWSCredentials CredentialsGenerator();
         private AWSCredentials _cachedCredentials;
-        private List<CredentialsGenerator> _credentialsGenerators { get; set; }
-        private readonly CredentialProfileStoreChain _credentialProfileChain = new CredentialProfileStoreChain();
+        private readonly List<CredentialsGenerator> _credentialsGenerators;
+        private readonly CredentialProfileStoreChain _credentialProfileChain = new();
+        private readonly EnvironmentState _lastKnownEnvironmentState = new();
 
         public DefaultAWSCredentialsIdentityResolver()
         {
@@ -51,8 +52,8 @@ namespace Amazon.Runtime.Credentials
 #if BCL
                     () => new AppConfigAWSCredentials(), // Test explicit keys/profile name first.
 #endif
-                    () => AssumeRoleWithWebIdentityCredentials.FromEnvironmentVariables(),
                     () => new EnvironmentVariablesAWSCredentials(), // Look for credentials set in environment vars.
+                    () => AssumeRoleWithWebIdentityCredentials.FromEnvironmentVariables(),
                     () => GetAWSCredentials(_credentialProfileChain),
                     () => ContainerEC2CredentialsWrapper(), // either get ECS / EKS credentials or instance profile credentials
                 };
@@ -66,12 +67,18 @@ namespace Amazon.Runtime.Credentials
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We need to catch all exceptions to be able to move the the next generator.")]
         public BaseIdentity ResolveIdentity()
         {
+            var hasEnvironmentChanged = false;
+
             try
             {
                 _cachedCredentialsLock.EnterReadLock();
                 if (_cachedCredentials != null)
                 {
-                    return _cachedCredentials;
+                    hasEnvironmentChanged = _lastKnownEnvironmentState.HasEnvironmentChanged();
+                    if (!hasEnvironmentChanged)
+                    { 
+                        return _cachedCredentials;
+                    }
                 }
             }
             finally
@@ -82,7 +89,7 @@ namespace Amazon.Runtime.Credentials
             try
             {
                 _cachedCredentialsLock.EnterWriteLock();
-                if (_cachedCredentials != null)
+                if (_cachedCredentials != null && !hasEnvironmentChanged)
                 {
                     return _cachedCredentials;
                 }
@@ -107,16 +114,20 @@ namespace Amazon.Runtime.Credentials
                     catch (Exception e)
                     {
                         _cachedCredentials = null;
-
                         errors.Add(e);
                     }
 
                     if (_cachedCredentials != null)
+                    {
                         break;
+                    }
                 }
 
                 if (_cachedCredentials != null)
+                {
+                    _lastKnownEnvironmentState.UpdateEnvironment();
                     return _cachedCredentials;
+                }
 
                 using (StringWriter writer = new StringWriter(CultureInfo.InvariantCulture))
                 {
@@ -147,10 +158,10 @@ namespace Amazon.Runtime.Credentials
         private static AWSCredentials GetAWSCredentials(ICredentialProfileSource source)
         {
             var profileName = GetProfileName();
-
-            CredentialProfile profile;
-            if (source.TryGetProfile(profileName, out profile))
+            if (source.TryGetProfile(profileName, out CredentialProfile profile))
+            {
                 return profile.GetAWSCredentials(source, true);
+            }
 
             throw new AmazonClientException($"Unable to find the \"{profileName}\" profile in CredentialProfileStoreChain.");
         }
@@ -160,10 +171,14 @@ namespace Amazon.Runtime.Credentials
             var profileName = AWSConfigs.AWSProfileName;
 
             if (string.IsNullOrEmpty(profileName?.Trim()))
+            {
                 profileName = Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
+            }
 
             if (string.IsNullOrEmpty(profileName?.Trim()))
+            {
                 profileName = DEFAULT_PROFILE_NAME;
+            }
 
             return profileName;
         }
@@ -190,6 +205,49 @@ namespace Amazon.Runtime.Credentials
                     $" Either {GenericContainerCredentials.RelativeURIEnvVariable} or {GenericContainerCredentials.FullURIEnvVariable} environment variables must be set.");
             }
             return DefaultInstanceProfileAWSCredentials.Instance;
+        }
+
+        /// <summary>
+        /// This helper class keeps track of the environment state at the time credentials were last resolved.
+        /// <para>
+        /// The <see cref="FallbackCredentialsFactory"/> was written with the assumption the environment wouldn't change between calls, so it returns
+        /// cached values if available. However, in some scenarios (such as a PowerShell interactive session), customers may set a different profile or
+        /// temporary access and secret keys (and we want to pick up that change to match the behavior of the AWS CLI).
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// This class intentionally doesn't check for variables related to the <see cref="GenericContainerCredentials"/> provider, as those are expected to 
+        /// be set once when the container starts and not to change for its lifecycle.
+        /// </remarks>
+        private class EnvironmentState
+        {
+            public string AccessKey { get; private set; }
+            public string SecretKey { get; private set; }
+            public string SessionToken { get; private set; }
+            public string ProfileName { get; private set; }
+
+            public bool HasEnvironmentChanged()
+            {
+                var secretKey = 
+                    Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY) ?? 
+                    Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.LEGACY_ENVIRONMENT_VARIABLE_SECRETKEY);
+
+                return 
+                    AccessKey != Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY) ||
+                    SecretKey != secretKey ||
+                    SessionToken != Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN) ||
+                    ProfileName != Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
+            }
+
+            public void UpdateEnvironment()
+            {
+                AccessKey = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY);
+                SecretKey = 
+                    Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY) ??
+                    Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.LEGACY_ENVIRONMENT_VARIABLE_SECRETKEY);
+                SessionToken = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN);
+                ProfileName = Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
+            }
         }
     }
 }

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
@@ -14,6 +14,7 @@
  */
 
 using Amazon.Runtime;
+using Amazon.Runtime.CredentialManagement;
 using Amazon.Runtime.Credentials;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -83,11 +84,9 @@ namespace AWSSDK.UnitTests
             var initialIdentity = identityResolver.ResolveIdentity();
             Assert.IsFalse(initialIdentity is DefaultInstanceProfileAWSCredentials);
 
-            // Since the specified profile does not exist, the identity resolver will default to IMDS (the last
-            // option in the credentials provider chain).
+            // Since the specified profile does not exist, the identity resolver will throw an exception.
             Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "non-existent-profile");
-            var updatedIdentity = identityResolver.ResolveIdentity();
-            Assert.IsTrue(updatedIdentity is DefaultInstanceProfileAWSCredentials);
+            Assert.ThrowsException<ProfileNotFoundException>(() => identityResolver.ResolveIdentity());
         }
     }
 }

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
@@ -1,0 +1,93 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.Runtime;
+using Amazon.Runtime.Credentials;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace AWSSDK.UnitTests
+{
+    [TestClass]
+    public class DefaultCredentialsResolverTests
+    {
+        private const string AWS_PROFILE_ENVIRONMENT_VARIABLE = "AWS_PROFILE";
+
+        private string _cachedContainersUriVariable;
+        private string _cachedProfileVariable;
+        private string _cachedAccessTokenVariable;
+        private string _cachedSecretKeyVariable;
+        private string _cachedSessionTokenVariable;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            // When running these tests on CodeBuild, we need to clear the "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" variable
+            // to prevent using the container credentials provider.
+            _cachedContainersUriVariable = Environment.GetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable);
+            Environment.SetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable, null);
+
+            _cachedProfileVariable = Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
+            _cachedAccessTokenVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY);
+            _cachedSecretKeyVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY);
+            _cachedSessionTokenVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Environment.SetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable, _cachedContainersUriVariable);
+            Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, _cachedProfileVariable);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, _cachedAccessTokenVariable);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, _cachedSecretKeyVariable);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN, _cachedSessionTokenVariable);
+        }
+
+        [TestMethod]
+        public void CredentialsAreReevaluatedWhenEnvVarsAreSet()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN, null);
+
+            // By setting the environment variables to null, the identity resolver will use either basic credentials (from the default 
+            // profile) or session credentials (when using an IAM role - for example, in CodeBuild).
+            var identityResolver = new DefaultAWSCredentialsIdentityResolver();
+            var initialIdentity = identityResolver.ResolveIdentity();
+            Assert.IsFalse(initialIdentity is EnvironmentVariablesAWSCredentials);
+
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, "updated_aws_access_key_id");
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, "updated_aws_secret_access_key");
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN, "updated_aws_session_token");
+
+            var updatedIdentity = identityResolver.ResolveIdentity();
+            Assert.IsTrue(updatedIdentity is EnvironmentVariablesAWSCredentials);
+        }
+
+        [TestMethod]
+        public void CredentialsAreReevaluatedWhenProfileChanges()
+        {
+            var identityResolver = new DefaultAWSCredentialsIdentityResolver();
+            var initialIdentity = identityResolver.ResolveIdentity();
+            Assert.IsFalse(initialIdentity is DefaultInstanceProfileAWSCredentials);
+
+            // Since the specified profile does not exist, the identity resolver will default to IMDS (the last
+            // option in the credentials provider chain).
+            Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "non-existent-profile");
+            var updatedIdentity = identityResolver.ResolveIdentity();
+            Assert.IsTrue(updatedIdentity is DefaultInstanceProfileAWSCredentials);
+        }
+    }
+}

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/InstanceProfileAWSCredentialsTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/InstanceProfileAWSCredentialsTest.cs
@@ -93,7 +93,6 @@ namespace AWSSDK.UnitTests
                 Expiration = currentTime.AddHours(6)
             };
 
-            using (new AWSConfigsDateFaker(() => currentTime.ToUniversalTime()))
             using (var imdsServlet = new EC2InstanceMetadataServlet())
             {
                 var instanceProfileAwsCredentials =


### PR DESCRIPTION
## Description
This PR makes two changes to the `DefaultAWSCredentialsIdentityResolver` (which is the replacement for the `FallbackCredentialsFactory` in V4):
* If there are changes to environment variables used by our credentials provider (such as `AWS_PROFILE`), do not return cached credentials
* If a custom / non-default profile is specified _and_ the profile doesn't exist, throw an error instead of going to the next provider in the credential chain (which at the moment is IMDS). With the previous behavior, customers running outside of EC2 would get a different error (`Unable to get IAM security credentials from EC2 Instance Metadata Service`) that wouldn't reference the invalid profile at all.

## Motivation and Context
Internal issue: `DOTNET-7855`

## Testing
* Dry-run: `DRY_RUN-cf127d60-49ba-48a7-b0e9-04eecaa186c3`
* Console app:
```csharp
var s3Client = new AmazonS3Client();
var response1 = await s3Client.ListBucketsAsync();
Console.WriteLine($"Found {response1.Buckets.Count} buckets for default profile");

Environment.SetEnvironmentVariable("AWS_PROFILE", "test-runner");
var response2 = await s3Client.ListBucketsAsync();
Console.WriteLine($"Found {response2.Buckets.Count} buckets for test-runner profile");

try
{
    Environment.SetEnvironmentVariable("AWS_PROFILE", "non-existent");
    await s3Client.ListBucketsAsync();
}
catch (AmazonClientException)
{
    Console.WriteLine("Failed as expected locally since non-existent profile will cause the credential search to be short-circuited.");
}
```

Output:
```
Found 30 buckets for default profile
Found 16 buckets for test-runner profile
Failed as expected locally since non-existent profile will cause the credential search to be short-circuited.
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license