### PR TITLE
Changed the default value of SSOAWSCredentialsOptions.SupportsGettingNewToken as false and improved error messaging if required SSO options are missing while generating new credentials.

### DIFF
--- a/generator/.DevConfigs/b39b85e0-42cc-4aac-a699-8dd1795a5fb0.json
+++ b/generator/.DevConfigs/b39b85e0-42cc-4aac-a699-8dd1795a5fb0.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Changed the default value of SSOAWSCredentialsOptions.SupportsGettingNewToken as false and improved error messaging if required SSO options are missing while generating new credentials."
+      ],
+        "type": "patch",
+        "updateMinimum": true
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/SSOAWSCredentialsOptions.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/_bcl+netstandard/SSOAWSCredentialsOptions.cs
@@ -94,7 +94,7 @@ namespace Amazon.Runtime
         /// NOTE: If setting to <c>true</c>, either <see cref="SsoVerificationCallback"/> or <see cref="PkceFlowOptions"/> must 
         /// also be set for authorization flow to succeed.
         /// </summary>
-        public bool SupportsGettingNewToken { get; set; } = true;
+        public bool SupportsGettingNewToken { get; set; } = false;
 
         /// <summary>
         /// The proxy settings to use when calling SSOOIDC and SSO Services.


### PR DESCRIPTION
## Description
- Changed the default value of `SSOAWSCredentialsOptions.SupportsGettingNewToken` as `false`
- Improved error messaging if required SSO options are missing while generating new credentials.

Test Scenarios:
- Using **Amazon.Extensions.NETCore.Setup** package (customer's scenario)
  Customer would use `aws sso login` and then rely on `CredentialsProfileStoreChain` factory
  ```C#
  var awsOptions = new AWSOptions
  {
      Region = RegionEndpoint.USEast1,
      Profile = "SSOAdmin",
  };
  var client = awsOptions.CreateServiceClient<IAmazonS3>();
  var buckets = await client.ListBucketsAsync();
  ```
  In this case, since now `SSOAWSCredentialsOptions.SupportsGettingNewToken` would resolve to `false`, it would eventually throw `AmazonClientException` with message:
  - `SSO Token has expired and failed to refresh` when token is expired.
  - `No valid SSO Token could be found.` where no token is found.

- Customer **explicitly created SSO credentials** (refer example at https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/sso-tutorial-app-only.html)
  ```C#
  var ssoCreds = LoadSsoCredentials("SSOAdmin");
  // Display the caller's identity.
  var ssoProfileClient = new AmazonSecurityTokenServiceClient(ssoCreds);
  Console.WriteLine($"\nSSO Profile:\n {await ssoProfileClient.GetCallerIdentityArn()}");

  static AWSCredentials LoadSsoCredentials(string profile)
  {
      var chain = new CredentialProfileStoreChain();
      if (!chain.TryGetAWSCredentials(profile, out var credentials))
          throw new Exception($"Failed to find the {profile} profile");

      var ssoCredentials = credentials as SSOAWSCredentials;

      ssoCredentials.Options.ClientName = "Example-SSO-App";
      ssoCredentials.Options.SsoVerificationCallback = args =>
      {
          // Launch a browser window that prompts the SSO user to complete an SSO login.
          //  This method is only invoked if the session doesn't already have a valid SSO token.
          // NOTE: Process.Start might not support launching a browser on macOS or Linux. If not,
          //       use an appropriate mechanism on those systems instead.
          Process.Start(new ProcessStartInfo
          {
              FileName = args.VerificationUriComplete,
              UseShellExecute = true
          });
      };
      ssoCredentials.Options.SupportsGettingNewToken = true;

      return ssoCredentials;
  }

  // Class to read the caller's identity.
  public static class Extensions
  {
      public static async Task<string> GetCallerIdentityArn(this IAmazonSecurityTokenService stsClient)
      {
          var response = await stsClient.GetCallerIdentityAsync(new GetCallerIdentityRequest());
          return response.Arn;
      }
  }
  ```

**AWS Toolkit for Visual Studio and PowerShell already explicitly set `SSOAWSCredentialsOptions.SupportsGettingNewToken` to `true`.**

**IMPORTANT:** We would also need to update the examples in V4 developer guide at [Tutorial for SSO using only .NET applications](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/sso-tutorial-app-only.html) (this is a link from V3 developer guide, use similar link from V4 developer guide) to explicitly set `ssoCredentials.Options.SupportsGettingNewToken = true;` as the default value is false. (expand **List Amazon S3 buckets** and **List IAM users** collapsible sections)

___
**NOTE:** There is perhaps another issue. The API documentation for [Profile](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Amazon/TProfile.html) states that `Represents a profile in the configuration file. For example in ~/.aws/config [profile foo] name = value Profile profile = new Profile("foo"); When this is set on the ClientConfig and that config is passed to the service client constructor the sdk will try to find the credentials associated with the Profile.Name property If set, this will override AWS_PROFILE and AWSConfigs.ProfileName.`

When I use code like below:
```C#
 var securityTokenResponse = (new AmazonSecurityTokenServiceClient(
                                new AmazonSecurityTokenServiceConfig() { Profile = new Profile("SSOAdmin") })
                            ).GetCallerIdentityAsync(new GetCallerIdentityRequest()).Result;
```
It doesn't consider the passed profile based on logic [here](https://github.com/aws/aws-sdk-net/blob/db805ae29dee57d427ba2d4b918ac371bd943c1e/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs#L204) (for V4) and here (for [V3](https://github.com/aws/aws-sdk-net/blob/124402b61bbc33d95f4b1947d665ee7f65040bf7/sdk/src/Core/Amazon.Runtime/Credentials/FallbackCredentialsFactory.cs#L74)).

## Motivation and Context
GitHub issue/discussion:
- https://github.com/aws/aws-sdk-net/issues/3704
- https://github.com/aws/aws-sdk-net/discussions/3535

## Testing
Dry-run `DRY_RUN-a741bd15-07fd-48e3-b260-603408b4134b` completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement