### PR TITLE
Remove the obsolete ReadWriteTimeout property from ClientConfig for non-.NET Framework targets

### DIFF
--- a/generator/.DevConfigs/90F61D8B-19CF-44D7-9373-852DF37452DC.json
+++ b/generator/.DevConfigs/90F61D8B-19CF-44D7-9373-852DF37452DC.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Remove the obsolete ReadWriteTimeout property from ClientConfig all targets except .NET Framework 4.7.2."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -77,7 +77,6 @@ namespace Amazon.Runtime
         private bool? useFIPSEndpoint;
         private bool? disableRequestCompression;
         private long? requestMinCompressionSizeBytes;
-        private TimeSpan? readWriteTimeout = null;
         private bool disableHostPrefixInjection = false;
         private bool? endpointDiscoveryEnabled = null;
         private bool? ignoreConfiguredEndpointUrls;
@@ -1112,6 +1111,9 @@ namespace Amazon.Runtime
         }
 #endif
 
+#if NETFRAMEWORK
+        private TimeSpan? readWriteTimeout = null;
+
         /// <summary>
         /// Overrides the default read-write timeout value.
         /// </summary>
@@ -1124,9 +1126,6 @@ namespace Amazon.Runtime
         /// <exception cref="System.ArgumentOutOfRangeException">The timeout specified is less than or equal to zero and is not Infinite.</exception>
         /// </remarks>
         /// <seealso cref="P:System.Net.HttpWebRequest.ReadWriteTimeout"/>
-#if NETSTANDARD
-        [Obsolete("ReadWriteTimeout is not consumed in asynchronous HTTP requests. Please use a cancellation token to handle stream read/write timeouts.")]
-#endif
         public TimeSpan? ReadWriteTimeout
         {
             get { return this.readWriteTimeout; }
@@ -1136,6 +1135,7 @@ namespace Amazon.Runtime
                 this.readWriteTimeout = value;
             }
         }
+#endif
 
         /// <summary>
         /// Gets and sets of the EndpointProvider property.

--- a/sdk/src/Services/Glacier/Custom/AmazonGlacierConfig.Extensions.cs
+++ b/sdk/src/Services/Glacier/Custom/AmazonGlacierConfig.Extensions.cs
@@ -34,9 +34,9 @@ namespace Amazon.Glacier
             // Set Timeout and ReadWriteTimeout for Glacier client to max timeout as per-request  
             // timeouts are not supported.
             this.Timeout = ClientConfig.MaxTimeout;
-#pragma warning disable CS0612,CS0618
+#if NETFRAMEWORK
             this.ReadWriteTimeout = ClientConfig.MaxTimeout;
-#pragma warning restore CS0612,CS0618
+#endif
 #endif
             base.Initialize();
         }

--- a/sdk/src/Services/IoTJobsDataPlane/Custom/AmazonIoTJobsDataPlaneConfig.cs
+++ b/sdk/src/Services/IoTJobsDataPlane/Custom/AmazonIoTJobsDataPlaneConfig.cs
@@ -36,9 +36,9 @@ namespace Amazon.IoTJobsDataPlane
             // Set Timeout and ReadWriteTimeout for Amazon IoTJobsDataPlane service to max timeout as per-request
             // timeouts are not supported.
             this.Timeout = ClientConfig.MaxTimeout;
-#pragma warning disable CS0612,CS0618
+#if NETFRAMEWORK
             this.ReadWriteTimeout = ClientConfig.MaxTimeout;
-#pragma warning restore CS0612,CS0618
+#endif
 #endif
         }
     }

--- a/sdk/src/Services/KinesisVideoArchivedMedia/Custom/AmazonKinesisVideoArchivedMediaConfig.cs
+++ b/sdk/src/Services/KinesisVideoArchivedMedia/Custom/AmazonKinesisVideoArchivedMediaConfig.cs
@@ -36,9 +36,9 @@ namespace Amazon.KinesisVideoArchivedMedia
             // Set Timeout and ReadWriteTimeout for Amazon KinesisVideoArchivedMedia service to max timeout as per-request
             // timeouts are not supported.
             this.Timeout = ClientConfig.MaxTimeout;
-#pragma warning disable CS0612,CS0618
+#if NETFRAMEWORK
             this.ReadWriteTimeout = ClientConfig.MaxTimeout;
-#pragma warning restore CS0612, CS0618
+#endif
 #endif
         }
     }

--- a/sdk/src/Services/KinesisVideoMedia/Custom/AmazonKinesisVideoMediaConfig.cs
+++ b/sdk/src/Services/KinesisVideoMedia/Custom/AmazonKinesisVideoMediaConfig.cs
@@ -36,9 +36,9 @@ namespace Amazon.KinesisVideoMedia
             // Set Timeout and ReadWriteTimeout for Amazon KinesisVideoMedia service to max timeout as per-request
             // timeouts are not supported.
             this.Timeout = ClientConfig.MaxTimeout;
-#pragma warning disable CS0612,CS0618
+#if NETFRAMEWORK
             this.ReadWriteTimeout = ClientConfig.MaxTimeout;
-#pragma warning restore CS0612,CS0618
+#endif
 #endif
         }
     }

--- a/sdk/src/Services/MediaStoreData/Custom/AmazonMediaStoreDataConfig.cs
+++ b/sdk/src/Services/MediaStoreData/Custom/AmazonMediaStoreDataConfig.cs
@@ -36,9 +36,9 @@ namespace Amazon.MediaStoreData
             // Set Timeout and ReadWriteTimeout for Amazon MediaStoreData service to max timeout as per-request
             // timeouts are not supported.
             this.Timeout = ClientConfig.MaxTimeout;
-#pragma warning disable CS0612, CS0618
+#if NETFRAMEWORK
             this.ReadWriteTimeout = ClientConfig.MaxTimeout;
-#pragma warning restore CS0612, CS0618
+#endif
 #endif
         }
     }

--- a/sdk/src/Services/S3/Custom/AmazonS3Config.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Config.cs
@@ -265,9 +265,9 @@ namespace Amazon.S3
             // Set Timeout and ReadWriteTimeout for S3 to max timeout as per-request
             // timeouts are not supported.
             this.Timeout = ClientConfig.MaxTimeout;
-#pragma warning disable CS0612,CS0618
+#if NETFRAMEWORK
             this.ReadWriteTimeout = ClientConfig.MaxTimeout;
-#pragma warning restore CS0612, CS0618
+#endif
 #endif
         }
 


### PR DESCRIPTION
## Description
The `ReadWriteTimeout` property on ClientConfig is marked obsolete in for non .NET Framework targets because the property didn't do anything. In non .NET Framework targets timeouts are supposed to be handled by cancellation tokens.

For V4 we are removing the `ReadWriteTimeout` entirely for non .NET Framework targets. This will avoid confusion of users accidently setting it and thinking it will do something.

## Testing
Dry Run: Pending
