### PR TITLE
Add empty input and no input protocol tests to ignore list

### DIFF
--- a/generator/ProtocolTestsGenerator/smithy-dotnet-codegen/src/main/java/software/amazon/smithy/dotnet/codegen/customizations/ProtocolTestCustomizations.java
+++ b/generator/ProtocolTestsGenerator/smithy-dotnet-codegen/src/main/java/software/amazon/smithy/dotnet/codegen/customizations/ProtocolTestCustomizations.java
@@ -90,8 +90,13 @@ public final class ProtocolTestCustomizations {
             "XmlUnionsWithStructMember",
             "XmlUnionsWithStringMember",
             "XmlUnionsWithBooleanMember",
-            "XmlUnionsWithUnionMember"
-
+            "XmlUnionsWithUnionMember",
+            // the .NET SDK will not support these tests as the service should be sending back valid xml in the response even if
+            // the response is empty. Net's built-in xml serializer throws an exception if no root element is present and we do not want
+            // to use exceptions and control flow.
+            "QueryEmptyInputAndEmptyOutput",
+            "QueryNoInputAndNoOutput",
+            "QueryNoInputAndOutput"
     );
     public static final List<String> VNextTests = Arrays.asList(
             // These tests are not actually breaking change but have their own backlog item to be addressed.
@@ -103,11 +108,6 @@ public final class ProtocolTestCustomizations {
             "QueryQueryFlattenedXmlMapWithXmlName",
             "QueryQueryFlattenedXmlMapWithXmlNamespace",
             "RestXmlXmlMapWithXmlNamespace",
-            // the .NET SDK will not support these tests as the service should be sending back valid xml in the response even if
-            // the response is empty. Net's built-in xml serializer throws an exception if no root element is present.
-            "QueryEmptyInputAndEmptyOutput",
-            "QueryNoInputAndNoOutput",
-            "QueryNoInputAndOutput",
             //These are the tests that are failing in v4 after updating to 1.54.0 and artifacts 1.0.3004.0. Each one needs to be investigated.
             "RestJsonEnumPayloadRequest",
             "RestJsonStringPayloadRequest",

--- a/sdk/test/ProtocolTests/Generated/QueryProtocol/dotnet-protocol-test-codegen/EmptyInputAndEmptyOutput.cs
+++ b/sdk/test/ProtocolTests/Generated/QueryProtocol/dotnet-protocol-test-codegen/EmptyInputAndEmptyOutput.cs
@@ -30,7 +30,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
 
 namespace AWSSDK.ProtocolTests.AwsQuery
@@ -38,77 +37,5 @@ namespace AWSSDK.ProtocolTests.AwsQuery
     [TestClass]
     public class EmptyInputAndEmptyOutput
     {
-        /// <summary>
-        /// Empty input serializes no extra query params
-        /// </summary>
-        /*
-        * This test either requires a breaking change and will be addressed
-        * in V4, or has a backlog item to be fixed in the future. Please
-        * refer to the VNextTests list to see which it is.
-        * */
-        [Ignore]
-        [TestMethod]
-        [TestCategory("ProtocolTest")]
-        [TestCategory("RequestTest")]
-        [TestCategory("AwsQuery")]
-        public void QueryEmptyInputAndEmptyOutputRequest()
-        {
-            // Arrange
-            var request = new EmptyInputAndEmptyOutputRequest
-            {
-            };
-            var config = new AmazonQueryProtocolConfig
-            {
-              ServiceURL = "https://test.com/"
-            };
-
-            var marshaller = new EmptyInputAndEmptyOutputRequestMarshaller();
-            // Act
-            var marshalledRequest = ProtocolTestUtils.RunMockRequest(request,marshaller,config);
-
-            // Assert
-            var expectedParams = QueryTestUtils.ConvertBodyToParameters("Action=EmptyInputAndEmptyOutput&Version=2020-01-08");
-            foreach(var queryParam in expectedParams.Keys)
-            {
-               Assert.IsTrue(marshalledRequest.Parameters.Keys.Contains(queryParam));
-               Assert.AreEqual(WebUtility.UrlDecode(expectedParams[queryParam].ToString()),WebUtility.UrlDecode(marshalledRequest.Parameters[queryParam].ToString()));
-            }
-
-            Assert.AreEqual("POST", marshalledRequest.HttpMethod);
-            Uri actualUri = AmazonServiceClient.ComposeUrl(marshalledRequest);
-            Assert.AreEqual("/", ProtocolTestUtils.GetEncodedResourcePathFromOriginalString(actualUri));
-            Assert.AreEqual("application/x-www-form-urlencoded; charset=utf-8",marshalledRequest.Headers["Content-Type"]);
-        }
-
-        /// <summary>
-        /// Empty output
-        /// </summary>
-        // This test requires a breaking change, and will be addressed in V4
-        [Ignore]
-        [TestMethod]
-        [TestCategory("ProtocolTest")]
-        [TestCategory("ResponseTest")]
-        [TestCategory("AwsQuery")]
-        public void QueryEmptyInputAndEmptyOutputResponse()
-        {
-            // Arrange
-            var webResponseData = new WebResponseData();
-            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200);
-            byte[] bytes = Encoding.ASCII.GetBytes("");
-            var stream = new MemoryStream(bytes);
-            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
-
-            // Act
-            var unmarshalledResponse = new EmptyInputAndEmptyOutputResponseUnmarshaller().Unmarshall(context);
-            var expectedResponse = new EmptyInputAndEmptyOutputResponse
-            {
-            };
-
-            // Assert
-            var actualResponse = (EmptyInputAndEmptyOutputResponse)unmarshalledResponse;
-            Comparer.CompareObjects<EmptyInputAndEmptyOutputResponse>(expectedResponse,actualResponse);
-            Assert.AreEqual((HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200), context.ResponseData.StatusCode);
-        }
-
     }
 }

--- a/sdk/test/ProtocolTests/Generated/QueryProtocol/dotnet-protocol-test-codegen/NoInputAndNoOutput.cs
+++ b/sdk/test/ProtocolTests/Generated/QueryProtocol/dotnet-protocol-test-codegen/NoInputAndNoOutput.cs
@@ -30,7 +30,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
 
 namespace AWSSDK.ProtocolTests.AwsQuery
@@ -38,78 +37,5 @@ namespace AWSSDK.ProtocolTests.AwsQuery
     [TestClass]
     public class NoInputAndNoOutput
     {
-        /// <summary>
-        /// No input serializes no additional query params
-        /// </summary>
-        /*
-        * This test either requires a breaking change and will be addressed
-        * in V4, or has a backlog item to be fixed in the future. Please
-        * refer to the VNextTests list to see which it is.
-        * */
-        [Ignore]
-        [TestMethod]
-        [TestCategory("ProtocolTest")]
-        [TestCategory("RequestTest")]
-        [TestCategory("AwsQuery")]
-        public void QueryNoInputAndNoOutputRequest()
-        {
-            // Arrange
-            var request = new NoInputAndNoOutputRequest
-            {
-            };
-            var config = new AmazonQueryProtocolConfig
-            {
-              ServiceURL = "https://test.com/"
-            };
-
-            var marshaller = new NoInputAndNoOutputRequestMarshaller();
-            // Act
-            var marshalledRequest = ProtocolTestUtils.RunMockRequest(request,marshaller,config);
-
-            // Assert
-            var expectedParams = QueryTestUtils.ConvertBodyToParameters("Action=NoInputAndNoOutput&Version=2020-01-08");
-            foreach(var queryParam in expectedParams.Keys)
-            {
-               Assert.IsTrue(marshalledRequest.Parameters.Keys.Contains(queryParam));
-               Assert.AreEqual(WebUtility.UrlDecode(expectedParams[queryParam].ToString()),WebUtility.UrlDecode(marshalledRequest.Parameters[queryParam].ToString()));
-            }
-
-            Assert.AreEqual("POST", marshalledRequest.HttpMethod);
-            Uri actualUri = AmazonServiceClient.ComposeUrl(marshalledRequest);
-            Assert.AreEqual("/", ProtocolTestUtils.GetEncodedResourcePathFromOriginalString(actualUri));
-            Assert.AreEqual("application/x-www-form-urlencoded; charset=utf-8",marshalledRequest.Headers["Content-Type"]);
-        }
-
-        /// <summary>
-        /// Empty output. Note that no assertion is made on the output body
-        /// itself.
-        /// </summary>
-        // This test requires a breaking change, and will be addressed in V4
-        [Ignore]
-        [TestMethod]
-        [TestCategory("ProtocolTest")]
-        [TestCategory("ResponseTest")]
-        [TestCategory("AwsQuery")]
-        public void QueryNoInputAndNoOutputResponse()
-        {
-            // Arrange
-            var webResponseData = new WebResponseData();
-            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200);
-            byte[] bytes = Encoding.ASCII.GetBytes("");
-            var stream = new MemoryStream(bytes);
-            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
-
-            // Act
-            var unmarshalledResponse = new NoInputAndNoOutputResponseUnmarshaller().Unmarshall(context);
-            var expectedResponse = new NoInputAndNoOutputResponse
-            {
-            };
-
-            // Assert
-            var actualResponse = (NoInputAndNoOutputResponse)unmarshalledResponse;
-            Comparer.CompareObjects<NoInputAndNoOutputResponse>(expectedResponse,actualResponse);
-            Assert.AreEqual((HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200), context.ResponseData.StatusCode);
-        }
-
     }
 }

--- a/sdk/test/ProtocolTests/Generated/QueryProtocol/dotnet-protocol-test-codegen/NoInputAndOutput.cs
+++ b/sdk/test/ProtocolTests/Generated/QueryProtocol/dotnet-protocol-test-codegen/NoInputAndOutput.cs
@@ -30,7 +30,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
 
 namespace AWSSDK.ProtocolTests.AwsQuery
@@ -38,77 +37,5 @@ namespace AWSSDK.ProtocolTests.AwsQuery
     [TestClass]
     public class NoInputAndOutput
     {
-        /// <summary>
-        /// No input serializes no payload
-        /// </summary>
-        /*
-        * This test either requires a breaking change and will be addressed
-        * in V4, or has a backlog item to be fixed in the future. Please
-        * refer to the VNextTests list to see which it is.
-        * */
-        [Ignore]
-        [TestMethod]
-        [TestCategory("ProtocolTest")]
-        [TestCategory("RequestTest")]
-        [TestCategory("AwsQuery")]
-        public void QueryNoInputAndOutputRequest()
-        {
-            // Arrange
-            var request = new NoInputAndOutputRequest
-            {
-            };
-            var config = new AmazonQueryProtocolConfig
-            {
-              ServiceURL = "https://test.com/"
-            };
-
-            var marshaller = new NoInputAndOutputRequestMarshaller();
-            // Act
-            var marshalledRequest = ProtocolTestUtils.RunMockRequest(request,marshaller,config);
-
-            // Assert
-            var expectedParams = QueryTestUtils.ConvertBodyToParameters("Action=NoInputAndOutput&Version=2020-01-08");
-            foreach(var queryParam in expectedParams.Keys)
-            {
-               Assert.IsTrue(marshalledRequest.Parameters.Keys.Contains(queryParam));
-               Assert.AreEqual(WebUtility.UrlDecode(expectedParams[queryParam].ToString()),WebUtility.UrlDecode(marshalledRequest.Parameters[queryParam].ToString()));
-            }
-
-            Assert.AreEqual("POST", marshalledRequest.HttpMethod);
-            Uri actualUri = AmazonServiceClient.ComposeUrl(marshalledRequest);
-            Assert.AreEqual("/", ProtocolTestUtils.GetEncodedResourcePathFromOriginalString(actualUri));
-            Assert.AreEqual("application/x-www-form-urlencoded; charset=utf-8",marshalledRequest.Headers["Content-Type"]);
-        }
-
-        /// <summary>
-        /// Empty output
-        /// </summary>
-        // This test requires a breaking change, and will be addressed in V4
-        [Ignore]
-        [TestMethod]
-        [TestCategory("ProtocolTest")]
-        [TestCategory("ResponseTest")]
-        [TestCategory("AwsQuery")]
-        public void QueryNoInputAndOutputResponse()
-        {
-            // Arrange
-            var webResponseData = new WebResponseData();
-            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200);
-            byte[] bytes = Encoding.ASCII.GetBytes("");
-            var stream = new MemoryStream(bytes);
-            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
-
-            // Act
-            var unmarshalledResponse = new NoInputAndOutputResponseUnmarshaller().Unmarshall(context);
-            var expectedResponse = new NoInputAndOutputResponse
-            {
-            };
-
-            // Assert
-            var actualResponse = (NoInputAndOutputResponse)unmarshalledResponse;
-            Comparer.CompareObjects<NoInputAndOutputResponse>(expectedResponse,actualResponse);
-            Assert.AreEqual((HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200), context.ResponseData.StatusCode);
-        }
-
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding these 3 tests to the tests to skip list b/c no aws service should be sending back a response with no XML root element. If we wanted to support this we would have to use exceptions as control flow which is a bad practice. Also, the fact that the exception is thrown by the built-in serializer means it isn't something we can change on our end.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement