### PR TITLE
Better exception messages

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SSOTokenManager.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/_bcl45+netstandard/SSOTokenManager.cs
@@ -351,21 +351,21 @@ namespace Amazon.Runtime.Credentials.Internal
         {
             if (string.IsNullOrEmpty(options.ClientName))
             {
-                throw new ArgumentNullException($"Options property cannot be empty: {nameof(options.ClientName)}");
+                throw new ArgumentNullException(nameof(options.ClientName));
             }
 
             if (options.PkceFlowOptions == null)
             {
                 if (options.SsoVerificationCallback == null)
                 {
-                    throw new ArgumentNullException($"Options property cannot be empty: {nameof(options.SsoVerificationCallback)}");
+                    throw new ArgumentNullException(nameof(options.SsoVerificationCallback));
                 }
             }
             else
             {
                 if (options.PkceFlowOptions.RetrieveAuthorizationCodeCallback == null)
                 {
-                    throw new ArgumentNullException($"Options property cannot be empty: {nameof(options.PkceFlowOptions.RetrieveAuthorizationCodeCallback)}");
+                    throw new ArgumentNullException(nameof(options.PkceFlowOptions.RetrieveAuthorizationCodeCallback));
                 }
             }
 
@@ -620,21 +620,21 @@ namespace Amazon.Runtime.Credentials.Internal
         {
             if (string.IsNullOrEmpty(options.ClientName))
             {
-                throw new ArgumentNullException($"Options property cannot be empty: {nameof(options.ClientName)}");
+                throw new ArgumentNullException(nameof(options.ClientName));
             }
 
             if (options.PkceFlowOptions == null)
             {
                 if (options.SsoVerificationCallback == null)
                 {
-                    throw new ArgumentNullException($"Options property cannot be empty: {nameof(options.SsoVerificationCallback)}");
+                    throw new ArgumentNullException(nameof(options.SsoVerificationCallback));
                 }
             }
             else
             {
                 if (options.PkceFlowOptions.RetrieveAuthorizationCodeCallbackAsync == null)
                 {
-                    throw new ArgumentNullException($"Options property cannot be empty: {nameof(options.PkceFlowOptions.RetrieveAuthorizationCodeCallbackAsync)}");
+                    throw new ArgumentNullException(nameof(options.PkceFlowOptions.RetrieveAuthorizationCodeCallbackAsync));
                 }
             }
 


### PR DESCRIPTION
Improve error messages.

<!--- Provide a general summary of your changes in the Title above -->

## Description

In some cases when the SDK throws an exception, the error message is "Value cannot be null. (Parameter 'Options property cannot be empty: ClientName')". It should be "Value cannot be null. (Parameter 'ClientName')". The problem is caused by incorrect usage of `ArgumentNullException` constructor.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement