### PR TITLE
Fixed an issue where property keys in credentials/config file were incorrectly considered as case-sensitive.

### DIFF
--- a/generator/.DevConfigs/4b3cafc2-86df-4da5-a531-ffd1a27950ac.json
+++ b/generator/.DevConfigs/4b3cafc2-86df-4da5-a531-ffd1a27950ac.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Fixed an issue where property keys in credentials/config file were incorrectly considered as case-sensitive."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/IniFile.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/IniFile.cs
@@ -595,6 +595,9 @@ namespace Amazon.Runtime.Internal.Util
                 nestedProperty = null;
                 if (TryParseProperty(Lines[lineNumber], out propertyName, out propertyValue))
                 {
+                    // Property keys are considered case-insensitive. Property keys SHOULD be stored lower-cased after parsing.
+                    propertyName = propertyName.ToLowerInvariant();
+
                     //if propertyValue is empty, that means that it is a continuation property
                     if (String.IsNullOrEmpty(propertyValue))
                     {
@@ -641,7 +644,9 @@ namespace Amazon.Runtime.Internal.Util
                 else if (StartsWithWhitespace(currentLine))
                 {
                     var separatorIndex = trimmedLine.IndexOf(keyValueSeparator, StringComparison.Ordinal);
-                    subpropertyName = trimmedLine.Substring(0, separatorIndex).Trim();
+
+                    // Property keys are considered case-insensitive. Property keys SHOULD be stored lower-cased after parsing.
+                    subpropertyName = trimmedLine.Substring(0, separatorIndex).ToLowerInvariant().Trim();
                     subpropertyValue = trimmedLine.Substring(separatorIndex + 1).Trim();
                     nestedProperty.SubpropertyKeys.Add(subpropertyName);
                     nestedProperty.SubpropertyValues.Add(subpropertyValue);

--- a/sdk/src/Core/GlobalSuppressions.cs
+++ b/sdk/src/Core/GlobalSuppressions.cs
@@ -201,6 +201,8 @@ using System.Diagnostics.CodeAnalysis;
 
 [module: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Amazon.Runtime.Internal.Auth.AWS4Signer.#CanonicalizeHeaders(System.Collections.Generic.IDictionary`2<System.String,System.String>)")]
 [module: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Amazon.Runtime.Internal.Auth.AWS4Signer.#CanonicalizeHeaderNames(System.Collections.Generic.IDictionary`2<System.String,System.String>)")]
+[assembly: SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Scope = "member", Target = "~M:Amazon.Runtime.Internal.Util.IniFile.SeekProperty(System.Int32@,System.String@,System.String@,Amazon.Runtime.Internal.Util.NestedProperty@)~System.Boolean")]
+[assembly: SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Scope = "member", Target = "~M:Amazon.Runtime.Internal.Util.IniFile.TryParseSubproperties(System.Int32@,System.String,Amazon.Runtime.Internal.Util.NestedProperty@)~System.Boolean")]
 
 // Types names matching namespaces
 [module: SuppressMessage("Microsoft.Naming", "CA1724:TypeNamesShouldNotMatchNamespaces", Scope = "type", Target = "Amazon.Auth.AccessControlPolicy.Policy")]

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/SharedCredentialsFileTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/SharedCredentialsFileTest.cs
@@ -447,6 +447,21 @@ namespace AWSSDK.UnitTests
             .AppendLine("\tname = value")
             .ToString();
 
+        private static readonly string CredentialsProfilePropertyKeyWithMixedCase = new StringBuilder()
+            .AppendLine("[foo]")
+            .AppendLine("AWS_ACCESS_KEY_ID=basic_aws_ACCESS_key_id")
+            .AppendLine("Aws_sEcRet_AcceSS_key=basic_Aws_sEcRet_AcceSS_key")
+            .AppendLine("OuTpUt=json")
+            .ToString();
+
+        private static readonly string ConfigProfileWithSubpropertiesPropertyKeyWithMixedCase = new StringBuilder()
+            .AppendLine("[profile foo]")
+            .AppendLine("REgiON=us-EAST-2")
+            .AppendLine("output=text")
+            .AppendLine("s3 = ")
+            .AppendLine("\tnAMe = ValuE")
+            .ToString();
+
         private static readonly string ProfileWithEmptySubpropertyDefinitions = new StringBuilder()
             .AppendLine("[profile foo]")
             .AppendLine("aws_access_key_id=basic_aws_access_key_id")
@@ -497,7 +512,31 @@ namespace AWSSDK.UnitTests
                     {"name","value" }
                 };
                 expectedNestedProperties.Add("s3", entry);
-                tester.ReadAndAssertProfile("foo", BasicProfileOptions,  expectedNestedProperties);
+                tester.ReadAndAssertProfile("foo", BasicProfileOptions, expectedNestedProperties);
+            }
+        }
+
+        [TestMethod]
+        public void ReadProfileWithSubpropertiesPropertyKeyWithMixedCase()
+        {
+            using (var tester = new SharedCredentialsFileTestFixture(CredentialsProfilePropertyKeyWithMixedCase, ConfigProfileWithSubpropertiesPropertyKeyWithMixedCase))
+            {
+                CredentialProfileOptions expectedProfileOptions = new CredentialProfileOptions
+                {
+                    AccessKey = "basic_aws_ACCESS_key_id",
+                    SecretKey = "basic_Aws_sEcRet_AcceSS_key",
+                };
+                var expectedProperties = new Dictionary<string, string>
+                {
+                    { "output", "json" }
+                };
+                var expectedNestedProperties = new Dictionary<string, Dictionary<string, string>>();
+                var entry = new Dictionary<string, string>
+                {
+                    { "name", "ValuE" }
+                };
+                expectedNestedProperties.Add("s3", entry);
+                tester.ReadAndAssertProfile("foo", expectedProfileOptions, expectedProperties, RegionEndpoint.USEast2, null, expectedNestedProperties);
             }
         }
 


### PR DESCRIPTION
## Description
Fixed an issue where property keys in credentials/config file were incorrectly considered as case-sensitive.

For a Property Key (refer SEP link in `DOTNET-7965` for more details):
- It is `An identifier defined by the SDK as a supported setting. Property keys MUST be considered case-insensitive.`. This is irrespective of whether it is a `credentials` or `config` file.
- **Implementation Guidance:** After parsing, profiles undergo complex merging logic to merge profile from multiple individual files. To reduce the risk of bugs, SDKs MAY lowercase all profile keys during the parsing phase to simplify later logic.
- Property keys are considered case-insensitive. Property keys SHOULD be stored lower-cased after parsing. When keys are retrieved from the profile, they should also be lower-cased.
- **Side-note:** (outside scope of this issue) When a profile has the same property defined in both the configuration and credentials files, the credentials properties must be used.
 
## Motivation and Context
Issue: https://github.com/aws/aws-sdk-net/issues/3630

## Testing
- Added test case.
- 1st dry-run:
  - .NET (V3) dry-run `DRY_RUN-ecd2eb13-5382-49e6-8705-98b308fc170d` completed successfully.
  - PowerShell (V4) dry-run `DRY_RUN-5e9a6012-086a-4a19-8550-9c1282b4d032` completed successfully.
- 2nd dry-run (after changing to use `ToLowerInvariant()`):
  - .NET (V3) dry-run `DRY_RUN-f6147e3c-cb02-40fe-a36a-9846bb65cf1a` completed successfully.
  - PowerShell (V4) dry-run `DRY_RUN-c8c7f70b-5c63-4c43-9eb9-c6b6cd2bf487` completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement