### PR TITLE
Fix an issue with buffer pooling in s3 after stj merge

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/MultipartUploadCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/MultipartUploadCommand.async.cs
@@ -214,8 +214,8 @@ namespace Amazon.S3.Transfer.Internal
                 long minPartSize = request?.PartSize != 0 ? request.PartSize : S3Constants.MinPartSize;
                 var uploadPartResponses = new List<UploadPartResponse>();
                 var readBuffer = ArrayPool<byte>.Shared.Rent(READ_BUFFER_SIZE);
-                var partBuffer = ArrayPool<byte>.Shared.Rent((int)minPartSize + (READ_BUFFER_SIZE));
-
+                var partBuffer = ArrayPool<byte>.Shared.Rent((int)minPartSize + readBuffer.Length);
+                
                 MemoryStream nextUploadBuffer = new MemoryStream(partBuffer);
                 using (var stream = request.InputStream)
                 {
@@ -232,7 +232,6 @@ namespace Amazon.S3.Transfer.Internal
                             // read the stream ahead and process it in the next iteration.
                             // this is used to set isLastPart when there is no data left in the stream.
                             readAheadBytesCount = await stream.ReadAsync(readBuffer, 0, readBuffer.Length).ConfigureAwait(false);
-
                             if ((nextUploadBuffer.Position > minPartSize || readAheadBytesCount == 0))
                             {
                                 if (nextUploadBuffer.Position == 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
S3 is the only XML-based service that uses buffer pooling. This happens when we upload an unseekable stream. Now that all JSON based services use buffer pooling for writing and reading, it is possible that when requesting a buffer from the pool, the pool will return a buffer with a size that is larger than requested. Microsoft guarantees that the size of the pool will be _at least_ the requested length. This manifested in the following error message (which only happened in dry runs and only on the 1st attempt). The test would always pass on the second attempt, meaning that one of the buffers that was used in the other integ tests was being used in this test.
```
 Error Message:
   Test method AWSSDK_DotNet.IntegrationTests.Tests.S3.TransferUtilityTests.UploadUnSeekableStreamWithMetadataAndHeadersTest threw exception: 
System.NotSupportedException: Memory stream is not expandable.
  Stack Trace:
      at System.IO.__Error.MemoryStreamNotExpandable()
   at System.IO.MemoryStream.set_Capacity(Int32 value)
   at System.IO.MemoryStream.EnsureCapacity(Int32 value)
```
The fix is to just be intentional with the length and use the buffer's length instead of `READ_BUFFER_SIZE` for the partbuffer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
This makes sure the integ test always passes on the 1st attempt
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
DRY_RUN-0bf015c5-4104-44e0-a944-24c22e5d605a
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement