### PR TITLE
Fix TransactWrite<T>.AddSaveItem when T does NOT contain DynamoDbProperty Attributes

### DIFF
--- a/generator/.DevConfigs/8e546afe-27ad-4b11-8400-e0f3c33f0a4a.json
+++ b/generator/.DevConfigs/8e546afe-27ad-4b11-8400-e0f3c33f0a4a.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "DynamoDBv2",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fixed issue with TransactWrite in the DataModel where it wasn't correctly handling cases where only keys were being saved."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 #if AWS_ASYNC_API
 using System.Threading;
 using System.Threading.Tasks;
@@ -134,11 +135,8 @@ namespace Amazon.DynamoDBv2.DataModel
             Expression conditionExpression = CreateConditionExpressionForVersion(storage);
             SetNewVersion(storage);
 
-            DocumentTransaction.AddDocumentToUpdate(storage.Document, new TransactWriteItemOperationConfig
-            {
-                ConditionalExpression = conditionExpression,
-                ReturnValuesOnConditionCheckFailure = DocumentModel.ReturnValuesOnConditionCheckFailure.None
-            });
+            AddDocumentTransaction(storage, conditionExpression);
+            
             var objectItem = new DynamoDBContext.ObjectWithItemStorage
             {
                 OriginalObject = item,
@@ -436,6 +434,45 @@ namespace Amazon.DynamoDBv2.DataModel
                 DocumentTransaction.TargetTable.Conversion,
                 DocumentTransaction.TargetTable.IsEmptyStringValueEnabled);
             return DynamoDBContext.CreateConditionExpressionForVersion(storage, conversionConfig);
+        }
+        
+
+        private void AddDocumentTransaction(ItemStorage storage, Expression conditionExpression)
+        {
+            var hashKeyPropertyNames = storage.Config.HashKeyPropertyNames;
+            var rangeKeyPropertyNames = storage.Config.RangeKeyPropertyNames;
+
+            var attributeNames = storage.Document.Keys.ToList();
+
+            foreach (var keyPropertyName in hashKeyPropertyNames)
+            {
+                attributeNames.Remove(keyPropertyName);
+            }
+
+            foreach (var rangeKeyPropertyName in rangeKeyPropertyNames)
+            {
+                attributeNames.Remove(rangeKeyPropertyName);
+            }
+
+            // If there are no attributes left, we need to use PutItem
+            // as UpdateItem requires at least one data attribute
+            if (attributeNames.Any())
+            {
+                DocumentTransaction.AddDocumentToUpdate(storage.Document, new TransactWriteItemOperationConfig
+                {
+                    ConditionalExpression = conditionExpression,
+                    ReturnValuesOnConditionCheckFailure = DocumentModel.ReturnValuesOnConditionCheckFailure.None
+                });
+            }
+            else
+            {
+
+                DocumentTransaction.AddDocumentToPut(storage.Document, new TransactWriteItemOperationConfig
+                {
+                    ConditionalExpression = conditionExpression,
+                    ReturnValuesOnConditionCheckFailure = DocumentModel.ReturnValuesOnConditionCheckFailure.None
+                });
+            }
         }
 
         private void SetNewVersion(ItemStorage storage)


### PR DESCRIPTION
## Description
fix: Fixed an issue where TransactWrite<T>.AddSaveItem throws when T does NOT contain DynamoDbProperty Attributes 

given that T does not contain any DynamoDbProperty, in order to use TransactWriteItem API to save the entity, it will require to perform PutItem operation instead of an UpdateItem operation.

## Motivation and Context
Issue https://github.com/aws/aws-sdk-net/issues/3095

## Testing
Tested locally using below code:

 [Fact]
 public async Task GivenCreateMultiTableTransactWrite_WhenAddSaveItem_ShouldSucceed()
 {
     DynamoDBOperationConfig TransactionDynamoDbOperationConfig = new DynamoDBOperationConfig()
     {
         SkipVersionCheck = true,
         ConditionalOperator = ConditionalOperatorValues.And
     };

     var table1 = new Table1() { Id = "Id2", RelatedId = "Id1"};
     var table2 = new Table2() { Id = "Id1", RelatedId = "Id2"};

     IDynamoDBContext dbContext = new DynamoDBContext(new AmazonDynamoDBClient());

     TransactWrite<Table1> t1 = dbContext.CreateTransactWrite<Table1>(TransactionDynamoDbOperationConfig);
     t1.AddSaveItem(table1);

     TransactWrite<Table2> t2 = dbContext.CreateTransactWrite<Table2>(TransactionDynamoDbOperationConfig);
     t2.AddSaveItem(table2);

     MultiTableTransactWrite transaction = dbContext.CreateMultiTableTransactWrite(t1,t2);
     await transaction.ExecuteAsync();
}

[DynamoDBTable("Table1")]
public class Table1
{
    [DynamoDBHashKey("Id")]
    public string Id { get; set; } = string.Empty;

    [DynamoDBRangeKey("RelatedId")]
    public string RelatedId { get; set; } = string.Empty;
}

[DynamoDBTable("Table2")]
public class Table2
{
    [DynamoDBHashKey("Id")]
    public string Id { get; set; } = string.Empty;

    [DynamoDBRangeKey("RelatedId")]
    public string RelatedId { get; set; } = string.Empty;

    [DynamoDBProperty("NonKey")]
    public string NonKey { get; set; } = string.Empty;
}


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ x ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement