### PR TITLE
Add warning about possible trimmed nested types for DataModel

### DIFF
--- a/generator/.DevConfigs/8A1C32C8-442C-456D-A5ED-AFA5AF737683.json
+++ b/generator/.DevConfigs/8A1C32C8-442C-456D-A5ED-AFA5AF737683.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "Patch",
+            "changeLogMessages": [
+                "Improved error message in DataModel when in Native AOT mode and nested types have been trimmed."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Description
For the Native AOT support with the Object Persistence Model high level library for DynamoDB we used the `DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)`. That assumed by using `DynamicallyAccessedMemberTypes.All` for the type being used with the library nothing for that type would be trimmed. It is possible for nested types referenced by the type being used with DynamoDB it is possible they could be trimmed. That seems surprising behavior that needs investigating but for the now the work around is for users wanting to use Native AOT and run into this problem is to add the `[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(<nested-type>))]` in some method or constructor or code that is for sure not being trimmed.

To help users know they need to do this when this situation arises the error message for when we can't instantiate an object has been updated to give them direction on adding the attribute.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3646

## Testing
Since the problem only happens with Native AOT I relied on manually testing. I recreated the problem by deploying a Lambda function using Native AOT and got the expected error message. Then followed the error message's direction of adding the `DynamicDependency` on the constructor of the parent type and redeployed. The redeployed version was successful

