### PR TITLE
🐛 update AWSSDK.Extensions.NETCore.Setup.nuspec for dependency update

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
@@ -28,10 +28,10 @@
       <group targetFramework="net8.0">
         <dependency id="AWSSDK.Core" version="4.0.0.0-preview.5" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
-        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
-	</dependencies>
+    </dependencies>
 
   </metadata> 
   <files>


### PR DESCRIPTION
The dependency for `Microsoft.Extensions.DependencyInjection.Abstractions` was updated in the `.csproj`, but not the `.nuspec`

## Description
update the `.nuspec` to match the `.csproj`

## Motivation and Context
If an assembly has a reference to `Microsoft.Extensions.DependencyInjection.Abstractions` < `8.0`, then this will cause a build failure.

fixes https://github.com/aws/aws-sdk-net/issues/3598

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license