### PR TITLE
Tweaks to the DefaultAWSCredentialsIdentityResolver

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -58,11 +58,21 @@ namespace Amazon.Runtime.Credentials
             };
         }
 
+        /// <summary>
+        /// Search the environment for configured AWS credentials. The search includes
+        /// environment variables, "default" AWS credentials profiles and EC2 instance metadata.
+        /// </summary>
+        /// <returns>AWSCredentials that can be used when creating AWS service clients.</returns>
         public static AWSCredentials GetCredentials()
         {
             return _defaultInstance.Value.ResolveIdentity();
         }
 
+        /// <summary>
+        /// Search the environment for configured AWS credentials. The search includes
+        /// environment variables, "default" AWS credentials profiles and EC2 instance metadata.
+        /// </summary>
+        /// <returns>AWSCredentials that can be used when creating AWS service clients.</returns>
         public static Task<AWSCredentials> GetCredentialsAsync()
         {
             return _defaultInstance.Value.ResolveIdentityAsync();


### PR DESCRIPTION
## Description
To make it easier to migrate to DefaultAWSCredentialsIdentityResolver added static `GetCredentials` API to match the calling pattern of `FallbackCredentialsFactory`. Also removed the write lock in the constructor since you can't have more then one thread at this point in the object.
