### PR TITLE
[SRA] Update auth resolver to correctly handle multiple schemes scenario

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
@@ -17,6 +17,7 @@ using Amazon.Runtime.Credentials.Internal;
 using Amazon.Runtime.Endpoints;
 using Amazon.Runtime.Identity;
 using Amazon.Runtime.Internal.Auth;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -51,7 +52,7 @@ namespace Amazon.Runtime.Internal
             var authOptions = ResolveAuthOptions(executionContext);
             if (authOptions == null || authOptions.Count == 0)
             {
-                throw new AmazonClientException($"No valid authentication schemes defined for ${executionContext.RequestContext.RequestName}");
+                throw new AmazonClientException($"No valid authentication schemes defined for {executionContext.RequestContext.RequestName}");
             }
 
             var clientConfig = executionContext.RequestContext.ClientConfig;
@@ -65,40 +66,64 @@ namespace Amazon.Runtime.Internal
                     continue;
                 }
 
-                executionContext.RequestContext.Signer = GetSigner(scheme);
-
-                if ((scheme is AwsV4aAuthScheme || scheme is AwsV4AuthScheme) && clientConfig.DefaultAWSCredentials != null)
+                try
                 {
-                    // We can use DefaultAWSCredentials if it was set by the user for these schemes.
-                    executionContext.RequestContext.Identity = clientConfig.DefaultAWSCredentials;
-                    break;
-                }
+                    executionContext.RequestContext.Signer = GetSigner(scheme);
 
-                if (scheme is BearerAuthScheme && clientConfig.AWSTokenProvider != null)
-                {
-                    // If the legacy token provider is set, we'll use it to resolve the identity.
+                    if ((scheme is AwsV4aAuthScheme || scheme is AwsV4AuthScheme) && clientConfig.DefaultAWSCredentials != null)
+                    {
+                        // We can use DefaultAWSCredentials if it was set by the user for these schemes.
+                        executionContext.RequestContext.Identity = clientConfig.DefaultAWSCredentials;
+                        return;
+                    }
+
+                    if (scheme is BearerAuthScheme && clientConfig.AWSTokenProvider != null)
+                    {
+                        // If the legacy token provider is set, we'll use it to resolve the identity.
 #if NETFRAMEWORK
-                    var resolvedToken = clientConfig.AWSTokenProvider.TryResolveToken(out var token);
-                    if (!resolvedToken)
-                    {
-                        continue;
-                    }
+                        var resolvedToken = clientConfig.AWSTokenProvider.TryResolveToken(out var token);
+                        if (!resolvedToken)
+                        {
+                            continue;
+                        }
 #else
-                    var resolvedToken = clientConfig.AWSTokenProvider.TryResolveTokenAsync().GetAwaiter().GetResult();
-                    if (!resolvedToken.Success)
-                    {
-                        continue;
-                    }
+                        var resolvedToken = clientConfig.AWSTokenProvider.TryResolveTokenAsync().GetAwaiter().GetResult();
+                        if (!resolvedToken.Success)
+                        {
+                            continue;
+                        }
 
-                    var token = resolvedToken.Value;
+                        var token = resolvedToken.Value;
 #endif
 
-                    executionContext.RequestContext.Identity = token;
-                    break;
-                }
+                        executionContext.RequestContext.Identity = token;
+                        return;
+                    }
 
-                var identityResolver = scheme.GetIdentityResolver(clientConfig.IdentityResolverConfiguration);
-                executionContext.RequestContext.Identity = identityResolver.ResolveIdentity();
+                    var identityResolver = scheme.GetIdentityResolver(clientConfig.IdentityResolverConfiguration);
+                    executionContext.RequestContext.Identity = identityResolver.ResolveIdentity();
+
+                    if (executionContext.RequestContext.Identity != null)
+                    {
+                        return;
+                    }
+                }
+                catch (Exception)
+                {
+                    // If there are multiple authentication schemes and we cannot resolve the identity for some reason (e.g. the CRT is
+                    // required for SigV4A signing), we'll attempt the next option before returning.
+                    if (authOptions.Count > 1)
+                    {
+                        continue;
+                    }
+
+                    throw;
+                }
+            }
+
+            if (executionContext.RequestContext.Identity == null)
+            {
+                throw new AmazonClientException($"Could not determine which authentication scheme to use for {executionContext.RequestContext.RequestName}");
             }
         }
 
@@ -107,7 +132,7 @@ namespace Amazon.Runtime.Internal
             var authOptions = ResolveAuthOptions(executionContext);
             if (authOptions == null || authOptions.Count == 0)
             {
-                throw new AmazonClientException($"No valid authentication schemes defined for ${executionContext.RequestContext.RequestName}");
+                throw new AmazonClientException($"No valid authentication schemes defined for {executionContext.RequestContext.RequestName}");
             }
 
             var clientConfig = executionContext.RequestContext.ClientConfig;
@@ -122,35 +147,59 @@ namespace Amazon.Runtime.Internal
                     continue;
                 }
 
-                executionContext.RequestContext.Signer = GetSigner(scheme);
-
-                if ((scheme is AwsV4aAuthScheme || scheme is AwsV4AuthScheme) && clientConfig.DefaultAWSCredentials != null)
+                try
                 {
-                    // We can use DefaultAWSCredentials if it was set by the user for these schemes.
-                    executionContext.RequestContext.Identity = clientConfig.DefaultAWSCredentials;
-                    break;
-                }
+                    executionContext.RequestContext.Signer = GetSigner(scheme);
 
-                if (scheme is BearerAuthScheme && clientConfig.AWSTokenProvider != null)
-                {
-                    // If the legacy token provider is set, we'll use it to resolve the identity.
-                    var resolvedToken = await clientConfig.AWSTokenProvider
-                        .TryResolveTokenAsync(cancellationToken)
+                    if ((scheme is AwsV4aAuthScheme || scheme is AwsV4AuthScheme) && clientConfig.DefaultAWSCredentials != null)
+                    {
+                        // We can use DefaultAWSCredentials if it was set by the user for these schemes.
+                        executionContext.RequestContext.Identity = clientConfig.DefaultAWSCredentials;
+                        return;
+                    }
+
+                    if (scheme is BearerAuthScheme && clientConfig.AWSTokenProvider != null)
+                    {
+                        // If the legacy token provider is set, we'll use it to resolve the identity.
+                        var resolvedToken = await clientConfig.AWSTokenProvider
+                            .TryResolveTokenAsync(cancellationToken)
+                            .ConfigureAwait(false);
+
+                        if (!resolvedToken.Success)
+                        {
+                            continue;
+                        }
+
+                        executionContext.RequestContext.Identity = resolvedToken.Value;
+                        return;
+                    }
+
+                    var identityResolver = scheme.GetIdentityResolver(clientConfig.IdentityResolverConfiguration);
+                    executionContext.RequestContext.Identity = await identityResolver
+                        .ResolveIdentityAsync(cancellationToken)
                         .ConfigureAwait(false);
 
-                    if (!resolvedToken.Success)
+                    if (executionContext.RequestContext.Identity != null)
+                    {
+                        return;
+                    }
+                }
+                catch (Exception)
+                {
+                    // If there are multiple authentication schemes and we cannot resolve the identity for some reason (e.g. the CRT is
+                    // required for SigV4A signing), we'll attempt the next option before returning.
+                    if (authOptions.Count > 1)
                     {
                         continue;
                     }
 
-                    executionContext.RequestContext.Identity = resolvedToken.Value;
-                    break;
+                    throw;
                 }
+            }
 
-                var identityResolver = scheme.GetIdentityResolver(clientConfig.IdentityResolverConfiguration);
-                executionContext.RequestContext.Identity = await identityResolver
-                    .ResolveIdentityAsync(cancellationToken)
-                    .ConfigureAwait(false);
+            if (executionContext.RequestContext.Identity == null)
+            {
+                throw new AmazonClientException($"Could not determine which authentication scheme to use for {executionContext.RequestContext.RequestName}");
             }
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
@@ -57,12 +57,13 @@ namespace Amazon.Runtime.Internal
 
             var clientConfig = executionContext.RequestContext.ClientConfig;
 
-            foreach (var authOption in authOptions)
+            for (int i = 0; i < authOptions.Count; i++)
             {
-                var scheme = _supportedSchemes.FirstOrDefault(s => s.SchemeId == authOption.SchemeId);
+                var scheme = _supportedSchemes.FirstOrDefault(s => s.SchemeId == authOptions[i].SchemeId);
                 if (scheme == null)
                 {
-                    // Current auth scheme option is not enabled, continue iterating.
+                    // Current auth scheme option is not enabled / supported, continue iterating.
+                    Logger.DebugFormat($"{authOptions[i].SchemeId} scheme is not supported for {executionContext.RequestContext.RequestName}");
                     continue;
                 }
 
@@ -108,12 +109,14 @@ namespace Amazon.Runtime.Internal
                         return;
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     // If there are multiple authentication schemes and we cannot resolve the identity for some reason (e.g. the CRT is
-                    // required for SigV4A signing), we'll attempt the next option before returning.
-                    if (authOptions.Count > 1)
+                    // required for SigV4A signing), we'll attempt the next option (if there are any left) before returning.
+                    var areSchemesLeft = i < authOptions.Count - 1;
+                    if (areSchemesLeft)
                     {
+                        Logger.DebugFormat($"Could not resolve identity for {executionContext.RequestContext.RequestName} using {scheme.SchemeId} scheme: {ex.Message}");
                         continue;
                     }
 
@@ -138,12 +141,13 @@ namespace Amazon.Runtime.Internal
             var clientConfig = executionContext.RequestContext.ClientConfig;
             var cancellationToken = executionContext.RequestContext.CancellationToken;
 
-            foreach (var authOption in authOptions)
+            for (int i = 0; i < authOptions.Count; i++)
             {
-                var scheme = _supportedSchemes.FirstOrDefault(s => s.SchemeId == authOption.SchemeId);
+                var scheme = _supportedSchemes.FirstOrDefault(s => s.SchemeId == authOptions[i].SchemeId);
                 if (scheme == null)
                 {
-                    // Current auth scheme option is not enabled, continue iterating.
+                    // Current auth scheme option is not enabled / supported, continue iterating.
+                    Logger.DebugFormat($"{authOptions[i].SchemeId} scheme is not supported for {executionContext.RequestContext.RequestName}");
                     continue;
                 }
 
@@ -184,12 +188,14 @@ namespace Amazon.Runtime.Internal
                         return;
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     // If there are multiple authentication schemes and we cannot resolve the identity for some reason (e.g. the CRT is
-                    // required for SigV4A signing), we'll attempt the next option before returning.
-                    if (authOptions.Count > 1)
+                    // required for SigV4A signing), we'll attempt the next option (if there are any left) before returning.
+                    var areSchemesLeft = i < authOptions.Count - 1;
+                    if (areSchemesLeft)
                     {
+                        Logger.DebugFormat($"Could not resolve identity for {executionContext.RequestContext.RequestName} using {scheme.SchemeId} scheme: {ex.Message}");
                         continue;
                     }
 


### PR DESCRIPTION
Updates the `AuthResolverHandler` to correctly handle scenarios where multiple schemes are defined. For example, if a service / operation defines `aws.auth#sigv4a,aws.auth#sigv4` and the CRT dependency is not available, we should still be able to resolve the identity (using SigV4).

## Testing
- Dry-run: `DRY_RUN-7a4951f9-165e-4cdd-92a0-23f2183911d9`
- There's only a few operations on the S3 model that have multiple auth schemes at the moment (and they're only applicable when running on Outposts), so I manually modified the model files, ran the generator, and confirmed that:
  - `"auth": ["aws.auth#sigv4a", "aws.auth#sigv4"]` without the CRT will use SigV4
  - `"auth": ["aws.auth#sigv4a"]` fails as expected without the CRT
  - `"auth": ["aws.auth#sigv4a", "aws.auth#sigv4"]` uses SigV4A when the CRT is available

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
