### PR TITLE
[V4] Support Native AOT trimming for DynamoDB DataModel

### DIFF
--- a/generator/.DevConfigs/7FE49E8F-93BF-419E-B3B2-265D9D6F35E3.json
+++ b/generator/.DevConfigs/7FE49E8F-93BF-419E-B3B2-265D9D6F35E3.json
@@ -1,0 +1,18 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Backport the .NET trimming attributes like DynamicallyAccessedMembersAttribute into ThirdParty.RuntimeBackports namespace for Target Frameworks before .NET 8. This simplifies the SDK's codebase by removing compilation conditional checks when using the attributes."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  },
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Add NativeAOT support for the DataModel namespace also known as the Object Persistence high level library."
+      ]
+    }
+  ]
+}

--- a/generator/.DevConfigs/7FE49E8F-93BF-419E-B3B2-265D9D6F35E3.json
+++ b/generator/.DevConfigs/7FE49E8F-93BF-419E-B3B2-265D9D6F35E3.json
@@ -8,7 +8,7 @@
   },
   "services": [
     {
-      "serviceName": "S3",
+      "serviceName": "DynamoDBv2",
       "type": "patch",
       "changeLogMessages": [
         "Add NativeAOT support for the DataModel namespace also known as the Object Persistence high level library."

--- a/sdk/src/Core/Amazon.Runtime/ClientContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientContext.cs
@@ -22,6 +22,8 @@ using Amazon.Util;
 using Amazon.Util.Internal;
 using Amazon.Util.Internal.PlatformServices;
 using Amazon.Runtime;
+using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime.Internal
 {
@@ -29,11 +31,9 @@ namespace Amazon.Runtime.Internal
     /// This class composes Client Context header for Amazon Web Service client.
     /// It contains information like app title, version code, version name, client id, OS platform etc.
     /// </summary>
-#if NET8_0_OR_GREATER
     // This class wasn't updated to use source generators because the object to JSON method uses the non generic IDictionary. Usage of this class is probably very low since it is not used directly
     // by the SDK and it is in an internal namespace.
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ClientContext has not been updated to support producing JSON using source generators. For requests that need client context JSON the JSON must be created manually.")]
-#endif
+    [RequiresUnreferencedCode("ClientContext has not been updated to support producing JSON using source generators. For requests that need client context JSON the JSON must be created manually.")]
     public partial class ClientContext
     {
         //client related keys

--- a/sdk/src/Core/Amazon.Runtime/ConstantClass.cs
+++ b/sdk/src/Core/Amazon.Runtime/ConstantClass.cs
@@ -27,15 +27,14 @@ using System.Linq;
 using System.Text;
 
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime
 {
     /// <summary>
     /// Base class for constant class that holds the value that will be sent to AWS for the static constants.
     /// </summary>
-#if NET8_0_OR_GREATER
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-#endif
     public class ConstantClass
     {
         static readonly object staticFieldsLock = new object();
@@ -91,11 +90,7 @@ namespace Amazon.Runtime
             return map.TryGetValue(this.Value, out foundValue) ? foundValue : this;
         }
 
-#if NET8_0_OR_GREATER
         protected static T FindValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string value) where T : ConstantClass
-#else
-        protected static T FindValue<T>(string value) where T : ConstantClass
-#endif
         {
             if (value == null)
                 return null;
@@ -115,11 +110,7 @@ namespace Amazon.Runtime
             return foundValue as T;
         }
 
-#if NET8_0_OR_GREATER
         private static void LoadFields([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
-#else
-        private static void LoadFields(Type type)
-#endif
         {
             if (staticFields.ContainsKey(type))
                 return;

--- a/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleAWSCredentials.cs
@@ -20,6 +20,8 @@ using Amazon.Util.Internal;
 using System;
 using System.Globalization;
 using System.Net;
+using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime
 {
@@ -89,10 +91,8 @@ namespace Amazon.Runtime
             PreemptExpiryTime = TimeSpan.FromMinutes(15);
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", 
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
         protected override CredentialsRefreshState GenerateNewCredentials()
         {
             var region = FallbackRegionFactory.GetRegionEndpoint() ?? DefaultSTSClientRegion;

--- a/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleWithWebIdentityCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleWithWebIdentityCredentials.cs
@@ -18,7 +18,9 @@ using Amazon.Runtime.SharedInterfaces;
 using Amazon.RuntimeDependencies;
 using Amazon.Util;
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -222,10 +224,8 @@ namespace Amazon.Runtime
         /// Gets a client to be used for AssumeRoleWithWebIdentity requests.
         /// </summary>
         /// <returns>The STS client.</returns>
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
         protected virtual ICoreAmazonSTS_WebIdentity CreateClient()
         {
             var region = FallbackRegionFactory.GetRegionEndpoint() ?? _defaultSTSClientRegion;

--- a/sdk/src/Core/Amazon.Runtime/Credentials/FederatedAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/FederatedAWSCredentials.cs
@@ -21,7 +21,9 @@ using Amazon.Runtime.SharedInterfaces;
 using Amazon.Util;
 using Amazon.RuntimeDependencies;
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
@@ -177,10 +179,8 @@ namespace Amazon.Runtime
             return newState;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
         private CredentialsRefreshState Authenticate(ICredentials userCredential)
         {
             CredentialsRefreshState state;

--- a/sdk/src/Core/Amazon.Runtime/Credentials/URIBasedRefreshingCredentialHelper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/URIBasedRefreshingCredentialHelper.cs
@@ -17,9 +17,11 @@ using Amazon.Util.Internal;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
 using ThirdParty.Json.LitJson;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime
 {
@@ -50,27 +52,21 @@ namespace Amazon.Runtime
         }
 
         [Obsolete("This method is not compatible with Native AOT builds. The GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
         protected static T GetObjectFromResponse<T>(Uri uri)
         {
             return GetObjectFromResponse<T>(uri, null, null);
         }
 
         [Obsolete("This method is not compatible with Native AOT builds. The GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
         protected static T GetObjectFromResponse<T>(Uri uri, IWebProxy proxy)
         {
             return GetObjectFromResponse<T>(uri, proxy, null);
         }
 
         [Obsolete("This method is not compatible with Native AOT builds. The GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("GetObjectFromResponse overload using the generic parameter taking in a JsonSerializerContext should be used instead.")]
         protected static T GetObjectFromResponse<T>(Uri uri, IWebProxy proxy, Dictionary<string, string> headers)
         {
             string json = GetContents(uri, proxy, headers);

--- a/sdk/src/Core/Amazon.Runtime/Documents/Document.cs
+++ b/sdk/src/Core/Amazon.Runtime/Documents/Document.cs
@@ -17,9 +17,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using ThirdParty.Json.LitJson;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime.Documents
 {
@@ -410,9 +412,7 @@ namespace Amazon.Runtime.Documents
         /// for performance critical work.  Additionally, if <paramref name="o"/> is a known primitive (ie <see cref="int"/>),
         /// using a <see cref="Document"/> constructor directly will be more performant.
         /// </summary> 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("FromObject is not currently supported for Native AOT compilation due unbounded reflection required.")]
-#endif
+        [RequiresUnreferencedCode("FromObject is not currently supported for Native AOT compilation due unbounded reflection required.")]
         public static Document FromObject(object o)
         {
             IJsonWrapper jsonData = JsonMapper.ToObject(JsonMapper.ToJson(o));
@@ -420,9 +420,7 @@ namespace Amazon.Runtime.Documents
             return FromObject(jsonData);
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("FromObject is not currently supported for Native AOT compilation due unbounded reflection required.")]
-#endif  
+        [RequiresUnreferencedCode("FromObject is not currently supported for Native AOT compilation due unbounded reflection required.")]
         private static Document FromObject(IJsonWrapper jsonData)
         {
             switch (jsonData.GetJsonType())
@@ -450,9 +448,7 @@ namespace Amazon.Runtime.Documents
             throw new NotSupportedException($"Couldn't convert {jsonData.GetJsonType()}");
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("FromObject is not currently supported for Native AOT compilation due unbounded reflection required.")]
-#endif  
+        [RequiresUnreferencedCode("FromObject is not currently supported for Native AOT compilation due unbounded reflection required.")]
         private static void Copy(IDictionary source, Dictionary<string, Document> target)
         {
             foreach (var key in source.Keys)

--- a/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EnumerableEventStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EnumerableEventStream.cs
@@ -30,6 +30,8 @@ using System.Threading;
 using System.Threading.Tasks;
 #endif
 
+using ThirdParty.RuntimeBackports;
+
 namespace Amazon.Runtime.EventStreams.Internal
 {
     /// <summary>
@@ -49,11 +51,7 @@ namespace Amazon.Runtime.EventStreams.Internal
     /// <typeparam name="TE">An implementation of EventStreamException (e.g. S3EventStreamException).</typeparam>
     [SuppressMessage("Microsoft.Naming", "CA1710", Justification = "EventStreamCollection is not descriptive.")]
     [SuppressMessage("Microsoft.Design", "CA1063", Justification = "IDisposable is a transient interface from IEventStream. Users need to be able to call Dispose.")]
-#if NET8_0_OR_GREATER
     public abstract class EnumerableEventStream<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TE> : EventStream<T, TE>, IEnumerableEventStream<T, TE>, IAsyncEnumerable<T> where T : IEventStreamEvent where TE : EventStreamException, new()
-#else
-    public abstract class EnumerableEventStream<T, TE> : EventStream<T, TE>, IEnumerableEventStream<T, TE>, IAsyncEnumerable<T> where T : IEventStreamEvent where TE : EventStreamException, new()
-#endif
     {
         private const string MutuallyExclusiveExceptionMessage = "Stream has already begun processing. Event-driven and Enumerable traversals of the stream are mutually exclusive. " +
                                                                  "You can either use the event driven or enumerable interface, but not both.";

--- a/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EventStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EventStream.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
+using ThirdParty.RuntimeBackports;
 
 #if AWS_ASYNC_API
 using System.Threading.Tasks;
@@ -67,11 +68,7 @@ namespace Amazon.Runtime.EventStreams.Internal
     /// </summary>
     /// <typeparam name="T">An implementation of IEventStreamEvent (e.g. IS3Event).</typeparam>
     /// <typeparam name="TE">An implementation of EventStreamException (e.g. S3EventStreamException).</typeparam>
-#if NET8_0_OR_GREATER
     public abstract class EventStream<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TE> : IEventStream<T, TE> where T : IEventStreamEvent where TE : EventStreamException, new()
-#else
-    public abstract class EventStream<T, TE> : IEventStream<T, TE> where T : IEventStreamEvent where TE : EventStreamException, new()
-#endif
     {
         /// <summary>
         /// "Unique" key for unknown event lookup.

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
@@ -18,8 +18,10 @@ using Amazon.RuntimeDependencies;
 using Amazon.Util.Internal;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime.Internal.Auth
 {
@@ -46,12 +48,10 @@ namespace Amazon.Runtime.Internal.Auth
         /// Instantiates an SigV4a signer using CRT's SigV4a implementation
         /// </summary>
         /// <param name="signPayload">Whether to sign the request's payload</param>
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", 
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075",
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
         public AWS4aSignerCRTWrapper(bool signPayload)
         {
             if (_awsSigV4AProvider == null)

--- a/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime.Internal
 {
@@ -25,12 +27,8 @@ namespace Amazon.Runtime.Internal
         public const string STS_SERVICE_CLASS_NAME = "Amazon.SecurityToken.AmazonSecurityTokenServiceClient";
         public const string STS_SERVICE_CONFIG_NAME = "Amazon.SecurityToken.AmazonSecurityTokenServiceConfig";
 
-#if NET8_0_OR_GREATER
-        public static TClient CreateServiceFromAnother<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] TClient, 
-                                    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] TConfig>(AmazonServiceClient originalServiceClient)
-#else
-        public static TClient CreateServiceFromAnother<TClient, TConfig>(AmazonServiceClient originalServiceClient)
-#endif
+        public static TClient CreateServiceFromAnother<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TClient, 
+                                    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfig>(AmazonServiceClient originalServiceClient)
             where TConfig : ClientConfig, new ()
             where TClient : AmazonServiceClient
         {
@@ -50,9 +48,7 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
-#endif
+        [RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
         public static TClient CreateServiceFromAssembly<TClient>(string assemblyName, string serviceClientClassName,
             RegionEndpoint region)
             where TClient : class
@@ -69,9 +65,7 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
-#endif
+        [RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
         public static TClient CreateServiceFromAssembly<TClient>(string assemblyName, string serviceClientClassName, 
             AWSCredentials credentials, RegionEndpoint region)
             where TClient : class
@@ -89,9 +83,7 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
-#endif
+        [RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
         public static TClient CreateServiceFromAssembly<TClient>(string assemblyName, string serviceClientClassName,
             AWSCredentials credentials, ClientConfig config)
             where TClient : class
@@ -109,9 +101,7 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
-#endif
+        [RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code should use Amazon.RuntimeDependencyRegistry to use explicitly provided runtime dependencies.")]
         public static TClient CreateServiceFromAssembly<TClient>(string assemblyName, string serviceClientClassName, AmazonServiceClient originalServiceClient)
             where TClient : class
         {
@@ -131,9 +121,7 @@ namespace Amazon.Runtime.Internal
             return newServiceClient;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
-#endif
+        [RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
         public static ClientConfig CreateServiceConfig(string assemblyName, string serviceConfigClassName)
         {
             var typeInfo = LoadServiceConfigType(assemblyName, serviceConfigClassName);
@@ -144,25 +132,19 @@ namespace Amazon.Runtime.Internal
             return config as ClientConfig;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
-#endif
+        [RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
         private static Type LoadServiceClientType(string assemblyName, string serviceClientClassName)
         {
             return LoadTypeFromAssembly(assemblyName, serviceClientClassName);
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
-#endif
+        [RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
         private static Type LoadServiceConfigType(string assemblyName, string serviceConfigClassName)
         {
             return LoadTypeFromAssembly(assemblyName, serviceConfigClassName);
         }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
-#endif
+    [RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
         internal static Type LoadTypeFromAssembly(string assemblyName, string className)
         {
             var assembly = GetSDKAssembly(assemblyName);
@@ -171,9 +153,7 @@ namespace Amazon.Runtime.Internal
             return type;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
-#endif
+        [RequiresUnreferencedCode("Using ServiceClientHelper to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
         private static Assembly GetSDKAssembly(string assemblyName)
         {
             return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => string.Equals(x.GetName().Name, assemblyName, StringComparison.Ordinal))

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumCRTWrapper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumCRTWrapper.cs
@@ -22,6 +22,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
+using ThirdParty.RuntimeBackports;
 
 namespace AWSSDK.Runtime.Internal.Util
 {
@@ -38,12 +39,10 @@ namespace AWSSDK.Runtime.Internal.Util
         private static volatile IChecksumProvider _instance;
 
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075",
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
         private static IChecksumProvider Instance
         {
             get

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Globalization;
@@ -21,15 +22,14 @@ using System.Text;
 using System.ComponentModel;
 
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime.Internal.Util
 {
     /// <summary>
     /// Logger wrapper for reflected log4net logging methods.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("SDK logging to Log4net is not supported when trimming is enabled.")]
-#endif
+    [RequiresUnreferencedCode("SDK logging to Log4net is not supported when trimming is enabled.")]
     internal class InternalLog4netLogger : InternalLogger
     {
         enum LoadState { Uninitialized, Failed, Loading, Success };

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/Logger.cs
@@ -16,12 +16,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.ComponentModel;
 using Amazon.Runtime;
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime.Internal.Util
 {
@@ -40,10 +42,8 @@ namespace Amazon.Runtime.Internal.Util
             loggers = new List<InternalLogger>();
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
             Justification = "Constructor looks to see if running in a NativeAOT environment and if so skips the Log4net internal logger which is not Native AOT complaint.")]
-#endif
         private Logger(Type type)
         {
             loggers = new List<InternalLogger>();

--- a/sdk/src/Core/Amazon.Runtime/Internal/_bcl+netstandard/SSOServiceClientHelpers.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/_bcl+netstandard/SSOServiceClientHelpers.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.SharedInterfaces;
 using Amazon.RuntimeDependencies;
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime.Internal
 {
@@ -12,10 +14,8 @@ namespace Amazon.Runtime.Internal
     /// Collection of helper methods for constructing the necessary Service client to
     /// interrogate AWS SSO Services.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
         Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
     public static class SSOServiceClientHelpers
     {
         public static ICoreAmazonSSOOIDC BuildSSOIDCClient(
@@ -42,10 +42,8 @@ namespace Amazon.Runtime.Internal
             return coreSSO;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
         public static ICoreAmazonSSO BuildSSOClient(
             RegionEndpoint region,
 #if BCL
@@ -69,10 +67,8 @@ namespace Amazon.Runtime.Internal
             return coreSSO;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
         public static ICoreAmazonSSO_Logout BuildSSOLogoutClient(
             RegionEndpoint region,
 #if BCL
@@ -96,10 +92,8 @@ namespace Amazon.Runtime.Internal
             return coreSSOLogout;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
         public static ICoreAmazonSSOOIDC_V2 BuildSSOIDC_V2Client(
             RegionEndpoint region,
 #if BCL
@@ -127,9 +121,7 @@ namespace Amazon.Runtime.Internal
         /// <summary>
         /// Attempts to get a service client at runtime which cannot be made a project reference.
         /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Using CreateClient to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
-#endif
+    [RequiresUnreferencedCode("Using CreateClient to dynamically load dependency is not supported for Native AOT. SDK calling code must use Amazon.RuntimeDependencyRegistry to explicitly provide runtime dependencies.")]
         private static T CreateClient<T>(
         RegionEndpoint region,
             string serviceClassName, 

--- a/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
@@ -24,6 +24,7 @@ using Amazon.Runtime.Internal.Util;
 using Amazon.Util.Internal.PlatformServices;
 using System.Text;
 using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Util.Internal
 {
@@ -177,11 +178,7 @@ namespace Amazon.Util.Internal
             }
         }
 
-#if NET8_0_OR_GREATER
         public static void ApplyValuesV2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T target, IDictionary<string, object> propertyValues)
-#else
-        public static void ApplyValuesV2<T>(T target, IDictionary<string, object> propertyValues)
-#endif
         {
             if (propertyValues == null || propertyValues.Count == 0)
                 return;

--- a/sdk/src/Core/Amazon.Util/Internal/JsonSerializerHelper.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/JsonSerializerHelper.cs
@@ -121,7 +121,9 @@ namespace Amazon.Util.Internal
         public bool WriteIndented {get;set;}
     }
 
+#pragma warning disable CA1019 // Since this is a dummy implementation of JsonSerializableAttribute for pre .NET 8 targets we don't need the accessor.
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    internal sealed class JsonSerializableAttribute : Attribute { internal JsonSerializableAttribute(Type type) { } }
+    public sealed class JsonSerializableAttribute : Attribute { public JsonSerializableAttribute(Type type) { } }
+#pragma warning restore CA1019
 #endif
 }

--- a/sdk/src/Core/RuntimeDependencies/CreateInstanceContext.cs
+++ b/sdk/src/Core/RuntimeDependencies/CreateInstanceContext.cs
@@ -26,7 +26,7 @@ namespace Amazon.RuntimeDependencies
         /// <summary>
         /// The type of context.
         /// </summary>
-        public enum ContextType 
+        public enum ContextType
         {
             /// <summary>
             /// Context for creating AmazonSecurityTokenServiceClient
@@ -56,7 +56,12 @@ namespace Amazon.RuntimeDependencies
             /// <summary>
             /// Context for creating AmazonSSOOIDCClient
             /// </summary>
-            SSOOIDCClient
+            SSOOIDCClient,
+
+            /// <summary>
+            /// Context for creating AmazonS3Client
+            /// </summary>
+            S3ClientContext
         }
 
         /// <summary>
@@ -120,6 +125,16 @@ namespace Amazon.RuntimeDependencies
         }
 
         /// <summary>
+        /// Create an instance of CreateInstanceContext with the SSOOIDCClientContext context
+        /// </summary>
+        /// <param name="context"></param>
+        public CreateInstanceContext(S3ClientContext context)
+        {
+            S3ClientContextData = context;
+            Type = ContextType.S3ClientContext;
+        }
+
+        /// <summary>
         /// The type of context being sent into the factory method. For each type there is a corresponding Data property set containing any relevant information that can be
         /// used for creating the dependency instance.
         /// </summary>
@@ -154,6 +169,11 @@ namespace Amazon.RuntimeDependencies
         /// Data for the SOOIDCClient context
         /// </summary>
         public SSOOIDCClientContext SSOOIDCClientContextData { get; }
+
+        /// <summary>
+        /// Data for the AmazonS3Client context
+        /// </summary>
+        public S3ClientContext S3ClientContextData {get;}
     }
 
 
@@ -260,5 +280,27 @@ namespace Amazon.RuntimeDependencies
         /// Proxy settings that can be applied to the service client config object.
         /// </summary>
         public IWebProxy ProxySettings { get; set; }
+    }
+
+    /// <summary>
+    /// Context for the factory method to create the AmazonS3Client runtime dependency.
+    /// </summary>
+    public class S3ClientContext
+    {
+        /// <summary>
+        /// The possibly actions the AmazonS3Client will be created for.
+        /// </summary>
+        public enum ActionContext { DynamoBDS3Link };
+
+
+        /// <summary>
+        /// The action the AmazonS3Client is being created for. For example creating an S3 client for the DynamoDB S3 Link feature.
+        /// </summary>
+        public ActionContext Action { get; set; }
+
+        /// <summary>
+        /// The region the SDK expects the S3 client to be configured for.
+        /// </summary>
+        public RegionEndpoint Region { get; set; }
     }
 }

--- a/sdk/src/Core/RuntimeDependencies/GlobalRuntimeDependencyRegistry.cs
+++ b/sdk/src/Core/RuntimeDependencies/GlobalRuntimeDependencyRegistry.cs
@@ -142,5 +142,27 @@ namespace Amazon.RuntimeDependencies
         {
             RegisterInstance(ServiceClientHelpers.SSO_OIDC_ASSEMBLY_NAME, ServiceClientHelpers.SSO_OIDC_SERVICE_CLASS_NAME, factory);
         }
+
+        /// <summary>
+        /// Register the Amazon.S3.AmazonS3Client instance from the AWSSDK.S3 package.
+        /// 
+        /// The S3 client is used by the DynamoDB high level feature called S3 link.
+        /// </summary>
+        /// <param name="instance"></param>
+        public void RegisterS3Client(object instance)
+        {
+            RegisterInstance(ServiceClientHelpers.S3_ASSEMBLY_NAME, ServiceClientHelpers.S3_SERVICE_CLASS_NAME, instance);
+        }
+
+        /// <summary>
+        /// Register the Amazon.S3.AmazonS3Client instance from the AWSSDK.S3 package.
+        /// 
+        /// The S3 client is used by the DynamoDB high level feature called S3 link.
+        /// </summary>
+        /// <param name="factory"></param>
+        public void RegisterS3Client(RuntimeDependencyFactory factory)
+        {
+            RegisterInstance(ServiceClientHelpers.S3_ASSEMBLY_NAME, ServiceClientHelpers.S3_SERVICE_CLASS_NAME, factory);
+        }
     }
 }

--- a/sdk/src/Core/ThirdParty/Json/JsonMapper.cs
+++ b/sdk/src/Core/ThirdParty/Json/JsonMapper.cs
@@ -21,6 +21,7 @@ using System.Reflection;
 
 using Amazon.Util;
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 
 namespace ThirdParty.Json.LitJson
 {
@@ -172,9 +173,7 @@ namespace ThirdParty.Json.LitJson
 
         #region Private Methods
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         private static void AddArrayMetadata (Type type)
         {
             if (array_metadata.ContainsKey (type))
@@ -210,9 +209,7 @@ namespace ThirdParty.Json.LitJson
             }
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         private static void AddObjectMetadata (Type type)
         {
             if (object_metadata.ContainsKey (type))
@@ -268,9 +265,7 @@ namespace ThirdParty.Json.LitJson
             }
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         private static void AddTypeProperties (Type type)
         {
             if (type_properties.ContainsKey (type))
@@ -307,9 +302,7 @@ namespace ThirdParty.Json.LitJson
             }
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         private static MethodInfo GetConvOp (Type t1, Type t2)
         {
             lock (conv_ops_lock) {
@@ -334,9 +327,7 @@ namespace ThirdParty.Json.LitJson
             return op;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         private static object ReadValue (Type inst_type, JsonReader reader)
         {
             reader.Read ();
@@ -507,9 +498,7 @@ namespace ThirdParty.Json.LitJson
             return instance;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         private static void ValidateRequiredFields(object instance, Type inst_type)
         {
             foreach (var prop in inst_type.GetProperties())
@@ -765,9 +754,7 @@ namespace ThirdParty.Json.LitJson
             table[json_type][value_type] = importer;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         private static void WriteValue (object obj, JsonWriter writer,
                                         bool writer_is_private,
                                         int depth)
@@ -919,9 +906,7 @@ namespace ThirdParty.Json.LitJson
         }
         #endregion
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         public static string ToJson (object obj)
         {
             lock (static_writer_lock) {
@@ -933,9 +918,7 @@ namespace ThirdParty.Json.LitJson
             }
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         public static void ToJson (object obj, JsonWriter writer)
         {
             WriteValue (obj, writer, false, 0);
@@ -961,17 +944,13 @@ namespace ThirdParty.Json.LitJson
                 delegate { return new JsonData (); }, json);
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         public static T ToObject<T>(JsonReader reader)
         {
             return (T) ReadValue (typeof (T), reader);
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         public static T ToObject<T> (TextReader reader)
         {
             JsonReader json_reader = new JsonReader (reader);
@@ -979,9 +958,7 @@ namespace ThirdParty.Json.LitJson
             return (T) ReadValue (typeof (T), json_reader);
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
-#endif
+        [RequiresUnreferencedCode("JsonMapper requires reflection of unknown types. System.Text.Json should be used instead.")]
         public static T ToObject<T> (string json)
         {
             JsonReader reader = new JsonReader (json);

--- a/sdk/src/Core/ThirdParty/RuntimeBackports/TrimmingAttributes.cs
+++ b/sdk/src/Core/ThirdParty/RuntimeBackports/TrimmingAttributes.cs
@@ -1,0 +1,160 @@
+﻿// Partially adapted from:
+//      https://raw.githubusercontent.com/dotnet/runtime/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+//      https://raw.githubusercontent.com/dotnet/runtime/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
+//      https://raw.githubusercontent.com/dotnet/runtime/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttribute.cs
+//      https://raw.githubusercontent.com/dotnet/runtime/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET8_0_OR_GREATER
+using System;
+
+namespace ThirdParty.RuntimeBackports
+{
+    [Flags]
+#pragma warning disable CA2217 // Do not mark enums with FlagsAttribute
+    public enum DynamicallyAccessedMemberTypes
+#pragma warning restore CA2217 // Do not mark enums with FlagsAttribute
+    {
+        All = -1,
+        None = 0,
+        PublicParameterlessConstructor = 1,
+        PublicConstructors = 3,
+        NonPublicConstructors = 4,
+        PublicMethods = 8,
+        NonPublicMethods = 16,
+        PublicFields = 32,
+        NonPublicFields = 64,
+        PublicNestedTypes = 128,
+        NonPublicNestedTypes = 256,
+        PublicProperties = 512,
+        NonPublicProperties = 1024,
+        PublicEvents = 2048,
+        NonPublicEvents = 4096,
+        Interfaces = 8192
+    }
+
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+
+    public sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    public sealed class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+        /// class, specifying the category of the tool and the identifier for an analysis rule.
+        /// </summary>
+        /// <param name="category">The category for the attribute.</param>
+        /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+
+        /// <summary>
+        /// Gets the category identifying the classification of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Category"/> property describes the tool or tool analysis category
+        /// for which a message suppression attribute applies.
+        /// </remarks>
+        public string Category { get; }
+
+        /// <summary>
+        /// Gets the identifier of the analysis tool rule to be suppressed.
+        /// </summary>
+        /// <remarks>
+        /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+        /// properties form a unique check identifier.
+        /// </remarks>
+        public string CheckId { get; }
+
+        /// <summary>
+        /// Gets or sets the scope of the code that is relevant for the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The Scope property is an optional argument that specifies the metadata scope for which
+        /// the attribute is relevant.
+        /// </remarks>
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// Gets or sets a fully qualified path that represents the target of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Target"/> property is an optional argument identifying the analysis target
+        /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+        /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+        /// The analysis tool user interface should be capable of automatically formatting the parameter.
+        /// </remarks>
+        public string Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional argument expanding on exclusion criteria.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="MessageId "/> property is an optional argument that specifies additional
+        /// exclusion where the literal metadata target is not sufficiently precise. For example,
+        /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+        /// and it may be desirable to suppress a violation against a statement in the method that will
+        /// give a rule violation, but not against all statements in the method.
+        /// </remarks>
+        public string MessageId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the justification for suppressing the code analysis message.
+        /// </summary>
+        public string Justification { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+    public sealed class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequiresUnreferencedCodeAttribute"/> class
+        /// with the specified message.
+        /// </summary>
+        /// <param name="message">
+        /// A message that contains information about the usage of unreferenced code.
+        /// </param>
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets a message that contains information about the usage of unreferenced code.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets or sets an optional URL that contains more information about the method,
+        /// why it requries unreferenced code, and what options a consumer has to deal with it.
+        /// </summary>
+        public string Url { get; set; }
+    }
+}
+#endif

--- a/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
@@ -16,6 +16,7 @@ using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.DynamoDBv2.DataModel;
 using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon
 {
@@ -333,9 +334,7 @@ namespace Amazon.Util
         /// <summary>
         /// The type of converter that should be used on this property
         /// </summary>
-#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
         public Type Converter { get; set; }
 
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/AWSConfigs.DynamoDB.cs
@@ -15,6 +15,7 @@ using Amazon.Util.Internal;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.DynamoDBv2.DataModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Amazon
 {
@@ -332,6 +333,9 @@ namespace Amazon.Util
         /// <summary>
         /// The type of converter that should be used on this property
         /// </summary>
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
         public Type Converter { get; set; }
 
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -21,6 +21,7 @@ using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.Util.Internal;
 using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
 
 
 #if NETSTANDARD
@@ -251,11 +252,7 @@ namespace Amazon.DynamoDBv2
         /// <typeparam name="TOutput"></typeparam>
         /// <param name="entry"></param>
         /// <returns></returns>
-#if NET8_0_OR_GREATER
         public TOutput ConvertFromEntry<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] TOutput>(DynamoDBEntry entry)
-#else
-        public TOutput ConvertFromEntry<TOutput>(DynamoDBEntry entry)
-#endif
         {
             TOutput output;
             if (TryConvertFromEntry<TOutput>(entry, out output))
@@ -272,11 +269,7 @@ namespace Amazon.DynamoDBv2
         /// <param name="entry"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-#if NET8_0_OR_GREATER
         public object ConvertFromEntry([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type outputType, DynamoDBEntry entry)
-#else
-        public object ConvertFromEntry(Type outputType, DynamoDBEntry entry)
-#endif
         {
             if (outputType == null) throw new ArgumentNullException("outputType");
             if (entry == null) throw new ArgumentNullException("entry");
@@ -294,11 +287,7 @@ namespace Amazon.DynamoDBv2
         /// <param name="entry"></param>
         /// <param name="output"></param>
         /// <returns>True if successfully converted, otherwise false.</returns>
-#if NET8_0_OR_GREATER
         public bool TryConvertFromEntry<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] TOutput>(DynamoDBEntry entry, out TOutput output)
-#else
-        public bool TryConvertFromEntry<TOutput>(DynamoDBEntry entry, out TOutput output)
-#endif
         {
             output = default(TOutput);
 
@@ -324,11 +313,7 @@ namespace Amazon.DynamoDBv2
         /// <param name="value"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-#if NET8_0_OR_GREATER
         public bool TryConvertFromEntry([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type outputType, DynamoDBEntry entry, out object value)
-#else
-        public bool TryConvertFromEntry(Type outputType, DynamoDBEntry entry, out object value)
-#endif
         {
             if (outputType == null) throw new ArgumentNullException("outputType");
             if (entry == null) throw new ArgumentNullException("entry");
@@ -376,11 +361,7 @@ namespace Amazon.DynamoDBv2
             //    yield return ConvertToEntry(value);
         }
 
-#if NET8_0_OR_GREATER
         internal IEnumerable<object> ConvertFromEntries([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type elementType, IEnumerable<DynamoDBEntry> entries)
-#else
-        internal IEnumerable<object> ConvertFromEntries(Type elementType, IEnumerable<DynamoDBEntry> entries)
-#endif
         {
             if (entries == null) throw new ArgumentNullException("entries");
 
@@ -560,11 +541,7 @@ namespace Amazon.DynamoDBv2
             return false;
         }
 
-#if NET8_0_OR_GREATER
         public object FromEntry(DynamoDBEntry entry, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType)
-#else
-        public object FromEntry(DynamoDBEntry entry, Type targetType)
-#endif
         {
             if (entry == null) throw new ArgumentNullException("entry");
             if (targetType == null) throw new ArgumentNullException("targetType");
@@ -577,11 +554,7 @@ namespace Amazon.DynamoDBv2
                 "Unable to convert [{0}] of type {1} to {2}", entry, entry.GetType().FullName, targetType.FullName));
         }
 
-#if NET8_0_OR_GREATER
         public bool TryFromEntry(DynamoDBEntry entry, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object value)
-#else
-        public bool TryFromEntry(DynamoDBEntry entry, Type targetType, out object value)
-#endif
         {
             var p = entry as Primitive;
 
@@ -658,31 +631,19 @@ namespace Amazon.DynamoDBv2
             return false;
         }
 
-#if NET8_0_OR_GREATER
         public virtual bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
-#else
-        public virtual bool TryFrom(Primitive p, Type targetType, out object result)
-#endif
         {
             result = null;
             return false;
         }
 
-#if NET8_0_OR_GREATER
         public virtual bool TryFrom(PrimitiveList pl, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
-#else
-        public virtual bool TryFrom(PrimitiveList pl, Type targetType, out object result)
-#endif
         {
             result = null;
             return false;
         }
 
-#if NET8_0_OR_GREATER
         public virtual bool TryFrom(DynamoDBList l, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
-#else
-        public virtual bool TryFrom(DynamoDBList l, Type targetType, out object result)
-#endif
         {
             result = null;
             return false;
@@ -751,11 +712,7 @@ namespace Amazon.DynamoDBv2
             return output;
         }
 
-#if NET8_0_OR_GREATER
         public override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
-#else
-        public override bool TryFrom(Primitive p, Type targetType, out object result)
-#endif
         {
             T t;
             var output = TryFrom(p, targetType, out t);
@@ -763,11 +720,7 @@ namespace Amazon.DynamoDBv2
             return output;
         }
 
-#if NET8_0_OR_GREATER
         public override bool TryFrom(PrimitiveList pl, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
-#else
-        public override bool TryFrom(PrimitiveList pl, Type targetType, out object result)
-#endif
         {
             T t;
             var output = TryFrom(pl, targetType, out t);
@@ -775,11 +728,7 @@ namespace Amazon.DynamoDBv2
             return output;
         }
 
-#if NET8_0_OR_GREATER
         public override bool TryFrom(DynamoDBList l, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
-#else
-        public override bool TryFrom(DynamoDBList l, Type targetType, out object result)
-#endif
         {
             T t;
             var output = TryFrom(l, targetType, out t);
@@ -800,11 +749,7 @@ namespace Amazon.DynamoDBv2
             return false;
         }
 
-#if NET8_0_OR_GREATER
         protected virtual bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out T result)
-#else
-        protected virtual bool TryFrom(Primitive p, Type targetType, out T result)
-#endif
         {
             result = default(T);
             return false;

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
@@ -17,6 +17,7 @@ using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
+using ThirdParty.RuntimeBackports;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -44,11 +45,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out byte result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out byte result)
-#endif
         {
             return byte.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
@@ -67,11 +64,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out sbyte result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out sbyte result)
-#endif
         {
             return SByte.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
@@ -90,11 +83,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out ushort result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out ushort result)
-#endif
         {
             return UInt16.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
@@ -113,11 +102,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out short result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out short result)
-#endif
         {
             return Int16.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
@@ -136,11 +121,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out uint result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out uint result)
-#endif
         {
             return UInt32.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
@@ -159,11 +140,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out int result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out int result)
-#endif
         {
             return Int32.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
@@ -182,11 +159,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out ulong result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out ulong result)
-#endif
         {
             return UInt64.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
@@ -205,11 +178,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out long result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out long result)
-#endif
         {
             return Int64.TryParse(p.StringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
@@ -227,11 +196,7 @@ namespace Amazon.DynamoDBv2
             p = new Primitive(value.ToString("r", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out float result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out float result)
-#endif
         {
             return Single.TryParse(p.StringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
         }
@@ -250,11 +215,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out double result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out double result)
-#endif
         {
             return Double.TryParse(p.StringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
         }
@@ -272,11 +233,7 @@ namespace Amazon.DynamoDBv2
             p = new Primitive(value.ToString("g", CultureInfo.InvariantCulture), DynamoDBEntryType.Numeric);
             return true;
         }
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out decimal result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out decimal result)
-#endif
         {
             return Decimal.TryParse(p.StringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
         }
@@ -295,11 +252,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out char result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out char result)
-#endif
         {
             return Char.TryParse(p.StringValue, out result);
         }
@@ -318,11 +271,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out string result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out string result)
-#endif
         {
             result = p.StringValue;
             return (result != null);
@@ -343,11 +292,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out DateTime result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out DateTime result)
-#endif
         {
             if (DateTime.TryParseExact(p.StringValue, AWSSDKUtils.ISO8601DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out result))
             {
@@ -370,11 +315,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out Guid result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out Guid result)
-#endif
         {
             result = new Guid(p.StringValue);
             return true;
@@ -394,11 +335,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out byte[] result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out byte[] result)
-#endif
         {
             result = p.Value as byte[];
             return (result != null);
@@ -418,11 +355,7 @@ namespace Amazon.DynamoDBv2
             return true;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out MemoryStream result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out MemoryStream result)
-#endif
         {
             var bytes = p.Value as byte[];
             if (bytes == null)
@@ -465,11 +398,7 @@ namespace Amazon.DynamoDBv2
             return succeeded;
         }
 
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out Enum result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out Enum result)
-#endif
         {
             result = null;
 
@@ -489,11 +418,7 @@ namespace Amazon.DynamoDBv2
             return succeeded;
         }
 
-#if NET8_0_OR_GREATER
         private Enum ConvertEnum(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType)
-#else
-        private Enum ConvertEnum(Primitive p, Type targetType)
-#endif
         {
             object numerical;
             // convert Primitive to numeric type, using current conversion
@@ -544,11 +469,7 @@ namespace Amazon.DynamoDBv2
             result = b.Value;
             return true;
         }
-#if NET8_0_OR_GREATER
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out bool result)
-#else
-        protected override bool TryFrom(Primitive p, Type targetType, out bool result)
-#endif
         {
             result = !p.StringValue.Equals("0", StringComparison.OrdinalIgnoreCase);
             return true;
@@ -558,11 +479,7 @@ namespace Amazon.DynamoDBv2
     internal abstract class CollectionConverter : Converter
     {
 
-#if NET8_0_OR_GREATER
         protected bool EntriesToCollection([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type elementType, IEnumerable<DynamoDBEntry> entries, out object result)
-#else
-        protected bool EntriesToCollection(Type targetType, Type elementType, IEnumerable<DynamoDBEntry> entries, out object result)
-#endif
         {
             var items = Conversion.ConvertFromEntries(elementType, entries);
             return Utils.ItemsToCollection(targetType, items, out result);
@@ -597,22 +514,14 @@ namespace Amazon.DynamoDBv2
             return false;
         }
 
-#if NET8_0_OR_GREATER
         public override bool TryFrom(PrimitiveList pl, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
-#else
-        public override bool TryFrom(PrimitiveList pl, Type targetType, out object result)
-#endif
         {
             var elementType = Utils.GetPrimitiveElementType(targetType);
             var primitives = pl.Entries;
             return EntriesToCollection(targetType, elementType, pl.Entries.Cast<DynamoDBEntry>(), out result);
         }
 
-#if NET8_0_OR_GREATER
         public override bool TryFrom(DynamoDBList l, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
-#else
-        public override bool TryFrom(DynamoDBList l, Type targetType, out object result)
-#endif
         {
             var elementType = Utils.GetPrimitiveElementType(targetType);
             var entries = l.Entries;

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
@@ -16,6 +16,7 @@
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -196,11 +197,7 @@ namespace Amazon.DynamoDBv2
             return false;
         }
 
-#if NET8_0_OR_GREATER
         public override bool TryFrom(DynamoDBList l, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out object result)
-#else
-        public override bool TryFrom(DynamoDBList l, Type targetType, out object result)
-#endif
         {
             var elementType = Utils.GetElementType(targetType);
             var entries = l.Entries;

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/V1PropertyConverters.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/V1PropertyConverters.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2
 {
@@ -40,28 +41,19 @@ namespace Amazon.DynamoDBv2
     /// The default value for this field is the standard V1 conversion.
     /// </summary>
 
-#if NET8_0_OR_GREATER
     public class SetPropertyConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] TCollection, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] TElement> : IPropertyConverter
         where TCollection : ICollection<TElement>, new()
-#else
-    public class SetPropertyConverter<TCollection, TElement> : IPropertyConverter
-        where TCollection : ICollection<TElement>, new()
-#endif
     {
         /// <summary>
         /// Reference to the type object for the TCollection generic.
         /// </summary>
-#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)]
-#endif
         protected static readonly Type collectionType = typeof(TCollection);
 
         /// <summary>
         /// Reference to the type object for the TElement generic.
         /// </summary>
-#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)]
-#endif
         protected static readonly Type elementType = typeof(TElement);
 
         /// <summary>
@@ -151,9 +143,7 @@ namespace Amazon.DynamoDBv2
     /// </summary>
     /// <typeparam name="TElement"></typeparam>
     public class ListToSetPropertyConverter<
-#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)]
-#endif
     TElement> : SetPropertyConverter<List<TElement>, TElement>
     { }
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Attributes.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Attributes.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Amazon.DynamoDBv2.DataModel
@@ -176,7 +177,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Converter must be the type of a class that implements IPropertyConverter.
         /// </summary>
         /// <param name="converter">Custom converter type.</param>
+#if NET8_0_OR_GREATER
+        public DynamoDBPropertyAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
+#else
         public DynamoDBPropertyAttribute(Type converter)
+#endif
         {
             Converter = converter;
         }
@@ -203,7 +208,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Name of attribute to be associated with property or field.
         /// </param>
         /// <param name="converter">Custom converter type.</param>
+#if NET8_0_OR_GREATER
+        public DynamoDBPropertyAttribute(string attributeName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
+#else
         public DynamoDBPropertyAttribute(string attributeName, Type converter)
+#endif
             : base(attributeName)
         {
             Converter = converter;
@@ -230,6 +239,9 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Type of the custom converter.
         /// Cannot be set at the same time as StoreAsEpoch.
         /// </summary>
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
         public Type Converter { get; set; }
 
         /// <summary>
@@ -275,7 +287,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Converter must be the type of a class that implements IPropertyConverter.
         /// </summary>
         /// <param name="converter">Custom converter type.</param>
+#if NET8_0_OR_GREATER
+        public DynamoDBHashKeyAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
+#else
         public DynamoDBHashKeyAttribute(Type converter)
+#endif
             : base(converter)
         {
         }
@@ -289,7 +305,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Name of attribute to be associated with property or field.
         /// </param>
         /// <param name="converter">Custom converter type.</param>
+#if NET8_0_OR_GREATER
+        public DynamoDBHashKeyAttribute(string attributeName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
+#else
         public DynamoDBHashKeyAttribute(string attributeName, Type converter)
+#endif
             : base(attributeName, converter)
         {
         }
@@ -330,7 +350,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Converter must be the type of a class that implements IPropertyConverter.
         /// </summary>
         /// <param name="converter">Custom converter type.</param>
+#if NET8_0_OR_GREATER
+        public DynamoDBRangeKeyAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
+#else
         public DynamoDBRangeKeyAttribute(Type converter)
+#endif
             : base(converter)
         {
         }
@@ -344,7 +368,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Name of attribute to be associated with property or field.
         /// </param>
         /// <param name="converter">Custom converter type.</param>
+#if NET8_0_OR_GREATER
+        public DynamoDBRangeKeyAttribute(string attributeName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
+#else
         public DynamoDBRangeKeyAttribute(string attributeName, Type converter)
+#endif
             : base(attributeName, converter)
         {
         }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Attributes.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Attributes.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -177,11 +178,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Converter must be the type of a class that implements IPropertyConverter.
         /// </summary>
         /// <param name="converter">Custom converter type.</param>
-#if NET8_0_OR_GREATER
         public DynamoDBPropertyAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
-#else
-        public DynamoDBPropertyAttribute(Type converter)
-#endif
         {
             Converter = converter;
         }
@@ -208,11 +205,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Name of attribute to be associated with property or field.
         /// </param>
         /// <param name="converter">Custom converter type.</param>
-#if NET8_0_OR_GREATER
         public DynamoDBPropertyAttribute(string attributeName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
-#else
-        public DynamoDBPropertyAttribute(string attributeName, Type converter)
-#endif
             : base(attributeName)
         {
             Converter = converter;
@@ -239,9 +232,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Type of the custom converter.
         /// Cannot be set at the same time as StoreAsEpoch.
         /// </summary>
-#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
         public Type Converter { get; set; }
 
         /// <summary>
@@ -287,11 +278,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Converter must be the type of a class that implements IPropertyConverter.
         /// </summary>
         /// <param name="converter">Custom converter type.</param>
-#if NET8_0_OR_GREATER
         public DynamoDBHashKeyAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
-#else
-        public DynamoDBHashKeyAttribute(Type converter)
-#endif
             : base(converter)
         {
         }
@@ -305,11 +292,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Name of attribute to be associated with property or field.
         /// </param>
         /// <param name="converter">Custom converter type.</param>
-#if NET8_0_OR_GREATER
         public DynamoDBHashKeyAttribute(string attributeName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
-#else
-        public DynamoDBHashKeyAttribute(string attributeName, Type converter)
-#endif
             : base(attributeName, converter)
         {
         }
@@ -350,11 +333,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Converter must be the type of a class that implements IPropertyConverter.
         /// </summary>
         /// <param name="converter">Custom converter type.</param>
-#if NET8_0_OR_GREATER
         public DynamoDBRangeKeyAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
-#else
-        public DynamoDBRangeKeyAttribute(Type converter)
-#endif
             : base(converter)
         {
         }
@@ -368,11 +347,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Name of attribute to be associated with property or field.
         /// </param>
         /// <param name="converter">Custom converter type.</param>
-#if NET8_0_OR_GREATER
         public DynamoDBRangeKeyAttribute(string attributeName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type converter)
-#else
-        public DynamoDBRangeKeyAttribute(string attributeName, Type converter)
-#endif
             : base(attributeName, converter)
         {
         }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BaseOperationConfig.cs
@@ -22,10 +22,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// This should only contain members that are relevant to all object persistence operations, 
     /// anything operation-specific should be added to derived classes.
     /// </remarks>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public abstract class BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGet.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGet.cs
@@ -17,6 +17,8 @@ using System;
 using System.Collections.Generic;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.Runtime.Telemetry.Tracing;
+using System.Diagnostics.CodeAnalysis;
+
 
 
 #if AWS_ASYNC_API
@@ -59,7 +61,11 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a generic interface for retrieving a batch of items
     /// from a single DynamoDB table
     /// </summary>
+#if NET8_0_OR_GREATER
+    public interface IBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : IBatchGet
+#else
     public interface IBatchGet<T> : IBatchGet
+#endif
     {
         /// <summary>
         /// List of generic results retrieved from DynamoDB.
@@ -127,7 +133,11 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a strongly-typed object for retrieving a batch of items
     /// from a single DynamoDB table
     /// </summary>
+#if NET8_0_OR_GREATER
+    public partial class BatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : BatchGet, IBatchGet<T>
+#else
     public partial class BatchGet<T> : BatchGet, IBatchGet<T>
+#endif
     {
         private readonly DynamoDBContext _context;
         private readonly DynamoDBFlatConfig _config;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGet.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGet.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.Runtime.Telemetry.Tracing;
 using System.Diagnostics.CodeAnalysis;
-
+using ThirdParty.RuntimeBackports;
 
 
 #if AWS_ASYNC_API
@@ -61,11 +61,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a generic interface for retrieving a batch of items
     /// from a single DynamoDB table
     /// </summary>
-#if NET8_0_OR_GREATER
-    public interface IBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : IBatchGet
-#else
-    public interface IBatchGet<T> : IBatchGet
-#endif
+    public interface IBatchGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T> : IBatchGet
     {
         /// <summary>
         /// List of generic results retrieved from DynamoDB.
@@ -133,11 +129,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a strongly-typed object for retrieving a batch of items
     /// from a single DynamoDB table
     /// </summary>
-#if NET8_0_OR_GREATER
-    public partial class BatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : BatchGet, IBatchGet<T>
-#else
-    public partial class BatchGet<T> : BatchGet, IBatchGet<T>
-#endif
+    public partial class BatchGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T> : BatchGet, IBatchGet<T>
     {
         private readonly DynamoDBContext _context;
         private readonly DynamoDBFlatConfig _config;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGetConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGetConfig.cs
@@ -20,10 +20,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the BatchGet operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class BatchGetConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWrite.cs
@@ -18,6 +18,8 @@ using System.Collections.Generic;
 using Amazon.DynamoDBv2.DocumentModel;
 using System.Globalization;
 using Amazon.Runtime.Telemetry.Tracing;
+using System.Diagnostics.CodeAnalysis;
+
 
 #if AWS_ASYNC_API
 using System.Threading.Tasks;
@@ -38,7 +40,12 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a generic interface for writing/deleting a batch of items
     /// in a single DynamoDB table
     /// </summary>
+#if NET8_0_OR_GREATER
+    public interface IBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : IBatchWrite
+
+#else
     public interface IBatchWrite<T> : IBatchWrite
+#endif
     {
         /// <summary>
         /// Creates a MultiTableBatchWrite object that is a combination
@@ -106,7 +113,11 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a strongly-typed object for writing/deleting a batch of items
     /// in a single DynamoDB table
     /// </summary>
+#if NET8_0_OR_GREATER
+    public partial class BatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : BatchWrite, IBatchWrite<T>
+#else
     public partial class BatchWrite<T> : BatchWrite, IBatchWrite<T>
+#endif
     {
         private readonly DynamoDBContext _context;
         private readonly DynamoDBFlatConfig _config;
@@ -117,7 +128,11 @@ namespace Amazon.DynamoDBv2.DataModel
         {
         }
 
+#if NET8_0_OR_GREATER
+        internal BatchWrite(DynamoDBContext context, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, DynamoDBFlatConfig config)
+#else
         internal BatchWrite(DynamoDBContext context, Type valuesType, DynamoDBFlatConfig config)
+#endif
         {
             _context = context;
             _config = config;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWrite.cs
@@ -19,7 +19,7 @@ using Amazon.DynamoDBv2.DocumentModel;
 using System.Globalization;
 using Amazon.Runtime.Telemetry.Tracing;
 using System.Diagnostics.CodeAnalysis;
-
+using ThirdParty.RuntimeBackports;
 
 #if AWS_ASYNC_API
 using System.Threading.Tasks;
@@ -40,12 +40,8 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a generic interface for writing/deleting a batch of items
     /// in a single DynamoDB table
     /// </summary>
-#if NET8_0_OR_GREATER
-    public interface IBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : IBatchWrite
+    public interface IBatchWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T> : IBatchWrite
 
-#else
-    public interface IBatchWrite<T> : IBatchWrite
-#endif
     {
         /// <summary>
         /// Creates a MultiTableBatchWrite object that is a combination
@@ -113,11 +109,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a strongly-typed object for writing/deleting a batch of items
     /// in a single DynamoDB table
     /// </summary>
-#if NET8_0_OR_GREATER
-    public partial class BatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : BatchWrite, IBatchWrite<T>
-#else
-    public partial class BatchWrite<T> : BatchWrite, IBatchWrite<T>
-#endif
+    public partial class BatchWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T> : BatchWrite, IBatchWrite<T>
     {
         private readonly DynamoDBContext _context;
         private readonly DynamoDBFlatConfig _config;
@@ -128,11 +120,7 @@ namespace Amazon.DynamoDBv2.DataModel
         {
         }
 
-#if NET8_0_OR_GREATER
-        internal BatchWrite(DynamoDBContext context, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, DynamoDBFlatConfig config)
-#else
-        internal BatchWrite(DynamoDBContext context, Type valuesType, DynamoDBFlatConfig config)
-#endif
+        internal BatchWrite(DynamoDBContext context, [DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valuesType, DynamoDBFlatConfig config)
         {
             _context = context;
             _config = config;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWriteConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchWriteConfig.cs
@@ -18,10 +18,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the BatchWrite operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class BatchWriteConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -48,9 +48,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Configuration object for setting options on the <see cref="DynamoDBContext"/> that
     /// will apply to all operations that use the context object.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class DynamoDBContextConfig
     {
         /// <summary>
@@ -150,9 +147,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// This will override any settings specified by the DynamoDBContext's DynamoDBContextConfig object.
     /// </summary>
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class DynamoDBOperationConfig
     {
         /// <summary>
@@ -382,9 +376,6 @@ namespace Amazon.DynamoDBv2.DataModel
         #endregion
     }
 
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class DynamoDBFlatConfig
     {
         public static string DefaultIndexName = string.Empty;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -19,8 +19,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 #if AWS_ASYNC_API
 using System.Threading.Tasks;
+
 #endif
 using Amazon.DynamoDBv2.DocumentModel;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -217,33 +219,21 @@ namespace Amazon.DynamoDBv2.DataModel
         #region BatchGet
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
-#else
-        public IBatchGet<T> CreateBatchGet<T>()
-#endif
+        public IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>()
         {
             return CreateBatchGet<T>((BatchGetConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the CreateBatchGet overload that takes BatchGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-#if NET8_0_OR_GREATER
-        public IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig)
-#else
-        public IBatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig)
-#endif
+        public IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchGet<T>(this, config);
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(BatchGetConfig batchGetConfig)
-#else
-        public IBatchGet<T> CreateBatchGet<T>(BatchGetConfig batchGetConfig)
-#endif
+        public IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(BatchGetConfig batchGetConfig)
         {
             return new BatchGet<T>(this, new DynamoDBFlatConfig(batchGetConfig?.ToDynamoDBOperationConfig(), Config));
         }
@@ -259,65 +249,41 @@ namespace Amazon.DynamoDBv2.DataModel
         #region BatchWrite
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
-#else
-        public IBatchWrite<T> CreateBatchWrite<T>()
-#endif
+        public IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>()
         {
             return CreateBatchWrite<T>((BatchWriteConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-#if NET8_0_OR_GREATER
-        public IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig)
-#else
-        public IBatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig)
-#endif
+        public IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<T>(this, config);
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType)
-#else
-        public IBatchWrite<object> CreateBatchWrite(Type valuesType)
-#endif
+        public IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valuesType)
         {
             return CreateBatchWrite(valuesType, (BatchWriteConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-#if NET8_0_OR_GREATER
-        public IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, DynamoDBOperationConfig operationConfig)
-#else
-        public IBatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig)
-#endif
+        public IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valuesType, DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<object>(this, valuesType, config);
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(BatchWriteConfig batchWriteConfig)
-#else
-        public IBatchWrite<T> CreateBatchWrite<T>(BatchWriteConfig batchWriteConfig)
-#endif
+        public IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(BatchWriteConfig batchWriteConfig)
         {
             return new BatchWrite<T>(this, new DynamoDBFlatConfig(batchWriteConfig?.ToDynamoDBOperationConfig(), Config));
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, BatchWriteConfig batchWriteConfig)
-#else
-        public IBatchWrite<object> CreateBatchWrite(Type valuesType, BatchWriteConfig batchWriteConfig)
-#endif
+        public IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valuesType, BatchWriteConfig batchWriteConfig)
         {
             return new BatchWrite<object>(this, valuesType, new DynamoDBFlatConfig(batchWriteConfig.ToDynamoDBOperationConfig(), Config));
         }
@@ -333,33 +299,21 @@ namespace Amazon.DynamoDBv2.DataModel
         #region TransactGet
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
-#else
-        public ITransactGet<T> CreateTransactGet<T>()
-#endif
+        public ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>()
         {
             return CreateTransactGet<T>((TransactGetConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the CreateTransactGet overload that takes TransactGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-#if NET8_0_OR_GREATER
-        public ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig)
-#else
-        public ITransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig)
-#endif
+        public ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new TransactGet<T>(this, config);
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(TransactGetConfig transactGetConfig)
-#else
-        public ITransactGet<T> CreateTransactGet<T>(TransactGetConfig transactGetConfig)
-#endif
+        public ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(TransactGetConfig transactGetConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(transactGetConfig?.ToDynamoDBOperationConfig(), this.Config);
             return new TransactGet<T>(this, config);
@@ -376,11 +330,7 @@ namespace Amazon.DynamoDBv2.DataModel
         #region TransactWrite
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
-#else
-        public ITransactWrite<T> CreateTransactWrite<T>()
-#endif
+        public ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>()
         {
             return CreateTransactWrite<T>((TransactWriteConfig)null);
         }
@@ -388,22 +338,14 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <inheritdoc/>
 
         [Obsolete("Use the CreateTransactWrite overload that takes TransactWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to CreateTransactWrite.")]
-#if NET8_0_OR_GREATER
-        public ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig)
-#else
-        public ITransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig)
-#endif
+        public ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new TransactWrite<T>(this, config);
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(TransactWriteConfig transactWriteConfig)
-#else
-        public ITransactWrite<T> CreateTransactWrite<T>(TransactWriteConfig transactWriteConfig)
-#endif
+        public ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(TransactWriteConfig transactWriteConfig)
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(transactWriteConfig?.ToDynamoDBOperationConfig(), this.Config);
             return new TransactWrite<T>(this, config);
@@ -419,11 +361,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #region Save/serialize
 
-#if NET8_0_OR_GREATER
-        private void SaveHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBFlatConfig flatConfig)
-#else
-        private void SaveHelper<T>(T value, DynamoDBFlatConfig flatConfig)
-#endif
+        private void SaveHelper<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBFlatConfig flatConfig)
         {
             if (value == null) return;
 
@@ -450,20 +388,12 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
 #if AWS_ASYNC_API 
-#if NET8_0_OR_GREATER
-        private async Task SaveHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#else
-        private async Task SaveHelperAsync<T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#endif
+        private async Task SaveHelperAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
         {
             await SaveHelperAsync(typeof(T), value, flatConfig, cancellationToken).ConfigureAwait(false);
         }
 
-#if NET8_0_OR_GREATER
-        private async Task SaveHelperAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#else
-        private async Task SaveHelperAsync(Type valueType, object value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#endif
+        private async Task SaveHelperAsync([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valueType, object value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
         {
             if (value == null) return;
 
@@ -492,22 +422,14 @@ namespace Amazon.DynamoDBv2.DataModel
 #endif
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value)
-#else
-        public Document ToDocument<T>(T value)
-#endif
+        public Document ToDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value)
         {
             return ToDocument<T>(value, (ToDocumentConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the ToDocument overload that takes ToDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to ToDocument.")]
-#if NET8_0_OR_GREATER
-        public Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig)
-#else
-        public Document ToDocument<T>(T value, DynamoDBOperationConfig operationConfig)
-#endif
+        public Document ToDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBOperationConfig operationConfig)
         {
             if (value == null) return null;
 
@@ -519,11 +441,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, ToDocumentConfig toDocumentConfig)
-#else
-        public Document ToDocument<T>(T value, ToDocumentConfig toDocumentConfig)
-#endif
+        public Document ToDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, ToDocumentConfig toDocumentConfig)
         {
             if (value == null) return null;
 
@@ -538,11 +456,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #region Load/deserialize
 
-#if NET8_0_OR_GREATER
-        private T LoadHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
-#else
-        private T LoadHelper<T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
-#endif
+        private T LoadHelper<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey(hashKey, rangeKey, storageConfig, flatConfig);
@@ -550,11 +464,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
 #if AWS_ASYNC_API
-#if NET8_0_OR_GREATER
-        private Task<T> LoadHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#else
-        private Task<T> LoadHelperAsync<T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#endif
+        private Task<T> LoadHelperAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey(hashKey, rangeKey, storageConfig, flatConfig);
@@ -562,11 +472,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 #endif
 
-#if NET8_0_OR_GREATER
-        private T LoadHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, DynamoDBFlatConfig flatConfig)
-#else
-        private T LoadHelper<T>(T keyObject, DynamoDBFlatConfig flatConfig)
-#endif
+        private T LoadHelper<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T keyObject, DynamoDBFlatConfig flatConfig)
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey<T>(keyObject, storageConfig, flatConfig);
@@ -575,11 +481,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
 #if AWS_ASYNC_API
 
-#if NET8_0_OR_GREATER
-        private Task<T> LoadHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#else
-        private Task<T> LoadHelperAsync<T>(T keyObject, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#endif
+        private Task<T> LoadHelperAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T keyObject, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey<T>(keyObject, storageConfig, flatConfig);
@@ -587,11 +489,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 #endif
 
-#if NET8_0_OR_GREATER
-        private T LoadHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig)
-#else
-        private T LoadHelper<T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig)
-#endif
+        private T LoadHelper<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig)
         {
             GetItemOperationConfig getConfig = new GetItemOperationConfig
             {
@@ -609,11 +507,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
 #if AWS_ASYNC_API
 
-#if NET8_0_OR_GREATER
-        private async Task<T> LoadHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig, CancellationToken cancellationToken)
-#else
-        private async Task<T> LoadHelperAsync<T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig, CancellationToken cancellationToken)
-#endif
+        private async Task<T> LoadHelperAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig, CancellationToken cancellationToken)
         {
             GetItemOperationConfig getConfig = new GetItemOperationConfig
             {
@@ -631,43 +525,27 @@ namespace Amazon.DynamoDBv2.DataModel
 #endif
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document)
-#else
-        public T FromDocument<T>(Document document)
-#endif
+        public T FromDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(Document document)
         {
             return FromDocument<T>(document, (FromDocumentConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the FromDocument overload that takes FromDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromDocument.")]
-#if NET8_0_OR_GREATER
-        public T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, DynamoDBOperationConfig operationConfig)
-#else
-        public T FromDocument<T>(Document document, DynamoDBOperationConfig operationConfig)
-#endif
+        public T FromDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(Document document, DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             return FromDocumentHelper<T>(document, flatConfig);
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, FromDocumentConfig fromDocumentConfig)
-#else
-        public T FromDocument<T>(Document document, FromDocumentConfig fromDocumentConfig)
-#endif
+        public T FromDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(Document document, FromDocumentConfig fromDocumentConfig)
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(fromDocumentConfig?.ToDynamoDBOperationConfig(), Config);
             return FromDocumentHelper<T>(document, flatConfig);
         }
 
-#if NET8_0_OR_GREATER
-        internal T FromDocumentHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, DynamoDBFlatConfig flatConfig)
-#else
-        internal T FromDocumentHelper<T>(Document document, DynamoDBFlatConfig flatConfig)
-#endif
+        internal T FromDocumentHelper<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(Document document, DynamoDBFlatConfig flatConfig)
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             ItemStorage storage = new ItemStorage(storageConfig);
@@ -677,22 +555,14 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents)
-#else
-        public IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents)
-#endif
+        public IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<Document> documents)
         {
             return FromDocuments<T>(documents, (FromDocumentConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the FromDocuments overload that takes FromDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromDocuments.")]
-#if NET8_0_OR_GREATER
-        public IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig)
-#else
-        public IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig)
-#endif
+        public IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig)
         {
             foreach (var document in documents)
             {
@@ -702,11 +572,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig)
-#else
-        public IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig)
-#endif
+        public IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig)
         {
             foreach (var document in documents)
             {
@@ -715,11 +581,7 @@ namespace Amazon.DynamoDBv2.DataModel
             }
         }
 
-#if NET8_0_OR_GREATER
-        internal IEnumerable<T> FromDocumentsHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, DynamoDBFlatConfig flatConfig)
-#else
-        internal IEnumerable<T> FromDocumentsHelper<T>(IEnumerable<Document> documents, DynamoDBFlatConfig flatConfig)
-#endif
+        internal IEnumerable<T> FromDocumentsHelper<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<Document> documents, DynamoDBFlatConfig flatConfig)
         {
             foreach (var document in documents)
             {
@@ -732,11 +594,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #region Delete
 
-#if NET8_0_OR_GREATER
-        private void DeleteHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
-#else
-        private void DeleteHelper<T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
-#endif
+        private void DeleteHelper<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey(hashKey, rangeKey, storageConfig, flatConfig);
@@ -746,11 +604,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
 #if AWS_ASYNC_API
-#if NET8_0_OR_GREATER
-        private Task DeleteHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#else
-        private Task DeleteHelperAsync<T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#endif
+        private Task DeleteHelperAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey(hashKey, rangeKey, storageConfig, flatConfig);
@@ -760,11 +614,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 #endif
 
-#if NET8_0_OR_GREATER
-        private void DeleteHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBFlatConfig flatConfig)
-#else
-        private void DeleteHelper<T>(T value, DynamoDBFlatConfig flatConfig)
-#endif
+        private void DeleteHelper<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBFlatConfig flatConfig)
         {
             if (value == null) throw new ArgumentNullException("value");
 
@@ -790,11 +640,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         private static readonly Task CompletedTask = Task.FromResult<object>(null);
 
-#if NET8_0_OR_GREATER
-        private Task DeleteHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#else
-        private Task DeleteHelperAsync<T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
-#endif
+        private Task DeleteHelperAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
         {
             if (value == null) throw new ArgumentNullException("value");
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Context.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 #if AWS_ASYNC_API
 using System.Threading.Tasks;
@@ -216,21 +217,33 @@ namespace Amazon.DynamoDBv2.DataModel
         #region BatchGet
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
+#else
         public IBatchGet<T> CreateBatchGet<T>()
+#endif
         {
             return CreateBatchGet<T>((BatchGetConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the CreateBatchGet overload that takes BatchGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
+#if NET8_0_OR_GREATER
+        public IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig)
+#else
         public IBatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchGet<T>(this, config);
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(BatchGetConfig batchGetConfig)
+#else
         public IBatchGet<T> CreateBatchGet<T>(BatchGetConfig batchGetConfig)
+#endif
         {
             return new BatchGet<T>(this, new DynamoDBFlatConfig(batchGetConfig?.ToDynamoDBOperationConfig(), Config));
         }
@@ -246,41 +259,65 @@ namespace Amazon.DynamoDBv2.DataModel
         #region BatchWrite
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
+#else
         public IBatchWrite<T> CreateBatchWrite<T>()
+#endif
         {
             return CreateBatchWrite<T>((BatchWriteConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
+#if NET8_0_OR_GREATER
+        public IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig)
+#else
         public IBatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<T>(this, config);
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType)
+#else
         public IBatchWrite<object> CreateBatchWrite(Type valuesType)
+#endif
         {
             return CreateBatchWrite(valuesType, (BatchWriteConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
+#if NET8_0_OR_GREATER
+        public IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, DynamoDBOperationConfig operationConfig)
+#else
         public IBatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new BatchWrite<object>(this, valuesType, config);
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(BatchWriteConfig batchWriteConfig)
+#else
         public IBatchWrite<T> CreateBatchWrite<T>(BatchWriteConfig batchWriteConfig)
+#endif
         {
             return new BatchWrite<T>(this, new DynamoDBFlatConfig(batchWriteConfig?.ToDynamoDBOperationConfig(), Config));
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, BatchWriteConfig batchWriteConfig)
+#else
         public IBatchWrite<object> CreateBatchWrite(Type valuesType, BatchWriteConfig batchWriteConfig)
+#endif
         {
             return new BatchWrite<object>(this, valuesType, new DynamoDBFlatConfig(batchWriteConfig.ToDynamoDBOperationConfig(), Config));
         }
@@ -296,21 +333,33 @@ namespace Amazon.DynamoDBv2.DataModel
         #region TransactGet
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
+#else
         public ITransactGet<T> CreateTransactGet<T>()
+#endif
         {
             return CreateTransactGet<T>((TransactGetConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the CreateTransactGet overload that takes TransactGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
+#if NET8_0_OR_GREATER
+        public ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig)
+#else
         public ITransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new TransactGet<T>(this, config);
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(TransactGetConfig transactGetConfig)
+#else
         public ITransactGet<T> CreateTransactGet<T>(TransactGetConfig transactGetConfig)
+#endif
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(transactGetConfig?.ToDynamoDBOperationConfig(), this.Config);
             return new TransactGet<T>(this, config);
@@ -327,7 +376,11 @@ namespace Amazon.DynamoDBv2.DataModel
         #region TransactWrite
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
+#else
         public ITransactWrite<T> CreateTransactWrite<T>()
+#endif
         {
             return CreateTransactWrite<T>((TransactWriteConfig)null);
         }
@@ -335,14 +388,22 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <inheritdoc/>
 
         [Obsolete("Use the CreateTransactWrite overload that takes TransactWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to CreateTransactWrite.")]
+#if NET8_0_OR_GREATER
+        public ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig)
+#else
         public ITransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(operationConfig, this.Config);
             return new TransactWrite<T>(this, config);
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(TransactWriteConfig transactWriteConfig)
+#else
         public ITransactWrite<T> CreateTransactWrite<T>(TransactWriteConfig transactWriteConfig)
+#endif
         {
             DynamoDBFlatConfig config = new DynamoDBFlatConfig(transactWriteConfig?.ToDynamoDBOperationConfig(), this.Config);
             return new TransactWrite<T>(this, config);
@@ -358,7 +419,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #region Save/serialize
 
+#if NET8_0_OR_GREATER
+        private void SaveHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBFlatConfig flatConfig)
+#else
         private void SaveHelper<T>(T value, DynamoDBFlatConfig flatConfig)
+#endif
         {
             if (value == null) return;
 
@@ -385,12 +450,20 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
 #if AWS_ASYNC_API 
+#if NET8_0_OR_GREATER
+        private async Task SaveHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#else
         private async Task SaveHelperAsync<T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#endif
         {
             await SaveHelperAsync(typeof(T), value, flatConfig, cancellationToken).ConfigureAwait(false);
         }
 
+#if NET8_0_OR_GREATER
+        private async Task SaveHelperAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#else
         private async Task SaveHelperAsync(Type valueType, object value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#endif
         {
             if (value == null) return;
 
@@ -419,14 +492,22 @@ namespace Amazon.DynamoDBv2.DataModel
 #endif
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value)
+#else
         public Document ToDocument<T>(T value)
+#endif
         {
             return ToDocument<T>(value, (ToDocumentConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the ToDocument overload that takes ToDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to ToDocument.")]
+#if NET8_0_OR_GREATER
+        public Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig)
+#else
         public Document ToDocument<T>(T value, DynamoDBOperationConfig operationConfig)
+#endif
         {
             if (value == null) return null;
 
@@ -438,7 +519,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, ToDocumentConfig toDocumentConfig)
+#else
         public Document ToDocument<T>(T value, ToDocumentConfig toDocumentConfig)
+#endif
         {
             if (value == null) return null;
 
@@ -453,15 +538,23 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #region Load/deserialize
 
+#if NET8_0_OR_GREATER
+        private T LoadHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
+#else
         private T LoadHelper<T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
+#endif
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey(hashKey, rangeKey, storageConfig, flatConfig);
             return LoadHelper<T>(key, flatConfig, storageConfig);
         }
 
-#if AWS_ASYNC_API 
+#if AWS_ASYNC_API
+#if NET8_0_OR_GREATER
+        private Task<T> LoadHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#else
         private Task<T> LoadHelperAsync<T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#endif
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey(hashKey, rangeKey, storageConfig, flatConfig);
@@ -469,15 +562,24 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 #endif
 
+#if NET8_0_OR_GREATER
+        private T LoadHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, DynamoDBFlatConfig flatConfig)
+#else
         private T LoadHelper<T>(T keyObject, DynamoDBFlatConfig flatConfig)
+#endif
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey<T>(keyObject, storageConfig, flatConfig);
             return LoadHelper<T>(key, flatConfig, storageConfig);
         }
 
-#if AWS_ASYNC_API 
+#if AWS_ASYNC_API
+
+#if NET8_0_OR_GREATER
+        private Task<T> LoadHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#else
         private Task<T> LoadHelperAsync<T>(T keyObject, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#endif
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey<T>(keyObject, storageConfig, flatConfig);
@@ -485,7 +587,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 #endif
 
+#if NET8_0_OR_GREATER
+        private T LoadHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig)
+#else
         private T LoadHelper<T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig)
+#endif
         {
             GetItemOperationConfig getConfig = new GetItemOperationConfig
             {
@@ -501,8 +607,13 @@ namespace Amazon.DynamoDBv2.DataModel
             return instance;
         }
 
-#if AWS_ASYNC_API 
+#if AWS_ASYNC_API
+
+#if NET8_0_OR_GREATER
+        private async Task<T> LoadHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig, CancellationToken cancellationToken)
+#else
         private async Task<T> LoadHelperAsync<T>(Key key, DynamoDBFlatConfig flatConfig, ItemStorageConfig storageConfig, CancellationToken cancellationToken)
+#endif
         {
             GetItemOperationConfig getConfig = new GetItemOperationConfig
             {
@@ -520,27 +631,43 @@ namespace Amazon.DynamoDBv2.DataModel
 #endif
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document)
+#else
         public T FromDocument<T>(Document document)
+#endif
         {
             return FromDocument<T>(document, (FromDocumentConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the FromDocument overload that takes FromDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromDocument.")]
+#if NET8_0_OR_GREATER
+        public T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, DynamoDBOperationConfig operationConfig)
+#else
         public T FromDocument<T>(Document document, DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             return FromDocumentHelper<T>(document, flatConfig);
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, FromDocumentConfig fromDocumentConfig)
+#else
         public T FromDocument<T>(Document document, FromDocumentConfig fromDocumentConfig)
+#endif
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(fromDocumentConfig?.ToDynamoDBOperationConfig(), Config);
             return FromDocumentHelper<T>(document, flatConfig);
         }
 
+#if NET8_0_OR_GREATER
+        internal T FromDocumentHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, DynamoDBFlatConfig flatConfig)
+#else
         internal T FromDocumentHelper<T>(Document document, DynamoDBFlatConfig flatConfig)
+#endif
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             ItemStorage storage = new ItemStorage(storageConfig);
@@ -550,14 +677,22 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents)
+#else
         public IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents)
+#endif
         {
             return FromDocuments<T>(documents, (FromDocumentConfig)null);
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the FromDocuments overload that takes FromDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromDocuments.")]
+#if NET8_0_OR_GREATER
+        public IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig)
+#else
         public IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig)
+#endif
         {
             foreach (var document in documents)
             {
@@ -567,7 +702,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig)
+#else
         public IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig)
+#endif
         {
             foreach (var document in documents)
             {
@@ -576,7 +715,11 @@ namespace Amazon.DynamoDBv2.DataModel
             }
         }
 
+#if NET8_0_OR_GREATER
+        internal IEnumerable<T> FromDocumentsHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, DynamoDBFlatConfig flatConfig)
+#else
         internal IEnumerable<T> FromDocumentsHelper<T>(IEnumerable<Document> documents, DynamoDBFlatConfig flatConfig)
+#endif
         {
             foreach (var document in documents)
             {
@@ -589,7 +732,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #region Delete
 
+#if NET8_0_OR_GREATER
+        private void DeleteHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
+#else
         private void DeleteHelper<T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig)
+#endif
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey(hashKey, rangeKey, storageConfig, flatConfig);
@@ -598,8 +745,12 @@ namespace Amazon.DynamoDBv2.DataModel
             table.DeleteHelper(key, null);
         }
 
-#if AWS_ASYNC_API 
+#if AWS_ASYNC_API
+#if NET8_0_OR_GREATER
+        private Task DeleteHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#else
         private Task DeleteHelperAsync<T>(object hashKey, object rangeKey, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#endif
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
             Key key = MakeKey(hashKey, rangeKey, storageConfig, flatConfig);
@@ -609,7 +760,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 #endif
 
+#if NET8_0_OR_GREATER
+        private void DeleteHelper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBFlatConfig flatConfig)
+#else
         private void DeleteHelper<T>(T value, DynamoDBFlatConfig flatConfig)
+#endif
         {
             if (value == null) throw new ArgumentNullException("value");
 
@@ -635,7 +790,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         private static readonly Task CompletedTask = Task.FromResult<object>(null);
 
+#if NET8_0_OR_GREATER
+        private Task DeleteHelperAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#else
         private Task DeleteHelperAsync<T>(T value, DynamoDBFlatConfig flatConfig, CancellationToken cancellationToken)
+#endif
         {
             if (value == null) throw new ArgumentNullException("value");
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextBuilder.cs
@@ -18,9 +18,6 @@ using System;
 namespace Amazon.DynamoDBv2.DataModel
 {
     /// <inheritdoc cref="IDynamoDBContextBuilder" />
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class DynamoDBContextBuilder : IDynamoDBContextBuilder
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -26,6 +26,7 @@ using Amazon.DynamoDBv2.Model;
 using Amazon.Util.Internal;
 using System.Globalization;
 using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -119,11 +120,7 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Table methods
 
         // Retrieves the target table for the specified type
-#if NET8_0_OR_GREATER
-        private Table GetTargetTableInternal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBFlatConfig flatConfig)
-#else
-        private Table GetTargetTableInternal<T>(DynamoDBFlatConfig flatConfig)
-#endif
+        private Table GetTargetTableInternal<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBFlatConfig flatConfig)
         {
             Type type = typeof(T);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig(type, flatConfig);
@@ -340,21 +337,13 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// Deserializes a DynamoDB document to an object
         /// </summary>
-#if NET8_0_OR_GREATER
-        private T DocumentToObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ItemStorage storage, DynamoDBFlatConfig flatConfig)
-#else
-        private T DocumentToObject<T>(ItemStorage storage, DynamoDBFlatConfig flatConfig)
-#endif
+        private T DocumentToObject<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ItemStorage storage, DynamoDBFlatConfig flatConfig)
         {
             Type type = typeof(T);
             return (T)DocumentToObject(type, storage, flatConfig);
         }
 
-#if NET8_0_OR_GREATER
-        private object DocumentToObject([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType, ItemStorage storage, DynamoDBFlatConfig flatConfig)
-#else
-        private object DocumentToObject(Type objectType, ItemStorage storage, DynamoDBFlatConfig flatConfig)
-#endif
+        private object DocumentToObject([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type objectType, ItemStorage storage, DynamoDBFlatConfig flatConfig)
         {
             if (storage == null) throw new ArgumentNullException("storage");
 
@@ -412,11 +401,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// Serializes an object into a DynamoDB document
         /// </summary>
-#if NET8_0_OR_GREATER
-        private ItemStorage ObjectToItemStorage<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T toStore, bool keysOnly, DynamoDBFlatConfig flatConfig)
-#else
-        private ItemStorage ObjectToItemStorage<T>(T toStore, bool keysOnly, DynamoDBFlatConfig flatConfig)
-#endif
+        private ItemStorage ObjectToItemStorage<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T toStore, bool keysOnly, DynamoDBFlatConfig flatConfig)
         {
             if (toStore == null) return null;
 
@@ -424,11 +409,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return ObjectToItemStorage(toStore, objectType, keysOnly, flatConfig);
         }
 
-#if NET8_0_OR_GREATER
-        private ItemStorage ObjectToItemStorage(object toStore, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType, bool keysOnly, DynamoDBFlatConfig flatConfig)
-#else
-        private ItemStorage ObjectToItemStorage(object toStore, Type objectType, bool keysOnly, DynamoDBFlatConfig flatConfig)
-#endif
+        private ItemStorage ObjectToItemStorage(object toStore, [DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type objectType, bool keysOnly, DynamoDBFlatConfig flatConfig)
         {
             ItemStorageConfig config = StorageConfigCache.GetConfig(objectType, flatConfig);
             ItemStorage storage = ObjectToItemStorageHelper(toStore, config, flatConfig, keysOnly, flatConfig.IgnoreNullValues.Value);
@@ -537,25 +518,17 @@ namespace Amazon.DynamoDBv2.DataModel
             }
         }
 
-#if NET8_0_OR_GREATER
-        private bool TryFromList([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
-#else
-        private bool TryFromList(Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
-#endif
+        private bool TryFromList([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
         {
             return targetType.IsArray ?
                  TryFromListToArray(targetType, list, flatConfig, out output) : //targetType is Array
                  TryFromListToIList(targetType, list, flatConfig, out output) ; //targetType is IList or has Add method.
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2062",
-            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2062",
+            Justification = "The user's type has been annotated with InternalConstants.DataModelModeledType with the public API into the library. At this point the type will not be trimmed.")]
 
-        private bool TryFromListToIList([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
-#else
-        private bool TryFromListToIList(Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
-#endif
+        private bool TryFromListToIList([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
         {
             if ((!Utils.ImplementsInterface(targetType, typeof(ICollection<>)) &&
                 !Utils.ImplementsInterface(targetType, typeof(IList))) ||
@@ -591,11 +564,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return true;
         }
 
-#if NET8_0_OR_GREATER
-        private bool TryFromListToArray([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
-#else
-        private bool TryFromListToArray(Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
-#endif
+        private bool TryFromListToArray([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
         {
             if (!Utils.CanInstantiateArray(targetType))
             {
@@ -619,13 +588,9 @@ namespace Amazon.DynamoDBv2.DataModel
             return true;
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
-            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
-        private bool TryFromMap([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, Document map, DynamoDBFlatConfig flatConfig, out object output)
-#else
-        private bool TryFromMap(Type targetType, Document map, DynamoDBFlatConfig flatConfig, out object output)
-#endif
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
+            Justification = "The user's type has been annotated with InternalConstants.DataModelModeledType with the public API into the library. At this point the type will not be trimmed.")]
+        private bool TryFromMap([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type targetType, Document map, DynamoDBFlatConfig flatConfig, out object output)
         {
             output = null;
 
@@ -697,13 +662,9 @@ namespace Amazon.DynamoDBv2.DataModel
             }
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
-            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
-        private bool TryToMap(object value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, DynamoDBFlatConfig flatConfig, out Document output)
-#else
-        private bool TryToMap(object value, Type type, DynamoDBFlatConfig flatConfig, out Document output)
-#endif
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
+            Justification = "The user's type has been annotated with InternalConstants.DataModelModeledType with the public API into the library. At this point the type will not be trimmed.")]
+        private bool TryToMap(object value, [DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type type, DynamoDBFlatConfig flatConfig, out Document output)
         {
             output = null;
 
@@ -736,11 +697,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return true;
         }
 
-#if NET8_0_OR_GREATER
         private bool TryToList(object value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type, DynamoDBFlatConfig flatConfig, out DynamoDBList output)
-#else
-        private bool TryToList(object value, Type type, DynamoDBFlatConfig flatConfig, out DynamoDBList output)
-#endif
         {
             if (!Utils.ImplementsInterface(type, typeof(ICollection<>)))
             {
@@ -807,21 +764,13 @@ namespace Amazon.DynamoDBv2.DataModel
             return false;
         }
 
-#if NET8_0_OR_GREATER
         private static bool IsSupportedDictionaryType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type, out Type valueType)
-#else
-        private static bool IsSupportedDictionaryType(Type type, out Type valueType)
-#endif
         {
             Type keyType;
             return IsSupportedDictionaryType(type, out keyType, out valueType);
         }
 
-#if NET8_0_OR_GREATER
         private static bool IsSupportedDictionaryType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type, out Type keyType, out Type valueType)
-#else
-        private static bool IsSupportedDictionaryType(Type type, out Type keyType, out Type valueType)
-#endif
         {
             keyType = valueType = null;
 
@@ -845,11 +794,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Deserializes a given Document to instance of targetType
         /// Use only for property conversions, not for full item conversion
         /// </summary>
-#if NET8_0_OR_GREATER
-        private object DeserializeFromDocument(Document document, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, DynamoDBFlatConfig flatConfig)
-#else
-        private object DeserializeFromDocument(Document document, Type targetType, DynamoDBFlatConfig flatConfig)
-#endif
+        private object DeserializeFromDocument(Document document, [DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type targetType, DynamoDBFlatConfig flatConfig)
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig(targetType, flatConfig, conversionOnly: true);
             ItemStorage storage = new ItemStorage(storageConfig);
@@ -862,11 +807,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Serializes a given value to Document
         /// Use only for property conversions, not for full item conversion
         /// </summary>
-#if NET8_0_OR_GREATER
-        private Document SerializeToDocument(object value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, DynamoDBFlatConfig flatConfig)
-#else
-        private Document SerializeToDocument(object value, Type type, DynamoDBFlatConfig flatConfig)
-#endif
+        private Document SerializeToDocument(object value, [DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type type, DynamoDBFlatConfig flatConfig)
         {
             ItemStorageConfig config = StorageConfigCache.GetConfig(type, flatConfig, conversionOnly: true);
             var itemStorage = ObjectToItemStorageHelper(value, config, flatConfig, keysOnly: false, ignoreNullValues: flatConfig.IgnoreNullValues.Value);
@@ -1212,12 +1153,7 @@ namespace Amazon.DynamoDBv2.DataModel
             }
         }
 
-#if NET8_0_OR_GREATER
-        private IEnumerable<T> FromSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ContextSearch cs)
-
-#else
-        private IEnumerable<T> FromSearch<T>(ContextSearch cs)
-#endif
+        private IEnumerable<T> FromSearch<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ContextSearch cs)
         {
             if (cs == null) throw new ArgumentNullException("cs");
 
@@ -1245,11 +1181,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #region Scan/Query
 
-#if NET8_0_OR_GREATER
-        private ContextSearch ConvertScan<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig)
-#else
-        private ContextSearch ConvertScan<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig)
-#endif
+        private ContextSearch ConvertScan<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, this.Config);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
@@ -1271,11 +1203,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return new ContextSearch(scan, flatConfig);
         }
 
-#if NET8_0_OR_GREATER
-        private ContextSearch ConvertFromScan<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig)
-#else
-        private ContextSearch ConvertFromScan<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig)
-#endif
+        private ContextSearch ConvertFromScan<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
@@ -1286,11 +1214,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return new ContextSearch(search, flatConfig);
         }
 
-#if NET8_0_OR_GREATER
-        private ContextSearch ConvertFromQuery<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig)
-#else
-        private ContextSearch ConvertFromQuery<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig)
-#endif
+        private ContextSearch ConvertFromQuery<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
@@ -1301,11 +1225,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return new ContextSearch(search, flatConfig);
         }
 
-#if NET8_0_OR_GREATER
-        private ContextSearch ConvertQueryByValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig)
-#else
-        private ContextSearch ConvertQueryByValue<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig)
-#endif
+        private ContextSearch ConvertQueryByValue<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig)
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
@@ -1314,11 +1234,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return query;
         }
 
-#if NET8_0_OR_GREATER
-        private ContextSearch ConvertQueryByValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, IEnumerable<QueryCondition> conditions, DynamoDBOperationConfig operationConfig, ItemStorageConfig storageConfig = null)
-#else
-        private ContextSearch ConvertQueryByValue<T>(object hashKeyValue, IEnumerable<QueryCondition> conditions, DynamoDBOperationConfig operationConfig, ItemStorageConfig storageConfig = null)
-#endif
+        private ContextSearch ConvertQueryByValue<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, IEnumerable<QueryCondition> conditions, DynamoDBOperationConfig operationConfig, ItemStorageConfig storageConfig = null)
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             if (storageConfig == null)
@@ -1358,11 +1274,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return new ContextSearch(query, currentConfig);
         }
 
-#if NET8_0_OR_GREATER
-        private AsyncSearch<T> FromSearchAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ContextSearch contextSearch)
-#else
-        private AsyncSearch<T> FromSearchAsync<T>(ContextSearch contextSearch)
-#endif
+        private AsyncSearch<T> FromSearchAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ContextSearch contextSearch)
         {
             return new AsyncSearch<T>(this, contextSearch);
         }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ContextInternal.cs
@@ -25,12 +25,10 @@ using Amazon.DynamoDBv2.Model;
 
 using Amazon.Util.Internal;
 using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public partial class DynamoDBContext
     {
         #region Versioning
@@ -121,7 +119,11 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Table methods
 
         // Retrieves the target table for the specified type
+#if NET8_0_OR_GREATER
+        private Table GetTargetTableInternal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBFlatConfig flatConfig)
+#else
         private Table GetTargetTableInternal<T>(DynamoDBFlatConfig flatConfig)
+#endif
         {
             Type type = typeof(T);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig(type, flatConfig);
@@ -338,12 +340,21 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// Deserializes a DynamoDB document to an object
         /// </summary>
+#if NET8_0_OR_GREATER
+        private T DocumentToObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ItemStorage storage, DynamoDBFlatConfig flatConfig)
+#else
         private T DocumentToObject<T>(ItemStorage storage, DynamoDBFlatConfig flatConfig)
+#endif
         {
             Type type = typeof(T);
             return (T)DocumentToObject(type, storage, flatConfig);
         }
+
+#if NET8_0_OR_GREATER
+        private object DocumentToObject([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType, ItemStorage storage, DynamoDBFlatConfig flatConfig)
+#else
         private object DocumentToObject(Type objectType, ItemStorage storage, DynamoDBFlatConfig flatConfig)
+#endif
         {
             if (storage == null) throw new ArgumentNullException("storage");
 
@@ -401,7 +412,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// Serializes an object into a DynamoDB document
         /// </summary>
+#if NET8_0_OR_GREATER
+        private ItemStorage ObjectToItemStorage<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T toStore, bool keysOnly, DynamoDBFlatConfig flatConfig)
+#else
         private ItemStorage ObjectToItemStorage<T>(T toStore, bool keysOnly, DynamoDBFlatConfig flatConfig)
+#endif
         {
             if (toStore == null) return null;
 
@@ -409,7 +424,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return ObjectToItemStorage(toStore, objectType, keysOnly, flatConfig);
         }
 
+#if NET8_0_OR_GREATER
+        private ItemStorage ObjectToItemStorage(object toStore, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType, bool keysOnly, DynamoDBFlatConfig flatConfig)
+#else
         private ItemStorage ObjectToItemStorage(object toStore, Type objectType, bool keysOnly, DynamoDBFlatConfig flatConfig)
+#endif
         {
             ItemStorageConfig config = StorageConfigCache.GetConfig(objectType, flatConfig);
             ItemStorage storage = ObjectToItemStorageHelper(toStore, config, flatConfig, keysOnly, flatConfig.IgnoreNullValues.Value);
@@ -517,14 +536,26 @@ namespace Amazon.DynamoDBv2.DataModel
                     entry, entry.GetType().FullName, propertyStorage.PropertyName, propertyStorage.MemberType.FullName));
             }
         }
+
+#if NET8_0_OR_GREATER
+        private bool TryFromList([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
+#else
         private bool TryFromList(Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
+#endif
         {
             return targetType.IsArray ?
                  TryFromListToArray(targetType, list, flatConfig, out output) : //targetType is Array
                  TryFromListToIList(targetType, list, flatConfig, out output) ; //targetType is IList or has Add method.
         }
 
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2062",
+            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
+
+        private bool TryFromListToIList([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
+#else
         private bool TryFromListToIList(Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
+#endif
         {
             if ((!Utils.ImplementsInterface(targetType, typeof(ICollection<>)) &&
                 !Utils.ImplementsInterface(targetType, typeof(IList))) ||
@@ -560,7 +591,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return true;
         }
 
+#if NET8_0_OR_GREATER
+        private bool TryFromListToArray([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
+#else
         private bool TryFromListToArray(Type targetType, DynamoDBList list, DynamoDBFlatConfig flatConfig, out object output)
+#endif
         {
             if (!Utils.CanInstantiateArray(targetType))
             {
@@ -584,7 +619,13 @@ namespace Amazon.DynamoDBv2.DataModel
             return true;
         }
 
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
+            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
+        private bool TryFromMap([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, Document map, DynamoDBFlatConfig flatConfig, out object output)
+#else
         private bool TryFromMap(Type targetType, Document map, DynamoDBFlatConfig flatConfig, out object output)
+#endif
         {
             output = null;
 
@@ -655,7 +696,14 @@ namespace Amazon.DynamoDBv2.DataModel
                 return SerializeToDocument(value, type, flatConfig);
             }
         }
+
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
+            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
+        private bool TryToMap(object value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, DynamoDBFlatConfig flatConfig, out Document output)
+#else
         private bool TryToMap(object value, Type type, DynamoDBFlatConfig flatConfig, out Document output)
+#endif
         {
             output = null;
 
@@ -687,7 +735,12 @@ namespace Amazon.DynamoDBv2.DataModel
             }
             return true;
         }
+
+#if NET8_0_OR_GREATER
+        private bool TryToList(object value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type, DynamoDBFlatConfig flatConfig, out DynamoDBList output)
+#else
         private bool TryToList(object value, Type type, DynamoDBFlatConfig flatConfig, out DynamoDBList output)
+#endif
         {
             if (!Utils.ImplementsInterface(type, typeof(ICollection<>)))
             {
@@ -754,12 +807,21 @@ namespace Amazon.DynamoDBv2.DataModel
             return false;
         }
 
+#if NET8_0_OR_GREATER
+        private static bool IsSupportedDictionaryType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type, out Type valueType)
+#else
         private static bool IsSupportedDictionaryType(Type type, out Type valueType)
+#endif
         {
             Type keyType;
             return IsSupportedDictionaryType(type, out keyType, out valueType);
         }
+
+#if NET8_0_OR_GREATER
+        private static bool IsSupportedDictionaryType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type, out Type keyType, out Type valueType)
+#else
         private static bool IsSupportedDictionaryType(Type type, out Type keyType, out Type valueType)
+#endif
         {
             keyType = valueType = null;
 
@@ -783,7 +845,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Deserializes a given Document to instance of targetType
         /// Use only for property conversions, not for full item conversion
         /// </summary>
+#if NET8_0_OR_GREATER
+        private object DeserializeFromDocument(Document document, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType, DynamoDBFlatConfig flatConfig)
+#else
         private object DeserializeFromDocument(Document document, Type targetType, DynamoDBFlatConfig flatConfig)
+#endif
         {
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig(targetType, flatConfig, conversionOnly: true);
             ItemStorage storage = new ItemStorage(storageConfig);
@@ -796,7 +862,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Serializes a given value to Document
         /// Use only for property conversions, not for full item conversion
         /// </summary>
+#if NET8_0_OR_GREATER
+        private Document SerializeToDocument(object value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, DynamoDBFlatConfig flatConfig)
+#else
         private Document SerializeToDocument(object value, Type type, DynamoDBFlatConfig flatConfig)
+#endif
         {
             ItemStorageConfig config = StorageConfigCache.GetConfig(type, flatConfig, conversionOnly: true);
             var itemStorage = ObjectToItemStorageHelper(value, config, flatConfig, keysOnly: false, ignoreNullValues: flatConfig.IgnoreNullValues.Value);
@@ -1141,7 +1211,13 @@ namespace Amazon.DynamoDBv2.DataModel
                 FlatConfig = flatConfig;
             }
         }
+
+#if NET8_0_OR_GREATER
+        private IEnumerable<T> FromSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ContextSearch cs)
+
+#else
         private IEnumerable<T> FromSearch<T>(ContextSearch cs)
+#endif
         {
             if (cs == null) throw new ArgumentNullException("cs");
 
@@ -1169,7 +1245,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         #region Scan/Query
 
+#if NET8_0_OR_GREATER
+        private ContextSearch ConvertScan<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig)
+#else
         private ContextSearch ConvertScan<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, this.Config);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
@@ -1191,7 +1271,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return new ContextSearch(scan, flatConfig);
         }
 
+#if NET8_0_OR_GREATER
+        private ContextSearch ConvertFromScan<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig)
+#else
         private ContextSearch ConvertFromScan<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
@@ -1202,7 +1286,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return new ContextSearch(search, flatConfig);
         }
 
+#if NET8_0_OR_GREATER
+        private ContextSearch ConvertFromQuery<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig)
+#else
         private ContextSearch ConvertFromQuery<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
@@ -1213,7 +1301,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return new ContextSearch(search, flatConfig);
         }
 
+#if NET8_0_OR_GREATER
+        private ContextSearch ConvertQueryByValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig)
+#else
         private ContextSearch ConvertQueryByValue<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig)
+#endif
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             ItemStorageConfig storageConfig = StorageConfigCache.GetConfig<T>(flatConfig);
@@ -1222,7 +1314,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return query;
         }
 
+#if NET8_0_OR_GREATER
+        private ContextSearch ConvertQueryByValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, IEnumerable<QueryCondition> conditions, DynamoDBOperationConfig operationConfig, ItemStorageConfig storageConfig = null)
+#else
         private ContextSearch ConvertQueryByValue<T>(object hashKeyValue, IEnumerable<QueryCondition> conditions, DynamoDBOperationConfig operationConfig, ItemStorageConfig storageConfig = null)
+#endif
         {
             DynamoDBFlatConfig flatConfig = new DynamoDBFlatConfig(operationConfig, Config);
             if (storageConfig == null)
@@ -1232,6 +1328,7 @@ namespace Amazon.DynamoDBv2.DataModel
             QueryFilter filter = ComposeQueryFilter(flatConfig, hashKeyValue, conditions, storageConfig, out indexNames);
             return ConvertQueryHelper<T>(flatConfig, storageConfig, filter, indexNames);
         }
+
         private ContextSearch ConvertQueryHelper<T>(DynamoDBFlatConfig currentConfig, ItemStorageConfig storageConfig, QueryFilter filter, List<string> indexNames)
         {
             Table table = GetTargetTable(storageConfig, currentConfig);
@@ -1261,7 +1358,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return new ContextSearch(query, currentConfig);
         }
 
+#if NET8_0_OR_GREATER
+        private AsyncSearch<T> FromSearchAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ContextSearch contextSearch)
+#else
         private AsyncSearch<T> FromSearchAsync<T>(ContextSearch contextSearch)
+#endif
         {
             return new AsyncSearch<T>(this, contextSearch);
         }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/DeleteConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/DeleteConfig.cs
@@ -18,10 +18,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the Delete operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class DeleteConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/FromDocumentConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/FromDocumentConfig.cs
@@ -20,10 +20,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the FromDocument operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class FromDocumentConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/FromQueryConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/FromQueryConfig.cs
@@ -22,10 +22,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Additional input for the FromQuery operation in the object-persistence programming model. This supplements
     /// <see cref="QueryOperationConfig"/>, which is shared between the document and object-persistence models.
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class FromQueryConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/FromScanConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/FromScanConfig.cs
@@ -23,10 +23,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Additional input for the FromScan operation in the object-persistence programming model. This supplements
     /// <see cref="ScanOperationConfig"/>, which is shared between the document and object-persistence models.
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class FromScanConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/GetTargetTableConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/GetTargetTableConfig.cs
@@ -18,10 +18,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the GetTargetTable operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class GetTargetTableConfig : BaseOperationConfig
     {
         /// <inheritdoc/>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using Amazon.DynamoDBv2.DocumentModel;
 
@@ -51,8 +52,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type to serialize as.</typeparam>
         /// <param name="value">Object to serialize.</param>
         /// <returns><see cref="Document"/> with attributes populated from object.</returns>
+#if NET8_0_OR_GREATER
+        Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value);
+#else
         Document ToDocument<T>(T value);
-
+#endif
         /// <summary>
         /// Serializes an object to a <see cref="Document"/>.
         /// </summary>
@@ -61,7 +65,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns><see cref="Document"/> with attributes populated from object.</returns>
         [Obsolete("Use the ToDocument overload that takes ToDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to ToDocument.")]
+#if NET8_0_OR_GREATER
+        Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig);
+#else
         Document ToDocument<T>(T value, DynamoDBOperationConfig operationConfig);
+#endif
 
         /// <summary>
         /// Serializes an object to a <see cref="Document"/>.
@@ -70,7 +78,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="value">Object to serialize.</param>
         /// <param name="toDocumentConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns><see cref="Document"/> with attributes populated from object.</returns>
+#if NET8_0_OR_GREATER
+        Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, ToDocumentConfig toDocumentConfig);
+#else
         Document ToDocument<T>(T value, ToDocumentConfig toDocumentConfig);
+#endif
 
         #endregion
 
@@ -84,7 +96,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>
         /// Object of type T, populated with properties from the document.
         /// </returns>
+#if NET8_0_OR_GREATER
+        T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document);
+#else
         T FromDocument<T>(Document document);
+#endif
 
         /// <summary>
         /// Deserializes a <see cref="Document"/> to an instance of type T.
@@ -96,8 +112,12 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Object of type T, populated with properties from the document.
         /// </returns>
         [Obsolete("Use the FromDocument overload that takes FromDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromDocument.")]
-
+#if NET8_0_OR_GREATER
+        T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, DynamoDBOperationConfig operationConfig);
+#else
         T FromDocument<T>(Document document, DynamoDBOperationConfig operationConfig);
+#endif
+
 
         /// <summary>
         /// Deserializes a <see cref="Document"/> to an instance of type T.
@@ -108,7 +128,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>
         /// Object of type T, populated with properties from the document.
         /// </returns>
+#if NET8_0_OR_GREATER
+        T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, FromDocumentConfig fromDocumentConfig);
+#else
         T FromDocument<T>(Document document, FromDocumentConfig fromDocumentConfig);
+#endif
 
         /// <summary>
         /// Deserializes a collections of documents to a collection of instances of type T.
@@ -118,7 +142,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>
         /// Collection of items of type T, each populated with properties from a corresponding document.
         /// </returns>
+#if NET8_0_OR_GREATER
+        IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents);
+#else
         IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents);
+#endif
 
         /// <summary>
         /// Deserializes a collections of documents to a collection of instances of type T.
@@ -130,7 +158,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Collection of items of type T, each populated with properties from a corresponding document.
         /// </returns>
         [Obsolete("Use the FromDocuments overload that takes FromDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromDocuments.")]
+#if NET8_0_OR_GREATER
+        IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig);
+#else
         IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig);
+#endif
 
         /// <summary>
         /// Deserializes a collections of documents to a collection of instances of type T.
@@ -141,7 +173,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>
         /// Collection of items of type T, each populated with properties from a corresponding document.
         /// </returns>
+#if NET8_0_OR_GREATER
+        IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig);
+#else
         IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig);
+#endif
 
         #endregion
 
@@ -153,7 +189,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to get</typeparam>
         /// <returns>Empty strongly-typed BatchGet object</returns>
+#if NET8_0_OR_GREATER
+        IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
+#else
         IBatchGet<T> CreateBatchGet<T>();
+#endif
 
         /// <summary>
         /// Creates a strongly-typed BatchGet object, allowing
@@ -163,7 +203,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>A BatchGet object using this context's configuration, which can be used to prepare and execute a BatchGet request</returns>
         [Obsolete("Use the CreateBatchGet overload that takes BatchGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
+#if NET8_0_OR_GREATER
+        IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
+#else
         IBatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Creates a strongly-typed BatchGet object, allowing
@@ -172,7 +216,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to get</typeparam>
         /// <param name="batchGetConfig">Config object that can be used to override properties on the table's context for this request</param>
         /// <returns>A BatchGet object based on the provided <see cref="BatchGetConfig"/>, which can be used to prepare and execute a BatchGet request</returns>
+#if NET8_0_OR_GREATER
+        IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(BatchGetConfig batchGetConfig);
+#else
         IBatchGet<T> CreateBatchGet<T>(BatchGetConfig batchGetConfig);
+#endif
 
         /// <summary>
         /// Creates a MultiTableBatchGet object, composed of multiple
@@ -192,7 +240,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
+#if NET8_0_OR_GREATER
+        IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
+#else
         IBatchWrite<T> CreateBatchWrite<T>();
+#endif
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -202,8 +254,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-
+#if NET8_0_OR_GREATER
+        IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
+#else
         IBatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -217,7 +272,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <param name="valuesType">The type of data which will be persisted in this batch.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
+#if NET8_0_OR_GREATER
+        IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType);
+#else
         IBatchWrite<object> CreateBatchWrite(Type valuesType);
+#endif
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -233,7 +292,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
+#if NET8_0_OR_GREATER
+        IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, DynamoDBOperationConfig operationConfig = null);
+#else
         IBatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -242,7 +305,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <param name="batchWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
+#if NET8_0_OR_GREATER
+        IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(BatchWriteConfig batchWriteConfig);
+#else
         IBatchWrite<T> CreateBatchWrite<T>(BatchWriteConfig batchWriteConfig);
+#endif
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -257,7 +324,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="valuesType">The type of data which will be persisted in this batch.</param>
         /// <param name="batchWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
+#if NET8_0_OR_GREATER
+        IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, BatchWriteConfig batchWriteConfig);
+#else
         IBatchWrite<object> CreateBatchWrite(Type valuesType, BatchWriteConfig batchWriteConfig);
+#endif
 
         /// <summary>
         /// Creates a MultiTableBatchWrite object, composed of multiple
@@ -277,7 +348,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to get.</typeparam>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
+#if NET8_0_OR_GREATER
+        ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
+#else
         ITransactGet<T> CreateTransactGet<T>();
+#endif
 
         /// <summary>
         /// Creates a strongly-typed TransactGet object, allowing
@@ -287,7 +362,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
         [Obsolete("Use the CreateTransactGet overload that takes TransactGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
+#if NET8_0_OR_GREATER
+        ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
+#else
         ITransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Creates a strongly-typed TransactGet object, allowing
@@ -296,7 +375,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to get.</typeparam>
         /// <param name="transactGetConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
+#if NET8_0_OR_GREATER
+        ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(TransactGetConfig transactGetConfig);
+#else
         ITransactGet<T> CreateTransactGet<T>(TransactGetConfig transactGetConfig);
+#endif
 
         /// <summary>
         /// Creates a MultiTableTransactGet object, composed of multiple
@@ -316,7 +399,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to write.</typeparam>
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
+#if NET8_0_OR_GREATER
+        ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
+#else
         ITransactWrite<T> CreateTransactWrite<T>();
+#endif
 
         /// <summary>
         /// Creates a strongly-typed TransactWrite object, allowing
@@ -326,7 +413,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
         [Obsolete("Use the CreateTransactWrite overload that takes TransactWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to CreateTransactWrite.")]
+#if NET8_0_OR_GREATER
+        ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
+#else
         ITransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Creates a strongly-typed TransactWrite object, allowing
@@ -335,7 +426,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to write.</typeparam>
         /// <param name="transactWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
+#if NET8_0_OR_GREATER
+        ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(TransactWriteConfig transactWriteConfig);
+#else
         ITransactWrite<T> CreateTransactWrite<T>(TransactWriteConfig transactWriteConfig);
+#endif
 
         /// <summary>
         /// Creates a MultiTableTransactWrite object, composed of multiple

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/IDynamoDBContext.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 using Amazon.DynamoDBv2.DocumentModel;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -52,11 +53,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type to serialize as.</typeparam>
         /// <param name="value">Object to serialize.</param>
         /// <returns><see cref="Document"/> with attributes populated from object.</returns>
-#if NET8_0_OR_GREATER
-        Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value);
-#else
-        Document ToDocument<T>(T value);
-#endif
+        Document ToDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value);
         /// <summary>
         /// Serializes an object to a <see cref="Document"/>.
         /// </summary>
@@ -65,11 +62,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns><see cref="Document"/> with attributes populated from object.</returns>
         [Obsolete("Use the ToDocument overload that takes ToDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to ToDocument.")]
-#if NET8_0_OR_GREATER
-        Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig);
-#else
-        Document ToDocument<T>(T value, DynamoDBOperationConfig operationConfig);
-#endif
+        Document ToDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBOperationConfig operationConfig);
 
         /// <summary>
         /// Serializes an object to a <see cref="Document"/>.
@@ -78,11 +71,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="value">Object to serialize.</param>
         /// <param name="toDocumentConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns><see cref="Document"/> with attributes populated from object.</returns>
-#if NET8_0_OR_GREATER
-        Document ToDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, ToDocumentConfig toDocumentConfig);
-#else
-        Document ToDocument<T>(T value, ToDocumentConfig toDocumentConfig);
-#endif
+        Document ToDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, ToDocumentConfig toDocumentConfig);
 
         #endregion
 
@@ -96,11 +85,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>
         /// Object of type T, populated with properties from the document.
         /// </returns>
-#if NET8_0_OR_GREATER
-        T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document);
-#else
-        T FromDocument<T>(Document document);
-#endif
+        T FromDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(Document document);
 
         /// <summary>
         /// Deserializes a <see cref="Document"/> to an instance of type T.
@@ -112,11 +97,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Object of type T, populated with properties from the document.
         /// </returns>
         [Obsolete("Use the FromDocument overload that takes FromDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromDocument.")]
-#if NET8_0_OR_GREATER
-        T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, DynamoDBOperationConfig operationConfig);
-#else
-        T FromDocument<T>(Document document, DynamoDBOperationConfig operationConfig);
-#endif
+        T FromDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(Document document, DynamoDBOperationConfig operationConfig);
 
 
         /// <summary>
@@ -128,11 +109,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>
         /// Object of type T, populated with properties from the document.
         /// </returns>
-#if NET8_0_OR_GREATER
-        T FromDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Document document, FromDocumentConfig fromDocumentConfig);
-#else
-        T FromDocument<T>(Document document, FromDocumentConfig fromDocumentConfig);
-#endif
+        T FromDocument<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(Document document, FromDocumentConfig fromDocumentConfig);
 
         /// <summary>
         /// Deserializes a collections of documents to a collection of instances of type T.
@@ -142,11 +119,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>
         /// Collection of items of type T, each populated with properties from a corresponding document.
         /// </returns>
-#if NET8_0_OR_GREATER
-        IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents);
-#else
-        IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents);
-#endif
+        IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<Document> documents);
 
         /// <summary>
         /// Deserializes a collections of documents to a collection of instances of type T.
@@ -158,11 +131,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Collection of items of type T, each populated with properties from a corresponding document.
         /// </returns>
         [Obsolete("Use the FromDocuments overload that takes FromDocumentConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromDocuments.")]
-#if NET8_0_OR_GREATER
-        IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig);
-#else
-        IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig);
-#endif
+        IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<Document> documents, DynamoDBOperationConfig operationConfig);
 
         /// <summary>
         /// Deserializes a collections of documents to a collection of instances of type T.
@@ -173,11 +142,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>
         /// Collection of items of type T, each populated with properties from a corresponding document.
         /// </returns>
-#if NET8_0_OR_GREATER
-        IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig);
-#else
-        IEnumerable<T> FromDocuments<T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig);
-#endif
+        IEnumerable<T> FromDocuments<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<Document> documents, FromDocumentConfig fromDocumentConfig);
 
         #endregion
 
@@ -189,11 +154,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to get</typeparam>
         /// <returns>Empty strongly-typed BatchGet object</returns>
-#if NET8_0_OR_GREATER
-        IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
-#else
-        IBatchGet<T> CreateBatchGet<T>();
-#endif
+        IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>();
 
         /// <summary>
         /// Creates a strongly-typed BatchGet object, allowing
@@ -203,11 +164,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>A BatchGet object using this context's configuration, which can be used to prepare and execute a BatchGet request</returns>
         [Obsolete("Use the CreateBatchGet overload that takes BatchGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-#if NET8_0_OR_GREATER
-        IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
-#else
-        IBatchGet<T> CreateBatchGet<T>(DynamoDBOperationConfig operationConfig = null);
-#endif
+        IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed BatchGet object, allowing
@@ -216,11 +173,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to get</typeparam>
         /// <param name="batchGetConfig">Config object that can be used to override properties on the table's context for this request</param>
         /// <returns>A BatchGet object based on the provided <see cref="BatchGetConfig"/>, which can be used to prepare and execute a BatchGet request</returns>
-#if NET8_0_OR_GREATER
-        IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(BatchGetConfig batchGetConfig);
-#else
-        IBatchGet<T> CreateBatchGet<T>(BatchGetConfig batchGetConfig);
-#endif
+        IBatchGet<T> CreateBatchGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(BatchGetConfig batchGetConfig);
 
         /// <summary>
         /// Creates a MultiTableBatchGet object, composed of multiple
@@ -240,11 +193,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-#if NET8_0_OR_GREATER
-        IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
-#else
-        IBatchWrite<T> CreateBatchWrite<T>();
-#endif
+        IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>();
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -254,11 +203,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-#if NET8_0_OR_GREATER
-        IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
-#else
-        IBatchWrite<T> CreateBatchWrite<T>(DynamoDBOperationConfig operationConfig = null);
-#endif
+        IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -272,11 +217,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <param name="valuesType">The type of data which will be persisted in this batch.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-#if NET8_0_OR_GREATER
-        IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType);
-#else
-        IBatchWrite<object> CreateBatchWrite(Type valuesType);
-#endif
+        IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valuesType);
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -292,11 +233,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
         [Obsolete("Use the CreateBatchWrite overload that takes BatchWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchWrite.")]
-#if NET8_0_OR_GREATER
-        IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, DynamoDBOperationConfig operationConfig = null);
-#else
-        IBatchWrite<object> CreateBatchWrite(Type valuesType, DynamoDBOperationConfig operationConfig = null);
-#endif
+        IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valuesType, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -305,11 +242,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to write</typeparam>
         /// <param name="batchWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-#if NET8_0_OR_GREATER
-        IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(BatchWriteConfig batchWriteConfig);
-#else
-        IBatchWrite<T> CreateBatchWrite<T>(BatchWriteConfig batchWriteConfig);
-#endif
+        IBatchWrite<T> CreateBatchWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(BatchWriteConfig batchWriteConfig);
 
         /// <summary>
         /// Creates a strongly-typed BatchWrite object, allowing
@@ -324,11 +257,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="valuesType">The type of data which will be persisted in this batch.</param>
         /// <param name="batchWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>Empty strongly-typed BatchWrite object</returns>
-#if NET8_0_OR_GREATER
-        IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valuesType, BatchWriteConfig batchWriteConfig);
-#else
-        IBatchWrite<object> CreateBatchWrite(Type valuesType, BatchWriteConfig batchWriteConfig);
-#endif
+        IBatchWrite<object> CreateBatchWrite([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valuesType, BatchWriteConfig batchWriteConfig);
 
         /// <summary>
         /// Creates a MultiTableBatchWrite object, composed of multiple
@@ -348,11 +277,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to get.</typeparam>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
-#if NET8_0_OR_GREATER
-        ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
-#else
-        ITransactGet<T> CreateTransactGet<T>();
-#endif
+        ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>();
 
         /// <summary>
         /// Creates a strongly-typed TransactGet object, allowing
@@ -362,11 +287,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
         [Obsolete("Use the CreateTransactGet overload that takes TransactGetConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to BatchGet.")]
-#if NET8_0_OR_GREATER
-        ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
-#else
-        ITransactGet<T> CreateTransactGet<T>(DynamoDBOperationConfig operationConfig = null);
-#endif
+        ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed TransactGet object, allowing
@@ -375,11 +296,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to get.</typeparam>
         /// <param name="transactGetConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>Empty strongly-typed TransactGet object.</returns>
-#if NET8_0_OR_GREATER
-        ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(TransactGetConfig transactGetConfig);
-#else
-        ITransactGet<T> CreateTransactGet<T>(TransactGetConfig transactGetConfig);
-#endif
+        ITransactGet<T> CreateTransactGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(TransactGetConfig transactGetConfig);
 
         /// <summary>
         /// Creates a MultiTableTransactGet object, composed of multiple
@@ -399,11 +316,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type of objects to write.</typeparam>
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
-#if NET8_0_OR_GREATER
-        ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
-#else
-        ITransactWrite<T> CreateTransactWrite<T>();
-#endif
+        ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>();
 
         /// <summary>
         /// Creates a strongly-typed TransactWrite object, allowing
@@ -413,11 +326,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
         [Obsolete("Use the CreateTransactWrite overload that takes TransactWriteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to CreateTransactWrite.")]
-#if NET8_0_OR_GREATER
-        ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
-#else
-        ITransactWrite<T> CreateTransactWrite<T>(DynamoDBOperationConfig operationConfig = null);
-#endif
+        ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Creates a strongly-typed TransactWrite object, allowing
@@ -426,11 +335,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of objects to write.</typeparam>
         /// <param name="transactWriteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>Empty strongly-typed TransactWrite object.</returns>
-#if NET8_0_OR_GREATER
-        ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(TransactWriteConfig transactWriteConfig);
-#else
-        ITransactWrite<T> CreateTransactWrite<T>(TransactWriteConfig transactWriteConfig);
-#endif
+        ITransactWrite<T> CreateTransactWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(TransactWriteConfig transactWriteConfig);
 
         /// <summary>
         /// Creates a MultiTableTransactWrite object, composed of multiple

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -36,9 +36,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Basic property storage information
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class SimplePropertyStorage
     {
         // local property name
@@ -51,21 +48,34 @@ namespace Amazon.DynamoDBv2.DataModel
         // Type of the property
 
 #if NET8_0_OR_GREATER
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 #endif
         public Type MemberType { get; protected set; }
         // Converter type, if one is present
+
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
         public Type ConverterType { get; set; }
         // Converter, if one is present
         public IPropertyConverter Converter { get; protected set; }
 
-        public SimplePropertyStorage(MemberInfo member)
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072",
+            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
+#endif
+        internal SimplePropertyStorage(MemberInfo member)
             : this(Utils.GetType(member))
         {
             Member = member;
             PropertyName = member.Name;
         }
+
+#if NET8_0_OR_GREATER
+        public SimplePropertyStorage([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]Type memberType)
+#else
         public SimplePropertyStorage(Type memberType)
+#endif
         {
             MemberType = memberType;
         }
@@ -80,9 +90,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// DynamoDB property storage information
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class PropertyStorage : SimplePropertyStorage
     {
         // flags
@@ -188,7 +195,11 @@ namespace Amazon.DynamoDBv2.DataModel
                 IndexNames.AddRange(index.IndexNames);
         }
 
-        public PropertyStorage(MemberInfo member)
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
+#endif
+        internal PropertyStorage(MemberInfo member)
             : base(member)
         {
             IndexNames = new List<string>();
@@ -199,9 +210,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Storage information for a single item
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class ItemStorage
     {
         public Document Document { get; set; }
@@ -238,9 +246,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Storage information for a specific class
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class StorageConfig
     {
         // normalized PropertyStorage objects
@@ -310,7 +315,11 @@ namespace Amazon.DynamoDBv2.DataModel
             throw new InvalidOperationException(errorMessage);
         }
 
+#if NET8_0_OR_GREATER
+        private static Dictionary<string, MemberInfo> GetMembersDictionary([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
+#else
         private static Dictionary<string, MemberInfo> GetMembersDictionary(Type type)
+#endif
         {
             Dictionary<string, MemberInfo> dictionary = new Dictionary<string, MemberInfo>(StringComparer.Ordinal);
 
@@ -324,9 +333,14 @@ namespace Amazon.DynamoDBv2.DataModel
             return dictionary;
         }
 
-        
+
+
         // constructor
-        public StorageConfig(Type targetType)
+#if NET8_0_OR_GREATER
+        internal StorageConfig([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType)
+#else
+        internal StorageConfig(Type targetType)
+#endif
         {
             if (!Utils.CanInstantiate(targetType))
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
@@ -346,9 +360,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Storage information for a specific class that is associated with a table
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class ItemStorageConfig : StorageConfig
     {
         // table
@@ -558,7 +569,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
 
         // constructor
-        public ItemStorageConfig(Type targetType)
+#if NET8_0_OR_GREATER
+        internal ItemStorageConfig([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType)
+#else
+        internal ItemStorageConfig(Type targetType)
+#endif
             : base(targetType)
         {
             AttributeToIndexesNameMapping = new Dictionary<string, List<string>>(StringComparer.Ordinal);
@@ -575,9 +590,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Cache of ItemStorageConfig objects
     /// </summary>
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class ItemStorageConfigCache : IDisposable
     {
         // Cache of ItemStorageConfig objects per table and the
@@ -607,12 +619,21 @@ namespace Amazon.DynamoDBv2.DataModel
             Context = context;
         }
 
+#if NET8_0_OR_GREATER
+        public ItemStorageConfig GetConfig<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
+#else
         public ItemStorageConfig GetConfig<T>(DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
+#endif
         {
             Type type = typeof(T);
             return GetConfig(type, flatConfig, conversionOnly);
         }
+
+#if NET8_0_OR_GREATER
+        public ItemStorageConfig GetConfig([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
+#else
         public ItemStorageConfig GetConfig(Type type, DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
+#endif
         {
             ConfigTableCache tableCache = null;
             ItemStorageConfig config;
@@ -697,7 +718,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return (config.LowerCamelCaseProperties ? Utils.ToLowerCamelCase(value) : value);
         }
 
+#if NET8_0_OR_GREATER
+        private ItemStorageConfig CreateStorageConfig([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type baseType, string actualTableName, DynamoDBFlatConfig flatConfig)
+#else
         private ItemStorageConfig CreateStorageConfig(Type baseType, string actualTableName, DynamoDBFlatConfig flatConfig)
+#endif
         {
             if (baseType == null) 
                 throw new ArgumentNullException("baseType");
@@ -745,7 +770,11 @@ namespace Amazon.DynamoDBv2.DataModel
             return config;
         }
 
+#if NET8_0_OR_GREATER
+        private static void PopulateConfigFromType(ItemStorageConfig config, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]  Type type)
+#else
         private static void PopulateConfigFromType(ItemStorageConfig config, Type type)
+#endif
         {
             DynamoDBTableAttribute tableAttribute = Utils.GetTableAttribute(type);
             if (tableAttribute == null)

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -30,6 +30,7 @@ using Amazon.Runtime;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
 using Amazon.Util.Internal;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -47,23 +48,17 @@ namespace Amazon.DynamoDBv2.DataModel
         public MemberInfo Member { get; protected set; }
         // Type of the property
 
-#if NET8_0_OR_GREATER
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-#endif
+        [DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)]
         public Type MemberType { get; protected set; }
         // Converter type, if one is present
 
-#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
         public Type ConverterType { get; set; }
         // Converter, if one is present
         public IPropertyConverter Converter { get; protected set; }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072",
             Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
-#endif
         internal SimplePropertyStorage(MemberInfo member)
             : this(Utils.GetType(member))
         {
@@ -71,11 +66,7 @@ namespace Amazon.DynamoDBv2.DataModel
             PropertyName = member.Name;
         }
 
-#if NET8_0_OR_GREATER
-        public SimplePropertyStorage([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]Type memberType)
-#else
-        public SimplePropertyStorage(Type memberType)
-#endif
+        public SimplePropertyStorage([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)]Type memberType)
         {
             MemberType = memberType;
         }
@@ -195,10 +186,8 @@ namespace Amazon.DynamoDBv2.DataModel
                 IndexNames.AddRange(index.IndexNames);
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
             Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
-#endif
         internal PropertyStorage(MemberInfo member)
             : base(member)
         {
@@ -315,11 +304,7 @@ namespace Amazon.DynamoDBv2.DataModel
             throw new InvalidOperationException(errorMessage);
         }
 
-#if NET8_0_OR_GREATER
-        private static Dictionary<string, MemberInfo> GetMembersDictionary([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
-#else
-        private static Dictionary<string, MemberInfo> GetMembersDictionary(Type type)
-#endif
+        private static Dictionary<string, MemberInfo> GetMembersDictionary([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type type)
         {
             Dictionary<string, MemberInfo> dictionary = new Dictionary<string, MemberInfo>(StringComparer.Ordinal);
 
@@ -336,11 +321,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
 
         // constructor
-#if NET8_0_OR_GREATER
-        internal StorageConfig([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType)
-#else
-        internal StorageConfig(Type targetType)
-#endif
+        internal StorageConfig([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type targetType)
         {
             if (!Utils.CanInstantiate(targetType))
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
@@ -569,11 +550,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
 
         // constructor
-#if NET8_0_OR_GREATER
-        internal ItemStorageConfig([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType)
-#else
-        internal ItemStorageConfig(Type targetType)
-#endif
+        internal ItemStorageConfig([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type targetType)
             : base(targetType)
         {
             AttributeToIndexesNameMapping = new Dictionary<string, List<string>>(StringComparer.Ordinal);
@@ -619,21 +596,13 @@ namespace Amazon.DynamoDBv2.DataModel
             Context = context;
         }
 
-#if NET8_0_OR_GREATER
-        public ItemStorageConfig GetConfig<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
-#else
-        public ItemStorageConfig GetConfig<T>(DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
-#endif
+        public ItemStorageConfig GetConfig<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
         {
             Type type = typeof(T);
             return GetConfig(type, flatConfig, conversionOnly);
         }
 
-#if NET8_0_OR_GREATER
-        public ItemStorageConfig GetConfig([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
-#else
-        public ItemStorageConfig GetConfig(Type type, DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
-#endif
+        public ItemStorageConfig GetConfig([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type type, DynamoDBFlatConfig flatConfig, bool conversionOnly = false)
         {
             ConfigTableCache tableCache = null;
             ItemStorageConfig config;
@@ -718,11 +687,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return (config.LowerCamelCaseProperties ? Utils.ToLowerCamelCase(value) : value);
         }
 
-#if NET8_0_OR_GREATER
-        private ItemStorageConfig CreateStorageConfig([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type baseType, string actualTableName, DynamoDBFlatConfig flatConfig)
-#else
-        private ItemStorageConfig CreateStorageConfig(Type baseType, string actualTableName, DynamoDBFlatConfig flatConfig)
-#endif
+        private ItemStorageConfig CreateStorageConfig([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type baseType, string actualTableName, DynamoDBFlatConfig flatConfig)
         {
             if (baseType == null) 
                 throw new ArgumentNullException("baseType");
@@ -770,11 +735,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return config;
         }
 
-#if NET8_0_OR_GREATER
-        private static void PopulateConfigFromType(ItemStorageConfig config, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]  Type type)
-#else
-        private static void PopulateConfigFromType(ItemStorageConfig config, Type type)
-#endif
+        private static void PopulateConfigFromType(ItemStorageConfig config, [DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)]  Type type)
         {
             DynamoDBTableAttribute tableAttribute = Utils.GetTableAttribute(type);
             if (tableAttribute == null)

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/LoadConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/LoadConfig.cs
@@ -20,10 +20,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the Load operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class LoadConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/QueryConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/QueryConfig.cs
@@ -22,10 +22,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the Query operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class QueryConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3ClientCache.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3ClientCache.cs
@@ -62,8 +62,8 @@ namespace Amazon.DynamoDBv2.DataModel
                         }
 
                         var msg = string.Format(CultureInfo.CurrentCulture,
-                            "Assembly {0} could not be found or loaded. This assembly must be available at runtime to use Amazon.Runtime.AssumeRoleAWSCredentials.",
-                            ServiceClientHelpers.STS_ASSEMBLY_NAME);
+                            "Assembly {0} could not be found or loaded. This assembly must be available at runtime to use the DynamoDB feature S3 Link.",
+                            ServiceClientHelpers.S3_ASSEMBLY_NAME);
                         var exception = new InvalidOperationException(msg, e);
                         Logger.GetLogger(typeof(S3ClientCache)).Error(exception, exception.Message);
                         throw exception;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3ClientCache.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3ClientCache.cs
@@ -48,7 +48,7 @@ namespace Amazon.DynamoDBv2.DataModel
                 output = GlobalRuntimeDependencyRegistry.Instance.GetInstance<ICoreAmazonS3>(ServiceClientHelpers.S3_ASSEMBLY_NAME, ServiceClientHelpers.S3_SERVICE_CLASS_NAME,
                     new CreateInstanceContext(new S3ClientContext { Action = S3ClientContext.ActionContext.DynamoBDS3Link, Region = region }));
 
-                if (output != null)
+                if (output == null)
                 {
                     try
                     {

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3ClientCache.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3ClientCache.cs
@@ -10,6 +10,8 @@ using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.SharedInterfaces;
 using Amazon.RuntimeDependencies;
 using Amazon.Util.Internal;
+using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -35,10 +37,8 @@ namespace Amazon.DynamoDBv2.DataModel
             this.clientsByRegion.Add(region.SystemName, client);
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", 
             Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
-#endif
         internal ICoreAmazonS3 GetClient(RegionEndpoint region)
         {
             ICoreAmazonS3 output;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3ClientCache.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/S3ClientCache.cs
@@ -1,17 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.SharedInterfaces;
+using Amazon.RuntimeDependencies;
+using Amazon.Util.Internal;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     internal class S3ClientCache
     {
         private AmazonDynamoDBClient ddbClient;
@@ -34,12 +35,40 @@ namespace Amazon.DynamoDBv2.DataModel
             this.clientsByRegion.Add(region.SystemName, client);
         }
 
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", 
+            Justification = "Reflection code is only used as a fallback in case the SDK was not trimmed. Trimmed scenarios should register dependencies with Amazon.RuntimeDependencyRegistry.GlobalRuntimeDependencyRegistry")]
+#endif
         internal ICoreAmazonS3 GetClient(RegionEndpoint region)
         {
             ICoreAmazonS3 output;
+
             if (!this.clientsByRegion.TryGetValue(region.SystemName, out output))
             {
-                output = ServiceClientHelpers.CreateServiceFromAssembly<ICoreAmazonS3>(ServiceClientHelpers.S3_ASSEMBLY_NAME, ServiceClientHelpers.S3_SERVICE_CLASS_NAME, this.ddbClient);
+                output = GlobalRuntimeDependencyRegistry.Instance.GetInstance<ICoreAmazonS3>(ServiceClientHelpers.S3_ASSEMBLY_NAME, ServiceClientHelpers.S3_SERVICE_CLASS_NAME,
+                    new CreateInstanceContext(new S3ClientContext { Action = S3ClientContext.ActionContext.DynamoBDS3Link, Region = region }));
+
+                if (output != null)
+                {
+                    try
+                    {
+                        output = ServiceClientHelpers.CreateServiceFromAssembly<ICoreAmazonS3>(ServiceClientHelpers.S3_ASSEMBLY_NAME, ServiceClientHelpers.S3_SERVICE_CLASS_NAME, this.ddbClient);
+                    }
+                    catch (Exception e)
+                    {
+                        if (InternalSDKUtils.IsRunningNativeAot())
+                        {
+                            throw new MissingRuntimeDependencyException(ServiceClientHelpers.S3_ASSEMBLY_NAME, ServiceClientHelpers.S3_SERVICE_CLASS_NAME, nameof(GlobalRuntimeDependencyRegistry.RegisterS3Client));
+                        }
+
+                        var msg = string.Format(CultureInfo.CurrentCulture,
+                            "Assembly {0} could not be found or loaded. This assembly must be available at runtime to use Amazon.Runtime.AssumeRoleAWSCredentials.",
+                            ServiceClientHelpers.STS_ASSEMBLY_NAME);
+                        var exception = new InvalidOperationException(msg, e);
+                        Logger.GetLogger(typeof(S3ClientCache)).Error(exception, exception.Message);
+                        throw exception;
+                    }
+                }
                 this.clientsByRegion.Add(region.SystemName, output);
             }
             return output;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/SaveConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/SaveConfig.cs
@@ -18,10 +18,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the Save operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class SaveConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ScanConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ScanConfig.cs
@@ -22,10 +22,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the Scan operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class ScanConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/ToDocumentConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/ToDocumentConfig.cs
@@ -18,10 +18,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the ToDocument operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class ToDocumentConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGet.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGet.cs
@@ -15,6 +15,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
 #if AWS_ASYNC_API
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,7 +45,11 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a generic interface for retrieving multiple items
     /// from a single DynamoDB table in a transaction.
     /// </summary>
+#if NET8_0_OR_GREATER
+    public interface ITransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : ITransactGet
+#else
     public interface ITransactGet<T> : ITransactGet
+#endif
     {
         /// <summary>
         /// List of generic results retrieved from DynamoDB.
@@ -110,7 +116,12 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a strongly-typed object for retrieving multiple items
     /// from a single DynamoDB table in a transaction.
     /// </summary>
+#if NET8_0_OR_GREATER
+    public partial class TransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : TransactGet, ITransactGet<T>
+#else
     public partial class TransactGet<T> : TransactGet, ITransactGet<T>
+#endif
+
     {
         private readonly DynamoDBContext _context;
         private readonly DynamoDBFlatConfig _config;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGet.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGet.cs
@@ -20,9 +20,11 @@ using System.Diagnostics.CodeAnalysis;
 #if AWS_ASYNC_API
 using System.Threading;
 using System.Threading.Tasks;
+
 #endif
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.Runtime.Telemetry.Tracing;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -45,11 +47,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a generic interface for retrieving multiple items
     /// from a single DynamoDB table in a transaction.
     /// </summary>
-#if NET8_0_OR_GREATER
-    public interface ITransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : ITransactGet
-#else
-    public interface ITransactGet<T> : ITransactGet
-#endif
+    public interface ITransactGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T> : ITransactGet
     {
         /// <summary>
         /// List of generic results retrieved from DynamoDB.
@@ -116,11 +114,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a strongly-typed object for retrieving multiple items
     /// from a single DynamoDB table in a transaction.
     /// </summary>
-#if NET8_0_OR_GREATER
-    public partial class TransactGet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : TransactGet, ITransactGet<T>
-#else
-    public partial class TransactGet<T> : TransactGet, ITransactGet<T>
-#endif
+    public partial class TransactGet<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T> : TransactGet, ITransactGet<T>
 
     {
         private readonly DynamoDBContext _context;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGetConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactGetConfig.cs
@@ -20,10 +20,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the TransactGet operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class TransactGetConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 #if AWS_ASYNC_API
 using System.Threading;
@@ -38,7 +39,11 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a generic interface for writing/deleting/version-checking multiple items
     /// in a single DynamoDB table in a transaction.
     /// </summary>
+#if NET8_0_OR_GREATER
+    public interface ITransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : ITransactWrite
+#else
     public interface ITransactWrite<T> : ITransactWrite
+#endif
     {
         /// <summary>
         /// Creates a MultiTableTransactWrite object that is a combination
@@ -176,9 +181,10 @@ namespace Amazon.DynamoDBv2.DataModel
     /// in a single DynamoDB table in a transaction.
     /// </summary>
 #if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Amazon.DynamoDBv2.Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
+    public partial class TransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : TransactWrite, ITransactWrite<T>
+#else
     public partial class TransactWrite<T> : TransactWrite, ITransactWrite<T>
+#endif
     {
         private readonly DynamoDBContext _context;
         private readonly DynamoDBFlatConfig _config;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
@@ -20,9 +20,11 @@ using System.Globalization;
 #if AWS_ASYNC_API
 using System.Threading;
 using System.Threading.Tasks;
+
 #endif
 using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.Runtime.Telemetry.Tracing;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -39,11 +41,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a generic interface for writing/deleting/version-checking multiple items
     /// in a single DynamoDB table in a transaction.
     /// </summary>
-#if NET8_0_OR_GREATER
-    public interface ITransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : ITransactWrite
-#else
-    public interface ITransactWrite<T> : ITransactWrite
-#endif
+    public interface ITransactWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T> : ITransactWrite
     {
         /// <summary>
         /// Creates a MultiTableTransactWrite object that is a combination
@@ -180,11 +178,7 @@ namespace Amazon.DynamoDBv2.DataModel
     /// Represents a strongly-typed object for writing/deleting/version-checking multiple items
     /// in a single DynamoDB table in a transaction.
     /// </summary>
-#if NET8_0_OR_GREATER
-    public partial class TransactWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : TransactWrite, ITransactWrite<T>
-#else
-    public partial class TransactWrite<T> : TransactWrite, ITransactWrite<T>
-#endif
+    public partial class TransactWrite<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T> : TransactWrite, ITransactWrite<T>
     {
         private readonly DynamoDBContext _context;
         private readonly DynamoDBFlatConfig _config;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWriteConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWriteConfig.cs
@@ -18,10 +18,6 @@ namespace Amazon.DynamoDBv2.DataModel
     /// <summary>
     /// Input for the TransactWrite operation in the object-persistence programming model
     /// </summary>
-#if NET8_0_OR_GREATER
-    // The DataModel namespace doesn't support trimming yet, so annotate public classes/methods as incompatible
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(Custom.Internal.InternalConstants.RequiresUnreferencedCodeMessage)]
-#endif
     public class TransactWriteConfig : BaseOperationConfig
     {
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
@@ -25,6 +25,7 @@ using Amazon.Util.Internal;
 using System.Globalization;
 using System.Collections;
 using Amazon.DynamoDBv2.DocumentModel;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -157,12 +158,8 @@ namespace Amazon.DynamoDBv2.DataModel
             throw new InvalidOperationException("Version property must be of primitive, numeric, integer, nullable type (e.g. int?, long?, byte?)");
         }
 
-#if NET8_0_OR_GREATER
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)]
         internal static Type GetPrimitiveElementType(Type collectionType)
-#else
-        internal static Type GetPrimitiveElementType(Type collectionType)
-#endif
         {
             var elementType = Utils.GetElementType(collectionType);
 
@@ -175,16 +172,12 @@ namespace Amazon.DynamoDBv2.DataModel
             throw new InvalidOperationException("Unable to determine element type");
         }
 
-#if NET8_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2073",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2073",
             Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063",
             Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        [return: DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)]
         internal static Type GetElementType(Type collectionType)
-#else
-        internal static Type GetElementType(Type collectionType)
-#endif
         {
             var elementType = collectionType.GetElementType();
 
@@ -199,22 +192,14 @@ namespace Amazon.DynamoDBv2.DataModel
             return elementType;
         }
 
-#if NET8_0_OR_GREATER
         internal static bool ItemsToCollection([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, IEnumerable<object> items, out object result)
-#else
-        internal static bool ItemsToCollection(Type targetType, IEnumerable<object> items, out object result)
-#endif
         {
             return targetType.IsArray ?
                 ItemsToArray(targetType, items, out result):  //targetType is Array
                 ItemsToIList(targetType, items, out result);  //targetType is IList or has Add method.
         }
 
-#if NET8_0_OR_GREATER
         private static bool ItemsToIList([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, IEnumerable<object> items, out object result)
-#else
-        private static bool ItemsToIList(Type targetType, IEnumerable<object> items, out object result)
-#endif
         {
             result = Utils.Instantiate(targetType);
 
@@ -238,11 +223,7 @@ namespace Amazon.DynamoDBv2.DataModel
             return false;
         }
 
-#if NET8_0_OR_GREATER
         private static bool ItemsToArray([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, IEnumerable<object> items, out object result)
-#else
-        private static bool ItemsToArray(Type targetType, IEnumerable<object> items, out object result)
-#endif
         {
             var itemlist = items.ToList();
             var array = (Array)InstantiateArray(targetType, itemlist.Count);
@@ -339,38 +320,22 @@ namespace Amazon.DynamoDBv2.DataModel
             new Type[] { typeof(DynamoDBContext) }
         };
 
-#if NET8_0_OR_GREATER
         internal static object InstantiateConverter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type objectType, IDynamoDBContext context)
-#else
-        internal static object InstantiateConverter(Type objectType, IDynamoDBContext context)
-#endif
         {
             return InstantiateHelper(objectType, validConverterConstructorInputs, new object[] { context });
         }
 
-#if NET8_0_OR_GREATER
         internal static object InstantiateArray([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type objectType, int length)
-#else
-        internal static object InstantiateArray(Type objectType,int length)
-#endif
         {
             return InstantiateHelper(objectType, validArrayConstructorInputs, new object[] { length });
         }
 
-#if NET8_0_OR_GREATER
         internal static object Instantiate([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type objectType)
-#else
-        internal static object Instantiate(Type objectType)
-#endif
         {
             return InstantiateHelper(objectType, validConstructorInputs, null);
         }
 
-#if NET8_0_OR_GREATER
         private static object InstantiateHelper([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type objectType, Type[][] validConstructorInputs, object[] optionalInput = null)
-#else
-        private static object InstantiateHelper(Type objectType, Type[][] validConstructorInputs, object[] optionalInput = null)
-#endif
         {
             if (objectType == null)
                 throw new ArgumentNullException("objectType");
@@ -394,11 +359,7 @@ namespace Amazon.DynamoDBv2.DataModel
             throw new InvalidOperationException("Unable to find valid constructor for type " + objectType.FullName);
         }
 
-#if NET8_0_OR_GREATER
         private static IEnumerable<ConstructorInfo> GetConstructors([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type typeInfo, Type[][] validConstructorInputs)
-#else
-        private static IEnumerable<ConstructorInfo> GetConstructors(Type typeInfo, Type[][] validConstructorInputs)
-#endif
         {
             foreach (var inputTypes in validConstructorInputs)
             {
@@ -408,38 +369,22 @@ namespace Amazon.DynamoDBv2.DataModel
             }
         }
 
-#if NET8_0_OR_GREATER
         public static bool CanInstantiate([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type objectType)
-#else
-        public static bool CanInstantiate(Type objectType)
-#endif
         {
             return CanInstantiateHelper(objectType, validConstructorInputs);
         }
 
-#if NET8_0_OR_GREATER
         public static bool CanInstantiateArray([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type objectType)
-#else
-        public static bool CanInstantiateArray(Type objectType)
-#endif
         {
             return objectType.IsArray && CanInstantiateHelper(objectType, validArrayConstructorInputs);
         }
 
-#if NET8_0_OR_GREATER
         public static bool CanInstantiateConverter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type objectType)
-#else
-        public static bool CanInstantiateConverter(Type objectType)
-#endif
         {
             return CanInstantiateHelper(objectType, validConverterConstructorInputs);
         }
 
-#if NET8_0_OR_GREATER
         private static bool CanInstantiateHelper([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type objectType, Type[][] validConstructorInputs)
-#else
-        private static bool CanInstantiateHelper(Type objectType, Type[][] validConstructorInputs)
-#endif
         {
             var objectTypeWrapper = objectType;
 
@@ -491,11 +436,7 @@ namespace Amazon.DynamoDBv2.DataModel
             }
         }
 
-#if NET8_0_OR_GREATER
         internal static bool ImplementsInterface([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type targetType, Type interfaceType)
-#else
-        internal static bool ImplementsInterface(Type targetType, Type interfaceType)
-#endif
         {
             if (!interfaceType.IsInterface)
                 throw new ArgumentOutOfRangeException("interfaceType", "Type is not an interface");
@@ -540,11 +481,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// members from the derived types will be used while ignoring same-name members
         /// in base types to avoid returning duplicate members.
         /// </summary>
-#if NET8_0_OR_GREATER
-        internal static List<MemberInfo> GetMembersFromType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
-#else
-        internal static List<MemberInfo> GetMembersFromType(Type type)
-#endif
+        internal static List<MemberInfo> GetMembersFromType([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type type)
 
         {
             Dictionary<string, MemberInfo> members = new Dictionary<string, MemberInfo>();

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Utils.cs
@@ -177,10 +177,10 @@ namespace Amazon.DynamoDBv2.DataModel
 
 #if NET8_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2073",
-            Justification = "By the time the DynamoDB high level libraries got to this code path the collection type with the generic type would have already been found by the compiler preventing the element type from being trimmed.")]
+            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063",
-            Justification = "By the time the DynamoDB high level libraries got to this code path the collection type with the generic type would have already been found by the compiler preventing the element type from being trimmed.")]
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)]
+            Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         internal static Type GetElementType(Type collectionType)
 #else
         internal static Type GetElementType(Type collectionType)
@@ -461,6 +461,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
             return true;
         }
+
         internal static Type GetType(MemberInfo member)
         {
             var pi = member as PropertyInfo;
@@ -470,6 +471,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
             return (pi != null ? pi.PropertyType : fi.FieldType);
         }
+
         internal static bool IsReadWrite(MemberInfo member)
         {
             PropertyInfo property = member as PropertyInfo;

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.Async.cs
@@ -19,14 +19,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
-#if NET8_0_OR_GREATER
-    public partial interface IAsyncSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>
-#else
-    public partial interface IAsyncSearch<T>
-#endif
+    public partial interface IAsyncSearch<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>
     {
         /// <summary>
         /// Initiates the asynchronous execution to get the next set of results from DynamoDB.
@@ -53,11 +50,7 @@ namespace Amazon.DynamoDBv2.DataModel
         Task<List<T>> GetRemainingAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 
-#if NET8_0_OR_GREATER
-    public partial class AsyncSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : IAsyncSearch<T>
-#else
-    public partial class AsyncSearch<T> : IAsyncSearch<T>
-#endif
+    public partial class AsyncSearch<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T> : IAsyncSearch<T>
 
     {
         /// <inheritdoc/>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/AsyncSearch.Async.cs
@@ -15,13 +15,18 @@
 
 using Amazon.Runtime.Telemetry.Tracing;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
+#if NET8_0_OR_GREATER
+    public partial interface IAsyncSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>
+#else
     public partial interface IAsyncSearch<T>
+#endif
     {
         /// <summary>
         /// Initiates the asynchronous execution to get the next set of results from DynamoDB.
@@ -48,7 +53,12 @@ namespace Amazon.DynamoDBv2.DataModel
         Task<List<T>> GetRemainingAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 
+#if NET8_0_OR_GREATER
+    public partial class AsyncSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : IAsyncSearch<T>
+#else
     public partial class AsyncSearch<T> : IAsyncSearch<T>
+#endif
+
     {
         /// <inheritdoc/>
         public virtual async Task<List<T>> GetNextSetAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/Context.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/Context.Async.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2.DocumentModel;
@@ -31,7 +32,11 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Save async
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, CancellationToken cancellationToken = default)
+#else
         public async Task SaveAsync<T>(T value, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -41,7 +46,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the SaveAsync overload that takes SaveConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to SaveAsync.")]
+#if NET8_0_OR_GREATER
+        public async Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#else
         public async Task SaveAsync<T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -50,7 +59,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
+#else
         public async Task SaveAsync<T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -59,7 +72,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, CancellationToken cancellationToken = default)
+#else
         public async Task SaveAsync(Type valueType, object value, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -69,7 +86,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the SaveAsync overload that takes SaveConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to SaveAsync.")]
+#if NET8_0_OR_GREATER
+        public async Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#else
         public async Task SaveAsync(Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -78,7 +99,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
+#else
         public async Task SaveAsync(Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -91,7 +116,11 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Load async
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, CancellationToken cancellationToken = default)
+#else
         public async Task<T> LoadAsync<T>(object hashKey, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -101,7 +130,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
+#if NET8_0_OR_GREATER
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#else
         public async Task<T> LoadAsync<T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -110,7 +143,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
+#else
         public async Task<T> LoadAsync<T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -119,7 +156,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
+#else
         public async Task<T> LoadAsync<T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -129,7 +170,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
+#if NET8_0_OR_GREATER
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#else
         public async Task<T> LoadAsync<T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -138,7 +183,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
+#else
         public async Task<T> LoadAsync<T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -147,7 +196,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, CancellationToken cancellationToken = default)
+#else
         public async Task<T> LoadAsync<T>(T keyObject, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -157,7 +210,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
+#if NET8_0_OR_GREATER
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#else
         public async Task<T> LoadAsync<T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -166,7 +223,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default)
+#else
         public async Task<T> LoadAsync<T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -179,7 +240,11 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Delete async
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, CancellationToken cancellationToken = default)
+#else
         public async Task DeleteAsync<T>(T value, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -189,7 +254,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
+#if NET8_0_OR_GREATER
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#else
         public async Task DeleteAsync<T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -198,7 +267,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
+#else
         public async Task DeleteAsync<T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -207,7 +280,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, CancellationToken cancellationToken = default)
+#else
         public async Task DeleteAsync<T>(object hashKey, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -217,7 +294,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
+#if NET8_0_OR_GREATER
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#else
         public async Task DeleteAsync<T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -226,7 +307,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
+#else
         public async Task DeleteAsync<T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -235,7 +320,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
+#else
         public async Task DeleteAsync<T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -245,7 +334,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
+#if NET8_0_OR_GREATER
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#else
         public async Task DeleteAsync<T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -254,7 +347,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
+#else
         public async Task DeleteAsync<T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -332,7 +429,11 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Scan async
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions)
+#else
         public IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(ScanAsync)))
             {
@@ -343,7 +444,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the ScanAsync overload that takes ScanConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to ScanAsync.")]
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null)
+#else
         public IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(ScanAsync)))
             {
@@ -353,7 +458,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig)
+#else
         public IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(ScanAsync)))
             {
@@ -363,7 +472,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig)
+#else
         public IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromScanAsync)))
             {
@@ -376,7 +489,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the FromScanAsync overload that takes ScanConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromScanAsync.")]
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null)
+#else
         public IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromScanAsync)))
             {
@@ -388,7 +505,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig)
+#else
         public IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromScanAsync)))
             {
@@ -404,7 +525,11 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Query async
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue)
+#else
         public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -415,7 +540,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the QueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to QueryAsync.")]
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null)
+#else
         public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -425,7 +554,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryConfig queryConfig)
+#else
         public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryConfig queryConfig)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -435,7 +568,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values)
+#else
         public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -449,7 +586,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the QueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to QueryAsync.")]
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null)
+#else
         public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -462,7 +603,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig)
+#else
         public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -475,7 +620,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig)
+#else
         public IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromQueryAsync)))
             {
@@ -488,7 +637,11 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the FromQueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromQueryAsync.")]
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null)
+#else
         public IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromQueryAsync)))
             {
@@ -500,7 +653,11 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig)
+#else
         public IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig)
+#endif
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromQueryAsync)))
             {

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/Context.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/Context.Async.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2.DocumentModel;
@@ -32,11 +33,7 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Save async
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, CancellationToken cancellationToken = default)
-#else
-        public async Task SaveAsync<T>(T value, CancellationToken cancellationToken = default)
-#endif
+        public async Task SaveAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -46,11 +43,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the SaveAsync overload that takes SaveConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to SaveAsync.")]
-#if NET8_0_OR_GREATER
-        public async Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task SaveAsync<T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task SaveAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -59,11 +52,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task SaveAsync<T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task SaveAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -72,11 +61,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, CancellationToken cancellationToken = default)
-#else
-        public async Task SaveAsync(Type valueType, object value, CancellationToken cancellationToken = default)
-#endif
+        public async Task SaveAsync([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valueType, object value, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -86,11 +71,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the SaveAsync overload that takes SaveConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to SaveAsync.")]
-#if NET8_0_OR_GREATER
-        public async Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task SaveAsync(Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task SaveAsync([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -99,11 +80,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task SaveAsync(Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task SaveAsync([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(SaveAsync)))
             {
@@ -116,11 +93,7 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Load async
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, CancellationToken cancellationToken = default)
-#else
-        public async Task<T> LoadAsync<T>(object hashKey, CancellationToken cancellationToken = default)
-#endif
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -130,11 +103,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
-#if NET8_0_OR_GREATER
-        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task<T> LoadAsync<T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -143,11 +112,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task<T> LoadAsync<T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -156,11 +121,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
-#else
-        public async Task<T> LoadAsync<T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
-#endif
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -170,11 +131,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
-#if NET8_0_OR_GREATER
-        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task<T> LoadAsync<T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -183,11 +140,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task<T> LoadAsync<T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -196,11 +149,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, CancellationToken cancellationToken = default)
-#else
-        public async Task<T> LoadAsync<T>(T keyObject, CancellationToken cancellationToken = default)
-#endif
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T keyObject, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -210,11 +159,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
-#if NET8_0_OR_GREATER
-        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task<T> LoadAsync<T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -223,11 +168,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task<T> LoadAsync<T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(LoadAsync)))
             {
@@ -240,11 +181,7 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Delete async
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, CancellationToken cancellationToken = default)
-#else
-        public async Task DeleteAsync<T>(T value, CancellationToken cancellationToken = default)
-#endif
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -254,11 +191,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
-#if NET8_0_OR_GREATER
-        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task DeleteAsync<T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -267,11 +200,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task DeleteAsync<T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -280,11 +209,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, CancellationToken cancellationToken = default)
-#else
-        public async Task DeleteAsync<T>(object hashKey, CancellationToken cancellationToken = default)
-#endif
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -294,11 +219,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
-#if NET8_0_OR_GREATER
-        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task DeleteAsync<T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -307,11 +228,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task DeleteAsync<T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -320,11 +237,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
-#else
-        public async Task DeleteAsync<T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
-#endif
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -334,11 +247,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
-#if NET8_0_OR_GREATER
-        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task DeleteAsync<T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -347,11 +256,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public async Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
-#else
-        public async Task DeleteAsync<T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
-#endif
+        public async Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(DeleteAsync)))
             {
@@ -429,11 +334,7 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Scan async
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions)
-#else
-        public IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions)
-#endif
+        public IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<ScanCondition> conditions)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(ScanAsync)))
             {
@@ -444,11 +345,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the ScanAsync overload that takes ScanConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to ScanAsync.")]
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null)
-#else
-        public IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null)
-#endif
+        public IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(ScanAsync)))
             {
@@ -458,11 +355,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig)
-#else
-        public IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig)
-#endif
+        public IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(ScanAsync)))
             {
@@ -472,11 +365,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig)
-#else
-        public IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig)
-#endif
+        public IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ScanOperationConfig scanConfig)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromScanAsync)))
             {
@@ -489,11 +378,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the FromScanAsync overload that takes ScanConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromScanAsync.")]
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null)
-#else
-        public IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null)
-#endif
+        public IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromScanAsync)))
             {
@@ -505,11 +390,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig)
-#else
-        public IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig)
-#endif
+        public IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromScanAsync)))
             {
@@ -525,11 +406,7 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Query async
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue)
-#else
-        public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue)
-#endif
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -540,11 +417,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the QueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to QueryAsync.")]
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null)
-#else
-        public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null)
-#endif
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -554,11 +427,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryConfig queryConfig)
-#else
-        public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryConfig queryConfig)
-#endif
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, QueryConfig queryConfig)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -568,11 +437,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values)
-#else
-        public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values)
-#endif
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -586,11 +451,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the QueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to QueryAsync.")]
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null)
-#else
-        public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null)
-#endif
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -603,11 +464,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig)
-#else
-        public IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig)
-#endif
+        public IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(QueryAsync)))
             {
@@ -620,11 +477,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig)
-#else
-        public IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig)
-#endif
+        public IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(QueryOperationConfig queryConfig)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromQueryAsync)))
             {
@@ -637,11 +490,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
         /// <inheritdoc/>
         [Obsolete("Use the FromQueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromQueryAsync.")]
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null)
-#else
-        public IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null)
-#endif
+        public IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromQueryAsync)))
             {
@@ -653,11 +502,7 @@ namespace Amazon.DynamoDBv2.DataModel
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig)
-#else
-        public IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig)
-#endif
+        public IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig)
         {
             using (DynamoDBTelemetry.CreateSpan(this, nameof(FromQueryAsync)))
             {

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2.DocumentModel;
@@ -40,7 +41,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="value">Object to save.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, CancellationToken cancellationToken = default);
+#else
         Task SaveAsync<T>(T value, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -54,7 +59,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the SaveAsync overload that takes SaveConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to SaveAsync.")]
+#if NET8_0_OR_GREATER
+        Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#else
         Task SaveAsync<T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -67,7 +76,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="saveConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
+#else
         Task SaveAsync<T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -79,7 +92,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="value">Object to save.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, CancellationToken cancellationToken = default);
+#else
         Task SaveAsync(Type valueType, object value, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -93,7 +110,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the SaveAsync overload that takes SaveConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to SaveAsync.")]
+#if NET8_0_OR_GREATER
+        Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#else
         Task SaveAsync(Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -106,7 +127,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="saveConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
+#else
         Task SaveAsync(Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
+#endif
 
         #endregion
 
@@ -123,7 +148,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="hashKey">Hash key element of the target item.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
+#if NET8_0_OR_GREATER
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, CancellationToken cancellationToken = default);
+#else
         Task<T> LoadAsync<T>(object hashKey, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash key.
@@ -140,7 +169,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
+#if NET8_0_OR_GREATER
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#else
         Task<T> LoadAsync<T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash key.
@@ -154,7 +187,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="loadConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
+#else
         Task<T> LoadAsync<T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash-and-range primary key.
@@ -167,7 +204,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="rangeKey">Range key element of the target item.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
+#if NET8_0_OR_GREATER
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
+#else
         Task<T> LoadAsync<T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash-and-range primary key.
@@ -186,7 +227,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
+#if NET8_0_OR_GREATER
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#else
         Task<T> LoadAsync<T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash-and-range primary key.
@@ -201,7 +246,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="loadConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
+#else
         Task<T> LoadAsync<T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Loads an object from DynamoDB for the given key.
@@ -217,7 +266,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="keyObject">Key of the target item.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
+#if NET8_0_OR_GREATER
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, CancellationToken cancellationToken = default);
+#else
         Task<T> LoadAsync<T>(T keyObject, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Loads an object from DynamoDB for the given key.
@@ -243,7 +296,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
+#if NET8_0_OR_GREATER
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#else
         Task<T> LoadAsync<T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Loads an object from DynamoDB for the given key.
@@ -259,7 +316,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="loadConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default);
+#else
         Task<T> LoadAsync<T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default);
+#endif
 
         #endregion
 
@@ -277,7 +338,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="value">Object to delete.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, CancellationToken cancellationToken = default);
+#else
         Task DeleteAsync<T>(T value, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given object.
@@ -293,7 +358,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
+#if NET8_0_OR_GREATER
+        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#else
         Task DeleteAsync<T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given object.
@@ -308,7 +377,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="deleteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
+#else
         Task DeleteAsync<T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given hash key.
@@ -322,7 +395,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="hashKey">Hash key element of the object to delete.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, CancellationToken cancellationToken = default);
+#else
         Task DeleteAsync<T>(object hashKey, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given hash key.
@@ -338,7 +415,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
+#if NET8_0_OR_GREATER
+        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#else
         Task DeleteAsync<T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given hash key.
@@ -353,7 +434,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="deleteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
+#else
         Task DeleteAsync<T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to a given hash-and-range primary key.
@@ -368,7 +453,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="rangeKey">Range key element of the object to delete.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
+#else
         Task DeleteAsync<T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to a given hash-and-range primary key.
@@ -385,7 +474,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
+#if NET8_0_OR_GREATER
+        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#else
         Task DeleteAsync<T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
+#endif
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to a given hash-and-range primary key.
@@ -401,7 +494,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="deleteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+#if NET8_0_OR_GREATER
+        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
+#else
         Task DeleteAsync<T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
+#endif
 
         #endregion
 
@@ -482,7 +579,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Conditions that the results should meet.
         /// </param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions);
+#else
         IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions);
+#endif
 
         /// <summary>
         /// Configures an async Scan operation against DynamoDB, finding items
@@ -496,7 +597,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
 
         [Obsolete("Use the ScanAsync overload that takes ScanConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to ScanAsync.")]
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null);
+#else
         IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Configures an async Scan operation against DynamoDB, finding items
@@ -508,7 +613,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </param>
         /// <param name="scanConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig);
+#else
         IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig);
+#endif
 
         /// <summary>
         /// Configures an async Scan operation against DynamoDB, finding items
@@ -517,7 +626,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of object.</typeparam>
         /// <param name="scanConfig">Scan request object.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig);
+#else
         IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig);
+#endif
 
         /// <summary>
         /// Configures an async Scan operation against DynamoDB, finding items
@@ -528,7 +641,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
         [Obsolete("Use the FromScanAsync overload that takes ScanConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromScanAsync.")]
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null);
+#else
         IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         ///  Configures an async Scan operation against DynamoDB, finding items
@@ -538,7 +655,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="scanConfig">Scan request object.</param>
         /// <param name="fromScanConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig);
+#else
         IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig);
+#endif
 
         #endregion
 
@@ -551,7 +672,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of object.</typeparam>
         /// <param name="hashKeyValue">Hash key of the items to query.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue);
+#else
         IAsyncSearch<T> QueryAsync<T>(object hashKeyValue);
+#endif
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -562,7 +687,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
         [Obsolete("Use the QueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to QueryAsync.")]
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null);
+#else
         IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -572,7 +701,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="hashKeyValue">Hash key of the items to query.</param>
         /// <param name="queryConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryConfig queryConfig);
+#else
         IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryConfig queryConfig);
+#endif
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -587,7 +720,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// For QueryOperator.Betwee, values should be two values.
         /// </param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values);
+#else
         IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values);
+#endif
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -604,7 +741,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
         [Obsolete("Use the QueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to QueryAsync.")]
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null);
+#else
         IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -620,7 +761,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </param>
         /// <param name="queryConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig);
+#else
         IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig);
+#endif
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB using a mid-level document model 
@@ -629,7 +774,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of object.</typeparam>
         /// <param name="queryConfig">Mid-level, document model query request object.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig);
+#else
         IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig);
+#endif
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -640,7 +789,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
         [Obsolete("Use the FromQueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromQueryAsync.")]
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null);
+#else
         IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB using a mid-level document model 
@@ -650,7 +803,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="queryConfig">Mid-level, document model query request object.</param>
         /// <param name="fromQueryConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
+#if NET8_0_OR_GREATER
+        IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig);
+#else
         IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig);
+#endif
 
         #endregion
     }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
@@ -20,6 +20,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2.DocumentModel;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -41,11 +42,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="value">Object to save.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, CancellationToken cancellationToken = default);
-#else
-        Task SaveAsync<T>(T value, CancellationToken cancellationToken = default);
-#endif
+        Task SaveAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -59,11 +56,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the SaveAsync overload that takes SaveConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to SaveAsync.")]
-#if NET8_0_OR_GREATER
-        Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#else
-        Task SaveAsync<T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#endif
+        Task SaveAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -76,11 +69,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="saveConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task SaveAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
-#else
-        Task SaveAsync<T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
-#endif
+        Task SaveAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -92,11 +81,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="value">Object to save.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, CancellationToken cancellationToken = default);
-#else
-        Task SaveAsync(Type valueType, object value, CancellationToken cancellationToken = default);
-#endif
+        Task SaveAsync([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valueType, object value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -110,11 +95,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the SaveAsync overload that takes SaveConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to SaveAsync.")]
-#if NET8_0_OR_GREATER
-        Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#else
-        Task SaveAsync(Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#endif
+        Task SaveAsync([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valueType, object value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Saves an object to DynamoDB.
@@ -127,11 +108,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="saveConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task SaveAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
-#else
-        Task SaveAsync(Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
-#endif
+        Task SaveAsync([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type valueType, object value, SaveConfig saveConfig, CancellationToken cancellationToken = default);
 
         #endregion
 
@@ -148,11 +125,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="hashKey">Hash key element of the target item.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
-#if NET8_0_OR_GREATER
-        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, CancellationToken cancellationToken = default);
-#else
-        Task<T> LoadAsync<T>(object hashKey, CancellationToken cancellationToken = default);
-#endif
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash key.
@@ -169,11 +142,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
-#if NET8_0_OR_GREATER
-        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#else
-        Task<T> LoadAsync<T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#endif
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash key.
@@ -187,11 +156,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="loadConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
-#else
-        Task<T> LoadAsync<T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
-#endif
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash-and-range primary key.
@@ -204,11 +169,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="rangeKey">Range key element of the target item.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
-#if NET8_0_OR_GREATER
-        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
-#else
-        Task<T> LoadAsync<T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
-#endif
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash-and-range primary key.
@@ -227,11 +188,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
-#if NET8_0_OR_GREATER
-        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#else
-        Task<T> LoadAsync<T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#endif
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Loads an object from DynamoDB for the given hash-and-range primary key.
@@ -246,11 +203,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="loadConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
-#else
-        Task<T> LoadAsync<T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
-#endif
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, LoadConfig loadConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Loads an object from DynamoDB for the given key.
@@ -266,11 +219,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="keyObject">Key of the target item.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
-#if NET8_0_OR_GREATER
-        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, CancellationToken cancellationToken = default);
-#else
-        Task<T> LoadAsync<T>(T keyObject, CancellationToken cancellationToken = default);
-#endif
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T keyObject, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Loads an object from DynamoDB for the given key.
@@ -296,11 +245,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>Object of type T, populated with the properties of the item loaded from DynamoDB.</returns>
         [Obsolete("Use the LoadAsync overload that takes LoadConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to LoadAsync.")]
-#if NET8_0_OR_GREATER
-        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#else
-        Task<T> LoadAsync<T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#endif
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T keyObject, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Loads an object from DynamoDB for the given key.
@@ -316,11 +261,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="loadConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task<T> LoadAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default);
-#else
-        Task<T> LoadAsync<T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default);
-#endif
+        Task<T> LoadAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T keyObject, LoadConfig loadConfig, CancellationToken cancellationToken = default);
 
         #endregion
 
@@ -338,11 +279,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="value">Object to delete.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, CancellationToken cancellationToken = default);
-#else
-        Task DeleteAsync<T>(T value, CancellationToken cancellationToken = default);
-#endif
+        Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given object.
@@ -358,11 +295,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
-#if NET8_0_OR_GREATER
-        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#else
-        Task DeleteAsync<T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#endif
+        Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given object.
@@ -377,11 +310,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="deleteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
-#else
-        Task DeleteAsync<T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
-#endif
+        Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given hash key.
@@ -395,11 +324,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="hashKey">Hash key element of the object to delete.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, CancellationToken cancellationToken = default);
-#else
-        Task DeleteAsync<T>(object hashKey, CancellationToken cancellationToken = default);
-#endif
+        Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given hash key.
@@ -415,11 +340,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
-#if NET8_0_OR_GREATER
-        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#else
-        Task DeleteAsync<T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#endif
+        Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to given hash key.
@@ -434,11 +355,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="deleteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
-#else
-        Task DeleteAsync<T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
-#endif
+        Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to a given hash-and-range primary key.
@@ -453,11 +370,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="rangeKey">Range key element of the object to delete.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
-#else
-        Task DeleteAsync<T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
-#endif
+        Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to a given hash-and-range primary key.
@@ -474,11 +387,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         [Obsolete("Use the DeleteAsync overload that takes DeleteConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to DeleteAsync.")]
-#if NET8_0_OR_GREATER
-        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#else
-        Task DeleteAsync<T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
-#endif
+        Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DynamoDBOperationConfig operationConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to a given hash-and-range primary key.
@@ -494,11 +403,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="deleteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
-#if NET8_0_OR_GREATER
-        Task DeleteAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
-#else
-        Task DeleteAsync<T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
-#endif
+        Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, object rangeKey, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
 
         #endregion
 
@@ -579,11 +484,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// Conditions that the results should meet.
         /// </param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions);
-#else
-        IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions);
-#endif
+        IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<ScanCondition> conditions);
 
         /// <summary>
         /// Configures an async Scan operation against DynamoDB, finding items
@@ -597,11 +498,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
 
         [Obsolete("Use the ScanAsync overload that takes ScanConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to ScanAsync.")]
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null);
-#else
-        IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null);
-#endif
+        IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<ScanCondition> conditions, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Configures an async Scan operation against DynamoDB, finding items
@@ -613,11 +510,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </param>
         /// <param name="scanConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig);
-#else
-        IAsyncSearch<T> ScanAsync<T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig);
-#endif
+        IAsyncSearch<T> ScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(IEnumerable<ScanCondition> conditions, ScanConfig scanConfig);
 
         /// <summary>
         /// Configures an async Scan operation against DynamoDB, finding items
@@ -626,11 +519,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of object.</typeparam>
         /// <param name="scanConfig">Scan request object.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig);
-#else
-        IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig);
-#endif
+        IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ScanOperationConfig scanConfig);
 
         /// <summary>
         /// Configures an async Scan operation against DynamoDB, finding items
@@ -641,11 +530,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
         [Obsolete("Use the FromScanAsync overload that takes ScanConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromScanAsync.")]
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null);
-#else
-        IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null);
-#endif
+        IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ScanOperationConfig scanConfig, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         ///  Configures an async Scan operation against DynamoDB, finding items
@@ -655,11 +540,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="scanConfig">Scan request object.</param>
         /// <param name="fromScanConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig);
-#else
-        IAsyncSearch<T> FromScanAsync<T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig);
-#endif
+        IAsyncSearch<T> FromScanAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(ScanOperationConfig scanConfig, FromScanConfig fromScanConfig);
 
         #endregion
 
@@ -672,11 +553,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of object.</typeparam>
         /// <param name="hashKeyValue">Hash key of the items to query.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue);
-#else
-        IAsyncSearch<T> QueryAsync<T>(object hashKeyValue);
-#endif
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -687,11 +564,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
         [Obsolete("Use the QueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to QueryAsync.")]
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null);
-#else
-        IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null);
-#endif
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -701,11 +574,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="hashKeyValue">Hash key of the items to query.</param>
         /// <param name="queryConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryConfig queryConfig);
-#else
-        IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryConfig queryConfig);
-#endif
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, QueryConfig queryConfig);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -720,11 +589,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// For QueryOperator.Betwee, values should be two values.
         /// </param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values);
-#else
-        IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values);
-#endif
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -741,11 +606,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
         [Obsolete("Use the QueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to QueryAsync.")]
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null);
-#else
-        IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null);
-#endif
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -761,11 +622,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </param>
         /// <param name="queryConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig);
-#else
-        IAsyncSearch<T> QueryAsync<T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig);
-#endif
+        IAsyncSearch<T> QueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKeyValue, QueryOperator op, IEnumerable<object> values, QueryConfig queryConfig);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB using a mid-level document model 
@@ -774,11 +631,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type of object.</typeparam>
         /// <param name="queryConfig">Mid-level, document model query request object.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig);
-#else
-        IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig);
-#endif
+        IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(QueryOperationConfig queryConfig);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB, finding items
@@ -789,11 +642,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="operationConfig">Config object which can be used to override the table used.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
         [Obsolete("Use the FromQueryAsync overload that takes QueryConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to FromQueryAsync.")]
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null);
-#else
-        IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null);
-#endif
+        IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(QueryOperationConfig queryConfig, DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Configures an async Query operation against DynamoDB using a mid-level document model 
@@ -803,11 +652,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="queryConfig">Mid-level, document model query request object.</param>
         /// <param name="fromQueryConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <returns>AsyncSearch which can be used to retrieve DynamoDB data.</returns>
-#if NET8_0_OR_GREATER
-        IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig);
-#else
-        IAsyncSearch<T> FromQueryAsync<T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig);
-#endif
+        IAsyncSearch<T> FromQueryAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(QueryOperationConfig queryConfig, FromQueryConfig fromQueryConfig);
 
         #endregion
     }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_netstandard/Context.Sync.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_netstandard/Context.Sync.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 using Amazon.DynamoDBv2.DocumentModel;
 
@@ -24,20 +25,32 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Table methods
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
+#else
         public ITable GetTargetTable<T>()
+#endif
         {
             return GetTargetTableInternal<T>(new DynamoDBFlatConfig(null, Config));
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the GetTargetTable overload that takes GetTargetTableConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to GetTargetTable.")]
+#if NET8_0_OR_GREATER
+        public ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null)
+#else
         public ITable GetTargetTable<T>(DynamoDBOperationConfig operationConfig = null)
+#endif
         {
             return GetTargetTableInternal<T>(new DynamoDBFlatConfig(operationConfig, Config));
         }
 
         /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+        public ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(GetTargetTableConfig getTargetTableConfig)
+#else
         public ITable GetTargetTable<T>(GetTargetTableConfig getTargetTableConfig)
+#endif
         {
             return GetTargetTableInternal<T>(new DynamoDBFlatConfig(getTargetTableConfig?.ToDynamoDBOperationConfig(), Config));
         }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_netstandard/Context.Sync.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_netstandard/Context.Sync.cs
@@ -17,6 +17,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 using Amazon.DynamoDBv2.DocumentModel;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -25,32 +26,20 @@ namespace Amazon.DynamoDBv2.DataModel
         #region Table methods
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
-#else
-        public ITable GetTargetTable<T>()
-#endif
+        public ITable GetTargetTable<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>()
         {
             return GetTargetTableInternal<T>(new DynamoDBFlatConfig(null, Config));
         }
 
         /// <inheritdoc/>
         [Obsolete("Use the GetTargetTable overload that takes GetTargetTableConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to GetTargetTable.")]
-#if NET8_0_OR_GREATER
-        public ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null)
-#else
-        public ITable GetTargetTable<T>(DynamoDBOperationConfig operationConfig = null)
-#endif
+        public ITable GetTargetTable<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig = null)
         {
             return GetTargetTableInternal<T>(new DynamoDBFlatConfig(operationConfig, Config));
         }
 
         /// <inheritdoc/>
-#if NET8_0_OR_GREATER
-        public ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(GetTargetTableConfig getTargetTableConfig)
-#else
-        public ITable GetTargetTable<T>(GetTargetTableConfig getTargetTableConfig)
-#endif
+        public ITable GetTargetTable<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(GetTargetTableConfig getTargetTableConfig)
         {
             return GetTargetTableInternal<T>(new DynamoDBFlatConfig(getTargetTableConfig?.ToDynamoDBOperationConfig(), Config));
         }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_netstandard/IDynamoDBContext.Sync.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_netstandard/IDynamoDBContext.Sync.cs
@@ -17,6 +17,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 using Amazon.DynamoDBv2.DocumentModel;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.DynamoDBv2.DataModel
 {
@@ -33,11 +34,7 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type to retrieve table for</typeparam>
         /// <returns>Table object</returns>
-#if NET8_0_OR_GREATER
-        ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
-#else
-        ITable GetTargetTable<T>();
-#endif
+        ITable GetTargetTable<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>();
 
         /// <summary>
         /// Retrieves the target table for the specified type
@@ -45,22 +42,14 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type to retrieve table for</typeparam>
         /// <returns>Table object</returns>
         [Obsolete("Use the GetTargetTable overload that takes GetTargetTableConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to GetTargetTable.")]
-#if NET8_0_OR_GREATER
-        ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
-#else
-        ITable GetTargetTable<T>(DynamoDBOperationConfig operationConfig = null);
-#endif
+        ITable GetTargetTable<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(DynamoDBOperationConfig operationConfig = null);
 
         /// <summary>
         /// Retrieves the target table for the specified type
         /// </summary>
         /// <typeparam name="T">Type to retrieve table for</typeparam>
         /// <returns>Table object</returns>
-#if NET8_0_OR_GREATER
-        ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(GetTargetTableConfig getTargetTableConfig);
-#else
-        ITable GetTargetTable<T>(GetTargetTableConfig getTargetTableConfig);
-#endif
+        ITable GetTargetTable<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(GetTargetTableConfig getTargetTableConfig);
 
         #endregion
     }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_netstandard/IDynamoDBContext.Sync.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_netstandard/IDynamoDBContext.Sync.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 using Amazon.DynamoDBv2.DocumentModel;
 
@@ -32,7 +33,11 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         /// <typeparam name="T">Type to retrieve table for</typeparam>
         /// <returns>Table object</returns>
+#if NET8_0_OR_GREATER
+        ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
+#else
         ITable GetTargetTable<T>();
+#endif
 
         /// <summary>
         /// Retrieves the target table for the specified type
@@ -40,14 +45,22 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <typeparam name="T">Type to retrieve table for</typeparam>
         /// <returns>Table object</returns>
         [Obsolete("Use the GetTargetTable overload that takes GetTargetTableConfig instead, since DynamoDBOperationConfig contains properties that are not applicable to GetTargetTable.")]
+#if NET8_0_OR_GREATER
+        ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(DynamoDBOperationConfig operationConfig = null);
+#else
         ITable GetTargetTable<T>(DynamoDBOperationConfig operationConfig = null);
+#endif
 
         /// <summary>
         /// Retrieves the target table for the specified type
         /// </summary>
         /// <typeparam name="T">Type to retrieve table for</typeparam>
         /// <returns>Table object</returns>
+#if NET8_0_OR_GREATER
+        ITable GetTargetTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(GetTargetTableConfig getTargetTableConfig);
+#else
         ITable GetTargetTable<T>(GetTargetTableConfig getTargetTableConfig);
+#endif
 
         #endregion
     }

--- a/sdk/src/Services/DynamoDBv2/Custom/Internal/InternalConstants.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Internal/InternalConstants.cs
@@ -13,10 +13,17 @@
  * permissions and limitations under the License.
  */
 
-namespace Amazon.DynamoDBv2.Custom.Internal
+using System.Diagnostics.CodeAnalysis;
+using ThirdParty.RuntimeBackports;
+
+namespace Amazon.DynamoDBv2
 {
     internal static class InternalConstants
     {
-        internal const string RequiresUnreferencedCodeMessage = "The Amazon DynamoDB high level libraries in the DataModel namespace have not been updated to support Native AOT.";
+        /// <summary>
+        /// This is DynamicallyAccessedMemberTypes value that must be used whenever identifing the System.Type that users will
+        /// use to the DataModel library for loading and saving data.
+        /// </summary>
+        internal const DynamicallyAccessedMemberTypes DataModelModeledType = DynamicallyAccessedMemberTypes.All;
     }
 }


### PR DESCRIPTION
## Description
Building off of the previous https://github.com/aws/aws-sdk-net/pull/3583 that added Native AOT for DocumentModel this adds support for DataModel. 

The changes replaces the `RequiresUnreferencedCodeAttribute` with `DynamicallyAccessedMembersAttribute` with the `DynamicallyAccessedMemberTypes` parameter set to the required level of reflection needed. Any time the type in question is the POCO used by the callers to represent type the `DynamicallyAccessedMemberTypes` is set to `All` since full reflection is required by the library for loading and saving the type.

I got tired of adding all of the `#if NET8_0_OR_GREATER` conditional compilations throughout the code when using the trimming attributes like `DynamicallyAccessedMemberTypes`. I backported the trimming attributes into the `ThirdParty.RuntimeBackports` namespace so I could use the trimming attributes in all targets. As part of this I also removed   `#if NET8_0_OR_GREATER` added for trimming attributes in Core and the DocumentModel as part of a global search.

Because of the S3Link feature that dynamically creates an S3Client I had to extend the `GlobalRuntimeDependencyRegistry` to allow registering the S3 client.


Using the following Lambda function using the DataModel library and deployed to Lambda I got the following cold start performances:

Without Native AOT: **1,697 ms**
Native AOT: **509 ms**
```
static IDynamoDBContext _context;

private static async Task Main()
{
    var ddbClient = new AmazonDynamoDBClient(RegionEndpoint.USWest2);

    _context = new DynamoDBContextBuilder()
                        .WithDynamoDBClient(() => ddbClient)
                        .Build();

    Func<string, ILambdaContext, Task<DataModelAotTest>> handler = FunctionHandler;
    await LambdaBootstrapBuilder.Create(handler, new SourceGeneratorLambdaJsonSerializer<LambdaFunctionJsonSerializerContext>())
        .Build()
        .RunAsync();
}

public static async Task<DataModelAotTest> FunctionHandler(string input, ILambdaContext context)
{
    var obj1 = new DataModelAotTest { Id = "1", Name = "Name1", FavoriteHobby = new Hobby { Name = "Hiking" } };

    await _context.SaveAsync(obj1);
    var obj2 = await _context.LoadAsync<DataModelAotTest>("1");

    return obj2;
}
```

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3475

## Testing
* Successful dry run
* Built and publish as Native AOT that exercised the library to confirm no trimming warnings were produced.
* Deployed and executed Native AOT Lambda function that used the library.

