### PR TITLE
[V4] Update signers to handle anonymous credentials

### DIFF
--- a/generator/.DevConfigs/8015db5e-dd8e-4ed8-b367-bbdfe058b43e.json
+++ b/generator/.DevConfigs/8015db5e-dd8e-4ed8-b367-bbdfe058b43e.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Update SDK signers to handle scenarios where anonymous credentials are provided."
+        ],
+        "type": "patch",
+        "updateMinimum": true
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -118,13 +118,16 @@ namespace Amazon.Runtime.Internal.Auth
                                   RequestMetrics metrics,
                                   BaseIdentity identity)
         {
-            var credentials = identity as AWSCredentials;
-            if (credentials is null)
+            if (identity is not AWSCredentials credentials)
             {
                 throw new AmazonClientException($"The identity parameter must be of type AWSCredentials for the signer {nameof(AWS4Signer)}.");
             }
 
             var immutableCredentials = credentials.GetCredentials();
+            if (immutableCredentials is null)
+            {
+                return;
+            }
 
             var signingResult = SignRequest(request, clientConfig, metrics, immutableCredentials.AccessKey, immutableCredentials.SecretKey);
             request.Headers[HeaderKeys.AuthorizationHeader] = signingResult.ForAuthorizationHeader;            

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4aSignerCRTWrapper.cs
@@ -127,6 +127,11 @@ namespace Amazon.Runtime.Internal.Auth
         {
             var credentials = identity as AWSCredentials;
             var immutableCredentials = credentials.GetCredentials();
+            if (immutableCredentials is null)
+            {
+                return;
+            }
+
             _awsSigV4AProvider.Sign(request, clientConfig, metrics, immutableCredentials);
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWSEndpointAuthSchemeSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWSEndpointAuthSchemeSigner.cs
@@ -38,13 +38,17 @@ namespace Amazon.Runtime.Internal.Auth
             var aws4Signer = signer as AWS4Signer;
             var useV4a = aws4aSigner != null;
             var useV4 = aws4Signer != null;
-            var credentials = identity as AWSCredentials;
-            if (credentials is null)
+
+            if (identity is not AWSCredentials credentials)
             {
                 throw new AmazonClientException($"The identity parameter must be of type AWSCredentials for the signer {nameof(AWSEndpointAuthSchemeSigner)}.");
             }
 
             var immutableCredentials = credentials.GetCredentials();
+            if (immutableCredentials is null)
+            {
+                return;
+            }
 
             AWSSigningResultBase signingResult;
             

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
@@ -42,7 +42,7 @@ namespace Amazon.Runtime.Internal.Auth
             }
 
             var immutableCredentials = credentials.GetCredentials();
-            if (String.IsNullOrEmpty(immutableCredentials.AccessKey))
+            if (string.IsNullOrEmpty(immutableCredentials?.AccessKey))
             {
                 throw new ArgumentOutOfRangeException("awsAccessKeyId", "The AWS Access Key ID cannot be NULL or a Zero length string");
             }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/QueryStringSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/QueryStringSigner.cs
@@ -50,7 +50,7 @@ namespace Amazon.Runtime.Internal.Auth
             var credentials = identity as AWSCredentials;
             var immutableCredentials = credentials.GetCredentials();
 
-            if (String.IsNullOrEmpty(immutableCredentials.AccessKey))
+            if (string.IsNullOrEmpty(immutableCredentials?.AccessKey))
             {
                 throw new ArgumentOutOfRangeException("awsAccessKeyId", "The AWS Access Key ID cannot be NULL or a Zero length string");
             }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/S3Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/S3Signer.cs
@@ -58,13 +58,17 @@ namespace Amazon.Runtime.Internal.Auth
             var aws4aSigner = signer as AWS4aSignerCRTWrapper;
             var useV4 = aws4Signer != null;
             var useV4a = aws4aSigner != null;
-            var credentials = identity as AWSCredentials;
-            if (credentials is null)
+
+            if (identity is not AWSCredentials credentials)
             {
                 throw new AmazonClientException($"The identity parameter must be of type AWSCredentials for the signer {nameof(S3Signer)}.");
             }
 
             var immutableCredentials = credentials.GetCredentials();
+            if (immutableCredentials is null)
+            {
+                return;
+            }
 
             if (useV4a)
             {


### PR DESCRIPTION
## Description
Reported in the V4 tracker (https://github.com/aws/aws-sdk-net/issues/3362#issuecomment-2700845385): If a customer's environment is set to assume a role with web identity, the request to STS doesn't include credentials but our SigV4 signer wasn't handling that properly after the SRA changes. 

## Testing
- Dry-run: `DRY_RUN-2ed08959-fb2c-4b95-a703-5ae52229c08f`

I also ran the app Martin shared locally, forcing the `AssumeRoleWithWebIdentityCredentials` provider to run (by setting the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable), and confirmed the request was made to STS (instead of throwing a null pointer exception - it still failed because I don't have an OIDC on my account but it reached the service).

Before:
```
AmazonSecurityTokenServiceClient 33|2025-03-06T00:07:17.695Z|ERROR|NullReferenceException making request AssumeRoleWithWebIdentityRequest to https://sts.us-west-2.amazonaws.com/. Attempt 1. 
--> System.NullReferenceException: Object reference not set to an instance of an object.
``` 

After:
```
AmazonSecurityTokenServiceClient 43|2025-03-06T00:08:28.281Z|ERROR|Error calling AssumeRole for role arn:aws:iam::000000000000:role/ec2-role 
---> Amazon.Runtime.AmazonClientException: Error calling AssumeRole for role arn:aws:iam::000000000000:role/ec2-role
---> Amazon.SecurityToken.Model.InvalidIdentityTokenException: The ID Token provided is not a valid JWT. (You may see this error if you sent an Access Token)
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
