### PR TITLE
Add telemetry data for Credentials retrieval

### DIFF
--- a/generator/.DevConfigs/a37aa538-27a8-4185-9c66-44d38de5cf57.json
+++ b/generator/.DevConfigs/a37aa538-27a8-4185-9c66-44d38de5cf57.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Add telemetry data for Credentials retrieval"
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Telemetry/Metrics/MetricsUtilities.cs
+++ b/sdk/src/Core/Amazon.Runtime/Telemetry/Metrics/MetricsUtilities.cs
@@ -46,7 +46,7 @@ namespace Amazon.Runtime.Telemetry.Metrics
         /// <param name="initialAttributes">The attributes associated with the metric.</param>
         public static void AddMonotonicCounterValue(IRequestContext requestContext, string metricName, string unit, long value = 1, Attributes initialAttributes = null)
         {
-            var serviceId = requestContext.ServiceMetaData.ServiceId;
+            var serviceId = requestContext.ClientConfig.ServiceId;
 
             if (initialAttributes == null)
                 initialAttributes = new Attributes();

--- a/sdk/src/Core/Amazon.Runtime/Telemetry/Tracing/TracingUtilities.cs
+++ b/sdk/src/Core/Amazon.Runtime/Telemetry/Tracing/TracingUtilities.cs
@@ -39,7 +39,7 @@ namespace Amazon.Runtime.Telemetry.Tracing
             SpanKind spanKind = SpanKind.INTERNAL,
             SpanContext parentContext = null)
         {
-            var serviceId = requestContext.ServiceMetaData.ServiceId;
+            var serviceId = requestContext.ClientConfig.ServiceId;
 
             if (initialAttributes == null)
                 initialAttributes = new Attributes();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add telemetry data for Credentials retrieval.

## Motivation and Context
The SDK used to emit telemetry data for Credentials retrieval here https://github.com/aws/aws-sdk-net-staging/blob/main-staging/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/CredentialsRetriever.cs#L57
The `CredentialsRetriever` handler was removed in V4 as part of the SRA I&A changes, this PRs adds the telemetry data back to the `Signer` handler.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`DRY_RUN-990010e0-a8db-4830-8fa6-fa05b2b8a155`

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement