### PR TITLE
Handle older S3 packages for operations that require MD5 or checksums

### DIFF
--- a/generator/.DevConfigs/43745a80-c082-4df4-a73e-413191e5b816.json
+++ b/generator/.DevConfigs/43745a80-c082-4df4-a73e-413191e5b816.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "updateMinimum": true,
+        "type": "Patch",
+        "changeLogMessages": [
+            "Update data integrity component to handle older versions of the `AWSSDK.S3` package when operations require a `Content-MD5` header"
+        ]
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
@@ -347,7 +347,13 @@ namespace Amazon.Runtime.Internal.Util
             // S3 does not support).
 
             // TODO: Similar to "SetRequestChecksum", this method should be removed in V4.
-            if (!string.IsNullOrEmpty(checksumAlgorithm))
+            if (fallbackToMD5)
+            {
+                // Reported in https://github.com/aws/aws-sdk-net/issues/3641
+                // Some operations will fail if the Content-MD5 header is not set, so we need to set it to maintain backwards compatibility.
+                SetChecksumData(request);
+            }
+            else if (!string.IsNullOrEmpty(checksumAlgorithm))
             {
                 SetChecksumData(request, checksumAlgorithm, fallbackToMD5, isRequestChecksumRequired: true);
             }


### PR DESCRIPTION
Fixes #3641 

## Description
In the `ChecksumUtils` class (the component responsible for calculating the request checksums), I added some logic to handle newer `Core` packages + older `S3` packages, however I only checked the multi-part upload scenario (which I knew it was going to break).

However, the approach I chose (to skip checksums entirely) breaks other use cases, such as `DeleteObjects` which will fail if there's no `Content-MD5 OR x-amz-checksum-*` headers in the request.

This PR expands the workaround we have (which has already been removed from V4), to use MD5 when needed.

## Testing
- Dry-run (in progress): `DRY_RUN-95b5e09f-5645-43aa-b89b-65e2e82fc551`
- Ran a console app locally using latest `Core` and `S3` before the data integrity changes:
```csharp
var s3 = new AmazonS3Client(RegionEndpoint.USWest2);

// Works
var deleteObjectsRequest = new DeleteObjectsRequest
{
    BucketName = "my-bucket",
    Objects = [new KeyVersion() { Key = "partitions.json" }]
};
await s3.DeleteObjectsAsync(deleteObjectsRequest);

// The original workaround was in place for directory buckets and MPUs, confirmed it still works as expected
var tu = new TransferUtility(s3);
await tu.UploadAsync(new TransferUtilityUploadRequest
{
    BucketName = "test-usw2-az1--x-s3",
    Key = "test.zip",
    FilePath = @"C:\Users\dspin\Downloads\net472.zip",
});
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [ ] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
