### PR TITLE
Add feature IDs for credential providers

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/AWSCredentialsFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/AWSCredentialsFactory.cs
@@ -205,10 +205,9 @@ namespace Amazon.Runtime.CredentialManagement
                     case CredentialProfileType.BasicWithServices:
                     case CredentialProfileType.BasicWithGlobalEndpoint:
                     case CredentialProfileType.BasicWithServicesAndGlobalEndpoint:
-                        return new BasicAWSCredentials(options.AccessKey, options.SecretKey)
-                        {
-                            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_PROFILE,
-                        };
+                        var basicCredentials = new BasicAWSCredentials(options.AccessKey, options.SecretKey);
+                        basicCredentials.FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_PROFILE);
+                        return basicCredentials;
                     case CredentialProfileType.Session:
                     case CredentialProfileType.SessionWithServices:
                     case CredentialProfileType.SessionWithGlobalEndpoint:
@@ -279,10 +278,10 @@ namespace Amazon.Runtime.CredentialManagement
                             ExternalId = options.ExternalID,
                             MfaSerialNumber = options.MfaSerial
                         };
-                        return new AssumeRoleAWSCredentials(sourceCredentials, options.RoleArn, roleSessionName, assumeRoleOptions)
-                        { 
-                            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_PROFILE_SOURCE_PROFILE,
-                        };
+
+                        var assumeRoleCredentials = new AssumeRoleAWSCredentials(sourceCredentials, options.RoleArn, roleSessionName, assumeRoleOptions);
+                        assumeRoleCredentials.FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_PROFILE_SOURCE_PROFILE);
+                        return assumeRoleCredentials;
                     
                     case CredentialProfileType.AssumeRoleCredentialSource:
                     case CredentialProfileType.AssumeRoleCredentialSourceWithGlobalEndpoint:
@@ -309,10 +308,10 @@ namespace Amazon.Runtime.CredentialManagement
 
                         roleSessionName = options.RoleSessionName ?? RoleSessionNamePrefix + AWSSDKUtils.CorrectedUtcNow.Ticks;
                         assumeRoleOptions = new AssumeRoleAWSCredentialsOptions();
-                        return new AssumeRoleAWSCredentials(sourceCredentials, options.RoleArn, roleSessionName, assumeRoleOptions)
-                        {
-                            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_PROFILE_NAMED_PROVIDER,
-                        };
+
+                        var assumeRoleSourceCredentials = new AssumeRoleAWSCredentials(sourceCredentials, options.RoleArn, roleSessionName, assumeRoleOptions);
+                        assumeRoleSourceCredentials.FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_PROFILE_NAMED_PROVIDER);
+                        return assumeRoleSourceCredentials;
                     
                     case CredentialProfileType.AssumeRoleWithWebIdentity:
                     case CredentialProfileType.AssumeRoleWithWebIdentityWithServices:
@@ -322,10 +321,9 @@ namespace Amazon.Runtime.CredentialManagement
                     case CredentialProfileType.AssumeRoleWithWebIdentitySessionNameWithServices:
                     case CredentialProfileType.AssumeRoleWithWebIdentitySessionNameWithGlobalEndpoint:
                     case CredentialProfileType.AssumeRoleWithWebIdentitySessionNameWithServicesAndGlobalEndpoint:
-                        return new AssumeRoleWithWebIdentityCredentials(options.WebIdentityTokenFile, options.RoleArn, options.RoleSessionName)
-                        {
-                            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_PROFILE_STS_WEB_ID_TOKEN,
-                        };
+                        var assumeRoleWebIdentityCredentials = new AssumeRoleWithWebIdentityCredentials(options.WebIdentityTokenFile, options.RoleArn, options.RoleSessionName);
+                        assumeRoleWebIdentityCredentials.FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_PROFILE_STS_WEB_ID_TOKEN);
+                        return assumeRoleWebIdentityCredentials;
                     
                     case CredentialProfileType.SSO:
                     {
@@ -336,10 +334,10 @@ namespace Amazon.Runtime.CredentialManagement
                         };
 
                         var isLegacyFormat = string.IsNullOrEmpty(options.SsoSession);
-                        return new SSOAWSCredentials(options.SsoAccountId, options.SsoRegion, options.SsoRoleName, options.SsoStartUrl, ssoCredentialsOptions)
-                        {
-                            FeatureIdSource = isLegacyFormat ? UserAgentFeatureId.CREDENTIALS_PROFILE_SSO_LEGACY : UserAgentFeatureId.CREDENTIALS_PROFILE_SSO,
-                        };
+                        var ssoCredentials = new SSOAWSCredentials(options.SsoAccountId, options.SsoRegion, options.SsoRoleName, options.SsoStartUrl, ssoCredentialsOptions);
+                        ssoCredentials.FeatureIdSources.Add(isLegacyFormat ? UserAgentFeatureId.CREDENTIALS_PROFILE_SSO_LEGACY : UserAgentFeatureId.CREDENTIALS_PROFILE_SSO);
+
+                        return ssoCredentials;
                     }
       
                     case CredentialProfileType.SAMLRole:
@@ -367,10 +365,9 @@ namespace Amazon.Runtime.CredentialManagement
                         }
                     
                     case CredentialProfileType.CredentialProcess:
-                        return new ProcessAWSCredentials(options.CredentialProcess)
-                        {
-                            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_PROFILE_PROCESS,
-                        };
+                        var processCredentials = new ProcessAWSCredentials(options.CredentialProcess);
+                        processCredentials.FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_PROFILE_PROCESS);
+                        return processCredentials;
 
                     default:
                         var defaultMessage = profileName == null

--- a/sdk/src/Core/Amazon.Runtime/Credentials/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AWSCredentials.cs
@@ -27,11 +27,11 @@ namespace Amazon.Runtime
         /// Internal property that can be used to specify how this instance of AWS credentials were resolved.
         /// </summary>
         /// <remarks>
-        /// Credential providers MUST override this property to have their specific feature ID tracked.
+        /// Credential providers MUST set this property to have their specific feature ID tracked.
         /// <para />
         /// If null, no value will be included in the user agent header.
         /// </remarks>
-        internal virtual UserAgentFeatureId FeatureIdSource { get; set; }
+        internal UserAgentFeatureId FeatureIdSource { get; set; }
 
         /// <summary>
         /// Returns a copy of ImmutableCredentials

--- a/sdk/src/Core/Amazon.Runtime/Credentials/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AWSCredentials.cs
@@ -13,8 +13,8 @@
  * permissions and limitations under the License.
  */
 
-
 using Amazon.Runtime.Identity;
+using Amazon.Runtime.Internal.UserAgent;
 
 namespace Amazon.Runtime
 {
@@ -23,6 +23,16 @@ namespace Amazon.Runtime
     /// </summary>
     public abstract class AWSCredentials : BaseIdentity
     {
+        /// <summary>
+        /// Internal property that can be used to specify how this instance of AWS credentials were resolved.
+        /// </summary>
+        /// <remarks>
+        /// Credential providers MUST override this property to have their specific feature ID tracked.
+        /// <para />
+        /// If null, no value will be included in the user agent header.
+        /// </remarks>
+        internal virtual UserAgentFeatureId FeatureIdSource { get; set; }
+
         /// <summary>
         /// Returns a copy of ImmutableCredentials
         /// </summary>

--- a/sdk/src/Core/Amazon.Runtime/Credentials/AWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AWSCredentials.cs
@@ -15,6 +15,7 @@
 
 using Amazon.Runtime.Identity;
 using Amazon.Runtime.Internal.UserAgent;
+using System.Collections.Generic;
 
 namespace Amazon.Runtime
 {
@@ -27,11 +28,11 @@ namespace Amazon.Runtime
         /// Internal property that can be used to specify how this instance of AWS credentials were resolved.
         /// </summary>
         /// <remarks>
-        /// Credential providers MUST set this property to have their specific feature ID tracked.
+        /// Credential providers MUST add to this property to have their specific feature ID tracked.
         /// <para />
-        /// If null, no value will be included in the user agent header.
+        /// If empty, no value will be included in the user agent header.
         /// </remarks>
-        internal UserAgentFeatureId FeatureIdSource { get; set; }
+        internal HashSet<UserAgentFeatureId> FeatureIdSources { get; set; } = new();
 
         /// <summary>
         /// Returns a copy of ImmutableCredentials

--- a/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleAWSCredentials.cs
@@ -85,7 +85,7 @@ namespace Amazon.Runtime
             RoleArn = roleArn;
             RoleSessionName = roleSessionName;
             Options = options;
-            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_STS_ASSUME_ROLE;
+            FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_STS_ASSUME_ROLE);
 
             // Make sure to fetch new credentials well before the current credentials expire to avoid
             // any request being made with expired credentials.

--- a/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleAWSCredentials.cs
@@ -13,16 +13,17 @@
  * permissions and limitations under the License.
  */
 using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.SharedInterfaces;
 using Amazon.RuntimeDependencies;
 using Amazon.Util.Internal;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
-using System.Diagnostics.CodeAnalysis;
-using ThirdParty.RuntimeBackports;
 using System.Threading.Tasks;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime
 {
@@ -33,7 +34,6 @@ namespace Amazon.Runtime
     public class AssumeRoleAWSCredentials : RefreshingAWSCredentials
     {
         private RegionEndpoint DefaultSTSClientRegion = RegionEndpoint.USEast1;
-
         private Logger _logger = Logger.GetLogger(typeof(AssumeRoleAWSCredentials));
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Amazon.Runtime
             RoleArn = roleArn;
             RoleSessionName = roleSessionName;
             Options = options;
-
+            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_STS_ASSUME_ROLE;
 
             // Make sure to fetch new credentials well before the current credentials expire to avoid
             // any request being made with expired credentials.

--- a/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleWithWebIdentityCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleWithWebIdentityCredentials.cs
@@ -26,6 +26,7 @@ using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Amazon.Runtime.Internal.UserAgent;
 
 namespace Amazon.Runtime
 {
@@ -66,6 +67,7 @@ namespace Amazon.Runtime
         private AssumeRoleWithWebIdentityCredentialsOptions _options;
 
         #region Properties
+        
         /// <summary>
         /// The absolute path to the file on disk containing an OIDC token
         /// </summary>
@@ -80,7 +82,8 @@ namespace Amazon.Runtime
         /// An identifier for the assumed role session.
         /// </summary>
         public string RoleSessionName { get; }
-#endregion Properties
+
+        #endregion Properties
 
         /// <summary>
         /// Constructs an AssumeRoleWithWebIdentityCredentials object.
@@ -123,6 +126,7 @@ namespace Amazon.Runtime
             RoleArn = roleArn;
             RoleSessionName = string.IsNullOrEmpty(roleSessionName) ? _roleSessionNameDefault : roleSessionName;
             _options = options;
+            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_STS_ASSUME_ROLE_WEB_ID;
 
             // Make sure to fetch new credentials well before the current credentials expire to avoid
             // any request being made with expired credentials.
@@ -139,7 +143,11 @@ namespace Amazon.Runtime
             var webIdentityTokenFile = Environment.GetEnvironmentVariable(WebIdentityTokenFileEnvVariable);
             var roleArn = Environment.GetEnvironmentVariable(RoleArnEnvVariable);
             var roleSessionName = Environment.GetEnvironmentVariable(RoleSessionNameEnvVariable);
-            return new AssumeRoleWithWebIdentityCredentials(webIdentityTokenFile, roleArn, roleSessionName);
+            
+            return new AssumeRoleWithWebIdentityCredentials(webIdentityTokenFile, roleArn, roleSessionName)
+            {
+                FeatureIdSource = UserAgentFeatureId.CREDENTIALS_ENV_VARS_STS_WEB_ID_TOKEN,
+            };
         }
 
         protected override CredentialsRefreshState GenerateNewCredentials()

--- a/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleWithWebIdentityCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleWithWebIdentityCredentials.cs
@@ -126,7 +126,7 @@ namespace Amazon.Runtime
             RoleArn = roleArn;
             RoleSessionName = string.IsNullOrEmpty(roleSessionName) ? _roleSessionNameDefault : roleSessionName;
             _options = options;
-            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_STS_ASSUME_ROLE_WEB_ID;
+            FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_STS_ASSUME_ROLE_WEB_ID);
 
             // Make sure to fetch new credentials well before the current credentials expire to avoid
             // any request being made with expired credentials.
@@ -143,11 +143,11 @@ namespace Amazon.Runtime
             var webIdentityTokenFile = Environment.GetEnvironmentVariable(WebIdentityTokenFileEnvVariable);
             var roleArn = Environment.GetEnvironmentVariable(RoleArnEnvVariable);
             var roleSessionName = Environment.GetEnvironmentVariable(RoleSessionNameEnvVariable);
+
+            var credentials = new AssumeRoleWithWebIdentityCredentials(webIdentityTokenFile, roleArn, roleSessionName);
+            credentials.FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_ENV_VARS_STS_WEB_ID_TOKEN);
             
-            return new AssumeRoleWithWebIdentityCredentials(webIdentityTokenFile, roleArn, roleSessionName)
-            {
-                FeatureIdSource = UserAgentFeatureId.CREDENTIALS_ENV_VARS_STS_WEB_ID_TOKEN,
-            };
+            return credentials;
         }
 
         protected override CredentialsRefreshState GenerateNewCredentials()

--- a/sdk/src/Core/Amazon.Runtime/Credentials/BasicAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/BasicAWSCredentials.cs
@@ -42,7 +42,7 @@ namespace Amazon.Runtime
             if (!string.IsNullOrEmpty(accessKey))
             {
                 _credentials = new ImmutableCredentials(accessKey, secretKey, null);
-                FeatureIdSource = UserAgentFeatureId.CREDENTIALS_CODE;
+                FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_CODE);
             }
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Credentials/BasicAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/BasicAWSCredentials.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
 
@@ -29,9 +30,7 @@ namespace Amazon.Runtime
 
         #endregion
 
-
         #region Constructors
-
 
         /// <summary>
         /// Constructs a BasicAWSCredentials object for the specified accessKey and secretKey.
@@ -48,7 +47,6 @@ namespace Amazon.Runtime
 
         #endregion
 
-
         #region Abstract class overrides
 
         /// <summary>
@@ -62,6 +60,8 @@ namespace Amazon.Runtime
 
             return _credentials.Copy();
         }
+
+        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_CODE;
 
         #endregion
 
@@ -78,7 +78,6 @@ namespace Amazon.Runtime
                 new object[] { _credentials },
                 new object[] { bac._credentials });
         }
-
         public override int GetHashCode()
         {
             return Hashing.Hash(_credentials);

--- a/sdk/src/Core/Amazon.Runtime/Credentials/BasicAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/BasicAWSCredentials.cs
@@ -42,6 +42,7 @@ namespace Amazon.Runtime
             if (!string.IsNullOrEmpty(accessKey))
             {
                 _credentials = new ImmutableCredentials(accessKey, secretKey, null);
+                FeatureIdSource = UserAgentFeatureId.CREDENTIALS_CODE;
             }
         }
 
@@ -60,8 +61,6 @@ namespace Amazon.Runtime
 
             return _credentials.Copy();
         }
-
-        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_CODE;
 
         #endregion
 

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultInstanceProfileAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultInstanceProfileAWSCredentials.cs
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
 using System;
@@ -85,6 +86,7 @@ namespace Amazon.Runtime
         }
 
         #region Overrides
+        
         /// <summary>
         /// Returns a copy of the most recent instance profile credentials.
         /// </summary>
@@ -262,7 +264,10 @@ namespace Amazon.Runtime
 
             return credentials;
         }
-#endregion
+
+        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_IMDS;
+
+        #endregion
 
         #region Private members
         private void RenewCredentials(object unused)
@@ -366,7 +371,8 @@ namespace Amazon.Runtime
         }
 #endregion
 
-#region IDisposable Support
+        #region IDisposable Support
+
         private bool _isDisposed = false;
 
         protected virtual void Dispose(bool disposing)
@@ -395,6 +401,7 @@ namespace Amazon.Runtime
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-#endregion
+
+        #endregion
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultInstanceProfileAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultInstanceProfileAWSCredentials.cs
@@ -85,7 +85,7 @@ namespace Amazon.Runtime
 
             _logger = Logger.GetLogger(typeof(DefaultInstanceProfileAWSCredentials));
             _credentialsRetrieverTimer = new Timer(RenewCredentials, null, TimeSpan.Zero, _neverTimespan); // This invokes synchronous calls in seperate thread.
-            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_IMDS;
+            FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_IMDS);
         }
 
         #region Overrides

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultInstanceProfileAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultInstanceProfileAWSCredentials.cs
@@ -78,11 +78,14 @@ namespace Amazon.Runtime
         private DefaultInstanceProfileAWSCredentials()
         {
             // if IMDS is turned off, no need to spin up the timer task
-            if (!EC2InstanceMetadata.IsIMDSEnabled) return;
+            if (!EC2InstanceMetadata.IsIMDSEnabled)
+            {
+                return;
+            }
 
             _logger = Logger.GetLogger(typeof(DefaultInstanceProfileAWSCredentials));
-            
             _credentialsRetrieverTimer = new Timer(RenewCredentials, null, TimeSpan.Zero, _neverTimespan); // This invokes synchronous calls in seperate thread.
+            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_IMDS;
         }
 
         #region Overrides
@@ -264,8 +267,6 @@ namespace Amazon.Runtime
 
             return credentials;
         }
-
-        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_IMDS;
 
         #endregion
 

--- a/sdk/src/Core/Amazon.Runtime/Credentials/EnvironmentVariablesAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/EnvironmentVariablesAWSCredentials.cs
@@ -57,7 +57,7 @@ namespace Amazon.Runtime
             // We need to do an initial fetch to validate that we can use environment variables to get the credentials.
             FetchCredentials();
 
-            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_ENV_VARS;
+            FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_ENV_VARS);
         }
 
         #endregion

--- a/sdk/src/Core/Amazon.Runtime/Credentials/EnvironmentVariablesAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/EnvironmentVariablesAWSCredentials.cs
@@ -32,8 +32,6 @@ namespace Amazon.Runtime
     /// </remarks>
     public class EnvironmentVariablesAWSCredentials : AWSCredentials
     {
-        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_ENV_VARS;
-
         // these variable names are standard across all AWS SDKs that support reading keys from
         // environment variables
         public const string ENVIRONMENT_VARIABLE_ACCESSKEY = "AWS_ACCESS_KEY_ID";
@@ -58,6 +56,8 @@ namespace Amazon.Runtime
 
             // We need to do an initial fetch to validate that we can use environment variables to get the credentials.
             FetchCredentials();
+
+            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_ENV_VARS;
         }
 
         #endregion

--- a/sdk/src/Core/Amazon.Runtime/Credentials/EnvironmentVariablesAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/EnvironmentVariablesAWSCredentials.cs
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
 using System;
 using System.Globalization;
@@ -31,6 +32,8 @@ namespace Amazon.Runtime
     /// </remarks>
     public class EnvironmentVariablesAWSCredentials : AWSCredentials
     {
+        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_ENV_VARS;
+
         // these variable names are standard across all AWS SDKs that support reading keys from
         // environment variables
         public const string ENVIRONMENT_VARIABLE_ACCESSKEY = "AWS_ACCESS_KEY_ID";

--- a/sdk/src/Core/Amazon.Runtime/Credentials/FederatedAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/FederatedAWSCredentials.cs
@@ -77,7 +77,7 @@ namespace Amazon.Runtime
             SAMLEndpoint = samlEndpoint ?? throw new ArgumentNullException("samlEndpoint");
             RoleArn = roleArn;
             PreemptExpiryTime = DefaultPreemptExpiryTime;
-            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_STS_FEDERATION_TOKEN;
+            FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_STS_FEDERATION_TOKEN);
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Credentials/FederatedAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/FederatedAWSCredentials.cs
@@ -14,20 +14,19 @@
  */
 
 using Amazon.Runtime.CredentialManagement;
-using Amazon.Runtime.Internal;
 using Amazon.Runtime.CredentialManagement.Internal;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.SharedInterfaces;
-using Amazon.Util;
 using Amazon.RuntimeDependencies;
 using Amazon.Util.Internal;
-using ThirdParty.RuntimeBackports;
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
 using System.Threading.Tasks;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime
 {
@@ -45,7 +44,6 @@ namespace Amazon.Runtime
         private static readonly RegionEndpoint DefaultSTSClientRegion = RegionEndpoint.USEast1;
         private static readonly TimeSpan MaximumCredentialTimespan = TimeSpan.FromHours(1);
         private static readonly TimeSpan DefaultPreemptExpiryTime = TimeSpan.FromMinutes(15);
-
         private readonly SAMLRoleSessionManager sessionManager = new SAMLRoleSessionManager();
 
         /// <summary>
@@ -79,6 +77,7 @@ namespace Amazon.Runtime
             SAMLEndpoint = samlEndpoint ?? throw new ArgumentNullException("samlEndpoint");
             RoleArn = roleArn;
             PreemptExpiryTime = DefaultPreemptExpiryTime;
+            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_STS_FEDERATION_TOKEN;
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Credentials/GenericContainerCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/GenericContainerCredentials.cs
@@ -66,12 +66,11 @@ namespace Amazon.Runtime
 
         internal Uri ResolvedEndpointUri { get; private set; }
 
-        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_HTTP;
-
         public GenericContainerCredentials()
         {
             PreemptExpiryTime = TimeSpan.FromMinutes(15);
             DetermineEndpoint();
+            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_HTTP;
         }
 
         protected override CredentialsRefreshState GenerateNewCredentials()

--- a/sdk/src/Core/Amazon.Runtime/Credentials/GenericContainerCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/GenericContainerCredentials.cs
@@ -70,7 +70,7 @@ namespace Amazon.Runtime
         {
             PreemptExpiryTime = TimeSpan.FromMinutes(15);
             DetermineEndpoint();
-            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_HTTP;
+            FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_HTTP);
         }
 
         protected override CredentialsRefreshState GenerateNewCredentials()

--- a/sdk/src/Core/Amazon.Runtime/Credentials/GenericContainerCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/GenericContainerCredentials.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Util;
 using Amazon.Util.Internal;
 using System;
@@ -64,6 +65,8 @@ namespace Amazon.Runtime
         private const string InvalidHostErrorMessage = "Cannot fetch credentials from container - the full URI contains an invalid host: {0}";
 
         internal Uri ResolvedEndpointUri { get; private set; }
+
+        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_HTTP;
 
         public GenericContainerCredentials()
         {

--- a/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
@@ -84,13 +84,13 @@ namespace Amazon.Runtime
             // Make sure to fetch new credentials well before the current credentials expire to avoid
             // any request being made with expired credentials.
             PreemptExpiryTime = TimeSpan.FromMinutes(15);
+
+            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_PROCESS;
         }
 
         #endregion
 
         #region Protected overridden methods
-
-        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_PROCESS;
 
         protected override CredentialsRefreshState GenerateNewCredentials()
         {

--- a/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
@@ -85,7 +85,7 @@ namespace Amazon.Runtime
             // any request being made with expired credentials.
             PreemptExpiryTime = TimeSpan.FromMinutes(15);
 
-            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_PROCESS;
+            FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_PROCESS);
         }
 
         #endregion

--- a/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
@@ -19,6 +19,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util.Internal;
 using System.Diagnostics.CodeAnalysis;
@@ -88,6 +89,8 @@ namespace Amazon.Runtime
         #endregion
 
         #region Protected overridden methods
+
+        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_PROCESS;
 
         protected override CredentialsRefreshState GenerateNewCredentials()
         {

--- a/sdk/src/Core/Amazon.Runtime/Credentials/SessionAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/SessionAWSCredentials.cs
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
 using System;
@@ -38,17 +39,16 @@ namespace Amazon.Runtime
             if (string.IsNullOrEmpty(token)) throw new ArgumentNullException("token");
 
             _lastCredentials = new ImmutableCredentials(awsAccessKeyId, awsSecretAccessKey, token);
+            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_STS_SESSION_TOKEN;
         }
 
         #endregion
-
 
         #region Credentials data
 
         private ImmutableCredentials _lastCredentials;
 
         #endregion
-
 
         #region Abstract class overrides
 

--- a/sdk/src/Core/Amazon.Runtime/Credentials/SessionAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/SessionAWSCredentials.cs
@@ -39,7 +39,7 @@ namespace Amazon.Runtime
             if (string.IsNullOrEmpty(token)) throw new ArgumentNullException("token");
 
             _lastCredentials = new ImmutableCredentials(awsAccessKeyId, awsSecretAccessKey, token);
-            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_STS_SESSION_TOKEN;
+            FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_STS_SESSION_TOKEN);
         }
 
         #endregion

--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/SSOAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/SSOAWSCredentials.cs
@@ -103,7 +103,7 @@ namespace Amazon.Runtime
             RoleName = roleName;
             StartUrl = startUrl;
             Options = options;
-            FeatureIdSource = string.IsNullOrEmpty(options.SessionName) ? UserAgentFeatureId.CREDENTIALS_SSO_LEGACY : UserAgentFeatureId.CREDENTIALS_SSO;
+            FeatureIdSources.Add(string.IsNullOrEmpty(options.SessionName) ? UserAgentFeatureId.CREDENTIALS_SSO_LEGACY : UserAgentFeatureId.CREDENTIALS_SSO);
 
             _ssoTokenManager = new SSOTokenManager(
                 SSOServiceClientHelpers.BuildSSOIDCClient(

--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/SSOAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/SSOAWSCredentials.cs
@@ -13,17 +13,18 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.Runtime.Credentials.Internal;
 using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.SharedInterfaces;
+using Amazon.Util;
+using Amazon.Util.Internal;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
-using Amazon.Runtime.Credentials.Internal;
-using Amazon.Util;
-using Amazon.Util.Internal;
 
 namespace Amazon.Runtime
 {
@@ -102,6 +103,7 @@ namespace Amazon.Runtime
             RoleName = roleName;
             StartUrl = startUrl;
             Options = options;
+            FeatureIdSource = string.IsNullOrEmpty(options.SessionName) ? UserAgentFeatureId.CREDENTIALS_SSO_LEGACY : UserAgentFeatureId.CREDENTIALS_SSO;
 
             _ssoTokenManager = new SSOTokenManager(
                 SSOServiceClientHelpers.BuildSSOIDCClient(

--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl/AppConfigAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl/AppConfigAWSCredentials.cs
@@ -28,8 +28,6 @@ namespace Amazon.Runtime
     /// </summary>
     public class AppConfigAWSCredentials : AWSCredentials
     {
-        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_CODE;
-
         private const string ACCESSKEY = "AWSAccessKey";
         private const string SECRETKEY = "AWSSecretKey";
 
@@ -69,7 +67,10 @@ namespace Amazon.Runtime
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
                     "The app.config/web.config files for the application did not contain credential information"));
             }
+
+            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_CODE;
         }
+
         #endregion
 
         #region Abstract class overrides

--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl/AppConfigAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl/AppConfigAWSCredentials.cs
@@ -13,10 +13,8 @@
  * permissions and limitations under the License.
  */
 using Amazon.Runtime.CredentialManagement;
-using Amazon.Runtime.CredentialManagement.Internal;
-using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
-using Amazon.Util;
 using System;
 using System.Collections.Specialized;
 using System.Configuration;
@@ -30,6 +28,8 @@ namespace Amazon.Runtime
     /// </summary>
     public class AppConfigAWSCredentials : AWSCredentials
     {
+        internal override UserAgentFeatureId FeatureIdSource => UserAgentFeatureId.CREDENTIALS_CODE;
+
         private const string ACCESSKEY = "AWSAccessKey";
         private const string SECRETKEY = "AWSSecretKey";
 

--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl/AppConfigAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl/AppConfigAWSCredentials.cs
@@ -68,7 +68,7 @@ namespace Amazon.Runtime
                     "The app.config/web.config files for the application did not contain credential information"));
             }
 
-            FeatureIdSource = UserAgentFeatureId.CREDENTIALS_CODE;
+            FeatureIdSources.Add(UserAgentFeatureId.CREDENTIALS_CODE);
         }
 
         #endregion

--- a/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentFeatureId.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentFeatureId.cs
@@ -151,11 +151,6 @@ namespace Amazon.Runtime.Internal.UserAgent
         public static readonly UserAgentFeatureId CREDENTIALS_STS_ASSUME_ROLE = new UserAgentFeatureId("i");
 
         /// <summary>
-        /// An operation called using credentials resolved from STS using assume role with SAML.
-        /// </summary>
-        public static readonly UserAgentFeatureId CREDENTIALS_STS_ASSUME_ROLE_SAML = new UserAgentFeatureId("j");
-
-        /// <summary>
         /// An operation called using credentials resolved from STS using assume role with web identity.
         /// </summary>
         public static readonly UserAgentFeatureId CREDENTIALS_STS_ASSUME_ROLE_WEB_ID = new UserAgentFeatureId("k");

--- a/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentFeatureId.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentFeatureId.cs
@@ -21,24 +21,9 @@ namespace Amazon.Runtime.Internal.UserAgent
     public class UserAgentFeatureId : ConstantClass
     {
         /// <summary>
-        /// An operation called using a C2j Resource model.
-        /// </summary>
-        public static readonly UserAgentFeatureId RESOURCE_MODEL = new UserAgentFeatureId("A");
-
-        /// <summary>
-        /// An operation called using a waiter.
-        /// </summary>
-        public static readonly UserAgentFeatureId WAITER = new UserAgentFeatureId("B");
-
-        /// <summary>
         /// An operation called using a paginator.
         /// </summary>
         public static readonly UserAgentFeatureId PAGINATOR = new UserAgentFeatureId("C");
-
-        /// <summary>
-        /// An operation called using the legacy retry mode.
-        /// </summary>
-        public static readonly UserAgentFeatureId RETRY_MODE_LEGACY = new UserAgentFeatureId("D");
 
         /// <summary>
         /// An operation called using the standard retry mode.
@@ -56,34 +41,14 @@ namespace Amazon.Runtime.Internal.UserAgent
         public static readonly UserAgentFeatureId S3_TRANSFER = new UserAgentFeatureId("G");
 
         /// <summary>
-        /// An operation called using the S3 Encryption Client V1.
-        /// </summary>
-        public static readonly UserAgentFeatureId S3_CRYPTO_V1N = new UserAgentFeatureId("H");
-
-        /// <summary>
-        /// An operation called using the S3 Encryption Client V2.
-        /// </summary>
-        public static readonly UserAgentFeatureId S3_CRYPTO_V2 = new UserAgentFeatureId("I");
-
-        /// <summary>
         /// An operation called using the S3 Express feature.
         /// </summary>
         public static readonly UserAgentFeatureId S3_EXPRESS_BUCKET = new UserAgentFeatureId("J");
 
         /// <summary>
-        /// An operation called using the S3 Access Grants feature.
-        /// </summary>
-        public static readonly UserAgentFeatureId S3_ACCESS_GRANTS = new UserAgentFeatureId("K");
-
-        /// <summary>
         /// An operation called using GZIP request compression.
         /// </summary>
         public static readonly UserAgentFeatureId GZIP_REQUEST_COMPRESSION = new UserAgentFeatureId("L");
-
-        /// <summary>
-        /// An operation called using the Smithy RPC v2 CBOR protocol.
-        /// </summary>
-        public static readonly UserAgentFeatureId PROTOCOL_RPC_V2_CBOR = new UserAgentFeatureId("M");
 
         /// <summary>
         /// An operation called using a user provided endpoint URL.
@@ -171,11 +136,6 @@ namespace Amazon.Runtime.Internal.UserAgent
         public static readonly UserAgentFeatureId CREDENTIALS_CODE = new UserAgentFeatureId("e");
 
         /// <summary>
-        /// An operation called using credentials resolved from JVM system properties.
-        /// </summary>
-        public static readonly UserAgentFeatureId CREDENTIALS_JVM_SYSTEM_PROPERTIES = new UserAgentFeatureId("f");
-
-        /// <summary>
         /// An operation called using credentials resolved from environment variables.
         /// </summary>
         public static readonly UserAgentFeatureId CREDENTIALS_ENV_VARS = new UserAgentFeatureId("g");
@@ -259,11 +219,6 @@ namespace Amazon.Runtime.Internal.UserAgent
         /// An operation called using credentials resolved from a process.
         /// </summary>
         public static readonly UserAgentFeatureId CREDENTIALS_PROCESS = new UserAgentFeatureId("w");
-
-        /// <summary>
-        /// An operation called using credentials resolved from the credentials section of a boto2 config file.
-        /// </summary>
-        public static readonly UserAgentFeatureId CREDENTIALS_BOTO2_CONFIG_FILE = new UserAgentFeatureId("x");
 
         /// <summary>
         /// An operation called using credentials resolved from a profile in an AWS SDK store.

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
@@ -17,6 +17,7 @@ using Amazon.Runtime.Credentials.Internal;
 using Amazon.Runtime.Endpoints;
 using Amazon.Runtime.Identity;
 using Amazon.Runtime.Internal.Auth;
+using Amazon.Runtime.Internal.UserAgent;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -128,6 +129,8 @@ namespace Amazon.Runtime.Internal
             {
                 throw new AmazonClientException($"Could not determine which authentication scheme to use for {executionContext.RequestContext.RequestName}");
             }
+
+            AddUserAgentDetails(executionContext);
         }
 
         protected async Task PreInvokeAsync(IExecutionContext executionContext)
@@ -207,6 +210,8 @@ namespace Amazon.Runtime.Internal
             {
                 throw new AmazonClientException($"Could not determine which authentication scheme to use for {executionContext.RequestContext.RequestName}");
             }
+
+            AddUserAgentDetails(executionContext);
         }
 
         protected virtual ISigner GetSigner(IAuthScheme<BaseIdentity> scheme)
@@ -275,5 +280,16 @@ namespace Amazon.Runtime.Internal
         /// Invokes the service auth scheme resolver to determine which auth options we should consider for this request.
         /// </summary>
         protected abstract List<IAuthSchemeOption> ResolveAuthOptions(IExecutionContext executionContext);
+
+        private static void AddUserAgentDetails(IExecutionContext executionContext)
+        {
+            var requestContext = executionContext.RequestContext;
+            if (requestContext.Identity == null || requestContext.Identity is not AWSCredentials credentials)
+            {
+                return;
+            }
+
+            requestContext.UserAgentDetails.AddFeature(credentials.FeatureIdSource);
+        }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
@@ -289,7 +289,10 @@ namespace Amazon.Runtime.Internal
                 return;
             }
 
-            requestContext.UserAgentDetails.AddFeature(credentials.FeatureIdSource);
+            foreach (var featureId in credentials.FeatureIdSources)
+            {
+                requestContext.UserAgentDetails.AddFeature(featureId);
+            }
         }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/ChecksumHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/ChecksumHandler.cs
@@ -13,8 +13,8 @@
 * permissions and limitations under the License.
 */
 
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Internal.Util;
-using System;
 
 namespace Amazon.Runtime.Internal
 {
@@ -59,6 +59,7 @@ namespace Amazon.Runtime.Internal
         /// <param name="executionContext">The execution context which contains both the request and response context.</param>
         protected virtual void PreInvoke(IExecutionContext executionContext)
         {
+            var requestContext = executionContext.RequestContext;
             var request = executionContext.RequestContext.Request;
             var clientConfig = executionContext.RequestContext.ClientConfig;
 
@@ -74,6 +75,35 @@ namespace Amazon.Runtime.Internal
             }
 
             ChecksumUtils.SetRequestChecksumV2(request, clientConfig);
+
+            switch (request.SelectedChecksum)
+            {
+                case CoreChecksumAlgorithm.CRC32C:
+                    requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.FLEXIBLE_CHECKSUMS_REQ_CRC32C);
+                    break;
+                case CoreChecksumAlgorithm.CRC32:
+                    requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.FLEXIBLE_CHECKSUMS_REQ_CRC32);
+                    break;
+                case CoreChecksumAlgorithm.SHA256:
+                    requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.FLEXIBLE_CHECKSUMS_REQ_SHA256);
+                    break;
+                case CoreChecksumAlgorithm.SHA1:
+                    requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.FLEXIBLE_CHECKSUMS_REQ_SHA1);
+                    break;
+                case CoreChecksumAlgorithm.CRC64NVME:
+                    requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.FLEXIBLE_CHECKSUMS_REQ_CRC64);
+                    break;
+            }
+
+            switch (clientConfig.RequestChecksumCalculation)
+            {
+                case RequestChecksumCalculation.WHEN_SUPPORTED:
+                    requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.FLEXIBLE_CHECKSUMS_REQ_WHEN_SUPPORTED);
+                    break;
+                case RequestChecksumCalculation.WHEN_REQUIRED:
+                    requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.FLEXIBLE_CHECKSUMS_REQ_WHEN_REQUIRED);
+                    break;
+            }
         }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/CompressionHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/CompressionHandler.cs
@@ -19,6 +19,7 @@ using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.Internal.Compression;
 using Amazon.Runtime.Telemetry.Tracing;
 using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Internal.UserAgent;
 
 namespace Amazon.Runtime.Internal
 {
@@ -74,8 +75,16 @@ namespace Amazon.Runtime.Internal
                 return;
             }
 
-            var compressionAlgorithm = CompressionFactory.GetCompressionAlgorithm(request.CompressionAlgorithm);
+            switch (request.CompressionAlgorithm)
+            {
+                case CompressionEncodingAlgorithm.gzip:
+                    executionContext.RequestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.GZIP_REQUEST_COMPRESSION);
+                    break;
+                default:
+                    break;
+            }
 
+            var compressionAlgorithm = CompressionFactory.GetCompressionAlgorithm(request.CompressionAlgorithm);
             if (request.ContentStream != null)
             {
                 request.ContentStream = new CompressionWrapperStream(request.ContentStream, compressionAlgorithm);

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Marshaller.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using Amazon.Runtime.Internal.UserAgent;
 using Amazon.Runtime.Telemetry;
 using Amazon.Runtime.Telemetry.Metrics;
 using Amazon.Util;
@@ -74,6 +75,16 @@ namespace Amazon.Runtime.Internal
                 {
                     // Set CoreChecksumMode to enabled to validate the integrity of this request's response if it is supported.
                     requestContext.OriginalRequest.CoreChecksumMode = CoreChecksumResponseBehavior.ENABLED;
+                }
+
+                switch (requestContext.ClientConfig.ResponseChecksumValidation)
+                {
+                    case ResponseChecksumValidation.WHEN_SUPPORTED:
+                        requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.FLEXIBLE_CHECKSUMS_RES_WHEN_SUPPORTED);
+                        break;
+                    case ResponseChecksumValidation.WHEN_REQUIRED:
+                        requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.FLEXIBLE_CHECKSUMS_RES_WHEN_REQUIRED);
+                        break;
                 }
 
                 requestContext.Request = requestContext.Marshaller.Marshall(requestContext.OriginalRequest);


### PR DESCRIPTION
## Description
Updates the credential providers to set the feature ID specifying how they were resolved. Still missing from this PR are:
- `CREDENTIALS_AWS_SDK_STORE`
- `SSO_LOGIN_DEVICE`
- `SSO_LOGIN_AUTH`

I followed a similar approach the JS team did, which was to add a property to our `AWSCredentials` class that can be overwritten by each individual implementation: https://github.com/aws/aws-sdk-js-v3/pull/6546/files

## Testing
Manually built the `AWSSDK.NetFramework.sln` solution (full dry-run will be done before merging to `v4-development`)

## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license