### PR TITLE
Update Microsoft.Extensions.AI to 9.1.0-preview.1.25064.3 and incorporate video blocks

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetFramework.csproj
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetFramework.csproj
@@ -37,7 +37,7 @@
   </Choose>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.0.1-preview.1.24570.5" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.1.0-preview.1.25064.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetStandard.csproj
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetStandard.csproj
@@ -41,7 +41,7 @@
   </Choose>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.0.1-preview.1.24570.5" />
+  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.1.0-preview.1.25064.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
@@ -15,17 +15,17 @@
       <group targetFramework="net472">
         <dependency id="AWSSDK.Core" version="4.0.0.0-preview.5" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.0-preview.5" />
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.0.1-preview.1.24570.5" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.1.0-preview.1.25064.3" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="AWSSDK.Core" version="4.0.0.0-preview.5" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.0-preview.5" />
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.0.1-preview.1.24570.5" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.1.0-preview.1.25064.3" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="AWSSDK.Core" version="4.0.0.0-preview.5" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.0-preview.5" />
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.0.1-preview.1.24570.5" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.1.0-preview.1.25064.3" />
       </group>
     </dependencies>
   </metadata> 

--- a/extensions/test/BedrockMEAITests/BedrockMEAITests.NetFramework.csproj
+++ b/extensions/test/BedrockMEAITests/BedrockMEAITests.NetFramework.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.0.1-preview.1.24570.5" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.1.0-preview.1.25064.3" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
## Description
- Updates to the latest Microsoft.Extensions.AI.Abstractions version
- Updates the bedrock chat client to recognize the video content support bedrock recently added

## Motivation and Context
- Staying up to date with the latest changes in all dependencies

## Testing
No special testing performed.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement