### PR TITLE
Issues/2576 dynamo db entry conversion

### DIFF
--- a/generator/.DevConfigs/e5fd3631-e192-4dcb-931b-69d45722ae02.json
+++ b/generator/.DevConfigs/e5fd3631-e192-4dcb-931b-69d45722ae02.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Allow to set DynamoDBEntryConversion per table."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -30,11 +30,17 @@ using Amazon.Runtime.Internal.Util;
 
 namespace Amazon.DynamoDBv2
 {
+
     /// <summary>
     /// Available conversion schemas.
     /// </summary>
-    internal enum ConversionSchema
+    public enum ConversionSchema
     {
+        /// <summary>
+        /// No schema set.
+        /// </summary>
+        Unset = -1,
+
         /// <summary>
         /// Default schema before 2014 L, M, BOOL, NULL support
         /// 

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -47,15 +47,17 @@ namespace Amazon.DynamoDBv2
         ///
         /// This schema pre-dates support for native DynamoDB types such as L (list), M (map), BOOL, and NULL.
         /// Common .NET type mappings:
-        /// - Number types (byte, int, float, decimal, etc.) → DynamoDB N (number)
-        /// - string, char → S (string)
-        /// - bool → N ("0" for false, "1" for true)
-        /// - DateTime, Guid → S (string)
-        /// - MemoryStream, byte[] → B (binary)
-        /// - List, HashSet, array of numeric types → NS (number set)
-        /// - List, HashSet, array of string types → SS (string set)
-        /// - List, HashSet, array of binary types → BS (binary set)
-        /// - Dictionary{string, object} → M (map)
+        /// <ul>
+        /// <li><para>Number types (byte, int, float, decimal, etc.) → DynamoDB N (number)</para></li>
+        /// <li><para>string, char → S (string)</para></li>
+        /// <li><para>bool → N ("0" for false, "1" for true)</para></li>
+        /// <li><para>DateTime, Guid → S (string)</para></li>
+        /// <li><para>MemoryStream, byte[] → B (binary)</para></li>
+        /// <li><para>List, HashSet, array of numeric types → NS (number set)</para></li>
+        /// <li><para>List, HashSet, array of string types → SS (string set)</para></li>
+        /// <li><para>List, HashSet, array of binary types → BS (binary set)</para></li>
+        /// <li><para>Dictionary{string, object} → M (map)</para></li>
+        /// </ul>
         /// </summary>
         V1 = 0,
 
@@ -63,17 +65,18 @@ namespace Amazon.DynamoDBv2
         /// Enhanced conversion schema that supports native DynamoDB types including L (list), M (map), BOOL, and NULL.
         /// 
         /// Common .NET type mappings:
-        /// - Number types (byte, int, float, decimal, etc.) → DynamoDB N (number)
-        /// - string, char → S (string)
-        /// - bool → BOOL
-        /// - DateTime, Guid → S (string)
-        /// - MemoryStream, byte[] → B (binary)
-        /// - HashSet of numeric types → NS (number set)
-        /// - HashSet of string types → SS (string set)
-        /// - HashSet of binary types → BS (binary set)
-        /// - List, array (numeric, string, binary types) → L (list)
-        /// - Dictionary{string, object} → M (map)
-        ///
+        /// <ul>
+        /// <li><para>Number types (byte, int, float, decimal, etc.) → DynamoDB N (number)</para></li>
+        /// <li><para>string, char → S (string)</para></li>
+        /// <li><para>bool → BOOL</para></li>
+        /// <li><para>DateTime, Guid → S (string)</para></li>
+        /// <li><para>MemoryStream, byte[] → B (binary)</para></li>
+        /// <li><para>HashSet of numeric types → NS (number set)</para></li>
+        /// <li><para>HashSet of string types → SS (string set)</para></li>
+        /// <li><para>HashSet of binary types → BS (binary set)</para></li>
+        /// <li><para>List, array (numeric, string, binary types) → L (list)</para></li>
+        /// <li><para>Dictionary{string, object} → M (map)</para></li>
+        /// </ul>
         /// Recommended for applications that need full fidelity with native DynamoDB types.
         /// </summary>
         V2 = 1,

--- a/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Conversion/DynamoDBEntryConversion.cs
@@ -32,46 +32,49 @@ namespace Amazon.DynamoDBv2
 {
 
     /// <summary>
-    /// Available conversion schemas.
+    /// Specifies the conversion schema used to map the types to DynamoDB types.
+    /// This schema influences how items are serialized and deserialized when interacting with DynamoDB.
     /// </summary>
     public enum ConversionSchema
     {
         /// <summary>
-        /// No schema set.
+        /// Indicates that no schema has been explicitly set.
         /// </summary>
         Unset = -1,
 
         /// <summary>
-        /// Default schema before 2014 L, M, BOOL, NULL support
-        /// 
-        /// The following .NET types are converted into the following DynamoDB types:
-        /// Number types (byte, int, float, decimal, etc.) are converted to N
-        /// String and char are converted to S
-        /// Bool is converted to N (0=false, 1=true)
-        /// DateTime and Guid are converto to S
-        /// MemoryStream and byte[] are converted to B
-        /// List, HashSet, and array of numerics types are converted to NS
-        /// List, HashSet, and array of string-based types are converted to SS
-        /// List, HashSet, and array of binary-based types are converted to BS
-        /// Dictionary{string,object} are converted to M
+        /// Legacy conversion schema (and current default for context-level configurations).
+        ///
+        /// This schema pre-dates support for native DynamoDB types such as L (list), M (map), BOOL, and NULL.
+        /// Common .NET type mappings:
+        /// - Number types (byte, int, float, decimal, etc.) → DynamoDB N (number)
+        /// - string, char → S (string)
+        /// - bool → N ("0" for false, "1" for true)
+        /// - DateTime, Guid → S (string)
+        /// - MemoryStream, byte[] → B (binary)
+        /// - List, HashSet, array of numeric types → NS (number set)
+        /// - List, HashSet, array of string types → SS (string set)
+        /// - List, HashSet, array of binary types → BS (binary set)
+        /// - Dictionary{string, object} → M (map)
         /// </summary>
         V1 = 0,
 
         /// <summary>
-        /// Schema fully supporting 2014 L, M, BOOL, NULL additions
+        /// Enhanced conversion schema that supports native DynamoDB types including L (list), M (map), BOOL, and NULL.
         /// 
-        /// The following .NET types are converted into the following DynamoDB types:
-        /// Number types (byte, int, float, decimal, etc.) are converted to N
-        /// String and char are converted to S
-        /// Bool is converted to BOOL
-        /// DateTime and Guid are converto to S
-        /// MemoryStream and byte[] are converted to B
-        /// HashSet of numerics types are converted to NS
-        /// HashSet of string-based types are converted to SS
-        /// HashSet of binary-based types are converted to BS
-        /// List and array of numerics, string-based types, and binary-based types
-        /// are converted to L type.
-        /// Dictionary{string,object} are converted to M
+        /// Common .NET type mappings:
+        /// - Number types (byte, int, float, decimal, etc.) → DynamoDB N (number)
+        /// - string, char → S (string)
+        /// - bool → BOOL
+        /// - DateTime, Guid → S (string)
+        /// - MemoryStream, byte[] → B (binary)
+        /// - HashSet of numeric types → NS (number set)
+        /// - HashSet of string types → SS (string set)
+        /// - HashSet of binary types → BS (binary set)
+        /// - List, array (numeric, string, binary types) → L (list)
+        /// - Dictionary{string, object} → M (map)
+        ///
+        /// Recommended for applications that need full fidelity with native DynamoDB types.
         /// </summary>
         V2 = 1,
     }

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Attributes.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Attributes.cs
@@ -53,11 +53,18 @@ namespace Amazon.DynamoDBv2.DataModel
         public bool LowerCamelCaseProperties { get; set; }
 
         /// <summary>
+        /// Gets and sets the Conversion Schema property.
+        /// </summary>
+        public ConversionSchema Conversion { get; }
+
+        /// <summary>
         /// Construct an instance of DynamoDBTableAttribute
         /// </summary>
         /// <param name="tableName"></param>
         public DynamoDBTableAttribute(string tableName)
-            : this(tableName, false) { }
+            : this(tableName, false, ConversionSchema.Unset)
+        {
+        }
 
         /// <summary>
         /// Construct an instance of DynamoDBTableAttribute
@@ -65,9 +72,21 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <param name="tableName"></param>
         /// <param name="lowerCamelCaseProperties"></param>
         public DynamoDBTableAttribute(string tableName, bool lowerCamelCaseProperties)
+            : this(tableName, lowerCamelCaseProperties, ConversionSchema.Unset)
+        {
+        }
+
+        /// <summary>
+        /// Construct an instance of DynamoDBTableAttribute
+        /// </summary>
+        /// <param name="tableName"></param>
+        /// <param name="lowerCamelCaseProperties"></param>
+        /// <param name="conversion"></param>
+        public DynamoDBTableAttribute(string tableName, bool lowerCamelCaseProperties, ConversionSchema conversion)
         {
             TableName = tableName;
             LowerCamelCaseProperties = lowerCamelCaseProperties;
+            Conversion = conversion;
         }
     }
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Attributes.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Attributes.cs
@@ -53,9 +53,15 @@ namespace Amazon.DynamoDBv2.DataModel
         public bool LowerCamelCaseProperties { get; set; }
 
         /// <summary>
-        /// Gets and sets the Conversion Schema property.
+        /// Gets and sets the <see cref="ConversionSchema"/> used for mapping between .NET and DynamoDB types.
+        /// 
+        /// The conversion schema determines how types are serialized and deserialized during data persistence. 
+        /// When resolving the effective schema, the following precedence is applied:
+        /// 1. If set on the operation configuration, it takes the highest precedence.
+        /// 2. If not set on the operation, but specified at the table level, the table configuration is used.
+        /// 3. If neither is set, the context-level configuration is used as the default fallback.
         /// </summary>
-        public ConversionSchema Conversion { get; }
+        public ConversionSchema Conversion { get; set; }
 
         /// <summary>
         /// Construct an instance of DynamoDBTableAttribute

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/Configs.cs
@@ -553,8 +553,10 @@ namespace Amazon.DynamoDBv2.DataModel
         public List<ScanCondition> QueryFilter { get; set; }
 
         /// <summary>
-        /// Entity Conversion specification which controls how conversion between
-        /// .NET and DynamoDB types happens.
+        /// Specifies the conversion behavior for .NET objects (entities) mapped to DynamoDB items.
+        /// 
+        /// This setting controls how conversion between .NET and DynamoDB types happens
+        /// on classes annotated with <see cref="DynamoDBTableAttribute"/>
         /// </summary>
         public DynamoDBEntryConversion ItemConversion { get; set; }
 

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModelTests.cs
@@ -1114,6 +1114,45 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 #pragma warning restore CS0618 // Re-enable the warning
             }
 
+            {
+
+#pragma warning disable CS0618 // Disable the warning for the deprecated DynamoDBContext constructors
+                ProductV2 productV2 = new ProductV2
+                {
+                    Id = 1,
+                    Name = "CloudSpotter",
+                    CompanyName = "CloudsAreGrate",
+                    Price = 1200,
+                    TagSet = new HashSet<string> { "Prod", "1.0" },
+                    CurrentStatus = Status.Active,
+                    FormerStatus = Status.Upcoming,
+                    Supports = Support.Unix | Support.Windows,
+                    PreviousSupport = null,
+                    InternalId = "T1000",
+                    IsPublic = true,
+                    AlwaysN = true,
+                    Rating = 4,
+                    Components = new List<string> { "Code", "Coffee" },
+                    KeySizes = new List<byte> { 16, 64, 128 },
+                    CompanyInfo = new CompanyInfo
+                    {
+                        Name = "MyCloud",
+                        Founded = new DateTime(1994, 7, 6),
+                        Revenue = 9001
+                    }
+                };
+              
+                using (var contextV1 = new DynamoDBContext(Client, new DynamoDBContextConfig { Conversion = conversionV1 }))
+                {
+                    var docV1 = contextV1.ToDocument(productV2, new ToDocumentConfig { Conversion = conversionV1 });
+                    var docV2 = contextV1.ToDocument(productV2, new ToDocumentConfig { });
+                    VerifyConversions(docV1, docV2);
+                }
+
+#pragma warning restore CS0618 // Re-enable the warning
+
+            }
+
             // Introduce a circular reference and try to serialize
             {
                 product.CompanyInfo = new CompanyInfo
@@ -2630,6 +2669,11 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
                 Status status = (Status)Enum.Parse(typeof(Status), text);
                 return status;
             }
+        }
+
+        [DynamoDBTable("HashTable", false, ConversionSchema.V2)]
+        public class ProductV2 : Product
+        {
         }
 
         /// <summary>


### PR DESCRIPTION
Allow to set DynamoDBEntryConversion per table

## Description
Update `DynamoDBTableAttribute` in order to allow `ConversionSchema` to be set at table level.

```Csharp
[DynamoDBTable("HashTable", false, ConversionSchema.V2)]
```
The ConversionSchema apply as follows:
- OperationConfig Conversion Schema
- Table Conversion Schema
- Context Conversion Schema 

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/2576

## Testing
Integration test added

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
