### PR TITLE
Mark code that has been deleted in V4 as obsolete in V3

### DIFF
--- a/sdk/src/Services/EC2/Custom/Util/ImageUtilities.cs
+++ b/sdk/src/Services/EC2/Custom/Util/ImageUtilities.cs
@@ -37,6 +37,8 @@ namespace Amazon.EC2.Util
     /// <summary>
     /// This class has utility methods for finding common Amazon machine images.
     /// </summary>
+    /// 
+    [Obsolete("This utility class is no longer maintained and will be removed in the next major version.")]
     public static partial class ImageUtilities
     {
         #region ImageKeys

--- a/sdk/src/Services/EC2/Custom/Util/LaunchNATInstanceRequest.cs
+++ b/sdk/src/Services/EC2/Custom/Util/LaunchNATInstanceRequest.cs
@@ -28,6 +28,7 @@ namespace Amazon.EC2.Util
     /// <summary>
     /// Request class to launch a NAT instance
     /// </summary>
+    [Obsolete("This utility class is no longer maintained and will be removed in the next major version.")]
     public class LaunchNATInstanceRequest
     {
         string subnetId;

--- a/sdk/src/Services/EC2/Custom/Util/LaunchVPCWithPublicAndPrivateSubnetsRequest.cs
+++ b/sdk/src/Services/EC2/Custom/Util/LaunchVPCWithPublicAndPrivateSubnetsRequest.cs
@@ -28,6 +28,7 @@ namespace Amazon.EC2.Util
     /// The properties used to create a VPC, a public subnet, private subnet and a NAT EC2 instance to allow EC2 instances in the private
     /// subnet to establish outbound connections to the internet.
     /// </summary>
+    [Obsolete("This utility class is no longer maintained and will be removed in the next major version.")]
     public class LaunchVPCWithPublicAndPrivateSubnetsRequest : LaunchVPCWithPublicSubnetRequest
     {
         string privateSubnetCiderBlock = "10.0.1.0/24";

--- a/sdk/src/Services/EC2/Custom/Util/LaunchVPCWithPublicAndPrivateSubnetsResponse.cs
+++ b/sdk/src/Services/EC2/Custom/Util/LaunchVPCWithPublicAndPrivateSubnetsResponse.cs
@@ -28,6 +28,7 @@ namespace Amazon.EC2.Util
     /// <summary>
     /// This object contains the VPC objects that were created as part of the launch VPC with public and private subnets operation.
     /// </summary>
+    [Obsolete("This utility class is no longer maintained and will be removed in the next major version.")]
     public class LaunchVPCWithPublicAndPrivateSubnetsResponse : LaunchVPCWithPublicSubnetResponse
     {
         /// <summary>

--- a/sdk/src/Services/EC2/Custom/Util/LaunchVPCWithPublicSubnetRequest.cs
+++ b/sdk/src/Services/EC2/Custom/Util/LaunchVPCWithPublicSubnetRequest.cs
@@ -27,6 +27,7 @@ namespace Amazon.EC2.Util
     /// <summary>
     /// The properties used to create a VPC with a subnet that will have an internet gateway attached making instances available to the internet.
     /// </summary>
+    [Obsolete("This utility class is no longer maintained and will be removed in the next major version.")]
     public class LaunchVPCWithPublicSubnetRequest
     {
         string vpcName;

--- a/sdk/src/Services/EC2/Custom/Util/LaunchVPCWithPublicSubnetResponse.cs
+++ b/sdk/src/Services/EC2/Custom/Util/LaunchVPCWithPublicSubnetResponse.cs
@@ -29,6 +29,7 @@ namespace Amazon.EC2.Util
     /// <summary>
     /// This object contains the VPC objects that were created as part of the launch VPC with public subnet operation.
     /// </summary>
+    [Obsolete("This utility class is no longer maintained and will be removed in the next major version.")]
     public class LaunchVPCWithPublicSubnetResponse
     {
         /// <summary>

--- a/sdk/src/Services/EC2/Custom/Util/VPCUtilities.cs
+++ b/sdk/src/Services/EC2/Custom/Util/VPCUtilities.cs
@@ -33,6 +33,7 @@ namespace Amazon.EC2.Util
     /// <summary>
     /// This class has utility methods used for setting up a VPC.
     /// </summary>
+    [Obsolete("This utility class is no longer maintained and will be removed in the next major version.")]
     public static partial class VPCUtilities
     {
         /// <summary>


### PR DESCRIPTION
## Description
In PR https://github.com/aws/aws-sdk-net/pull/3684 some utility code that hasn't been maintained has been deleted. This is the retro V3 PR to mark that deleted code as obsolete to inform any potential V3 users that are using this code that it has been removed.

## Testing
Dry Run: Pending

