### PR TITLE
Maintain copy of stream for exceptions during unmarshalling

### DIFF
--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCExceptionUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCExceptionUnmarshaller.cs
@@ -102,11 +102,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write(" Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorRespons" +
-                    "e errorResponse, ref StreamingUtf8JsonReader reader)\r\n        {\r\n            con" +
-                    "text.Read(ref reader);\r\n\r\n");
+            this.Write(@" Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
+        {
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
+");
             
-            #line 43 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 44 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
 
             if  (this.Config.ServiceModel.IsAwsQueryCompatible)
             {
@@ -117,14 +120,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("            ");
             
-            #line 48 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 49 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
             #line hidden
             this.Write(" unmarshalledObject = new ");
             
-            #line 48 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 49 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
@@ -132,7 +135,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             this.Write("(errorResponse.Message, errorResponse.InnerException,\r\n                errorType," +
                     " errorCode, errorResponse.RequestId, errorResponse.StatusCode);\r\n");
             
-            #line 50 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 51 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
 
             }
             else
@@ -143,14 +146,14 @@ namespace ServiceClientGenerator.Generators.Marshallers
             #line hidden
             this.Write("            ");
             
-            #line 55 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 56 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
             #line hidden
             this.Write(" unmarshalledObject = new ");
             
-            #line 55 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 56 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.UnmarshallerBaseName));
             
             #line default
@@ -159,17 +162,18 @@ namespace ServiceClientGenerator.Generators.Marshallers
                     "nse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode)" +
                     ";\r\n");
             
-            #line 57 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 58 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
 
             }
 
             
             #line default
             #line hidden
-            this.Write("        \r\n            int targetDepth = context.CurrentDepth;\r\n            while " +
-                    "(context.ReadAtDepth(targetDepth, ref reader))\r\n            {\r\n");
+            this.Write("        \r\n            int targetDepth = context.CurrentDepth;\r\n            if (!s" +
+                    "tring.IsNullOrEmpty(context.ResponseBody))\r\n            {\r\n                while" +
+                    " (context.ReadAtDepth(targetDepth, ref reader))\r\n                {\r\n");
             
-            #line 64 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 67 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
 
     if(this.Structure != null)
     {
@@ -179,31 +183,32 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("                if (context.TestExpression(\"");
+            this.Write("                    if (context.TestExpression(\"");
             
-            #line 70 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 73 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.MarshallName));
             
             #line default
             #line hidden
-            this.Write("\", targetDepth))\r\n                {\r\n                    var unmarshaller = ");
+            this.Write("\", targetDepth))\r\n                    {\r\n                        var unmarshaller" +
+                    " = ");
             
-            #line 72 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 75 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));
             
             #line default
             #line hidden
-            this.Write(";\r\n                    unmarshalledObject.");
+            this.Write(";\r\n                        unmarshalledObject.");
             
-            #line 73 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 76 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.PropertyName));
             
             #line default
             #line hidden
-            this.Write(" = unmarshaller.Unmarshall(context, ref reader);\r\n                    continue;\r\n" +
-                    "                }\r\n");
+            this.Write(" = unmarshaller.Unmarshall(context, ref reader);\r\n                        continu" +
+                    "e;\r\n                    }\r\n");
             
-            #line 76 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 79 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
 
         }
     }
@@ -211,9 +216,10 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("            }\r\n          \r\n            return unmarshalledObject;\r\n        }\r\n\r\n");
+            this.Write("                }\r\n            }\r\n          \r\n            return unmarshalledObje" +
+                    "ct;\r\n        }\r\n\r\n");
             
-            #line 85 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
+            #line 89 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"
 
     this.AddStructureSingletonMethod();
 

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCExceptionUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCExceptionUnmarshaller.tt
@@ -38,8 +38,9 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public <#=this.UnmarshallerBaseName #> Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
 <#
             if  (this.Config.ServiceModel.IsAwsQueryCompatible)
             {
@@ -59,24 +60,27 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
 #>
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
 <#
     if(this.Structure != null)
     {
         foreach (var member in this.Structure.Members)
         {
 #>
-                if (context.TestExpression("<#=member.MarshallName#>", targetDepth))
-                {
-                    var unmarshaller = <#= member.DetermineTypeUnmarshallerInstantiate() #>;
-                    unmarshalledObject.<#=member.PropertyName#> = unmarshaller.Unmarshall(context, ref reader);
-                    continue;
-                }
+                    if (context.TestExpression("<#=member.MarshallName#>", targetDepth))
+                    {
+                        var unmarshaller = <#= member.DetermineTypeUnmarshallerInstantiate() #>;
+                        unmarshalledObject.<#=member.PropertyName#> = unmarshaller.Unmarshall(context, ref reader);
+                        continue;
+                    }
 <#
         }
     }
 #>
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BackupInUseExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BackupInUseExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public BackupInUseException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             BackupInUseException unmarshalledObject = new BackupInUseException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BackupNotFoundExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BackupNotFoundExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public BackupNotFoundException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             BackupNotFoundException unmarshalledObject = new BackupNotFoundException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BatchExecuteStatementRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BatchExecuteStatementRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -96,8 +97,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BatchGetItemRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BatchGetItemRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -99,8 +100,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BatchWriteItemRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/BatchWriteItemRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -110,8 +111,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ConditionalCheckFailedExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ConditionalCheckFailedExceptionUnmarshaller.cs
@@ -59,19 +59,23 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ConditionalCheckFailedException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ConditionalCheckFailedException unmarshalledObject = new ConditionalCheckFailedException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
-                if (context.TestExpression("Item", targetDepth))
+                while (context.ReadAtDepth(targetDepth, ref reader))
                 {
-                    var unmarshaller = new JsonDictionaryUnmarshaller<string, AttributeValue, StringUnmarshaller, AttributeValueUnmarshaller>(StringUnmarshaller.Instance, AttributeValueUnmarshaller.Instance);
-                    unmarshalledObject.Item = unmarshaller.Unmarshall(context, ref reader);
-                    continue;
+                    if (context.TestExpression("Item", targetDepth))
+                    {
+                        var unmarshaller = new JsonDictionaryUnmarshaller<string, AttributeValue, StringUnmarshaller, AttributeValueUnmarshaller>(StringUnmarshaller.Instance, AttributeValueUnmarshaller.Instance);
+                        unmarshalledObject.Item = unmarshaller.Unmarshall(context, ref reader);
+                        continue;
+                    }
                 }
             }
           

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ContinuousBackupsUnavailableExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ContinuousBackupsUnavailableExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ContinuousBackupsUnavailableException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ContinuousBackupsUnavailableException unmarshalledObject = new ContinuousBackupsUnavailableException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/CreateBackupRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/CreateBackupRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -86,8 +87,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/CreateGlobalTableRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/CreateGlobalTableRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -96,8 +97,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/CreateTableRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/CreateTableRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -228,8 +229,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DeleteBackupRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DeleteBackupRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DeleteItemRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DeleteItemRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -187,8 +188,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DeleteResourcePolicyRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DeleteResourcePolicyRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -86,8 +87,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DeleteTableRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DeleteTableRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeBackupRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeBackupRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeContinuousBackupsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeContinuousBackupsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeContributorInsightsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeContributorInsightsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -86,8 +87,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeEndpointsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeEndpointsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeExportRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeExportRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeGlobalTableRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeGlobalTableRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeGlobalTableSettingsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeGlobalTableSettingsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeImportRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeImportRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeKinesisStreamingDestinationRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeKinesisStreamingDestinationRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeLimitsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeLimitsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeTableReplicaAutoScalingRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeTableReplicaAutoScalingRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeTableRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeTableRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeTimeToLiveRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DescribeTimeToLiveRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DisableKinesisStreamingDestinationRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DisableKinesisStreamingDestinationRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -97,8 +98,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DuplicateItemExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/DuplicateItemExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public DuplicateItemException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             DuplicateItemException unmarshalledObject = new DuplicateItemException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/EnableKinesisStreamingDestinationRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/EnableKinesisStreamingDestinationRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -97,8 +98,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExecuteStatementRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExecuteStatementRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -126,8 +127,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExecuteTransactionRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExecuteTransactionRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -107,8 +108,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExportConflictExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExportConflictExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ExportConflictException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ExportConflictException unmarshalledObject = new ExportConflictException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExportNotFoundExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExportNotFoundExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ExportNotFoundException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ExportNotFoundException unmarshalledObject = new ExportNotFoundException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExportTableToPointInTimeRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ExportTableToPointInTimeRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -150,8 +151,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/GetItemRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/GetItemRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -142,8 +143,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/GetResourcePolicyRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/GetResourcePolicyRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -80,8 +81,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/GlobalTableAlreadyExistsExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/GlobalTableAlreadyExistsExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public GlobalTableAlreadyExistsException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             GlobalTableAlreadyExistsException unmarshalledObject = new GlobalTableAlreadyExistsException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/GlobalTableNotFoundExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/GlobalTableNotFoundExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public GlobalTableNotFoundException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             GlobalTableNotFoundException unmarshalledObject = new GlobalTableNotFoundException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/IdempotentParameterMismatchExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/IdempotentParameterMismatchExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public IdempotentParameterMismatchException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             IdempotentParameterMismatchException unmarshalledObject = new IdempotentParameterMismatchException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ImportConflictExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ImportConflictExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ImportConflictException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ImportConflictException unmarshalledObject = new ImportConflictException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ImportNotFoundExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ImportNotFoundExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ImportNotFoundException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ImportNotFoundException unmarshalledObject = new ImportNotFoundException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ImportTableRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ImportTableRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -130,8 +131,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/IndexNotFoundExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/IndexNotFoundExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public IndexNotFoundException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             IndexNotFoundException unmarshalledObject = new IndexNotFoundException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/InternalServerErrorExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/InternalServerErrorExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public InternalServerErrorException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             InternalServerErrorException unmarshalledObject = new InternalServerErrorException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/InvalidExportTimeExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/InvalidExportTimeExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public InvalidExportTimeException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             InvalidExportTimeException unmarshalledObject = new InvalidExportTimeException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/InvalidRestoreTimeExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/InvalidRestoreTimeExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public InvalidRestoreTimeException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             InvalidRestoreTimeException unmarshalledObject = new InvalidRestoreTimeException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ItemCollectionSizeLimitExceededExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ItemCollectionSizeLimitExceededExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ItemCollectionSizeLimitExceededException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ItemCollectionSizeLimitExceededException unmarshalledObject = new ItemCollectionSizeLimitExceededException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/LimitExceededExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/LimitExceededExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public LimitExceededException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             LimitExceededException unmarshalledObject = new LimitExceededException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListBackupsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListBackupsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -110,8 +111,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListContributorInsightsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListContributorInsightsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -92,8 +93,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListExportsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListExportsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -92,8 +93,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListGlobalTablesRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListGlobalTablesRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -92,8 +93,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListImportsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListImportsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -92,8 +93,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListTablesRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListTablesRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -86,8 +87,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListTagsOfResourceRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ListTagsOfResourceRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -86,8 +87,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/PointInTimeRecoveryUnavailableExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/PointInTimeRecoveryUnavailableExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public PointInTimeRecoveryUnavailableException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             PointInTimeRecoveryUnavailableException unmarshalledObject = new PointInTimeRecoveryUnavailableException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/PolicyNotFoundExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/PolicyNotFoundExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public PolicyNotFoundException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             PolicyNotFoundException unmarshalledObject = new PolicyNotFoundException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ProvisionedThroughputExceededExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ProvisionedThroughputExceededExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ProvisionedThroughputExceededException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ProvisionedThroughputExceededException unmarshalledObject = new ProvisionedThroughputExceededException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/PutItemRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/PutItemRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -187,8 +188,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/PutResourcePolicyRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/PutResourcePolicyRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -98,8 +99,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/QueryRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/QueryRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -241,8 +242,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ReplicaAlreadyExistsExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ReplicaAlreadyExistsExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ReplicaAlreadyExistsException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ReplicaAlreadyExistsException unmarshalledObject = new ReplicaAlreadyExistsException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ReplicaNotFoundExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ReplicaNotFoundExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ReplicaNotFoundException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ReplicaNotFoundException unmarshalledObject = new ReplicaNotFoundException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/RequestLimitExceededExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/RequestLimitExceededExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public RequestLimitExceededException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             RequestLimitExceededException unmarshalledObject = new RequestLimitExceededException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ResourceInUseExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ResourceInUseExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ResourceInUseException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ResourceInUseException unmarshalledObject = new ResourceInUseException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ResourceNotFoundExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ResourceNotFoundExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public ResourceNotFoundException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             ResourceNotFoundException unmarshalledObject = new ResourceNotFoundException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/RestoreTableFromBackupRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/RestoreTableFromBackupRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -157,8 +158,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/RestoreTableToPointInTimeRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/RestoreTableToPointInTimeRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -175,8 +176,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ScanRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/ScanRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -222,8 +223,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TableAlreadyExistsExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TableAlreadyExistsExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public TableAlreadyExistsException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             TableAlreadyExistsException unmarshalledObject = new TableAlreadyExistsException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TableInUseExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TableInUseExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public TableInUseException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             TableInUseException unmarshalledObject = new TableInUseException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TableNotFoundExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TableNotFoundExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public TableNotFoundException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             TableNotFoundException unmarshalledObject = new TableNotFoundException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TagResourceRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TagResourceRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -96,8 +97,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactGetItemsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactGetItemsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -96,8 +97,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactWriteItemsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactWriteItemsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -113,8 +114,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactionCanceledExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactionCanceledExceptionUnmarshaller.cs
@@ -59,19 +59,23 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public TransactionCanceledException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             TransactionCanceledException unmarshalledObject = new TransactionCanceledException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
-                if (context.TestExpression("CancellationReasons", targetDepth))
+                while (context.ReadAtDepth(targetDepth, ref reader))
                 {
-                    var unmarshaller = new JsonListUnmarshaller<CancellationReason, CancellationReasonUnmarshaller>(CancellationReasonUnmarshaller.Instance);
-                    unmarshalledObject.CancellationReasons = unmarshaller.Unmarshall(context, ref reader);
-                    continue;
+                    if (context.TestExpression("CancellationReasons", targetDepth))
+                    {
+                        var unmarshaller = new JsonListUnmarshaller<CancellationReason, CancellationReasonUnmarshaller>(CancellationReasonUnmarshaller.Instance);
+                        unmarshalledObject.CancellationReasons = unmarshaller.Unmarshall(context, ref reader);
+                        continue;
+                    }
                 }
             }
           

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactionConflictExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactionConflictExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public TransactionConflictException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             TransactionConflictException unmarshalledObject = new TransactionConflictException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactionInProgressExceptionUnmarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/TransactionInProgressExceptionUnmarshaller.cs
@@ -59,14 +59,18 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
         /// <returns></returns>
         public TransactionInProgressException Unmarshall(JsonUnmarshallerContext context, Amazon.Runtime.Internal.ErrorResponse errorResponse, ref StreamingUtf8JsonReader reader)
         {
-            context.Read(ref reader);
-
+            // Some error responses have no body and only send the error information in the header
+            if (!string.IsNullOrEmpty(context.ResponseBody))
+                context.Read(ref reader);
             TransactionInProgressException unmarshalledObject = new TransactionInProgressException(errorResponse.Message, errorResponse.InnerException,
                 errorResponse.Type, errorResponse.Code, errorResponse.RequestId, errorResponse.StatusCode);
         
             int targetDepth = context.CurrentDepth;
-            while (context.ReadAtDepth(targetDepth, ref reader))
+            if (!string.IsNullOrEmpty(context.ResponseBody))
             {
+                while (context.ReadAtDepth(targetDepth, ref reader))
+                {
+                }
             }
           
             return unmarshalledObject;

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UntagResourceRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UntagResourceRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -91,8 +92,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateContinuousBackupsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateContinuousBackupsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -91,8 +92,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateContributorInsightsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateContributorInsightsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -92,8 +93,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateGlobalTableRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateGlobalTableRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -96,8 +97,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateGlobalTableSettingsRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateGlobalTableSettingsRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -135,8 +136,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateItemRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateItemRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -212,8 +213,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateKinesisStreamingDestinationRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateKinesisStreamingDestinationRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -97,8 +98,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateTableReplicaAutoScalingRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateTableReplicaAutoScalingRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -123,8 +124,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateTableRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateTableRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -190,8 +191,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateTimeToLiveRequestMarshaller.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/Internal/MarshallTransformations/UpdateTimeToLiveRequestMarshaller.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using System.Text.Json;
 using System.Buffers;
+using ThirdParty.RuntimeBackports;
 #pragma warning disable CS0612,CS0618
 namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 {
@@ -63,9 +64,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
             request.HttpMethod = "POST";
 
             request.ResourcePath = "/";
-#if NETCOREAPP3_1_OR_GREATER
-            ArrayBufferWriter<byte> arrayBufferWriter = new ArrayBufferWriter<byte>();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayBufferWriter);
+#if !NETFRAMEWORK
+            using ArrayPoolBufferWriter<byte> arrayPoolBufferWriter = new ArrayPoolBufferWriter<byte>();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(arrayPoolBufferWriter);
 #else
             using var memoryStream = new MemoryStream();
             using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
@@ -91,8 +92,9 @@ namespace Amazon.DynamoDBv2.Model.Internal.MarshallTransformations
 
             writer.WriteEndObject();
             writer.Flush();
-#if NETCOREAPP3_1_OR_GREATER
-            request.Content = arrayBufferWriter.WrittenMemory.ToArray();
+            // ToArray() must be called here because aspects of sigv4 signing require a byte array
+#if !NETFRAMEWORK
+            request.Content = arrayPoolBufferWriter.WrittenMemory.ToArray();
 #else
             request.Content = memoryStream.ToArray();
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR includes 2 changes. The first change is that if during unmarshalling we get an exception, we create a copy of the existing stream because when a `StreamingUtf8JsonReader` is instantiated it automatically reads from the stream and fills the buffer. This moves the position to the end of the streaming and when we try to get the body of the response via `GetResponseBodyBytes`, the `WrappingStream`'s position is at the end and the unmarshaller thinks there is nothing to read. To get around this we copy the stream to a copy stream and set the `WrappingStream` to the stream copy. 

The second change is that if the exception sent back by the service has no body and only a header, we do not try to read the response because `System.Text.Json`'s `Utf8JsonReader` will throw an exception if it cannot find a valid json token unlike `LitJson's` `JsonReader` which doesn't throw an exception if the body is empty.

I've included some of the generated changes as an example.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
All unit tests in CoreAndCustom.NetFramework sln pass with this change

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests pass


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement