### PR TITLE
Remove a few duplicate dictionary lookups in some core classes

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -280,10 +280,9 @@ namespace Amazon.Runtime.Internal.Auth
             headers.Remove(HeaderKeys.AuthorizationHeader);
             headers.Remove(HeaderKeys.XAmzContentSha256Header);
 
-            if (headers.ContainsKey(HeaderKeys.XAmzDecodedContentLengthHeader))
+            if (headers.TryGetValue(HeaderKeys.XAmzDecodedContentLengthHeader, out string decodedContentLength))
             {
-                headers[HeaderKeys.ContentLengthHeader] =
-                    headers[HeaderKeys.XAmzDecodedContentLengthHeader];
+                headers[HeaderKeys.ContentLengthHeader] = decodedContentLength;
                 headers.Remove(HeaderKeys.XAmzDecodedContentLengthHeader);
             }
         }
@@ -507,13 +506,13 @@ namespace Amazon.Runtime.Internal.Auth
             {
                 computedContentHash = chunkedBodyHash;
 
-                if (request.Headers.ContainsKey(HeaderKeys.ContentLengthHeader))
+                if (request.Headers.TryGetValue(HeaderKeys.ContentLengthHeader, out string contentLength))
                 {
                     // Set X-Amz-Decoded-Content-Length with the true size of the data
-                    request.Headers[HeaderKeys.XAmzDecodedContentLengthHeader] = request.Headers[HeaderKeys.ContentLengthHeader];
+                    request.Headers[HeaderKeys.XAmzDecodedContentLengthHeader] = contentLength;
 
                     // Substitute the originally declared content length with the inflated length due to chunking metadata and/or trailing headers
-                    var originalContentLength = long.Parse(request.Headers[HeaderKeys.ContentLengthHeader], CultureInfo.InvariantCulture);
+                    var originalContentLength = long.Parse(contentLength, CultureInfo.InvariantCulture);
                     request.Headers[HeaderKeys.ContentLengthHeader]
                         = ChunkedUploadWrapperStream.ComputeChunkedContentLength(originalContentLength, signatureLength, request.TrailingHeaders, request.SelectedChecksum).ToString(CultureInfo.InvariantCulture);
                 }

--- a/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
+++ b/sdk/src/Services/S3/Custom/Util/AmazonS3Util.cs
@@ -231,9 +231,9 @@ namespace Amazon.S3.Util
         /// <returns>The MIME type for the extension, or text/plain</returns>
         public static string MimeTypeFromExtension(string ext)
         {
-            if (extensionToMime.ContainsKey(ext))
+            if (extensionToMime.TryGetValue(ext, out string mimeType))
             {
-                return extensionToMime[ext];
+                return mimeType;
             }
             else
             {


### PR DESCRIPTION
## Description
I found and removed a few duplicate dictionary lookups within the `AWS4Signer` and `AmazonS3Util` classes.

## Motivation and Context
There is a small performance boost by avoiding duplicate look-ups.

## Testing
I have re-run the existing unit tests. The changes seem trivial enough that I haven't explicitly added more coverage in these areas. Please let me know if you'd prefer I do.

## Screenshots (if appropriate)
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement