### PR TITLE
[SRA] Remove default assignment and obsolete attribute from AWSTokenProvider property

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -95,7 +95,7 @@ namespace Amazon.Runtime
         private bool didProcessServiceURL = false;
         private AWSCredentials _defaultAWSCredentials = null;
         private IIdentityResolverConfiguration _identityResolverConfiguration = DefaultIdentityResolverConfiguration.Instance;
-        private IAWSTokenProvider _awsTokenProvider = new DefaultAWSTokenProviderChain();
+        private IAWSTokenProvider _awsTokenProvider;
         private TelemetryProvider telemetryProvider = AWSConfigs.TelemetryProvider;
         private AccountIdEndpointMode? accountIdEndpointMode = null;
 
@@ -202,7 +202,6 @@ namespace Amazon.Runtime
         }
 
         /// <inheritdoc />
-        [Obsolete("This property is deprecated in favor of the new Identity resolvers configured through IdentityResolverConfiguration.")]
         public IAWSTokenProvider AWSTokenProvider
         {
             get { return this._awsTokenProvider; }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSTokenIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSTokenIdentityResolver.cs
@@ -26,10 +26,8 @@ namespace Amazon.Runtime.Credentials
     {
         private readonly IAWSTokenProvider _tokenProvider;
 
-        public DefaultAWSTokenIdentityResolver() : this(null) { }
-
-        public DefaultAWSTokenIdentityResolver(string profileName)
-            => _tokenProvider = new AWSTokenProviderChain(new ProfileTokenProvider(profileName));
+        public DefaultAWSTokenIdentityResolver() 
+            => _tokenProvider = new AWSTokenProviderChain(new ProfileTokenProvider());
 
         BaseIdentity IIdentityResolver.ResolveIdentity()
         {

--- a/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
@@ -21,6 +21,7 @@ using Amazon.Util;
 using Amazon.Runtime.Telemetry;
 using Amazon.Runtime.Credentials.Internal;
 using Amazon.Runtime.Identity;
+using Amazon.Runtime.Credentials;
 
 #if NETSTANDARD
 using System.Net.Http;
@@ -84,10 +85,12 @@ namespace Amazon.Runtime
         IIdentityResolverConfiguration IdentityResolverConfiguration { get; }
 
         /// <summary>
-        /// For Services using Bearer authentication, this controls how <see cref="BearerTokenSigner"/>
+        /// For services using Bearer authentication, this provider can be used to override how the <see cref="BearerTokenSigner"/>
         /// resolves a <see cref="AWSToken"/>.
         /// <para />
         /// See <see cref="DefaultAWSTokenProviderChain"/> for additional information.
+        /// <para />
+        /// If null, the SDK will use the <see cref="DefaultAWSTokenIdentityResolver"/> to resolve the bearer token.
         /// </summary>
         IAWSTokenProvider AWSTokenProvider { get; }
 


### PR DESCRIPTION
## Description
Another change based on our bug bash feedback: `AWSTokenProvider` was marked as deprecated but there isn't a lot of documentation on how to extend the new `IIdentityResolverConfiguration` interface (something we'll need to include in the developer guide).

For now, remove the obsolete attribute and the default assignment (so that the SDK uses the SRA resolvers by default), but still honor the token provider if it's set (which both PowerShell and the Toolkit do).

## Testing
- Dry-run: `DRY_RUN-a1367950-84d3-462d-b9ef-c78aaf6bfd88`

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
