### PR TITLE
Add AWSSDK.BedrockRuntime dependency for AWSSDK.Extensions.Bedrock.MEAI package

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
@@ -14,14 +14,17 @@
     <dependencies>
       <group targetFramework="net472">
         <dependency id="AWSSDK.Core" version="4.0.0.0-preview.5" />
+        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.0-preview.5" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.0.1-preview.1.24570.5" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="AWSSDK.Core" version="4.0.0.0-preview.5" />
+        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.0-preview.5" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.0.1-preview.1.24570.5" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="AWSSDK.Core" version="4.0.0.0-preview.5" />
+        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.0-preview.5" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.0.1-preview.1.24570.5" />
       </group>
     </dependencies>


### PR DESCRIPTION
## Description
As part of V4 preview 5 we released `AWSSDK.Extensions.Bedrock.MEAI` but the nuspec file is missing the dependency for `AWSSDK.BedrockRuntime`. This makes users have to manually add the dependency for `AWSSDK.BedrockRuntime` in their applications. This PR updates the nuspec file to make sure `AWSSDK.BedrockRuntime` is restored with the package.

Tagging the original PR author @stephentoub in case you try out the recent package and notice the issue.