### PR TITLE
Support DateOnly / TimeOnly in DynamoDBContext

### DIFF
--- a/generator/.DevConfigs/3C7AB270-F926-4FBE-ABA6-B849BF35C377.json
+++ b/generator/.DevConfigs/3C7AB270-F926-4FBE-ABA6-B849BF35C377.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Add Support for DateOnly and TimeOnly in DynamoDB high level libraries. This support is available in .NET 8 and above."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -322,7 +322,7 @@ namespace Amazon.DynamoDBv2
             return converter.TryFromEntry(entry, outputType, out value);
         }
 
-#endregion
+        #endregion
 
         #region Internal members
 
@@ -378,7 +378,7 @@ namespace Amazon.DynamoDBv2
             return pl;
         }
 
-#endregion
+        #endregion
 
         #region Private members
 
@@ -413,6 +413,10 @@ namespace Amazon.DynamoDBv2
             AddConverter(new BoolConverterV1());
             AddConverter(new PrimitiveCollectionConverterV1());
             AddConverter(new DictionaryConverterV1());
+#if NET8_0_OR_GREATER
+            AddConverter(new DateOnlyConverterV1());
+            AddConverter(new TimeOnlyConverterV1());
+#endif
         }
 
         private void SetV2Converters()
@@ -438,6 +442,10 @@ namespace Amazon.DynamoDBv2
             AddConverter(new EnumConverterV2());
             AddConverter(new BoolConverterV2());
             AddConverter(new CollectionConverterV2());
+#if NET8_0_OR_GREATER
+            AddConverter(new DateOnlyConverterV2());
+            AddConverter(new TimeOnlyConverterV2());
+#endif
         }
 
         // Converts items to Primitives.

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
@@ -36,7 +36,7 @@ namespace Amazon.DynamoDBv2
     {
         public override IEnumerable<Type> GetTargetTypes()
         {
-            return new[] { typeof(byte), typeof(Nullable<byte>) }; 
+            return new[] { typeof(byte), typeof(Nullable<byte>) };
         }
 
         protected override bool TryTo(byte value, out Primitive p)
@@ -444,7 +444,51 @@ namespace Amazon.DynamoDBv2
         }
     }
 
-#endregion
+#if NET8_0_OR_GREATER
+    internal class DateOnlyConverterV1 : Converter<DateOnly>
+    {
+        private const string DateOnlyFormat = "yyyy-MM-dd";
+
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(DateOnly), typeof(DateOnly?) };
+        }
+
+        protected override bool TryTo(DateOnly value, out Primitive p)
+        {
+            p = new Primitive(value.ToString(DateOnlyFormat, CultureInfo.InvariantCulture), DynamoDBEntryType.String);
+            return true;
+        }
+
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out DateOnly result)
+        {
+            return DateOnly.TryParseExact(p.StringValue, DateOnlyFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out result);
+        }
+    }
+
+    internal class TimeOnlyConverterV1 : Converter<TimeOnly>
+    {
+        private const string TimeOnlyFormat = "HH:mm:ss.fff";
+
+        public override IEnumerable<Type> GetTargetTypes()
+        {
+            return new[] { typeof(TimeOnly), typeof(TimeOnly?) };
+        }
+
+        protected override bool TryTo(TimeOnly value, out Primitive p)
+        {
+            p = new Primitive(value.ToString(TimeOnlyFormat, CultureInfo.InvariantCulture), DynamoDBEntryType.String);
+            return true;
+        }
+
+        protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out TimeOnly result)
+        {
+            return TimeOnly.TryParseExact(p.StringValue, TimeOnlyFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out result);
+        }
+    }
+#endif
+
+    #endregion
 
     #region Converters supporting reading V2 DDB items, but writing V1 items
 
@@ -569,5 +613,5 @@ namespace Amazon.DynamoDBv2
         }
     }
 
-#endregion
+    #endregion
 }

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV1.cs
@@ -462,7 +462,8 @@ namespace Amazon.DynamoDBv2
 
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out DateOnly result)
         {
-            return DateOnly.TryParseExact(p.StringValue, DateOnlyFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out result);
+            return DateOnly.TryParseExact(p.StringValue, DateOnlyFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out result)
+                || DateOnly.TryParse(p.StringValue, CultureInfo.InvariantCulture, out result);
         }
     }
 
@@ -483,7 +484,8 @@ namespace Amazon.DynamoDBv2
 
         protected override bool TryFrom(Primitive p, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type targetType, out TimeOnly result)
         {
-            return TimeOnly.TryParseExact(p.StringValue, TimeOnlyFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out result);
+            return TimeOnly.TryParseExact(p.StringValue, TimeOnlyFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out result)
+                || TimeOnly.TryParse(p.StringValue, CultureInfo.InvariantCulture, out result);
         }
     }
 #endif

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/SchemaV2.cs
@@ -86,6 +86,14 @@ namespace Amazon.DynamoDBv2
     internal class EnumConverterV2 : EnumConverterV1
     { }
 
+#if NET8_0_OR_GREATER
+    internal class DateOnlyConverterV2 : DateOnlyConverterV1
+    { }
+
+    internal class TimeOnlyConverterV2 : TimeOnlyConverterV1
+    { }
+#endif
+
     #endregion
 
     /// <summary>

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBEntryConversionTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBEntryConversionTests.cs
@@ -244,6 +244,46 @@ namespace AWSSDK_DotNet.UnitTests
             Assert.AreEqual(expectedList, entry);
         }
 
+#if NET8_0_OR_GREATER
+        [DataTestMethod]
+        [DynamicData((nameof(DynamoDBEntryConversions)))]
+        public void ConvertToEntry_DateOnly(DynamoDBEntryConversion conversion)
+        {
+            var dateTime = new DateOnly(2024, 07, 03);
+            var entry = conversion.ConvertToEntry(dateTime);
+            Assert.AreEqual(new Primitive("2024-07-03", false), entry);
+        }
+
+        [DataTestMethod]
+        [DynamicData((nameof(DynamoDBEntryConversions)))]
+        public void ConvertFromEntry_DateOnly(DynamoDBEntryConversion conversion)
+        {
+            var entry = new Primitive("2024-07-03", false);
+            var actualDateTime = conversion.ConvertFromEntry<DateOnly>(entry);
+            var expectedDateTime = new DateOnly(2024, 07, 03);
+            Assert.AreEqual(expectedDateTime, actualDateTime);
+        }
+
+        [DataTestMethod]
+        [DynamicData((nameof(DynamoDBEntryConversions)))]
+        public void ConvertToEntry_TimeOnly(DynamoDBEntryConversion conversion)
+        {
+            var dateTime = new TimeOnly(18, 31, 56, 123);
+            var entry = conversion.ConvertToEntry(dateTime);
+            Assert.AreEqual(new Primitive("18:31:56.123", false), entry);
+        }
+
+        [DataTestMethod]
+        [DynamicData((nameof(DynamoDBEntryConversions)))]
+        public void ConvertFromEntry_TimeOnly(DynamoDBEntryConversion conversion)
+        {
+            var entry = new Primitive("18:31:56.123", false);
+            var actualDateTime = conversion.ConvertFromEntry<TimeOnly>(entry);
+            var expectedDateTime = new TimeOnly(18, 31, 56, 123);
+            Assert.AreEqual(expectedDateTime, actualDateTime);
+        }
+#endif
+
         private void AssertAllConvertersAreRegistered(DynamoDBEntryConversion conversion, string suffix)
         {
             var converters = GetConverters(suffix);

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBEntryConversionTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBEntryConversionTests.cs
@@ -249,8 +249,8 @@ namespace AWSSDK_DotNet.UnitTests
         [DynamicData((nameof(DynamoDBEntryConversions)))]
         public void ConvertToEntry_DateOnly(DynamoDBEntryConversion conversion)
         {
-            var dateTime = new DateOnly(2024, 07, 03);
-            var entry = conversion.ConvertToEntry(dateTime);
+            var dateOnly = new DateOnly(2024, 07, 03);
+            var entry = conversion.ConvertToEntry(dateOnly);
             Assert.AreEqual(new Primitive("2024-07-03", false), entry);
         }
 
@@ -259,17 +259,17 @@ namespace AWSSDK_DotNet.UnitTests
         public void ConvertFromEntry_DateOnly(DynamoDBEntryConversion conversion)
         {
             var entry = new Primitive("2024-07-03", false);
-            var actualDateTime = conversion.ConvertFromEntry<DateOnly>(entry);
-            var expectedDateTime = new DateOnly(2024, 07, 03);
-            Assert.AreEqual(expectedDateTime, actualDateTime);
+            var actualDateOnly = conversion.ConvertFromEntry<DateOnly>(entry);
+            var expectedDateOnly = new DateOnly(2024, 07, 03);
+            Assert.AreEqual(expectedDateOnly, actualDateOnly);
         }
 
         [DataTestMethod]
         [DynamicData((nameof(DynamoDBEntryConversions)))]
         public void ConvertToEntry_TimeOnly(DynamoDBEntryConversion conversion)
         {
-            var dateTime = new TimeOnly(18, 31, 56, 123);
-            var entry = conversion.ConvertToEntry(dateTime);
+            var timeOnly = new TimeOnly(18, 31, 56, 123);
+            var entry = conversion.ConvertToEntry(timeOnly);
             Assert.AreEqual(new Primitive("18:31:56.123", false), entry);
         }
 
@@ -278,8 +278,21 @@ namespace AWSSDK_DotNet.UnitTests
         public void ConvertFromEntry_TimeOnly(DynamoDBEntryConversion conversion)
         {
             var entry = new Primitive("18:31:56.123", false);
-            var actualDateTime = conversion.ConvertFromEntry<TimeOnly>(entry);
-            var expectedDateTime = new TimeOnly(18, 31, 56, 123);
+            var actualTimeOnly = conversion.ConvertFromEntry<TimeOnly>(entry);
+            var expectedTimeOnly = new TimeOnly(18, 31, 56, 123);
+            Assert.AreEqual(expectedTimeOnly, actualTimeOnly);
+        }
+
+        [DataTestMethod]
+        [DynamicData((nameof(DynamoDBEntryConversions)))]
+        public void ConvertFromEntry_ShouldBeAbleToReadDateOnlyAsDateTime(DynamoDBEntryConversion conversion)
+        {
+            var dateOnly = new DateOnly(2024, 07, 03);
+            var entry = conversion.ConvertToEntry(dateOnly);
+
+            var actualDateTime = conversion.ConvertFromEntry<DateTime>(entry);
+            var expectedDateTime = new DateTime(2024, 07, 03, 0, 0, 0, DateTimeKind.Utc);
+
             Assert.AreEqual(expectedDateTime, actualDateTime);
         }
 #endif


### PR DESCRIPTION
## Description
Added DateOnly and TimeOnly converters (for both V1 and V2 schemas).

## Motivation and Context
Fixes #3673 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement