### PR TITLE
[SRA] Remove AWSSignerType attribute from service configs

### DIFF
--- a/generator/.DevConfigs/3388e8f1-17fe-40f7-bcf3-bb43641e5f7a.json
+++ b/generator/.DevConfigs/3388e8f1-17fe-40f7-bcf3-bb43641e5f7a.json
@@ -1,0 +1,10 @@
+{
+    "core": {
+        "updateMinimum": true,
+        "type": "Patch",
+        "changeLogMessages": [
+            "Remove redundant `AWSSignerType` attribute from service configuration classes.",
+            "Fix `EndpointDiscoveryHandler` not to fail when a request contains bearer token credentials."
+        ]
+    }
+}

--- a/generator/ServiceClientGeneratorLib/Generators/Endpoints/EndpointResolver.partial.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Endpoints/EndpointResolver.partial.cs
@@ -25,7 +25,7 @@ namespace ServiceClientGenerator.Generators.Endpoints
                 case "AWS::S3::DisableMultiRegionAccessPoints": return "config.DisableMultiregionAccessPoints";
                 case "AWS::S3::UseGlobalEndpoint": return "config.USEast1RegionalEndpointValue == S3UsEast1RegionalEndpointValue.Legacy";
                 case "AWS::STS::UseGlobalEndpoint": return "false";
-                case "AWS::Auth::AccountId": return "(requestContext.Identity as AWSCredentials)?.GetCredentials()?.AccountId";
+                case "AWS::Auth::AccountId": return "requestContext.Identity is AWSCredentials credentials ? credentials.GetCredentials().AccountId : null";
                 case "AWS::Auth::AccountIdEndpointMode": return "config.AccountIdEndpointMode.ToString().ToLower()";
                 default: throw new Exception("Unknown builtIn");
             }

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceConfig.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceConfig.cs
@@ -18,7 +18,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+    #line 1 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class ServiceConfig : BaseGenerator
     {
@@ -29,7 +29,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         public override string TransformText()
         {
             
-            #line 6 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 6 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 
     AddLicenseHeader();
 
@@ -40,35 +40,28 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "zon.Util.Internal;\r\nusing Amazon.Runtime.Internal.Auth;\r\nusing Amazon.Runtime.En" +
                     "dpoints;\r\nusing ");
             
-            #line 16 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 16 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
             #line hidden
             this.Write(".Internal;\r\n\r\nnamespace ");
             
-            #line 18 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 18 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
             #line hidden
             this.Write("\r\n{\r\n    /// <summary>\r\n    /// Configuration for accessing Amazon ");
             
-            #line 21 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 21 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
-            this.Write(" service\r\n    /// </summary>\r\n    [AWSSignerType(\"");
+            this.Write(" service\r\n    /// </summary>\r\n    public partial class Amazon");
             
-            #line 23 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Config.ServiceModel.SignatureVersion));
-            
-            #line default
-            #line hidden
-            this.Write("\")]\r\n    public partial class Amazon");
-            
-            #line 24 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 23 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -76,42 +69,42 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config : ClientConfig\r\n    {\r\n        private static readonly string UserAgentStr" +
                     "ing =\r\n            InternalSDKUtils.BuildUserAgentString(\"");
             
-            #line 27 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 26 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceId));
             
             #line default
             #line hidden
             this.Write("\", \"");
             
-            #line 27 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 26 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceFileVersion));
             
             #line default
             #line hidden
             this.Write("\");\r\n\r\n");
             
-            #line 29 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 28 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
  if (this.Config.EndpointsRuleSet != null) { 
             
             #line default
             #line hidden
             this.Write("        private static readonly Amazon");
             
-            #line 30 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 29 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("EndpointResolver EndpointResolver =\r\n            new Amazon");
             
-            #line 31 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 30 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("EndpointResolver();\r\n");
             
-            #line 32 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 31 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 }
             
             #line default
@@ -127,7 +120,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             {
                 return """);
             
-            #line 42 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 41 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceId));
             
             #line default
@@ -135,7 +128,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("\";\r\n            }\r\n        }\r\n        /// <summary>\r\n        /// Default construc" +
                     "tor\r\n        /// </summary>\r\n        public Amazon");
             
-            #line 48 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 47 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -143,7 +136,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("Config()\r\n            : base(new Amazon.Runtime.Internal.DefaultConfigurationProv" +
                     "ider(Amazon");
             
-            #line 49 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 48 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
@@ -151,14 +144,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("DefaultConfiguration.GetAllConfigurations()))\r\n        {\r\n            base.Servic" +
                     "eId = \"");
             
-            #line 51 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 50 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceId));
             
             #line default
             #line hidden
             this.Write("\";\r\n");
             
-            #line 52 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 51 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 
             if(!string.IsNullOrEmpty(this.Config.AuthenticationServiceName))
             {
@@ -168,14 +161,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            this.AuthenticationServiceName = \"");
             
-            #line 56 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 55 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AuthenticationServiceName));
             
             #line default
             #line hidden
             this.Write("\";\r\n");
             
-            #line 57 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 56 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 
             }
             if(this.Config.OverrideMaxRetries.HasValue)
@@ -186,14 +179,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            this.MaxErrorRetry = ");
             
-            #line 62 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 61 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.OverrideMaxRetries));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 63 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 62 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 
             }
             if(!string.IsNullOrEmpty(this.Config.DefaultRegion))
@@ -205,14 +198,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             this.Write("            var region = FallbackRegionFactory.GetRegionEndpoint(false);\r\n       " +
                     "     this.RegionEndpoint = region ?? RegionEndpoint.");
             
-            #line 69 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 68 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.DefaultRegion));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 70 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 69 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 
             }
 
@@ -220,7 +213,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line default
             #line hidden
             
-            #line 73 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 72 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 
             if (this.Config.EndpointsRuleSet != null)
             {
@@ -230,14 +223,14 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("            this.EndpointProvider = new Amazon");
             
-            #line 77 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 76 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write("EndpointProvider();\r\n");
             
-            #line 78 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 77 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 
             }
 
@@ -255,7 +248,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             {
                 return """);
             
-            #line 90 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 89 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.RegionLookupName));
             
             #line default
@@ -264,7 +257,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "ceVersion property.\r\n        /// </summary>\r\n        public override string Serv" +
                     "iceVersion\r\n        {\r\n            get\r\n            {\r\n                return \"");
             
-            #line 101 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 100 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceModel.APIVersion));
             
             #line default
@@ -286,7 +279,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
 
 ");
             
-            #line 116 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 115 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
  if (this.Config.EndpointsRuleSet != null)
        foreach(var parameter in this.Config.ServiceModel.ClientContextParameters) {
 
@@ -295,34 +288,34 @@ namespace ServiceClientGenerator.Generators.SourceFiles
             #line hidden
             this.Write("        /// <summary>\r\n        /// ");
             
-            #line 120 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 119 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameter.documentation));
             
             #line default
             #line hidden
             this.Write("\r\n        /// </summary>\r\n        public ");
             
-            #line 122 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 121 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameter.nativeType));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 122 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 121 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(parameter.name));
             
             #line default
             #line hidden
             this.Write(" { get; set; }\r\n\r\n");
             
-            #line 124 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 123 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 }
             
             #line default
             #line hidden
             
-            #line 125 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 124 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
  if (this.Config.EndpointsRuleSet != null) { 
             
             #line default
@@ -350,7 +343,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
 
 ");
             
-            #line 147 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 146 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
  } 
 else if (this.Config.IsTestService) 
 { 
@@ -370,7 +363,7 @@ else if (this.Config.IsTestService)
         }
 ");
             
-            #line 161 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
+            #line 160 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\ServiceConfig.tt"
 }
             
             #line default

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceConfig.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/ServiceConfig.tt
@@ -20,7 +20,6 @@ namespace <#=this.Config.Namespace#>
     /// <summary>
     /// Configuration for accessing Amazon <#=this.Config.ClassName#> service
     /// </summary>
-    [AWSSignerType("<#=Config.ServiceModel.SignatureVersion#>")]
     public partial class Amazon<#=this.Config.ClassName#>Config : ClientConfig
     {
         private static readonly string UserAgentString =

--- a/sdk/src/Core/Amazon.Runtime/Credentials/Internal/AuthSchemeOption.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/Internal/AuthSchemeOption.cs
@@ -54,7 +54,7 @@ namespace Amazon.Runtime.Credentials.Internal
         };
 
         /// <summary>
-        /// Default auth scheme options for services / operations that that only support SigV4A.
+        /// Default auth scheme options for services / operations that that only support bearer authentication.
         /// </summary>
         public static readonly List<IAuthSchemeOption> DEFAULT_BEARER = new()
         {

--- a/sdk/src/Core/Amazon.Runtime/Internal/AWSSignerTypeAttribute.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/AWSSignerTypeAttribute.cs
@@ -2,6 +2,7 @@
 
 namespace Amazon.Runtime.Internal
 {
+    [Obsolete("This attribute should not be used as the SDK resolves which signer to use at the request level")]
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class AWSSignerTypeAttribute : Attribute
     {

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/CSMHandler/CSMCallAttemptHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/CSMHandler/CSMCallAttemptHandler.cs
@@ -105,7 +105,10 @@ namespace Amazon.Runtime.Internal
             requestContext.CSMCallAttempt.Api = CSMUtilities.
                 GetApiNameFromRequest(requestContext.Request.RequestName, requestContext.ServiceMetaData.OperationNameMapping, requestContext.CSMCallAttempt.Service);
 
-            requestContext.CSMCallAttempt.AccessKey = (requestContext.Identity as AWSCredentials)?.GetCredentials()?.AccessKey;
+            if (requestContext.Identity is AWSCredentials credentials)
+            {
+                requestContext.CSMCallAttempt.AccessKey = credentials.GetCredentials().AccessKey;
+            }
 
             requestContext.CSMCallAttempt.AttemptLatency = (long)requestContext
                 .Metrics.StopEvent(Metric.CSMAttemptLatency)

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/EndpointDiscoveryHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/EndpointDiscoveryHandler.cs
@@ -38,7 +38,12 @@ namespace Amazon.Runtime.Internal
         {
             var requestContext = executionContext.RequestContext;
             var regionalEndpoint = requestContext.Request.Endpoint;
-            var immutableCredentials = (requestContext.Identity as AWSCredentials)?.GetCredentials();
+            
+            ImmutableCredentials immutableCredentials = null;
+            if (requestContext.Identity is AWSCredentials credentials)
+            {
+                immutableCredentials = credentials.GetCredentials();
+            }
 
             PreInvoke(executionContext, immutableCredentials);
 
@@ -71,7 +76,12 @@ namespace Amazon.Runtime.Internal
         {
             var requestContext = executionContext.RequestContext;
             var regionalEndpoint = requestContext.Request.Endpoint;
-            var immutableCredentials = await ((requestContext.Identity as AWSCredentials)?.GetCredentialsAsync()).ConfigureAwait(false);
+
+            ImmutableCredentials immutableCredentials = null;
+            if (requestContext.Identity is AWSCredentials credentials)
+            {
+                immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            }
 
             PreInvoke(executionContext, immutableCredentials);
 

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Signer.cs
@@ -106,12 +106,14 @@ namespace Amazon.Runtime.Internal
             using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.AuthSigningDurationMetricName))
             {
                 ImmutableCredentials immutableCredentials = null;
-
-                using (TracingUtilities.CreateSpan(requestContext, TelemetryConstants.CredentialsRetrievalSpanName))
-                using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.ResolveIdentityDurationMetricName))
-                using (requestContext.Metrics.StartEvent(Metric.CredentialsRequestTime))
+                if (requestContext.Identity is AWSCredentials awsCredentials)
                 {
-                    immutableCredentials = (requestContext.Identity as AWSCredentials)?.GetCredentials();
+                    using (TracingUtilities.CreateSpan(requestContext, TelemetryConstants.CredentialsRetrievalSpanName))
+                    using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.ResolveIdentityDurationMetricName))
+                    using (requestContext.Metrics.StartEvent(Metric.CredentialsRequestTime))
+                    {
+                        immutableCredentials = awsCredentials.GetCredentials();
+                    }
                 }
 
                 if (immutableCredentials?.UseToken == true && 
@@ -168,10 +170,8 @@ namespace Amazon.Runtime.Internal
             using (requestContext.Metrics.StartEvent(Metric.RequestSigningTime))
             using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.AuthSigningDurationMetricName))
             {
-                var awsCredentials = requestContext.Identity as AWSCredentials;
                 ImmutableCredentials immutableCredentials = null;
-
-                if (awsCredentials != null)
+                if (requestContext.Identity is AWSCredentials awsCredentials)
                 {
                     using (TracingUtilities.CreateSpan(requestContext, TelemetryConstants.CredentialsRetrievalSpanName))
                     using (MetricsUtilities.MeasureDuration(requestContext, TelemetryConstants.ResolveIdentityDurationMetricName))

--- a/sdk/test/UnitTests/Custom/Runtime/EndpointDiscoveryTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/EndpointDiscoveryTests.cs
@@ -64,7 +64,7 @@ namespace AWSSDK.UnitTests
             var config = SetupConfig();
             var client = new EndpointDiscoveryTestClient(config, baseUrl: endpoint);
             var executionContext = CreateExecutionContext(client, config, true, null);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
             Assert.AreEqual(expectedEndpoint,
@@ -84,7 +84,7 @@ namespace AWSSDK.UnitTests
             var config = SetupConfig();
             var client = new EndpointDiscoveryTestClient(config);
             var executionContext = CreateExecutionContext(client, config, true, null);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
             Assert.AreEqual("https://test123.amazonaws.com/shared/",
@@ -115,7 +115,7 @@ namespace AWSSDK.UnitTests
             var config = SetupConfig();
             var client = new EndpointDiscoveryTestClient(config);
             var executionContext = CreateExecutionContext(client, config, true, null);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
             Assert.AreEqual("https://test123.amazonaws.com/shared/",
@@ -156,7 +156,7 @@ namespace AWSSDK.UnitTests
             SortedDictionary<string, string> identifiers = new SortedDictionary<string, string>();
             identifiers.Add(IDENTIFIER_NAME, "test");
             var executionContext = CreateExecutionContext(client, config, true, identifiers);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
             Assert.AreEqual("https://test123.amazonaws.com/shared/CreateTable",
@@ -178,7 +178,7 @@ namespace AWSSDK.UnitTests
             SortedDictionary<string, string> identifiers = new SortedDictionary<string, string>();
             identifiers.Add(IDENTIFIER_NAME, "test");
             var executionContext = CreateExecutionContext(client, config, true, identifiers);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
             Assert.AreEqual("https://test123.amazonaws.com/shared/CreateTable",
@@ -208,7 +208,7 @@ namespace AWSSDK.UnitTests
             SortedDictionary<string, string> identifiers = new SortedDictionary<string, string>();
             identifiers.Add(IDENTIFIER_NAME, "test");
             var executionContext = CreateExecutionContext(client, config, true, identifiers);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             Utils.AssertExceptionExpected(
                 () => { EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials); },
@@ -227,7 +227,7 @@ namespace AWSSDK.UnitTests
             var config = SetupConfig(true);
             var client = new EndpointDiscoveryTestClient(config, true);
             var executionContext = CreateExecutionContext(client, config, false, null);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
             var endpoints = client.WaitForCachedValue(CACHEKEY);
@@ -247,7 +247,7 @@ namespace AWSSDK.UnitTests
             var config = SetupConfig(true);
             var client = new EndpointDiscoveryTestClient(config);
             var executionContext = CreateExecutionContext(client, config, false, null);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
             var endpoints = client.WaitForCachedValue(CACHEKEY);
@@ -268,7 +268,7 @@ namespace AWSSDK.UnitTests
             SortedDictionary<string, string> identifiers = new SortedDictionary<string, string>();
             identifiers.Add(IDENTIFIER_NAME, "test");
             var executionContext = CreateExecutionContext(client, config, false, identifiers);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
             var endpoints = client.WaitForCachedValue(CACHEKEY_IDENTIFIERS);
@@ -287,7 +287,7 @@ namespace AWSSDK.UnitTests
             var config = SetupConfig(true);
             var client = new EndpointDiscoveryTestClient(config, true);
             var executionContext = CreateExecutionContext(client, config, false, null);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
 
@@ -303,7 +303,7 @@ namespace AWSSDK.UnitTests
             var config = SetupConfig(true);
             var client = new EndpointDiscoveryTestClient(config);
             var executionContext = CreateExecutionContext(client, config, false, null);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
 
@@ -321,7 +321,7 @@ namespace AWSSDK.UnitTests
             SortedDictionary<string, string> identifiers = new SortedDictionary<string, string>();
             identifiers.Add(IDENTIFIER_NAME, "test");
             var executionContext = CreateExecutionContext(client, config, false, identifiers);
-            var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+            var immutableCredentials = GetCredentialsFromContext(executionContext);
 
             EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
 
@@ -343,7 +343,7 @@ namespace AWSSDK.UnitTests
                 var config = SetupConfig();
                 var client = new EndpointDiscoveryTestClient(config);
                 var executionContext = CreateExecutionContext(client, config, true, null);
-                var immutableCredentials = (executionContext.RequestContext.Identity as AWSCredentials)?.GetCredentials();
+                var immutableCredentials = GetCredentialsFromContext(executionContext);
                 EndpointDiscoveryHandler.DiscoverEndpoints(executionContext.RequestContext, false, immutableCredentials);
 
                 Assert.AreEqual(1, client.CacheCount);
@@ -429,6 +429,16 @@ namespace AWSSDK.UnitTests
         {
             return endpoints.Any(endpoint =>
                 string.Equals(endpoint?.Address, address, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private ImmutableCredentials GetCredentialsFromContext(ExecutionContext executionContext)
+        {
+            if (executionContext.RequestContext.Identity is AWSCredentials credentials)
+            {
+                return credentials.GetCredentials();
+            }
+
+            return null;
         }
     }
 


### PR DESCRIPTION
## Description
Updates the SDK's service clients not to include the `AWSSignerType` attribute anymore. That attribute was used by PowerShell and is redundant with the SRA (I have a PR to refactor PS in our staging repo).

## Motivation and Context
`DOTNET-7867`

## Testing
- Dry-run: `DRY_RUN-7c7189b7-fb31-458b-b219-21a2051289ce`

Manually created an app following [Setting up to use the AWS CLI with CodeCatalyst](https://docs.aws.amazon.com/codecatalyst/latest/userguide/set-up-cli.html) and confirmed it succeeded:
```csharp
AWSConfigs.AWSProfileName = "codecatalyst";
var codecatalyst = new AmazonCodeCatalystClient();
await codecatalyst.ListSourceRepositoriesAsync(new ListSourceRepositoriesRequest
{
    ProjectName = "hello-world",
    SpaceName = "demo-dspin",
});
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license