### PR TITLE
Update ChecksumHandler not to add headers when using anonymous credentials

### DIFF
--- a/generator/.DevConfigs/4bb04754-22ee-413b-aa2b-6ee543bd3287.json
+++ b/generator/.DevConfigs/4bb04754-22ee-413b-aa2b-6ee543bd3287.json
@@ -1,0 +1,10 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Update the SDK's checksum component to skip adding headers when a request is made with anonymous credentials."
+        ],
+        "backwardIncompatibilitiesToIgnore": [],
+        "type": "patch",
+        "updateMinimum": true
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/ChecksumHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/ChecksumHandler.cs
@@ -78,6 +78,14 @@ namespace Amazon.Runtime.Internal
             var request = executionContext.RequestContext.Request;
             var clientConfig = executionContext.RequestContext.ClientConfig;
 
+            // Credentials would be null in the case of anonymous users getting public resources from S3
+            // https://github.com/aws/aws-sdk-net/issues/3696
+            ImmutableCredentials immutableCredentials = executionContext.RequestContext.ImmutableCredentials;
+            if (immutableCredentials == null && executionContext.RequestContext.Signer.RequiresCredentials)
+            {
+                return;
+            }
+
             if (request.ChecksumData == null)
             {
                 return;

--- a/sdk/test/Services/S3/UnitTests/Custom/S3ExpressChecksumTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/S3ExpressChecksumTests.cs
@@ -366,7 +366,8 @@ namespace AWSSDK.UnitTests
                 Marshaller = marshaller,
                 OriginalRequest = request,
                 Unmarshaller = null,
-                IsAsync = false
+                IsAsync = false,
+                ImmutableCredentials = new ImmutableCredentials("access key", "secret", "token"),
             };
             var executionContext = new ExecutionContext(
                 requestContext,

--- a/sdk/test/Services/S3/UnitTests/Custom/UserAgentTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/UserAgentTests.cs
@@ -100,7 +100,8 @@ namespace AWSSDK.UnitTests
                 Marshaller = PutObjectRequestMarshaller.Instance,
                 OriginalRequest = request,
                 Unmarshaller = null,
-                IsAsync = false
+                IsAsync = false,
+                ImmutableCredentials = new ImmutableCredentials("access key", "secret", "token"),
             };
 
             var executionContext = new ExecutionContext(requestContext, new ResponseContext());

--- a/sdk/test/UnitTests/Custom/Runtime/ChecksumHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/ChecksumHandlerTests.cs
@@ -209,7 +209,8 @@ namespace AWSSDK.UnitTests
                 ClientConfig = new AmazonCloudWatchConfig
                 {
                     RequestChecksumCalculation = requestChecksumCalculation,
-                }
+                },
+                ImmutableCredentials = new ImmutableCredentials("access key", "secret", "token"),
             };
 
             return new ExecutionContext(requestContext, null);


### PR DESCRIPTION
Fixes #3696 

## Description
After the default data integrity change, the SDK started adding the new checksum headers (`x-amz-checksum-*` and `x-amz-trailer`) to requests, but those are populated by the signers (which won't run when using anonymous credentials).

This bug has existed for a while, but it's happening now since previously the checksum handler would not run as part of the request pipeline.

## Testing
- Dry-runs:
  - SDK: `DRY_RUN-24c9a6ef-2b34-4489-9691-7b61b963d921`
  - PowerShell: `DRY_RUN-ef0cce69-2802-42eb-b2a8-6f827303215a`

We don't have tests for open S3 buckets, so I manually ran a console app to confirm (I had to update my bucket ACL too: `aws s3api put-bucket-acl --bucket dspin-test-accelerate --grant-write uri=http://acs.amazonaws.com/groups/global/AllUsers`).

Before with a checksum:
```csharp
var s3 = new AmazonS3Client(new AnonymousAWSCredentials());
await s3.PutObjectAsync(new PutObjectRequest
{
    BucketName = "dspin-test-accelerate",
    Key = "sdk-versions.json",
    FilePath = "_sdk-versions.json",
    CannedACL = S3CannedACL.PublicRead,

    // Code fails if an algorithm is set (and suceeds without one)
    ChecksumAlgorithm = ChecksumAlgorithm.SHA256,
});
```

```
AmazonS3Client 35|2025-03-07T11:57:26.909Z|ERROR|Received error response: [<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidRequest</Code><Message>x-amz-sdk-checksum-algorithm specified, but no corresponding x-amz-checksum-* or x-amz-trailer headers were found.</Message><RequestId>KZY9HTV5J61AYKXD</RequestId><HostId>hSyUrV2l7wD7vMXqSGQXXO472fMPl+wnzsfDvd35ayNvXTXYl4Ep68y0l38wqWg4GLNXdVWmm74=</HostId></Error>]
--> Amazon.S3.Model.InvalidRequestException: x-amz-sdk-checksum-algorithm specified, but no corresponding x-amz-checksum-* or x-amz-trailer headers were found.
```

After:
```csharp
var s3 = new AmazonS3Client(new AnonymousAWSCredentials());
await s3.PutObjectAsync(new PutObjectRequest
{
    BucketName = "dspin-test-accelerate",
    Key = "sdk-versions.json",
    FilePath = "_sdk-versions.json",
    CannedACL = S3CannedACL.PublicRead,
});
```

```
AmazonS3Client 34|2025-03-07T11:58:41.604Z|DEBUG|Received response (truncated to 1024 bytes): []
AmazonS3Client 35|2025-03-07T11:58:41.617Z|INFO|Request metrics: {"properties":{"AsyncCall":"True","ServiceName":"AmazonS3","ServiceEndpoint":"https://dspin-test-accelerate.s3.us-west-2.amazonaws.com/","MethodName":"PutObjectRequest","AmzId2":"Y/2YnwVPZkTGSoVVOnYUZHKhpMg18Y+/ZePcl+WlstB6BLM9zqj9m+qSvfmuDCJL+YivkQVdhyo=","StatusCode":"OK","BytesProcessed":"0","AWSRequestID":"XHX9HPDMPHH8JHRB"},"timings":{"HttpRequestTime":946.4923,"ResponseUnmarshallTime":3.2284,"ResponseProcessingTime":29.633,"ClientExecuteTime":2559.1312},"counters":{}}
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
