### PR TITLE
[V4] Updated EventStreams Byte to SByte to be inline with the spec where Byte was intended to be signed.

### DIFF
--- a/generator/.DevConfigs/76c15841-f43d-47fb-8633-20d2a76774ee.json
+++ b/generator/.DevConfigs/76c15841-f43d-47fb-8633-20d2a76774ee.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "[Breaking Change] Updated EventStreams Byte to SByte to be inline with the spec where Byte was intended to be signed."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/EventStreams/EventStreamHeader.cs
+++ b/sdk/src/Core/Amazon.Runtime/EventStreams/EventStreamHeader.cs
@@ -36,7 +36,7 @@ namespace Amazon.Runtime.EventStreams
     {
         BoolTrue = 0,
         BoolFalse,
-        Byte,
+        SByte,
         Int16,
         Int32,
         Int64,
@@ -88,14 +88,14 @@ namespace Amazon.Runtime.EventStreams
         void SetBool(bool value);
 
         /// <summary>
-        /// Returns the current value as a byte
+        /// Returns the current value as a signed byte
         /// </summary>
-        Byte AsByte();
+        sbyte AsSByte();
 
         /// <summary>
         /// Sets the current value
         /// </summary>
-        void SetByte(Byte value);
+        void SetSByte(sbyte value);
 
         /// <summary>
         /// Gets the current value as a 16 bit integer. (Host Order).
@@ -236,8 +236,8 @@ namespace Amazon.Runtime.EventStreams
                 case EventStreamHeaderType.BoolFalse:
                     header.HeaderValue = false;
                     break;
-                case EventStreamHeaderType.Byte:
-                    header.HeaderValue = buffer[newOffset];
+                case EventStreamHeaderType.SByte:
+                    header.HeaderValue = (sbyte)buffer[newOffset];
                     newOffset += _sizeOfByte;
                     break;
                 case EventStreamHeaderType.Int16:
@@ -313,8 +313,8 @@ namespace Amazon.Runtime.EventStreams
                 case EventStreamHeaderType.BoolTrue:
                 case EventStreamHeaderType.BoolFalse:
                     break;
-                case EventStreamHeaderType.Byte:
-                    buffer[newOffset++] = (byte)HeaderValue;
+                case EventStreamHeaderType.SByte:
+                    buffer[newOffset++] = (byte)(sbyte)HeaderValue;
                     break;
                 case EventStreamHeaderType.Int16:
                     serializedBytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((Int16)HeaderValue));
@@ -382,7 +382,7 @@ namespace Amazon.Runtime.EventStreams
                 case EventStreamHeaderType.BoolTrue:
                 case EventStreamHeaderType.BoolFalse:
                     break;
-                case EventStreamHeaderType.Byte:
+                case EventStreamHeaderType.SByte:
                     len += _sizeOfByte;
                     break;
                 case EventStreamHeaderType.Int16:
@@ -434,20 +434,20 @@ namespace Amazon.Runtime.EventStreams
         }
 
         /// <summary>
-        /// Returns the current value as a byte
+        /// Returns the current value as a signed byte
         /// </summary>
-        public Byte AsByte()
+        public sbyte AsSByte()
         {
-            return (Byte)HeaderValue;
+            return (sbyte)HeaderValue;
         }
 
         /// <summary>
         /// Sets the current value
         /// </summary>
-        public void SetByte(Byte value)
+        public void SetSByte(sbyte value)
         {
             HeaderValue = value;
-            HeaderType = EventStreamHeaderType.Byte;
+            HeaderType = EventStreamHeaderType.SByte;
         }
 
         /// <summary>

--- a/sdk/test/UnitTests/Custom/Runtime/EventStreams/EventStreamMessageTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/EventStreams/EventStreamMessageTest.cs
@@ -148,10 +148,9 @@ namespace AWSSDK.UnitTests
                                 var boolVal = header.GetProperty(HeaderValueField).GetBoolean();
                                 Assert.AreEqual(boolVal, headerValue.AsBool());
                                 break;
-                            case EventStreamHeaderType.Byte:
-                                //commenting this out for now because the test case clearly defines a signed byte and this needs to be changed internally
-                                //var byteVal = header.GetProperty(HeaderValueField).GetSByte();
-                                //Assert.AreEqual(byteVal, headerValue.AsSByte());
+                            case EventStreamHeaderType.SByte:                                
+                                var byteVal = header.GetProperty(HeaderValueField).GetSByte();
+                                Assert.AreEqual(byteVal, headerValue.AsSByte());
                                 break;
                             case EventStreamHeaderType.Int16:
                                 var int16Val = header.GetProperty(HeaderValueField).GetInt16();
@@ -162,8 +161,8 @@ namespace AWSSDK.UnitTests
                                 Assert.AreEqual(int32Val, headerValue.AsInt32());
                                 break;
                             case EventStreamHeaderType.Int64:
-                                var intVal = header.GetProperty(HeaderValueField).GetInt64();
-                                Assert.AreEqual(intVal, headerValue.AsInt64());
+                                var int64Val = header.GetProperty(HeaderValueField).GetInt64();
+                                Assert.AreEqual(int64Val, headerValue.AsInt64());
                                 break;
                             case EventStreamHeaderType.Timestamp:
                                 var dateVal = header.GetProperty(HeaderValueField).GetInt64();
@@ -227,10 +226,9 @@ namespace AWSSDK.UnitTests
                                 var boolVal = header.GetProperty(HeaderValueField).GetBoolean();
                                 headerValue.SetBool(boolVal);
                                 break;
-                            case EventStreamHeaderType.Byte:
-                                // commenting this out for now b/c the test case clearly defines a signed byte and this needs to be changed internally
-                                //var byteVal = (sbyte)(int)header[HeaderValueField];
-                                //headerValue.SetSByte(byteVal);
+                            case EventStreamHeaderType.SByte:                                
+                                var byteVal = header.GetProperty(HeaderValueField).GetSByte();
+                                headerValue.SetSByte(byteVal);
                                 break;
                             case EventStreamHeaderType.Int16:
                                 var int16Val = header.GetProperty(HeaderValueField).GetInt16();
@@ -241,8 +239,8 @@ namespace AWSSDK.UnitTests
                                 headerValue.SetInt32(int32Val);
                                 break;
                             case EventStreamHeaderType.Int64:
-                                var intVal = (long)header.GetProperty(HeaderValueField).GetInt64();
-                                headerValue.SetInt64(intVal);
+                                var int64Val = (long)header.GetProperty(HeaderValueField).GetInt64();
+                                headerValue.SetInt64(int64Val);
                                 break;
                             case EventStreamHeaderType.Timestamp:
                                 var dateVal = header.GetProperty(HeaderValueField).GetInt64();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changed `EventStreamHeaderType.Byte` to `EventStreamHeaderType.SByte` to be compliant with the specification that a byte is an `Int8` which is a signed 8 bit integer not an unsigned 8 bit integer. Updated unit tests and handling of the SByte.

From the SPEC:

```
struct {
    select (HeaderValueType) {
        case boolean_true:
        case boolean_false:
            struct {};
        case byte:
            int8 value;
        case short:
            int16 value;
        case integer:
            int32 value;
        case long:
            int64 value;
        case byte_array:
            byte data<1..2^15-1>;
        case string:
            utf8 data<1..2^15-1>;
        case timestamp:
            int64 millis_since_epoch;
        case uuid:
            byte value[16];
    } value;
} HeaderValue;
```

The fixed unit test should have been testing a -47 which it couldn't have done as an unsigned byte.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

https://sim.amazon.com/issues/DOTNET-7943

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Fixed Unit Tests. 
* DryRun: DRY_RUN-a606d350-0953-430b-834d-8565a689965f

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement