### PR TITLE
fix: Added check following double-checked locking optimization to validate _awsSigV4AProvider is not initialized after acquiring initial lock in AWS4aSignerCRTWrapper constructor.

### DIFF
--- a/generator/.DevConfigs/47bbe572-c28d-4a91-b201-50af880a5961.json
+++ b/generator/.DevConfigs/47bbe572-c28d-4a91-b201-50af880a5961.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Added check following double-checked locking optimization to validate _awsSigV4AProvider is not initialized after acquiring initial lock in AWS4aSignerCRTWrapper constructor."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
@@ -58,33 +58,36 @@ namespace Amazon.Runtime.Internal.Auth
             {
                 lock(_lock)
                 {
-                    _awsSigV4AProvider = GlobalRuntimeDependencyRegistry.Instance.GetInstance<IAWSSigV4aProvider>(CRT_WRAPPER_ASSEMBLY_NAME, CRT_WRAPPER_CLASS_NAME,
-                            new CreateInstanceContext(new SigV4aCrtSignerContext(signPayload)));
-
                     if (_awsSigV4AProvider == null)
                     {
-                        try
-                        {
-                            var crtWrapperType = ServiceClientHelpers.LoadTypeFromAssembly(CRT_WRAPPER_ASSEMBLY_NAME, CRT_WRAPPER_CLASS_NAME);
-                            var constructor = crtWrapperType.GetConstructor(new Type[]
-                            {
-                                typeof(bool)
-                            });
-                            _awsSigV4AProvider = constructor.Invoke(new object[] { signPayload }) as IAWSSigV4aProvider;
+                        _awsSigV4AProvider = GlobalRuntimeDependencyRegistry.Instance.GetInstance<IAWSSigV4aProvider>(CRT_WRAPPER_ASSEMBLY_NAME, CRT_WRAPPER_CLASS_NAME,
+                                new CreateInstanceContext(new SigV4aCrtSignerContext(signPayload)));
 
-                        }
-                        catch (Exception)
+                        if (_awsSigV4AProvider == null)
                         {
-                            if (InternalSDKUtils.IsRunningNativeAot())
+                            try
                             {
-                                throw new MissingRuntimeDependencyException(CRT_WRAPPER_NUGET_PACKGE_NAME, CRT_WRAPPER_CLASS_NAME, nameof(GlobalRuntimeDependencyRegistry.RegisterSigV4aProvider));
+                                var crtWrapperType = ServiceClientHelpers.LoadTypeFromAssembly(CRT_WRAPPER_ASSEMBLY_NAME, CRT_WRAPPER_CLASS_NAME);
+                                var constructor = crtWrapperType.GetConstructor(new Type[]
+                                {
+                                    typeof(bool)
+                                });
+                                _awsSigV4AProvider = constructor.Invoke(new object[] { signPayload }) as IAWSSigV4aProvider;
+
                             }
+                            catch (Exception)
+                            {
+                                if (InternalSDKUtils.IsRunningNativeAot())
+                                {
+                                    throw new MissingRuntimeDependencyException(CRT_WRAPPER_NUGET_PACKGE_NAME, CRT_WRAPPER_CLASS_NAME, nameof(GlobalRuntimeDependencyRegistry.RegisterSigV4aProvider));
+                                }
 
-                            throw new AWSCommonRuntimeException
-                            (
-                                string.Format(CultureInfo.InvariantCulture, "Attempting to make a request that requires an implementation of AWS Signature V4a. " +
-                                $"Add a reference to the {CRT_WRAPPER_NUGET_PACKGE_NAME} NuGet package to your project to include the AWS Signature V4a signer.")
-                            );
+                                throw new AWSCommonRuntimeException
+                                (
+                                    string.Format(CultureInfo.InvariantCulture, "Attempting to make a request that requires an implementation of AWS Signature V4a. " +
+                                    $"Add a reference to the {CRT_WRAPPER_NUGET_PACKGE_NAME} NuGet package to your project to include the AWS Signature V4a signer.")
+                                );
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Description
Added check following double-checked locking optimization to validate `_awsSigV4AProvider` is not initialized after acquiring initial lock in `AWS4aSignerCRTWrapper` constructor.

## Motivation and Context
Internal ticket.

## Testing
Dry-run `DRY_RUN-b0dc4da4-3eef-4b3d-83c1-553b43380ac3` completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement