### PR TITLE
Update HttpRequestMessageFactory to correctly set the Content-Length header

### DIFF
--- a/generator/.DevConfigs/fd7bf4a4-a773-4855-9bfd-7177595cb738.json
+++ b/generator/.DevConfigs/fd7bf4a4-a773-4855-9bfd-7177595cb738.json
@@ -1,0 +1,10 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Update `HttpRequestMessageFactory` to correctly set the `Content-Length` header for .NET Standard / .NET 8"
+        ],
+        "backwardIncompatibilitiesToIgnore": [],
+        "type": "patch",
+        "updateMinimum": true
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
@@ -625,7 +625,7 @@ namespace Amazon.Runtime
             if ((isChunkedUploadWrapperStreamWithLength || isTrailingHeadersWrapperStreamWithLength || isCompressionWrapperStreamWithLength)
                 || (chunkedUploadWrapperStream == null && trailingHeadersWrapperStream == null && compressionWrapperStream == null))
             {
-                _request.Content.Headers.ContentLength = contentStream.Length;
+                _request.Content.Headers.ContentLength = contentStream.Length - contentStream.Position;
             }
 
             WriteContentHeaders(contentHeaders);

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
@@ -1,23 +1,20 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Amazon.S3;
-
-using Amazon.DNXCore.IntegrationTests;
 using Amazon.S3.Model;
 using System.Net;
 using System.Threading;
 using System.IO;
+using Amazon.S3.Util;
 
 namespace Amazon.DNXCore.IntegrationTests.S3
 {
     /// <summary>
     /// Summary description for PutObjectTest
     /// </summary>
-    
+
     public class PutObjectTest : TestBase<AmazonS3Client>
     {
         public static readonly long MEG_SIZE = (int)Math.Pow(2, 20);
@@ -34,7 +31,7 @@ namespace Amazon.DNXCore.IntegrationTests.S3
             File.WriteAllText(filePath, "This is some sample text.!!");
             bucketName = UtilityMethods.CreateBucketAsync(Client, "PutObjectTest", true).Result;
         }
-        
+
         protected override void Dispose(bool disposing)
         {
             UtilityMethods.DeleteBucketWithObjectsAsync(Client, bucketName).Wait();
@@ -43,7 +40,7 @@ namespace Amazon.DNXCore.IntegrationTests.S3
             {
                 File.Delete(filePath);
             }
-            
+
             base.Dispose(disposing);
         }
 
@@ -130,8 +127,8 @@ namespace Amazon.DNXCore.IntegrationTests.S3
 
             Console.WriteLine("S3 generated ETag: {0}", response.ETag);
             Assert.True(response.ETag.Length > 0);
-        } 
-         
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -187,6 +184,48 @@ namespace Amazon.DNXCore.IntegrationTests.S3
             Assert.Equal("disposition", headers.ContentDisposition);
             Assert.DoesNotContain("Content-Encoding", headers.Keys, StringComparer.OrdinalIgnoreCase);
             Assert.Null(headers.ContentEncoding);
+        }
+
+        /// <summary>
+        /// Reported in https://github.com/aws/aws-sdk-net/issues/3629
+        /// </summary>
+        [Fact]
+        public async Task TestResetStreamPosition()
+        {
+            var memoryStream = new MemoryStream();
+            long offset;
+
+            using (var writer = new StreamWriter(memoryStream, Encoding.UTF8, 1024, leaveOpen: true))
+            {
+                writer.AutoFlush = true;
+                await writer.WriteAsync("Hello");
+                offset = memoryStream.Position;
+                await writer.WriteAsync("World");
+                await writer.FlushAsync();
+            }
+
+            memoryStream.Seek(offset, SeekOrigin.Begin);
+
+            var putRequest = new PutObjectRequest
+            {
+                CannedACL = S3CannedACL.NoACL,
+                BucketName = bucketName,
+                Key = "test-file.txt",
+                AutoResetStreamPosition = false,
+                AutoCloseStream = !memoryStream.CanSeek,
+                InputStream = memoryStream.CanSeek ? memoryStream : AmazonS3Util.MakeStreamSeekable(memoryStream),
+                UseChunkEncoding = false,
+            };
+
+            var putResponse = await Client.PutObjectAsync(putRequest);
+            Assert.True(putResponse.HttpStatusCode == HttpStatusCode.OK);
+
+            var getResponse = await Client.GetObjectAsync(bucketName, "test-file.txt");
+            using (var reader = new StreamReader(getResponse.ResponseStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                Assert.Equal("World", content);
+            }
         }
 
         private async Task<HeadersCollection> TestPutAndGet(PutObjectRequest request)


### PR DESCRIPTION
## Description
Fixes #3629 

Updates the .NET Standard implementation of the `HttpRequestMessageFactory` class to consider the current stream position when setting the `Content-Length` header (note: we have an [existing test for a similar scenario](https://github.com/aws/aws-sdk-net/blob/29fda0c9adc353b460e6abe716b1916d9ba17bb4/sdk/test/Services/S3/IntegrationTests/PutObjectTests.cs#L1309) but it only runs for the .NET Framework - another data point for https://github.com/aws/aws-sdk-net/issues/1181).

## Testing
- Dry-run: `DRY_RUN-fd5ab0eb-2c23-4fe3-9280-70cf24752fa6`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license