### PR TITLE
Added check in DateTimeToEpochSeconds to inspect null value for Nullable DateTime property decorated with StoreAsEpoch attribute, where it was incorrectly relying on exception to return the entry.

### DIFF
--- a/generator/.DevConfigs/1e7deb77-2bae-4ec5-a8b5-349452eb941a.json
+++ b/generator/.DevConfigs/1e7deb77-2bae-4ec5-a8b5-349452eb941a.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Added check in DateTimeToEpochSeconds to inspect null value for Nullable DateTime property decorated with StoreAsEpoch attribute, where it was incorrectly relying on exception to return the entry."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Document.cs
@@ -290,6 +290,13 @@ namespace Amazon.DynamoDBv2.DocumentModel
             int? epochSeconds = null;
             try
             {
+                var primitiveValue = entry.AsPrimitive();
+
+                // entry.AsPrimitive() could return null for UnconvertedDynamoDBEntry. UnconvertedDynamoDBEntry will always have a value due to check in it's constructor. Hence, we can process it further for epoch conversion.
+                if (primitiveValue != null
+                        && primitiveValue.Value == null)
+                    return entry;
+
                 var dateTime = entry.AsDateTime();
                 epochSeconds = AWSSDKUtils.ConvertToUnixEpochSeconds(dateTime);
             }

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -144,6 +144,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 EpochDate2 = EpochDate,
                 NonEpochDate1 = EpochDate,
                 NonEpochDate2 = EpochDate,
+                NullableEpochDate1 = null,
+                NullableEpochDate2 = EpochDate,
                 LongEpochDate1 = LongEpochDate,
                 LongEpochDate2 = LongEpochDate.AddDays(12),
                 NullableLongEpochDate1 = null,
@@ -157,6 +159,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ApproximatelyEqual(EpochDate, storedEmployee.EpochDate2);
             ApproximatelyEqual(EpochDate, storedEmployee.NonEpochDate1);
             ApproximatelyEqual(EpochDate, storedEmployee.NonEpochDate2);
+            Assert.IsNull(storedEmployee.NullableEpochDate1);
+            ApproximatelyEqual(EpochDate, storedEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(LongEpochDate, storedEmployee.LongEpochDate1);
             ApproximatelyEqual(LongEpochDate.AddDays(12), storedEmployee.LongEpochDate2);
             Assert.IsNull(storedEmployee.NullableLongEpochDate1);
@@ -293,6 +297,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 EpochDate2 = currTime,
                 NonEpochDate1 = currTime,
                 NonEpochDate2 = currTime,
+                NullableEpochDate1 = null,
+                NullableEpochDate2 = currTime,
                 LongEpochDate1 = longEpochTime,
                 LongEpochDate2 = longEpochTimeBefore1970,
                 NullableLongEpochDate1 = longEpochTime,
@@ -311,6 +317,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.IsNull(storedEmployee.NullableEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.LongEpochDate1);
             ApproximatelyEqual(expectedLongEpochTimeBefore1970, storedEmployee.LongEpochDate2);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.NullableLongEpochDate1.Value);
@@ -327,6 +335,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.IsNull(storedEmployee.NullableEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.LongEpochDate1);
             ApproximatelyEqual(expectedLongEpochTimeBefore1970, storedEmployee.LongEpochDate2);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.NullableLongEpochDate1.Value);
@@ -341,6 +351,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.IsNull(storedEmployee.NullableEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.LongEpochDate1);
             ApproximatelyEqual(expectedLongEpochTimeBefore1970, storedEmployee.LongEpochDate2);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.NullableLongEpochDate1.Value);
@@ -386,6 +398,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 EpochDate2 = currTime,
                 NonEpochDate1 = currTime,
                 NonEpochDate2 = currTime,
+                NullableEpochDate1 = null,
+                NullableEpochDate2 = currTime,
                 LongEpochDate1 = longEpochTime,
                 LongEpochDate2 = longEpochTimeBefore1970,
                 NullableLongEpochDate1 = longEpochTime,
@@ -406,6 +420,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.IsNull(storedEmployee.NullableEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.LongEpochDate1);
             ApproximatelyEqual(expectedLongEpochTimeBefore1970, storedEmployee.LongEpochDate2);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.NullableLongEpochDate1.Value);
@@ -422,6 +438,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.IsNull(storedEmployee.NullableEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.LongEpochDate1);
             ApproximatelyEqual(expectedLongEpochTimeBefore1970, storedEmployee.LongEpochDate2);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.NullableLongEpochDate1.Value);
@@ -436,6 +454,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ApproximatelyEqual(expectedCurrTime, storedEmployee.EpochDate2);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate1);
             ApproximatelyEqual(expectedCurrTime, storedEmployee.NonEpochDate2);
+            Assert.IsNull(storedEmployee.NullableEpochDate1);
+            ApproximatelyEqual(expectedCurrTime, storedEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.LongEpochDate1);
             ApproximatelyEqual(expectedLongEpochTimeBefore1970, storedEmployee.LongEpochDate2);
             ApproximatelyEqual(expectedLongEpochTime, storedEmployee.NullableLongEpochDate1.Value);
@@ -2132,6 +2152,12 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             public DateTime NonEpochDate1 { get; set; }
 
             public DateTime NonEpochDate2 { get; set; }
+
+            [DynamoDBProperty(StoreAsEpoch = true)]
+            public DateTime? NullableEpochDate1 { get; set; }
+
+            [DynamoDBProperty(StoreAsEpoch = true)]
+            public DateTime? NullableEpochDate2 { get; set; }
 
             [DynamoDBProperty(StoreAsEpochLong = true)]
             public DateTime LongEpochDate1 { get; set; }

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/TTLTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/TTLTests.cs
@@ -40,6 +40,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 EpochDate2 = EpochDate,
                 NonEpochDate1 = EpochDate,
                 NonEpochDate2 = EpochDate,
+                NullableEpochDate2 = EpochDate,
                 LongEpochDate1 = LongEpochDate,
                 LongEpochDate2 = LongEpochDate.AddMonths(3),
                 NullableLongEpochDate2 = LongEpochDate.AddMonths(-3)
@@ -50,6 +51,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             var storedEmployee = Context.Load<EpochEmployee>(employee.Name, employee.Age);
             Assert.IsNotNull(storedEmployee);
             ApproximatelyEqual(EpochDate, storedEmployee.CreationTime);
+            Assert.IsNull(storedEmployee.NullableEpochDate1);
+            ApproximatelyEqual(EpochDate, storedEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(LongEpochDate, storedEmployee.LongEpochDate1);
             ApproximatelyEqual(LongEpochDate.AddMonths(3), storedEmployee.LongEpochDate2);
             Assert.IsNull(storedEmployee.NullableLongEpochDate1);
@@ -57,6 +60,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             storedEmployee = Context.Load<EpochEmployee>(employee);
             Assert.IsNotNull(storedEmployee);
             ApproximatelyEqual(EpochDate, storedEmployee.CreationTime);
+            Assert.IsNull(storedEmployee.NullableEpochDate1);
+            ApproximatelyEqual(EpochDate, storedEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(LongEpochDate, storedEmployee.LongEpochDate1);
             ApproximatelyEqual(LongEpochDate.AddMonths(3), storedEmployee.LongEpochDate2);
             Assert.IsNull(storedEmployee.NullableLongEpochDate1);
@@ -66,6 +71,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             var storedNumericEmployee = Context.Load<NumericEpochEmployee>(employee.CreationTime, employee.Name);
             Assert.IsNotNull(storedNumericEmployee);
             ApproximatelyEqual(EpochDate, storedNumericEmployee.CreationTime);
+            Assert.IsNull(storedNumericEmployee.NullableEpochDate1);
+            ApproximatelyEqual(EpochDate, storedNumericEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(LongEpochDate, storedNumericEmployee.LongEpochDate1);
             ApproximatelyEqual(LongEpochDate.AddMonths(3), storedNumericEmployee.LongEpochDate2);
             Assert.IsNull(storedEmployee.NullableLongEpochDate1);
@@ -74,6 +81,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             storedNumericEmployee = Context.Load<NumericEpochEmployee>(numericEmployee);
             Assert.IsNotNull(storedNumericEmployee);
             ApproximatelyEqual(EpochDate, storedNumericEmployee.CreationTime);
+            Assert.IsNull(storedNumericEmployee.NullableEpochDate1);
+            ApproximatelyEqual(EpochDate, storedNumericEmployee.NullableEpochDate2.Value);
             ApproximatelyEqual(LongEpochDate, storedNumericEmployee.LongEpochDate1);
             ApproximatelyEqual(LongEpochDate.AddMonths(3), storedNumericEmployee.LongEpochDate2);
             Assert.IsNull(storedEmployee.NullableLongEpochDate1);
@@ -82,6 +91,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             var doc = Context.ToDocument(employee);
             ApproximatelyEqual(EpochDate, doc["CreationTime"].AsDateTime());
             ApproximatelyEqual(EpochDate, doc["EpochDate2"].AsDateTime());
+            Assert.IsNull(doc["NullableEpochDate1"].AsPrimitive().Value);
+            ApproximatelyEqual(EpochDate, doc["NullableEpochDate2"].AsDateTime());
             ApproximatelyEqual(EpochDate, doc["NonEpochDate1"].AsDateTime());
             ApproximatelyEqual(EpochDate, doc["NonEpochDate1"].AsDateTime());
             ApproximatelyEqual(LongEpochDate, doc["LongEpochDate1"].AsDateTime());
@@ -92,6 +103,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             var docV1 = doc.ForceConversion(DynamoDBEntryConversion.V1);
             ApproximatelyEqual(EpochDate, docV1["CreationTime"].AsDateTime());
             ApproximatelyEqual(EpochDate, docV1["EpochDate2"].AsDateTime());
+            Assert.IsNull(docV1["NullableEpochDate1"].AsPrimitive().Value);
+            ApproximatelyEqual(EpochDate, docV1["NullableEpochDate2"].AsDateTime());
             ApproximatelyEqual(EpochDate, docV1["NonEpochDate1"].AsDateTime());
             ApproximatelyEqual(EpochDate, docV1["NonEpochDate1"].AsDateTime());
             ApproximatelyEqual(LongEpochDate, docV1["LongEpochDate1"].AsDateTime());
@@ -102,6 +115,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             var docV2 = doc.ForceConversion(DynamoDBEntryConversion.V2);
             ApproximatelyEqual(EpochDate, docV2["CreationTime"].AsDateTime());
             ApproximatelyEqual(EpochDate, docV2["EpochDate2"].AsDateTime());
+            Assert.IsNull(docV2["NullableEpochDate1"].AsPrimitive().Value);
+            ApproximatelyEqual(EpochDate, docV2["NullableEpochDate2"].AsDateTime());
             ApproximatelyEqual(EpochDate, docV2["NonEpochDate1"].AsDateTime());
             ApproximatelyEqual(EpochDate, docV2["NonEpochDate1"].AsDateTime());
             ApproximatelyEqual(LongEpochDate, docV2["LongEpochDate1"].AsDateTime());
@@ -118,6 +133,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             var epochMap = epochTable.ToAttributeMap(doc);
             Assert.IsNotNull(epochMap["CreationTime"].N);
             Assert.IsNotNull(epochMap["EpochDate2"].N);
+            Assert.IsFalse(epochMap.ContainsKey("NullableEpochDate1"));
+            Assert.IsNotNull(epochMap["NullableEpochDate2"].N);
             Assert.IsNotNull(epochMap["NonEpochDate1"].S);
             Assert.IsNotNull(epochMap["NonEpochDate2"].S);
             Assert.IsNotNull(epochMap["LongEpochDate1"].N);
@@ -172,7 +189,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             // construct tables with StoreAsEpoch and StoreAsEpochLong
             var config = new TableConfig(hashRangeTable.TableName)
             {
-                AttributesToStoreAsEpoch = new List<string> { "CreationTime", "EpochDate2" },
+                AttributesToStoreAsEpoch = new List<string> { "CreationTime", "EpochDate2", "NullableEpochDate1", "NullableEpochDate2" },
                 AttributesToStoreAsEpochLong = new List<string> { "LongEpochDate", "NullableLongEpochDate1", "NullableLongEpochDate2" }
             };
             var epochTable = Table.LoadTable(Client, config);
@@ -181,7 +198,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
             config = new TableConfig(numericHashRangeTable.TableName)
             {
-                AttributesToStoreAsEpoch = new List<string> { "CreationTime", "EpochDate2" },
+                AttributesToStoreAsEpoch = new List<string> { "CreationTime", "EpochDate2", "NullableEpochDate1", "NullableEpochDate2" },
                 AttributesToStoreAsEpochLong = new List<string> { "LongEpochDate", "NullableLongEpochDate1", "NullableLongEpochDate2" }
             };
             var numericEpochTable = Table.LoadTable(Client, config);
@@ -193,6 +210,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.IsNotNull(map["CreationTime"].S);
             Assert.IsNotNull(map["EpochDate2"].S);
             Assert.IsNotNull(map["NonEpochDate"].S);
+            Assert.IsNotNull(map["NullableEpochDate1"].S);
+            Assert.IsFalse(map.ContainsKey("NullableEpochDate2"));
             Assert.IsNotNull(map["LongEpochDate"].S);
             Assert.IsNotNull(map["NullableLongEpochDate1"].S);
             Assert.IsFalse(map.ContainsKey("NullableLongEpochDate2"));
@@ -201,7 +220,9 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             Assert.IsNotNull(epochMap["CreationTime"].N);
             Assert.IsNotNull(epochMap["EpochDate2"].N);
             Assert.IsNotNull(epochMap["NonEpochDate"].S);
+            Assert.IsNotNull(epochMap["NullableEpochDate1"].N);
             Assert.IsNotNull(epochMap["LongEpochDate"].N);
+            Assert.IsNotNull(epochMap["NullableLongEpochDate1"].N);
 
             // put
             epochTable.PutItem(CreateTestDocument());
@@ -241,6 +262,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             doc2["CreationTime"] = EpochDate;
             doc2["EpochDate2"] = EpochDate;
             doc2["NonEpochDate"] = EpochDate;
+            doc2["NullableEpochDate1"] = (DateTime?) EpochDate;
+            doc2["NullableEpochDate2"] = (DateTime?) null;
             doc2["LongEpochDate"] = LongEpochDate;
             doc2["NullableLongEpochDate1"] = (DateTime?) LongEpochDate;
             doc2["NullableLongEpochDate2"] = (DateTime?) null;
@@ -335,6 +358,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             doc["CreationTime"] = EpochDate;
             doc["EpochDate2"] = EpochDate;
             doc["NonEpochDate"] = EpochDate;
+            doc["NullableEpochDate1"] = (DateTime?) EpochDate;
+            doc["NullableEpochDate2"] = (DateTime?) null;
             doc["LongEpochDate"] = LongEpochDate;
             doc["NullableLongEpochDate1"] = (DateTime?) LongEpochDate;
             doc["NullableLongEpochDate2"] = (DateTime?) null;
@@ -348,6 +373,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 Assert.AreEqual(EpochSeconds, nonEpochDoc["CreationTime"].AsInt());
                 Assert.AreEqual(EpochSeconds, nonEpochDoc["EpochDate2"].AsInt());
                 ApproximatelyEqual(EpochDate, nonEpochDoc["NonEpochDate"].AsDateTime());
+                Assert.AreEqual(EpochSeconds, nonEpochDoc["NullableEpochDate1"].AsInt());
                 Assert.AreEqual(LongEpochSeconds, nonEpochDoc["LongEpochDate"].AsLong());
                 Assert.AreEqual(LongEpochSeconds, nonEpochDoc["NullableLongEpochDate1"].AsLong());
                 Assert.IsFalse(nonEpochDoc.ContainsKey("NullableLongEpochDate2"));
@@ -359,6 +385,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             ApproximatelyEqual(EpochDate, epochDoc["CreationTime"].AsDateTime());
             ApproximatelyEqual(EpochDate, epochDoc["EpochDate2"].AsDateTime());
             ApproximatelyEqual(EpochDate, epochDoc["NonEpochDate"].AsDateTime());
+            ApproximatelyEqual(EpochDate, epochDoc["NullableEpochDate1"].AsDateTime());
             ApproximatelyEqual(LongEpochDate, epochDoc["LongEpochDate"].AsDateTime());
             ApproximatelyEqual(LongEpochDate, epochDoc["NullableLongEpochDate1"].AsDateTime());
             if (checkForConditionalUpdate)
@@ -374,6 +401,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 Assert.AreEqual(EpochSeconds, ed["CreationTime"].AsInt());
                 Assert.AreEqual(EpochSeconds, ed["EpochDate2"].AsInt());
                 ApproximatelyEqual(EpochDate, ed["NonEpochDate"].AsDateTime());
+                Assert.AreEqual(EpochSeconds, ed["NullableEpochDate1"].AsInt());
                 Assert.AreEqual(LongEpochSeconds, ed["LongEpochDate"].AsLong());
                 Assert.AreEqual(LongEpochSeconds, ed["NullableLongEpochDate1"].AsLong());
             }
@@ -386,6 +414,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 ApproximatelyEqual(EpochDate, ed["CreationTime"].AsDateTime());
                 ApproximatelyEqual(EpochDate, ed["EpochDate2"].AsDateTime());
                 ApproximatelyEqual(EpochDate, ed["NonEpochDate"].AsDateTime());
+                ApproximatelyEqual(EpochDate, ed["NullableEpochDate1"].AsDateTime());
                 ApproximatelyEqual(LongEpochDate, ed["LongEpochDate"].AsDateTime());
                 ApproximatelyEqual(LongEpochDate, ed["NullableLongEpochDate1"].AsDateTime());
             }


### PR DESCRIPTION
## Description
Added check in `DateTimeToEpochSeconds` to inspect `null` value for **Nullable DateTime** property decorated with `StoreAsEpoch` attribute, where it was incorrectly relying on exception to return the entry.

This is a follow up PR from other PR https://github.com/aws/aws-sdk-net/pull/3703 to add similar validation for now obsolete `StoreAsEpoch` attribute. Added some test coverage which was missing earlier.

## Motivation and Context
Issue https://github.com/aws/aws-sdk-net/issues/3700

## Testing
- Updated integration tests.
- Dry run `DRY_RUN-bcd0c702-ed84-4e17-a246-ff129e00843b` completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement