### PR TITLE
fix: Fixed an issue where custom AmazonEC2Client.DryRun() method was not working for non-BCL targets. Also included this method in IAmazonEC2 interface.

### DIFF
--- a/generator/.DevConfigs/2a17f370-6558-4542-a38f-2361e83b84ea.json
+++ b/generator/.DevConfigs/2a17f370-6558-4542-a38f-2361e83b84ea.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "EC2",
+      "type": "patch",
+      "changeLogMessages": [
+        "fix: Fixed an issue where custom AmazonEC2Client.DryRun() method was not working for non-BCL targets. Also included this method in IAmazonEC2 interface."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/EC2/Custom/AmazonEC2Client.Extensions.cs
+++ b/sdk/src/Services/EC2/Custom/AmazonEC2Client.Extensions.cs
@@ -34,7 +34,7 @@ namespace Amazon.EC2
     /// pay only for capacity that you actually use. Amazon EC2 provides developers the tools to build failure resilient applications and isolate
     /// themselves from common failure scenarios. </para> <para> Visit http://aws.amazon.com/ec2/ for more information. </para>
     /// </summary>
-    public partial class AmazonEC2Client
+    public partial class AmazonEC2Client : AmazonServiceClient, IAmazonEC2
     {
         #region DryRun
 
@@ -112,7 +112,7 @@ namespace Amazon.EC2
                     _methodCache = new Dictionary<Type, DryRunInfo>();
 
                     var ec2RequestType = typeof(AmazonEC2Request);
-                    var allMembers = typeof(AmazonEC2Client).GetMembers();
+                    var allMembers = typeof(AmazonEC2Client).GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                     foreach (var member in allMembers)
                     {
                         MethodInfo method = member as MethodInfo;

--- a/sdk/src/Services/EC2/Custom/IAmazonEC2.Extensions.cs
+++ b/sdk/src/Services/EC2/Custom/IAmazonEC2.Extensions.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using Amazon.EC2.Model;
+using Amazon.Runtime;
+using System;
+
+namespace Amazon.EC2
+{
+    public partial interface IAmazonEC2 : IAmazonService, IDisposable
+	{
+		/// <summary>
+		/// Checks whether you have the required permissions for the action, without actually making the request.
+		/// </summary>
+		/// <param name="request">Request to do a dry run of.</param>
+		/// <returns>Result of the dry run.</returns>
+		DryRunResponse DryRun(AmazonEC2Request request);
+	}
+}


### PR DESCRIPTION
## Description
fix: Fixed an issue where custom AmazonEC2Client.DryRun() method was not working for non-BCL targets. Also included this method in IAmazonEC2 interface.

This PR addressed following:
- Includes `DryRun()` method as part of `IAmazonEC2` interface for easier mock-ability.
- For non-BCL targets it includes NonPublic methods in reflection search. Kindly note that we need to explicitly use `BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic`.

Based on discussion with @normj, we should perhaps deprecate/obsolete this method in **V4** and remove customization in [ec2.customizations.json](https://github.com/aws/aws-sdk-net/blob/c3a8d89d4faad2febb0084a04c0e4ae66981ad63/generator/ServiceModels/ec2/ec2.customizations.json#L138) to not exclude `DryRun` property from request models (this was done due to legacy reasons when EC2 code was hand-coded). Created separate backlog item for it in Input queue.

## Motivation and Context
Issue #3595

## Testing
- Tested locally using below code:
  ```C#
  IAmazonEC2 ec2Client = new AmazonEC2Client();
  var ec2DryRunRespose = ec2Client.DryRun(new StartInstancesRequest { InstanceIds = new() { "<<EC2InstanceID>>" } });
  ```
  No unit test/integration test was added since we would need to spin up new EC2 instance. We would also deprecate this method in **V4**.

- Catapult  dry-run completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement