### PR TITLE
[V4] Adjustments to fix failing DateTimes asserts in tests due to local/UTC inconsistencies.

### DIFF
--- a/generator/.DevConfigs/4edfd844-7122-4e1b-9eed-12395d959dda.json
+++ b/generator/.DevConfigs/4edfd844-7122-4e1b-9eed-12395d959dda.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Adjustments to fix failing DateTimes asserts in tests due to local/UTC inconsistencies."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -52,14 +52,14 @@ namespace Amazon.Runtime
             internal bool IsExpiredWithin(TimeSpan preemptExpiryTime)
             {
                 var now = AWSSDKUtils.CorrectedUtcNow;
-                var exp = Expiration;
+                var exp = Expiration.ToUniversalTime();
                 return now > exp - preemptExpiryTime;
             }
 
             internal TimeSpan GetTimeToLive(TimeSpan preemptExpiryTime)
             {
                 var now = AWSSDKUtils.CorrectedUtcNow;
-                var exp = Expiration;
+                var exp = Expiration.ToUniversalTime();
 
                 return exp - now + preemptExpiryTime;
             }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -227,10 +227,10 @@ namespace AWSSDK_DotNet.UnitTests
         {   
             //Arrange
             var dateWithNoDecimals = "2022-05-05T11:56:11Z";
-            var expectedDateNoDecimal = DateTime.Parse(dateWithNoDecimals);
+            var expectedDateNoDecimal = DateTime.Parse(dateWithNoDecimals, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
 
             var dateWithDecimals = "2022-05-05T11:56:11.000Z";
-            var expectedDateDecimal = DateTime.Parse(dateWithDecimals);
+            var expectedDateDecimal = DateTime.Parse(dateWithDecimals, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
 
             var jsonDateWithNoDecimals = JsonMapper.ToJson(new
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When running tests locally the following tests were found to be failing:

* TestParsingResponse_200Result
* TestDateTimeDeserializationWithDdbContext
* StaticStabilityWhenIMDSExperiencesAnOutageScenarioTest

These were not caught running dry-run on the server previously because the server was set to +0 timezone offset (UTC) so local and UTC times were effectively the same.

**TestDateTimeDeserializationWithDdbContext**

This was caused from our intended breaking change of `DynamoDB RetrieveDateTimeInUtc has been switched to true as the default.`. Because the dates were being returning in UTC and the input dates were being passed as local the assert comparisons were failing. Required a test update.

**TestParsingResponse_200Result**

Required adding back in the `.ToUniversalTime()` removed from a recent PR (https://github.com/aws/aws-sdk-net/pull/3541). Public properties such as Expiration should be UTC but there is no guarantee they will be if they can be publicly set. The `.ToUniversalTime()` defensive call has been added back in.

**StaticStabilityWhenIMDSExperiencesAnOutageScenarioTest**

Required adding back of `.ToUniversalTime()` and in addition adjustments to `EC2InstanceMetadataServlet ` for invalid mocked responses. The code was using JsonMapper.ToJson(from an object containing a UTC datetime) but because of the default datetime export handling in the mapper mocked IMDS service was setting the expiration as a datetime string without the `Z` even though it was a UTC expiration datetime. This cause the response parser to assume it was an unspecified datetime which then got double converted to UTC with the reintroduced `.ToUniversalTime()` call.

Added in code to override the datetime export handling for `EC2InstanceMetadataServlet ` to return the properly formatted datetime strings with a `Z`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

dry-run: DRY_RUN-ed208a00-5381-46b7-a858-ad97c0247863 (Succeeded)

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement