### PR TITLE
Improve error message when no credentials are found

### DIFF
--- a/generator/.DevConfigs/F17B90E5-428E-4C68-A27C-A501F825CAE0.json
+++ b/generator/.DevConfigs/F17B90E5-428E-4C68-A27C-A501F825CAE0.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Improved error message when searching for AWS credentials and no credentials were found."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }


### PR DESCRIPTION
## Description
Today when resolving AWS credentials the final provider in the chain is the EC2 IMDS provider. There isn't a test to see if there will be credentials from IMDS as part of the search. As the request is being made the EC2 IMDS provider fails with an error message about failing to find credentials from IMDS and if the user is running in an unconfigured dev environment the error message is really confusing.

In this PR when we reach the end stage of IMDS do a check to get credentials from IMDS. If it fails then search path returns back an error message that no AWS credentials were found and provides the error messages from all of the attempted credential providers.

Since the IMDS credential provider caches the credentials resolved from IMDS having the search path do the credential validation does not result in a second resolution when the request is sent. Basically it just moves the fetch from IMDS if it exists to earlier in the process.

## Testing
Manual test with modifying my dev environments credentials setup to confirm the error message
Dry Run: DRY_RUN-8e89c57a-7bd5-4046-9904-3ff563d7dd20

