### PR TITLE
Introduce AddCredentialsFactory() extension methods

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSOptions.cs
@@ -21,6 +21,7 @@ using Amazon;
 using Amazon.Runtime;
 
 using Amazon.Extensions.NETCore.Setup;
+using AWSSDK.Extensions.NETCore.Setup;
 
 namespace Amazon.Extensions.NETCore.Setup
 {
@@ -110,7 +111,7 @@ namespace Amazon.Extensions.NETCore.Setup
         /// <returns>The service client that implements the service interface.</returns>
         public T CreateServiceClient<T>() where T : IAmazonService
         {
-            return (T)ClientFactory.CreateServiceClient(null, typeof(T), this);
+            return (T)ClientFactory.CreateServiceClient(null, typeof(T), this, new DefaultAWSCredentialsFactory(this));
         }
 
         /// <summary>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/DefaultAWSCredentialsFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/DefaultAWSCredentialsFactory.cs
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using Amazon.Extensions.NETCore.Setup;
+using Amazon.Runtime;
+using Amazon.Runtime.CredentialManagement;
+using Microsoft.Extensions.Logging;
+
+namespace AWSSDK.Extensions.NETCore.Setup
+{
+    public class DefaultAWSCredentialsFactory : IAWSCredentialsFactory
+    {
+        private readonly AWSOptions _options;
+        private readonly ILogger<DefaultAWSCredentialsFactory> _logger;
+
+        public DefaultAWSCredentialsFactory(AWSOptions options, ILogger<DefaultAWSCredentialsFactory> logger = null)
+        {
+            _options = options;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Creates the AWSCredentials using either AWSOptions.Credentials, AWSOptions.Profile + AWSOptions.ProfilesLocation,
+        /// or the SDK fallback credentials search.
+        /// </summary>
+        public AWSCredentials Create()
+        {
+            if (_options?.Credentials != null)
+            {
+                _logger?.LogInformation("Using AWS credentials specified with the AWSOptions.Credentials property");
+                return _options.Credentials;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_options?.Profile))
+            {
+                var chain = new CredentialProfileStoreChain(_options.ProfilesLocation);
+                if (chain.TryGetAWSCredentials(_options.Profile, out var result))
+                {
+                    _logger?.LogInformation("Found AWS credentials for the profile {OptionsProfile}", _options.Profile);
+                    return result;
+                }
+
+                _logger?.LogInformation("Failed to find AWS credentials for the profile {OptionsProfile}", _options.Profile);
+            }
+
+            var credentials = FallbackCredentialsFactory.GetCredentials();
+            if (credentials == null)
+            {
+                _logger?.LogError("Last effort to find AWS Credentials with AWS SDK's default credential search failed");
+                throw new AmazonClientException("Failed to find AWS Credentials for constructing AWS service client");
+            }
+
+            _logger?.LogInformation("Found credentials using the AWS SDK's default credential search");
+
+            return credentials;
+        }
+    }
+}

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/IAWSCredentialsFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/IAWSCredentialsFactory.cs
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using Amazon.Runtime;
+
+namespace AWSSDK.Extensions.NETCore.Setup
+{
+    public interface IAWSCredentialsFactory
+    {
+        AWSCredentials Create();
+    }
+}

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
@@ -88,10 +88,22 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddCredentialsFactory(
             this IServiceCollection collection,
             Func<IServiceProvider, IAWSCredentialsFactory> awsCredentialsFactoryFunc,
-            ServiceLifetime lifetime = ServiceLifetime.Singleton,
-            bool tryAdd = false)
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
         {
-            return collection.AddCredentialsFactoryInternal(awsCredentialsFactoryFunc, lifetime, tryAdd);
+            return collection.AddCredentialsFactoryInternal(awsCredentialsFactoryFunc, lifetime, tryAdd: false);
+        }
+
+        /// <summary>
+        /// Adds a IAWSCredentialsFactory object obtained via th provided awsCredentialsFactoryFunc to the dependency
+        /// injection framework if no IAWSCredentialsFactory is already registered.
+        /// This factory will be used to create the credentials for the Amazon service clients.
+        /// </summary>
+        public static IServiceCollection TryAddCredentialsFactory(
+            this IServiceCollection collection,
+            Func<IServiceProvider, IAWSCredentialsFactory> awsCredentialsFactoryFunc,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        {
+            return collection.AddCredentialsFactoryInternal(awsCredentialsFactoryFunc, lifetime, tryAdd: true);
         }
 
         /// <summary>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
@@ -129,9 +129,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection"></param>
         /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
         /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
-        /// <param name="credentialsFactoryFunc">A func which takes an IServiceProvider and the AWSOptions resolved via the optionsFunc and
-        /// returns the IAWSCredentialsFactory used to create the service client overriding the default added using AddCredentialsFactory. If none is provided, the registered IAWSCredentialsFactory will be used,
-        /// and if none has been registered a new instance of DefaultAWSCredentialsFactory will be used.
+        /// <param name="credentialsFactoryFunc">
+        /// A func which takes an IServiceProvider and the AWSOptions provided to this call and returns an IAWSCredentialsFactory used to create the service client.
+        /// Must be provided if options are provided to this call _and_ a custom IAWSCredentialsFactory is registered via [Try]AddCredentialsFactory; otherwise the
+        /// default will be used.
         /// </param>
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection AddAWSService<T>(this IServiceCollection collection, AWSOptions options, ServiceLifetime lifetime = ServiceLifetime.Singleton, Func<IServiceProvider, AWSOptions, IAWSCredentialsFactory> credentialsFactoryFunc = null) where T : IAmazonService
@@ -147,9 +148,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
         /// <param name="collection"></param>
         /// <param name="optionsFunc">A func which returns the AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
-        /// <param name="credentialsFactoryFunc">A func which takes an IServiceProvider and the AWSOptions resolved via the optionsFunc and
-        /// returns the IAWSCredentialsFactory used to create the service client overriding the default added using AddCredentialsFactory. If none is provided, the registered IAWSCredentialsFactory will be used,
-        /// and if none has been registered a new instance of DefaultAWSCredentialsFactory will be used.
+        /// <param name="credentialsFactoryFunc">
+        /// A func which takes an IServiceProvider and the AWSOptions resolved by optionsFunc and returns an IAWSCredentialsFactory used to create the service client.
+        /// Must be provided if options are provided to this call _and_ a custom IAWSCredentialsFactory is registered via [Try]AddCredentialsFactory; otherwise the
+        /// default will be used.
         /// </param>
         /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
@@ -186,9 +188,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection"></param>
         /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
         /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
-        /// /// <param name="credentialsFactoryFunc">A func which takes an IServiceProvider and the AWSOptions resolved via the optionsFunc and
-        /// returns the IAWSCredentialsFactory used to create the service client overriding the default added using AddCredentialsFactory. If none is provided, the registered IAWSCredentialsFactory will be used,
-        /// and if none has been registered a new instance of DefaultAWSCredentialsFactory will be used.
+        /// <param name="credentialsFactoryFunc">
+        /// A func which takes an IServiceProvider and the AWSOptions resolved by optionsFunc and returns an IAWSCredentialsFactory used to create the service client.
+        /// Must be provided if options are provided to this call _and_ a custom IAWSCredentialsFactory is registered via [Try]AddCredentialsFactory; otherwise the
+        /// default will be used.
         /// </param>
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection TryAddAWSService<T>(this IServiceCollection collection, AWSOptions options, ServiceLifetime lifetime = ServiceLifetime.Singleton, Func<IServiceProvider, AWSOptions, IAWSCredentialsFactory> credentialsFactoryFunc = null) where T : IAmazonService
@@ -204,9 +207,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
         /// <param name="collection"></param>
         /// <param name="optionsFunc">A func which returns the AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
-        /// <param name="credentialsFactoryFunc">A func which takes an IServiceProvider and the AWSOptions resolved via the optionsFunc and
-        /// returns the IAWSCredentialsFactory used to create the service client overriding the default added using AddCredentialsFactory. If none is provided, the registered IAWSCredentialsFactory will be used,
-        /// and if none has been registered a new instance of DefaultAWSCredentialsFactory will be used.
+        /// <param name="credentialsFactoryFunc">
+        /// A func which takes an IServiceProvider and the AWSOptions resolved by optionsFunc and returns an IAWSCredentialsFactory used to create the service client.
+        /// Must be provided if options are provided to this call _and_ a custom IAWSCredentialsFactory is registered via [Try]AddCredentialsFactory; otherwise the
+        /// default will be used.
         /// </param>
         /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
@@ -248,8 +248,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 collection.Add(serviceDescriptor);
             }
 
-            collection.TryAddTransient<AWSCredentials>(sp => sp.GetRequiredService<IAWSCredentialsFactory>().Create());
-
             return collection;
         }
 

--- a/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
+++ b/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
@@ -8,6 +8,9 @@ using Amazon.S3;
 using Amazon.Extensions.NETCore.Setup;
 using Moq;
 using System;
+using Amazon.Runtime;
+using AWSSDK.Extensions.NETCore.Setup;
+using Castle.Core.Logging;
 
 namespace DependencyInjectionTests
 {
@@ -147,6 +150,282 @@ namespace DependencyInjectionTests
             var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
             Assert.NotNull(controller.S3Client);
             Assert.Equal(expectRegion, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void InjectS3ClientWithOverridingConfigAndCustomCredentialsProviderFunc()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddAWSService<IAmazonS3>(
+                new AWSOptions {Region = RegionEndpoint.EUCentral1 },
+                credentialsFactoryFunc: (sp, options) => new DefaultAWSCredentialsFactory(options, Mock.Of<Microsoft.Extensions.Logging.ILogger<DefaultAWSCredentialsFactory>>()));
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.EUCentral1, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void GivenCustomAddCredentialsFactoryCall_WhenInjectingS3Client_ThenUseCustomCredentials()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            var mockCredentialsFactory = new Mock<IAWSCredentialsFactory>();
+            mockCredentialsFactory
+                .Setup(x => x.Create())
+                .Returns(new BasicAWSCredentials("test", "test"));
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddCredentialsFactory(_ => mockCredentialsFactory.Object);
+            services.AddAWSService<IAmazonS3>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.USWest2, controller.S3Client.Config.RegionEndpoint);
+            mockCredentialsFactory.Verify(x => x.Create(), Times.Once);
+        }
+
+        [Fact]
+        public void GivenCustomAddCredentialsFactory_WhenInjectingS3ClientWithOverridingConfigAndCustomCredentialsProviderFunc_ThenUseOverride()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            var mockCredentialsFactory = new Mock<IAWSCredentialsFactory>();
+            mockCredentialsFactory
+                .Setup(x => x.Create())
+                .Returns(new BasicAWSCredentials("test", "test"));
+
+            var mockOverridenCredentialsFactory = new Mock<IAWSCredentialsFactory>();
+            mockOverridenCredentialsFactory
+                .Setup(x => x.Create())
+                .Returns(new BasicAWSCredentials("overriden", "overriden"));
+
+            var awsOptions = new AWSOptions {Region = RegionEndpoint.EUCentral1 };
+            AWSOptions providedOptionsToCredentialsFactoryFunc = new AWSOptions();
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddCredentialsFactory(sp => mockCredentialsFactory.Object);
+            services.AddAWSService<IAmazonS3>(
+                awsOptions,
+                credentialsFactoryFunc: (sp, options) =>
+                {
+                    providedOptionsToCredentialsFactoryFunc = options;
+                    return mockOverridenCredentialsFactory.Object;
+                });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.EUCentral1, controller.S3Client.Config.RegionEndpoint);
+            Assert.Equal(providedOptionsToCredentialsFactoryFunc, awsOptions);
+            mockOverridenCredentialsFactory.Verify(x => x.Create(), Times.Once);
+            mockCredentialsFactory.Verify(x => x.Create(), Times.Never);
+        }
+
+        [Fact]
+        public void GivenCustomAddCredentialsFactory_WhenInjectingS3ClientWithOverridingConfigAndNoCustomCredentialsProviderFunc_ThrowException()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            var mockCredentialsFactory = new Mock<IAWSCredentialsFactory>();
+            mockCredentialsFactory
+                .Setup(x => x.Create())
+                .Returns(new BasicAWSCredentials("test", "test"));
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddCredentialsFactory(sp => mockCredentialsFactory.Object);
+            services.AddAWSService<IAmazonS3>(new AWSOptions {Region = RegionEndpoint.EUCentral1 });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Func<TestController> controllerAction = () => ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.Throws<ArgumentNullException>(controllerAction);
+            mockCredentialsFactory.Verify(x => x.Create(), Times.Never);
+        }
+
+        [Fact]
+        public void GivenDefaultAddCredentialsFactory_WhenInjectingS3ClientWithSameConfigAsRegisteredAndNoCustomCredentialsProviderFunc_ThenWork()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            var awsOptions = new AWSOptions {Region = RegionEndpoint.EUCentral1 };
+            var mockCredentialsFactory = new Mock<IAWSCredentialsFactory>();
+            mockCredentialsFactory
+                .Setup(x => x.Create())
+                .Returns(new BasicAWSCredentials("test", "test"));
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(awsOptions);
+            services.AddCredentialsFactory(_ => mockCredentialsFactory.Object);
+            services.AddAWSService<IAmazonS3>(awsOptions);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.EUCentral1, controller.S3Client.Config.RegionEndpoint);
+            mockCredentialsFactory.Verify(x => x.Create(), Times.Once);
+        }
+
+        [Fact]
+        public void GivenDefaultAddCredentialsFactoryCall_WhenInjectingS3ClientWithOverridingConfigAndNoCustomCredentialsProviderFunc_ThenWork()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddCredentialsFactory();
+            services.AddAWSService<IAmazonS3>(new AWSOptions {Region = RegionEndpoint.EUCentral1 });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.EUCentral1, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void GivenDefaultAddCredentialsFactoryCall_WhenInjectingS3Client_ThenWork()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddCredentialsFactory();
+            services.AddAWSService<IAmazonS3>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.USWest2, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void GivenNoAddCredentialsFactoryCall_WhenInjectingS3ClientWithOverridingConfigAndNoCustomCredentialsProviderFunc_ThenUseDefault()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddAWSService<IAmazonS3>(new AWSOptions {Region = RegionEndpoint.EUCentral1 });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.EUCentral1, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void GivenNoAddCredentialsFactoryCall_WhenInjectingS3ClientWithNoOverridingConfigAndNoCustomCredentialsProviderFunc_ThenUseDefault()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddAWSService<IAmazonS3>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.USWest2, controller.S3Client.Config.RegionEndpoint);
+        }
+
+        [Fact]
+        public void GivenNoAddCredentialsFactoryCall_WhenInjectingS3ClientWithNoOverridingConfigButCustomCredentialsProviderFunc_ThenUseCustom()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            var mockOverridenCredentialsFactory = new Mock<IAWSCredentialsFactory>();
+            mockOverridenCredentialsFactory
+                .Setup(x => x.Create())
+                .Returns(new BasicAWSCredentials("overriden", "overriden"));
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddAWSService<IAmazonS3>((AWSOptions)null, credentialsFactoryFunc: (sp, options) => mockOverridenCredentialsFactory.Object);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.USWest2, controller.S3Client.Config.RegionEndpoint);
+            mockOverridenCredentialsFactory.Verify(x => x.Create(), Times.Once);
+        }
+
+        [Fact]
+        public void GivenCustomAddCredentialsFactoryCall_WhenInjectingS3ClientWithNoOverridingConfigButCustomCredentialsProviderFunc_ThenUseCustom()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonFile("./TestFiles/GetClientConfigSettingsTest.json");
+
+            IConfiguration config = builder.Build();
+
+            var mockCredentialsFactory = new Mock<IAWSCredentialsFactory>();
+            mockCredentialsFactory
+                .Setup(x => x.Create())
+                .Returns(new BasicAWSCredentials("test", "test"));
+
+            var mockOverridenCredentialsFactory = new Mock<IAWSCredentialsFactory>();
+            mockOverridenCredentialsFactory
+                .Setup(x => x.Create())
+                .Returns(new BasicAWSCredentials("overriden", "overriden"));
+
+            ServiceCollection services = new ServiceCollection();
+            services.AddDefaultAWSOptions(config.GetAWSOptions());
+            services.AddCredentialsFactory(_ => mockCredentialsFactory.Object);
+            services.AddAWSService<IAmazonS3>((AWSOptions)null, credentialsFactoryFunc: (sp, options) => mockOverridenCredentialsFactory.Object);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var controller = ActivatorUtilities.CreateInstance<TestController>(serviceProvider);
+            Assert.NotNull(controller.S3Client);
+            Assert.Equal(RegionEndpoint.USWest2, controller.S3Client.Config.RegionEndpoint);
+            mockOverridenCredentialsFactory.Verify(x => x.Create(), Times.Once);
+            mockCredentialsFactory.Verify(x => x.Create(), Times.Never);
         }
 
         public class TestController


### PR DESCRIPTION
## Description
This PR updates the [AWSSDK.Extensions.NETCore.Setup](https://github.com/aws/aws-sdk-net/tree/main/extensions/src/AWSSDK.Extensions.NETCore.Setup) nuget package with the following:

- Introduces `IServiceCollection.[Try]AddCredentialsFactory` extension methods
- Provides a `DefaultAWSCredentialsFactory` that is effectively a move of the private `ClientFactory.CreateCredentials` method
- Updates the `ClientFactory` to use the injected `IAWSCredentialsFactory`
- Adds a registration for `AWSCredentials` so that it can be injected by consuming code.

## Motivation and Context
There are scenarios where it's necessary to obtain `AWSCredentials`. One scenario is adding sigv4 headers when making RESTful calls using the idiomatic `HttpClient`; as an aside I happen to be using the [AwsSignatureVersion4](https://www.nuget.org/packages/AwsSignatureVersion4) nuget package for this. Today a consumer has to effectively copy the `ClientFactory.CreateCredentials` method to be able to register an `AWSCredentials` object that is created in a way that leverages `AWSOptions`. With these changes a consumer simply needs to call `services.AddCredentialsFactory()` and then inject `AWSOptions` where needed.

These updates also provide a hook for a consumer to customize the way in which `AWSCredentials` are provided to ServiceClients.

## Testing
I added 10 unit tests to the `DependencyInjectionTests`. I'm also using what is effectively a fork with these changes in production code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [?] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement