### PR TITLE
Fix bug in V4 where copy object wasn't working for some special characters

### DIFF
--- a/generator/.DevConfigs/1667b220-e786-4bc9-9852-a85e630ac8e0.json
+++ b/generator/.DevConfigs/1667b220-e786-4bc9-9852-a85e630ac8e0.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fix: Fix a bug where copy object wasn't working with some special characters."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
@@ -389,7 +389,7 @@ namespace Amazon.S3
                     Amazon.S3.Internal.S3Signer.SignRequest(iRequest, metrics, immutableCredentials.AccessKey, immutableCredentials.SecretKey);
                     signingResult.Authorization = iRequest.Headers[HeaderKeys.AuthorizationHeader];
                     signingResult.Authorization = signingResult.Authorization.Substring(signingResult.Authorization.IndexOf(":", StringComparison.Ordinal) + 1);
-                    signingResult.Authorization = "&Signature=" + AmazonS3Util.UrlEncode(signingResult.Authorization, false);
+                    signingResult.Authorization = "&Signature=" + AWSSDKUtils.UrlEncode(signingResult.Authorization, false);
                     signingResult.Result = ComposeUrl(iRequest).AbsoluteUri + signingResult.Authorization;
                     break;
             }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyObjectRequestMarshaller.cs
@@ -164,15 +164,16 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             {
                 var isAccessPoint = S3ArnUtils.IsS3AccessPointsArn(bucket) || S3ArnUtils.IsS3OutpostsArn(bucket);
                 // 'object/' needed appended to key for copy header with access points
-                source = AmazonS3Util.UrlEncode(String.Concat(bucket, isAccessPoint ? "/object/" : "/", key), !isAccessPoint);
+
+                source = AWSSDKUtils.UrlEncode(String.Concat(bucket, isAccessPoint ? "/object/" : "/", key), false);
                 if (!String.IsNullOrEmpty(version))
                 {
-                    source = string.Format(CultureInfo.InvariantCulture, "{0}?versionId={1}", source, AmazonS3Util.UrlEncode(version, true));
+                    source = string.Format(CultureInfo.InvariantCulture, "{0}?versionId={1}", source, AWSSDKUtils.UrlEncode(version, true));
                 }
             }
             else
             {
-                source = AmazonS3Util.UrlEncode(bucket, true);
+                source = AWSSDKUtils.UrlEncode(bucket, true);
             }
 
             return source;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/CopyPartRequestMarshaller.cs
@@ -120,15 +120,15 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             {
                 var isAccessPoint = S3ArnUtils.IsS3AccessPointsArn(bucket) || S3ArnUtils.IsS3OutpostsArn(bucket);
                 // 'object/' needed appended to key for copy header with access points
-                source = AmazonS3Util.UrlEncode(String.Concat(bucket, isAccessPoint ? "/object/" : "/", key), !isAccessPoint);
+                source = AWSSDKUtils.UrlEncode(String.Concat(bucket, isAccessPoint ? "/object/" : "/", key), false);
                 if (!String.IsNullOrEmpty(version))
                 {
-                    source = string.Format(CultureInfo.InvariantCulture, "{0}?versionId={1}", source, AmazonS3Util.UrlEncode(version, true));
+                    source = string.Format(CultureInfo.InvariantCulture, "{0}?versionId={1}", source, AWSSDKUtils.UrlEncode(version, true));
                 }
             }
             else
             {
-                source = AmazonS3Util.UrlEncode(bucket, true);
+                source = AWSSDKUtils.UrlEncode(bucket, true);
             }
 
             return source;

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/S3Transforms.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/S3Transforms.cs
@@ -35,7 +35,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (value == null)
                 return string.Empty;
 
-            return AmazonS3Util.UrlEncode(value, path);
+            return AWSSDKUtils.UrlEncode(value, path);
         }
 
         internal static string ToURLEncodedValue(int value, bool path)

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
@@ -241,17 +241,6 @@ namespace Amazon.S3.Util
             }
         }
 
-        /// <summary>
-        /// URL encodes a string. If the path property is specified,
-        /// the accepted path characters {/+:} are not encoded.
-        /// </summary>
-        /// <param name="data">The string to encode</param>
-        /// <param name="path">Whether the string is a URL path or not</param>
-        /// <returns></returns>
-        public static string UrlEncode(string data, bool path)
-        {
-            return AWSSDKUtils.UrlEncode(data, path);
-        }
 
         /// <summary>
         /// Converts a non-seekable stream into a System.IO.MemoryStream.

--- a/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CopyObjectTests.cs
@@ -73,6 +73,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             BaseClean();
         }
         [DataTestMethod]
+        [DataRow(testKey, testKey)]
         [DataRow("ObjectWithAllSpecialCharacters/'()!*$+,;=&", "DestinationObjectWithAllSpecialCharacters/'()!*$+,;=&")]
         [TestCategory("S3")]
         public void TestCopyObject(string sourceKey, string destinationKey)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In V4 we [updated our valid path characters ](https://github.com/aws/aws-sdk-net/blob/v4-development/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs#L122-L128)list to be in accordance with RFC3389. We also updated url encode logic to only encode the characters in that list if the resource path was part of a label substitution. If the character is not part of a label subsitution, we don't encode those characters. CopyObject's marshaller has a special method which was calling its own AmazonS3Util.UrlEncode method which was passing in `true` to UrlEncode, essentially not encoding. In this PR I remove that method altogether and update all occurences to use AWSSDKUtils.UrlEncode. I pass in false so we do url-encode as we should.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Internal ticket
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
DRY_RUN-4a57b081-ad7e-4a0e-a5e8-d0af921d8554
Added integ tests
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement