### PR TITLE
Update CHANGELOG to call out breaking change where the default value of SSOAWSCredentialsOptions.SupportsGettingNewToken is now set as false

### DIFF
--- a/changelogs/SDK.CHANGELOG.2025.md
+++ b/changelogs/SDK.CHANGELOG.2025.md
@@ -13,7 +13,7 @@
 	* [Breaking Change] Move IEventStreamEvent to Amazon.Runtime.EventStreams namespace from Amazon.Runtime.EventStreams.Internal
 	* [Breaking Change] Renamed IEventStream to IEventOutputStream and IEnumerableEventStream to IEnumerableEventOutputStream
 	* Add core support for bi directional HTTP 2 service operations. Support is only available in .NET 8 and later.
-	* Changed the default value of SSOAWSCredentialsOptions.SupportsGettingNewToken as false and improved error messaging if required SSO options are missing while generating new credentials.
+	* [Breaking Change] Changed the default value of SSOAWSCredentialsOptions.SupportsGettingNewToken as false and improved error messaging if required SSO options are missing while generating new credentials.
 	* Fix `EndpointDiscoveryHandler` not to fail when a request contains bearer token credentials.
 	* Log a warning when `ServiceUrl` and `RegionEndpoint` are set at the same time. The SDK will log whichever of the two is used.
 	* Remove redundant `AWSSignerType` attribute from service configuration classes.

--- a/changelogs/SDK.CHANGELOG.ALL.md
+++ b/changelogs/SDK.CHANGELOG.ALL.md
@@ -13,7 +13,7 @@
 	* [Breaking Change] Move IEventStreamEvent to Amazon.Runtime.EventStreams namespace from Amazon.Runtime.EventStreams.Internal
 	* [Breaking Change] Renamed IEventStream to IEventOutputStream and IEnumerableEventStream to IEnumerableEventOutputStream
 	* Add core support for bi directional HTTP 2 service operations. Support is only available in .NET 8 and later.
-	* Changed the default value of SSOAWSCredentialsOptions.SupportsGettingNewToken as false and improved error messaging if required SSO options are missing while generating new credentials.
+	* [Breaking Change] Changed the default value of SSOAWSCredentialsOptions.SupportsGettingNewToken as false and improved error messaging if required SSO options are missing while generating new credentials.
 	* Fix `EndpointDiscoveryHandler` not to fail when a request contains bearer token credentials.
 	* Log a warning when `ServiceUrl` and `RegionEndpoint` are set at the same time. The SDK will log whichever of the two is used.
 	* Remove redundant `AWSSignerType` attribute from service configuration classes.


### PR DESCRIPTION
## Description
Update CHANGELOG to call out breaking change where the default value of `SSOAWSCredentialsOptions.SupportsGettingNewToken` is now set as `false`.

## Motivation and Context
https://github.com/aws/aws-sdk-net/pull/3737

## Testing
N/A

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement