### PR TITLE
Remove deprecated IMDSv1 support

### DIFF
--- a/generator/.DevConfigs/321FCC2C-F938-46E4-BF84-29E947716685.json
+++ b/generator/.DevConfigs/321FCC2C-F938-46E4-BF84-29E947716685.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "[Breaking Change] Remove support for deprecated IMDS v1."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfile.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfile.cs
@@ -121,14 +121,6 @@ namespace Amazon.Runtime.CredentialManagement
         public EC2MetadataServiceEndpointMode? EC2MetadataServiceEndpointMode { get; set; }
 
         /// <summary>
-        /// If set to true the SDK logic for falling back to V1 will be disabled.
-        /// When using the SDK on an EC2 instance that has configured instance metadata service to 
-        /// use V1 only, a InvalidOperationException exception will be thrown when attempting to access
-        /// the metadata in EC2 instance metadata.This includes AWS credentials and region information.
-        /// </summary>
-        public bool? EC2MetadataV1Disabled { get; set; }
-
-        /// <summary>
         /// Configures the endpoint calculation to go to a dual stack (ipv6 enabled) endpoint
         /// for the configured region.
         /// </summary>

--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/SharedCredentialsFile.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/SharedCredentialsFile.cs
@@ -60,7 +60,6 @@ namespace Amazon.Runtime.CredentialManagement
         private const string SsoSession = "sso_session";
         private const string EC2MetadataServiceEndpointField = "ec2_metadata_service_endpoint";
         private const string EC2MetadataServiceEndpointModeField = "ec2_metadata_service_endpoint_mode";
-        private const string EC2MetadataV1DisabledField = "ec2_metadata_v1_disabled";
         private const string UseDualstackEndpointField = "use_dualstack_endpoint";
         private const string UseFIPSEndpointField = "use_fips_endpoint";
         private const string EndpointUrlField = "endpoint_url";
@@ -94,7 +93,6 @@ namespace Amazon.Runtime.CredentialManagement
             SsoSession,
             EC2MetadataServiceEndpointField,
             EC2MetadataServiceEndpointModeField,
-            EC2MetadataV1DisabledField,
             UseDualstackEndpointField,
             UseFIPSEndpointField,
             DefaultConfigurationModeField,
@@ -414,9 +412,6 @@ namespace Amazon.Runtime.CredentialManagement
 
             if (profile.EC2MetadataServiceEndpointMode != null)
                 reservedProperties[EC2MetadataServiceEndpointModeField] = profile.EC2MetadataServiceEndpointMode.ToString().ToLowerInvariant();
-
-            if (profile.EC2MetadataV1Disabled != null)
-                reservedProperties[EC2MetadataV1DisabledField] = profile.EC2MetadataV1Disabled.ToString().ToLowerInvariant();
 
             if (profile.UseDualstackEndpoint != null)
                 reservedProperties[UseDualstackEndpointField] = profile.UseDualstackEndpoint.ToString().ToLowerInvariant();
@@ -794,20 +789,6 @@ namespace Amazon.Runtime.CredentialManagement
                     }
                 }
 
-                string ec2MetadataV1DisabledString;
-                bool? ec2MetadataV1Disabled = null;
-                if (reservedProperties.TryGetValue(EC2MetadataV1DisabledField, out ec2MetadataV1DisabledString))
-                {
-                    bool ec2MetadataV1DisabledOut;
-                    if (!bool.TryParse(ec2MetadataV1DisabledString, out ec2MetadataV1DisabledOut))
-                    {
-                        Logger.GetLogger(GetType()).InfoFormat("Invalid value {0} for {1} in profile {2}. A boolean true/false is expected.", ec2MetadataV1DisabledString, EC2MetadataV1DisabledField, profileName);
-                        profile = null;
-                        return false;
-                    }
-                    ec2MetadataV1Disabled = ec2MetadataV1DisabledOut;
-                }
-
                 string useDualstackEndpointString;
                 bool? useDualstackEndpoint = null;
                 if (reservedProperties.TryGetValue(UseDualstackEndpointField, out useDualstackEndpointString))
@@ -966,7 +947,6 @@ namespace Amazon.Runtime.CredentialManagement
                     MaxAttempts = maxAttempts,
                     EC2MetadataServiceEndpoint = ec2MetadataServiceEndpoint,
                     EC2MetadataServiceEndpointMode = ec2MetadataServiceEndpointMode,
-                    EC2MetadataV1Disabled = ec2MetadataV1Disabled,
                     UseDualstackEndpoint = useDualstackEndpoint,
                     UseFIPSEndpoint = useFIPSEndpoint,
                     NestedProperties = nestedProperties,

--- a/sdk/src/Core/Amazon.Runtime/Credentials/InstanceProfileAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/InstanceProfileAWSCredentials.cs
@@ -79,7 +79,6 @@ namespace Amazon.Runtime
 
                 if (httpStatusCode == HttpStatusCode.Unauthorized)
                 {
-                    EC2InstanceMetadata.ClearTokenFlag();
                     Logger.GetLogger(typeof(EC2InstanceMetadata)).Error(e, "EC2 Metadata service returned unauthorized for token based secure data flow.");
                     throw;
                 }
@@ -136,7 +135,6 @@ namespace Amazon.Runtime
 
                     if (httpStatusCode == HttpStatusCode.Unauthorized)
                     {
-                        EC2InstanceMetadata.ClearTokenFlag();
                         Logger.GetLogger(typeof(EC2InstanceMetadata)).Error(e, "EC2 Metadata service returned unauthorized for token based secure data flow.");
                     }
 
@@ -231,7 +229,6 @@ namespace Amazon.Runtime
 
                 if (httpStatusCode == HttpStatusCode.Unauthorized)
                 {
-                    EC2InstanceMetadata.ClearTokenFlag();
                     Logger.GetLogger(typeof(EC2InstanceMetadata)).Error(e, "EC2 Metadata service returned unauthorized for token based secure data flow.");
                 }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/InternalConfiguration.cs
@@ -52,11 +52,6 @@ namespace Amazon.Runtime.Internal
         public string EC2MetadataServiceEndpoint { get; set; }
 
         /// <summary>
-        /// Controls whether request EC2 metadata v1 fallback is disabled.
-        /// </summary>
-        public bool? EC2MetadataV1Disabled { get; set; }
-
-        /// <summary>
         /// Internet protocol version to be used for communicating with the EC2 Instance Metadata Service
         /// </summary>
         public EC2MetadataServiceEndpointMode? EC2MetadataServiceEndpointMode { get; set; }
@@ -134,7 +129,6 @@ namespace Amazon.Runtime.Internal
         public const string ENVIRONMENT_VARIABLE_AWS_RETRY_MODE = "AWS_RETRY_MODE";
         public const string ENVIRONMENT_VARIABLE_AWS_EC2_METADATA_SERVICE_ENDPOINT = "AWS_EC2_METADATA_SERVICE_ENDPOINT";
         public const string ENVIRONMENT_VARIABLE_AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE = "AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE";
-        public const string ENVIRONMENT_VARIABLE_AWS_EC2_METADATA_V1_DISABLED = "AWS_EC2_METADATA_V1_DISABLED";
         public const string ENVIRONMENT_VARIABLE_AWS_USE_DUALSTACK_ENDPOINT = "AWS_USE_DUALSTACK_ENDPOINT";
         public const string ENVIRONMENT_VARIABLE_AWS_USE_FIPS_ENDPOINT = "AWS_USE_FIPS_ENDPOINT";
         public const string ENVIRONMENT_VARIABLE_AWS_IGNORE_CONFIGURED_ENDPOINT_URLS = "AWS_IGNORE_CONFIGURED_ENDPOINT_URLS";
@@ -160,7 +154,6 @@ namespace Amazon.Runtime.Internal
             RetryMode = GetEnvironmentVariable<RequestRetryMode>(ENVIRONMENT_VARIABLE_AWS_RETRY_MODE);
             EC2MetadataServiceEndpoint = GetEC2MetadataEndpointEnvironmentVariable();
             EC2MetadataServiceEndpointMode = GetEnvironmentVariable<EC2MetadataServiceEndpointMode>(ENVIRONMENT_VARIABLE_AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE);
-            EC2MetadataV1Disabled = GetEnvironmentVariable<bool>(ENVIRONMENT_VARIABLE_AWS_EC2_METADATA_V1_DISABLED);
             UseDualstackEndpoint = GetEnvironmentVariable<bool>(ENVIRONMENT_VARIABLE_AWS_USE_DUALSTACK_ENDPOINT);
             UseFIPSEndpoint = GetEnvironmentVariable<bool>(ENVIRONMENT_VARIABLE_AWS_USE_FIPS_ENDPOINT);
             IgnoreConfiguredEndpointUrls = GetEnvironmentVariable(ENVIRONMENT_VARIABLE_AWS_IGNORE_CONFIGURED_ENDPOINT_URLS, false);
@@ -336,7 +329,6 @@ namespace Amazon.Runtime.Internal
                 MaxAttempts = profile.MaxAttempts;
                 EC2MetadataServiceEndpoint = profile.EC2MetadataServiceEndpoint;
                 EC2MetadataServiceEndpointMode = profile.EC2MetadataServiceEndpointMode;
-                EC2MetadataV1Disabled = profile.EC2MetadataV1Disabled;
                 UseDualstackEndpoint = profile.UseDualstackEndpoint;
                 UseFIPSEndpoint = profile.UseFIPSEndpoint;
                 IgnoreConfiguredEndpointUrls = profile.IgnoreConfiguredEndpointUrls;
@@ -361,7 +353,6 @@ namespace Amazon.Runtime.Internal
                 new KeyValuePair<string, object>("max_attempts", profile.MaxAttempts),
                 new KeyValuePair<string, object>("ec2_metadata_service_endpoint", profile.EC2MetadataServiceEndpoint),
                 new KeyValuePair<string, object>("ec2_metadata_service_endpoint_mode", profile.EC2MetadataServiceEndpointMode),
-                new KeyValuePair<string, object>("ec2_metadata_v1_disabled", profile.EC2MetadataV1Disabled),
                 new KeyValuePair<string, object>("use_dualstack_endpoint", profile.UseDualstackEndpoint),
                 new KeyValuePair<string, object>("use_fips_endpoint", profile.UseFIPSEndpoint),
                 new KeyValuePair<string,object>( "ignore_configured_endpoint_urls", profile.IgnoreConfiguredEndpointUrls),
@@ -433,7 +424,6 @@ namespace Amazon.Runtime.Internal
             _cachedConfiguration.MaxAttempts = SeekValue(standardGenerators, (c) => c.MaxAttempts);
             _cachedConfiguration.EC2MetadataServiceEndpoint = SeekString(standardGenerators, (c) => c.EC2MetadataServiceEndpoint);
             _cachedConfiguration.EC2MetadataServiceEndpointMode = SeekValue(standardGenerators, (c) => c.EC2MetadataServiceEndpointMode);
-            _cachedConfiguration.EC2MetadataV1Disabled = SeekValue(standardGenerators, (c) => c.EC2MetadataV1Disabled);
             _cachedConfiguration.UseDualstackEndpoint = SeekValue(standardGenerators, (c) => c.UseDualstackEndpoint);
             _cachedConfiguration.UseFIPSEndpoint = SeekValue(standardGenerators, (c) => c.UseFIPSEndpoint);
             _cachedConfiguration.IgnoreConfiguredEndpointUrls = SeekValue(standardGenerators, (c) => c.IgnoreConfiguredEndpointUrls);
@@ -522,17 +512,6 @@ namespace Amazon.Runtime.Internal
             get
             {
                 return _cachedConfiguration.EC2MetadataServiceEndpoint;
-            }
-        }
-
-        /// <summary>
-        /// Controls whether request EC2 metadata v1 fallback is disabled.
-        /// </summary>
-        public static bool? EC2MetadataV1Disabled
-        {
-            get
-            {
-                return _cachedConfiguration.EC2MetadataV1Disabled;
             }
         }
 

--- a/sdk/src/Core/Amazon.Util/EC2InstanceMetadata.cs
+++ b/sdk/src/Core/Amazon.Util/EC2InstanceMetadata.cs
@@ -63,8 +63,6 @@ namespace Amazon.Util
 
         private static Dictionary<string, string> _cache = new Dictionary<string, string>();
 
-        private static bool useNullToken = false;
-
         private static ReaderWriterLockSlim metadataLock = new ReaderWriterLockSlim(); // Lock to control getting metadata across multiple threads.
         private static readonly TimeSpan metadataLockTimeout = TimeSpan.FromMilliseconds(5000);
         private static readonly string _userAgent = InternalSDKUtils.BuildUserAgentString(string.Empty, string.Empty);
@@ -116,10 +114,7 @@ namespace Amazon.Util
         public static string EC2ApiTokenUrl => ServiceEndpoint + LATEST + "/api/token";
 
         /// <summary>
-        /// If set to true the SDK logic for falling back to V1 will be disabled.
-        /// When using the SDK on an EC2 instance that has configured instance metadata service to 
-        /// use V1 only, a InvalidOperationException exception will be thrown when attempting to access
-        /// the metadata in EC2 instance metadata.This includes AWS credentials and region information.
+        /// Disable accessing EC2 instance metadata service (IMDS).
         /// The default value is false.
         /// </summary>
         public static bool IsIMDSEnabled
@@ -135,23 +130,6 @@ namespace Amazon.Util
                 return !True.Equals(value, StringComparison.OrdinalIgnoreCase);
             }
         }
-
-        private static bool? _ec2MetadataV1Disabled;
-        
-        /// <summary>
-        /// Controls whether request EC2 metadata v1 fallback is disabled.
-        /// </summary>
-        public static bool EC2MetadataV1Disabled
-        {
-            get
-            {
-                if (_ec2MetadataV1Disabled.HasValue)
-                    return _ec2MetadataV1Disabled.Value;
-                return FallbackInternalConfigurationFactory.EC2MetadataV1Disabled.GetValueOrDefault();
-            }
-            set { _ec2MetadataV1Disabled = value; }
-        }
-
 
         /// <summary>
         /// Allows to configure the proxy used for HTTP requests. The default value is null.
@@ -647,9 +625,11 @@ namespace Amazon.Util
         /// <returns>The API token or null if an API token couldn't be obtained and doesn't need to be used</returns>
         private static string FetchApiToken(int tries)
         {
+            const string errorFailFastMessage = "IMDS rejected request to get API token.";
+            const string errorMessage = "Unable to retrieve token for use in IMDSv2.";
             for (int retry = 1; retry <= tries; retry++)
             {
-                if (!IsIMDSEnabled || useNullToken)
+                if (!IsIMDSEnabled)
                 {
                     return null;
                 }
@@ -672,55 +652,26 @@ namespace Amazon.Util
                         || httpStatusCode == HttpStatusCode.MethodNotAllowed
                         || httpStatusCode == HttpStatusCode.Forbidden)
                     {
-                        if (EC2MetadataV1Disabled)
-                        {
-                            throw new InvalidOperationException("Unable to retrieve token for use in IMDSv2 call and IMDSv1 has been disabled.");
-                        }
-
-                        useNullToken = true;
-                        return null;
+                        throw new InvalidOperationException(errorFailFastMessage);
                     }
 
                     if (retry >= tries)
                     {
                         if (httpStatusCode == HttpStatusCode.BadRequest)
                         {
-                            Logger.GetLogger(typeof(EC2InstanceMetadata)).Error(e, "Unable to contact EC2 Metadata service to obtain a metadata token.");
+                            Logger.GetLogger(typeof(EC2InstanceMetadata)).Error(e, errorMessage);
                             throw;
                         }
 
-                        Logger.GetLogger(typeof(EC2InstanceMetadata)).Error(e, "Unable to contact EC2 Metadata service to obtain a metadata token. Attempting to access IMDS without a token.");
-
-                        //If there isn't a status code, it was a failure to contact the server which would be
-                        //a request failure, a network issue, or a timeout. Cache this response and fallback
-                        //to IMDS flow without a token unless EC2MetadataV1Disabled is set to true. If the non
-                        //token IMDS flow returns unauthorized, the useNullToken flag will be cleared and the IMDS
-                        //flow will attempt to obtain another token.
-
-                        if (EC2MetadataV1Disabled)
-                        {
-                            throw new InvalidOperationException("Unable to retrieve token for use in IMDSv2 call and IMDSv1 has been disabled.");
-                        }
-
-                        if (httpStatusCode == null)
-                        {
-                            useNullToken = true;
-                        }
-
-                        //Return null to fallback to the IMDS flow without using a token.                    
-                        return null;
+                        Logger.GetLogger(typeof(EC2InstanceMetadata)).Error(e, errorMessage);
+                        throw new InvalidOperationException(errorMessage);
                     }
 
                     PauseExponentially(retry - 1);
                 }
             }
 
-            return null;
-        }
-
-        public static void ClearTokenFlag()
-        {
-            useNullToken = false;
+            throw new InvalidOperationException(errorMessage);
         }
 
         private static List<string> GetItems(string relativeOrAbsolutePath, int tries, bool slurp)
@@ -735,16 +686,20 @@ namespace Amazon.Util
             //token cannot be obtained we will fallback to not using a token.
             if (token == null)
             {
-                token = FetchApiToken(DEFAULT_RETRIES);
+                try
+                {
+                    token = FetchApiToken(DEFAULT_RETRIES);
+                }
+                catch(InvalidOperationException e)
+                {
+                    Logger.GetLogger(typeof(EC2InstanceMetadata)).InfoFormat("Failed to retrieve IMDS data \"{0}\" because IMDS API token could not be retrieved: {1}", relativeOrAbsolutePath, e.Message);
+                    return null; // If we could not get a token then assume we are not running in an EC2 instance and return null.
+                }
             }
 
             var headers = new Dictionary<string, string>();
             headers.Add(HeaderKeys.UserAgentHeader, _userAgent);
-
-            if (!string.IsNullOrEmpty(token))
-            {
-                headers.Add(HeaderKeys.XAwsEc2MetadataToken, token);
-            }
+            headers.Add(HeaderKeys.XAwsEc2MetadataToken, token);
 
             try
             {
@@ -792,7 +747,6 @@ namespace Amazon.Util
                 }
                 else if (httpStatusCode == HttpStatusCode.Unauthorized)
                 {
-                    ClearTokenFlag();
                     Logger.GetLogger(typeof(EC2InstanceMetadata)).Error(e, "EC2 Metadata service returned unauthorized for token based secure data flow.");
                     throw;
                 }

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/FallbackFactoryTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/FallbackFactoryTest.cs
@@ -229,37 +229,6 @@ namespace AWSSDK.UnitTests
             }
         }
 
-        [DataTestMethod]
-        [DataRow(true, false, "ec-metadata-v1-enabled", true)]  // service client should supersede conflicting env var and profile values
-        [DataRow(false, true, "ec-metadata-v1-disabled", false)]
-        [DataRow(null, true, "ec-metadata-v1-enabled", true)]   // env var should supersede conflicting profile value
-        [DataRow(null, false, "ec-metadata-v1-disabled", false)]
-        [DataRow(null, null, "ec-metadata-v1-disabled", true)]    // profile should drive value
-        [DataRow(null, null, "ec-metadata-v1-enabled", false)]
-        [DataRow(null, null, "default", false)]             // should default to false when no config values specified
-        public void TestEC2MetadataV1DisabledConfigurationHierarchy(bool? ec2InstanceMetadataConfigValue, bool? envVarValue, string profileName, bool expectedEC2MetadataV1DisabledValue)
-        {
-            // Reset private _ec2MetadataV1Disabled field to its null
-            ReflectionHelpers.Invoke(typeof(EC2InstanceMetadata), "_ec2MetadataV1Disabled", new object[] { null });
-
-            if (ec2InstanceMetadataConfigValue.HasValue)
-            {
-                EC2InstanceMetadata.EC2MetadataV1Disabled = ec2InstanceMetadataConfigValue.Value;
-            }
-
-            var envVariables = new Dictionary<string, string>();
-            if (envVarValue.HasValue)
-            {
-                envVariables.Add(AWS_EC2_METADATA_V1_DISABLED, envVarValue.Value.ToString());
-            }
-
-            using (new FallbackFactoryTestFixture(ProfileText, profileName, envVariables))
-            {
-                Assert.AreEqual(expectedEC2MetadataV1DisabledValue, EC2InstanceMetadata.EC2MetadataV1Disabled);
-            }
-
-        }
-
         [TestMethod]
         public void TestEnableEndpointDiscoveryEnvVariable()
         {

--- a/sdk/test/UnitTests/Custom/Runtime/EC2InstanceMetadataServlet.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/EC2InstanceMetadataServlet.cs
@@ -20,8 +20,6 @@ namespace AWSSDK.UnitTests
 
         public EC2InstanceMetadataServlet()
         {
-            ResetUseNullToken();
-
             SetupResponseHandler();
 
             var currentEndpointUrl = Environment.GetEnvironmentVariable("AWS_EC2_METADATA_SERVICE_ENDPOINT");
@@ -34,9 +32,6 @@ namespace AWSSDK.UnitTests
         public override void Dispose()
         {
             _metadataServiceEndpointSwitch.Dispose();
-
-            ResetUseNullToken();
-
             base.Dispose();
         }
 
@@ -116,19 +111,6 @@ namespace AWSSDK.UnitTests
         {
             Environment.SetEnvironmentVariable("AWS_EC2_METADATA_SERVICE_ENDPOINT", address);
             FallbackInternalConfigurationFactory.Reset();
-        }
-
-        private static FieldInfo ResetUseNullToken()
-        {
-            var nullTokenField = 
-                typeof(EC2InstanceMetadata)
-                    .GetField("useNullToken", BindingFlags.NonPublic | BindingFlags.Static);
-
-
-            nullTokenField.SetValue(null, false);
-
-            Assert.IsFalse((bool)nullTokenField.GetValue(null));
-            return nullTokenField;
         }
     }
 }


### PR DESCRIPTION
## Description
Remove deprecated IMDS v1 support from the SDK. IMDS v2 has been deployed in all areas so there is no reason to use IMDS v1 and this makes the .NET SDK consistent with other AWS SDKs.

The approach to enforce no V1 behavior is done is the `FetchApiToken` always logs and throws an exception if it was not able to retrieve the token. The `GetItems` call which calls `FetchApiToken` will immediately return null if the `FetchApiToken` throws an exception. Returning null from `GetItems` was needed to maintain behavior in V3 where if you try to access data from the `EC2InstanceMetadata` and you weren't running on EC2 instance you would get a null.


## Testing
Refactored the EC2 instance metadata tests and got them passing.
Manually deployed an application to EC2 and confirm credentials were retrieved
Dry run: DRY_RUN-292cd345-1ae4-4fff-993a-068cd7ed8550 (successful)

