### PR TITLE
Update protocol test generator to generate error response tests. Don't do case sensitive header lookups in tests.

### DIFF
--- a/generator/.DevConfigs/c1bcdcb3-ce85-4cc9-829b-7cea143ae236.json
+++ b/generator/.DevConfigs/c1bcdcb3-ce85-4cc9-829b-7cea143ae236.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Enable error protocol tests and make headers case insensitive in test project"
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }

--- a/generator/ProtocolTestsGenerator/smithy-dotnet-codegen/src/main/java/software/amazon/smithy/dotnet/codegen/HttpProtocolTestGenerator.java
+++ b/generator/ProtocolTestsGenerator/smithy-dotnet-codegen/src/main/java/software/amazon/smithy/dotnet/codegen/HttpProtocolTestGenerator.java
@@ -73,8 +73,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                     writer.openBlock("public class $L \n{", "}", operationName, () -> {
                         generateRequestTests(operation);
                         generateResponseTests(operation);
-                        // TODO: Due to an issue with how  we do case sensitive header matches, we will skip error response tests until this is fixed
-                        // generateErrorResponseTests(operation, operationIndex);
+                        generateErrorResponseTests(operation, operationIndex);
                     });
                 });
             });

--- a/sdk/test/ProtocolTests/Generated/EC2Protocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
+++ b/sdk/test/ProtocolTests/Generated/EC2Protocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
@@ -69,5 +69,48 @@ namespace AWSSDK.ProtocolTests.AwsEc2
             Assert.AreEqual((HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200), context.ResponseData.StatusCode);
         }
 
+        /// <summary>
+        /// Parses simple XML errors
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("AwsEc2")]
+        public void Ec2InvalidGreetingErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "text/xml;charset=UTF-8";
+            byte[] bytes = Encoding.ASCII.GetBytes("<Response>\n    <Errors>\n        <Error>\n            <Code>InvalidGreeting</Code>\n            <Message>Hi</Message>\n        </Error>\n    </Errors>\n    <RequestID>foo-id</RequestID>\n</Response>\n");
+            var stream = new MemoryStream(bytes);
+            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(InvalidGreetingException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("AwsEc2")]
+        public void Ec2ComplexErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "text/xml;charset=UTF-8";
+            byte[] bytes = Encoding.ASCII.GetBytes("<Response>\n    <Errors>\n        <Error>\n            <Code>ComplexError</Code>\n            <Message>Hi</Message>\n            <TopLevel>Top level</TopLevel>\n            <Nested>\n                <Foo>bar</Foo>\n            </Nested>\n        </Error>\n    </Errors>\n    <RequestID>foo-id</RequestID>\n</Response>\n");
+            var stream = new MemoryStream(bytes);
+            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(ComplexErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
     }
 }

--- a/sdk/test/ProtocolTests/Generated/JSONRPC10/dotnet-protocol-test-codegen/GreetingWithErrors.cs
+++ b/sdk/test/ProtocolTests/Generated/JSONRPC10/dotnet-protocol-test-codegen/GreetingWithErrors.cs
@@ -32,6 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 
 namespace AWSSDK.ProtocolTests.JsonRpc10
@@ -39,5 +40,305 @@ namespace AWSSDK.ProtocolTests.JsonRpc10
     [TestClass]
     public class GreetingWithErrors
     {
+        /// <summary>
+        /// Parses simple JSON errors
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10InvalidGreetingErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"aws.protocoltests.json10#InvalidGreeting\",\n    \"Message\": \"Hi\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(InvalidGreetingException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
+        /// <summary>
+        /// Serializes the X-Amzn-ErrorType header. For an example service,
+        /// see Amazon EKS.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10FooErrorUsingXAmznErrorTypeErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["X-Amzn-Errortype"] = "FooError";
+            byte[] bytes = Encoding.ASCII.GetBytes("");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some X-Amzn-Errortype headers contain URLs. Clients need to split
+        /// the URL on ':' and take only the first half of the string. For
+        /// example,
+        /// 'ValidationException:http://internal.amazon.com/coral/com.amazon.coral.validate/'
+        /// is to be interpreted as 'ValidationException'.  For an example
+        /// service see Amazon Polly.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10FooErrorUsingXAmznErrorTypeWithUriErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["X-Amzn-Errortype"] = "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/";
+            byte[] bytes = Encoding.ASCII.GetBytes("");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// X-Amzn-Errortype might contain a URL and a namespace. Client
+        /// should extract only the shape name. This is a pathalogical case
+        /// that might not actually happen in any deployed AWS service.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10FooErrorUsingXAmznErrorTypeWithUriAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["X-Amzn-Errortype"] = "aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/";
+            byte[] bytes = Encoding.ASCII.GetBytes("");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// This example uses the 'code' property in the output rather than
+        /// X-Amzn-Errortype. Some services do this though it's preferable to
+        /// send the X-Amzn-Errortype. Client implementations must first
+        /// check for the X-Amzn-Errortype and then check for a top-level
+        /// 'code' property.  For example service see Amazon S3 Glacier.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10FooErrorUsingCodeErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"code\": \"FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using code, and it might contain a
+        /// namespace. Clients should just take the last part of the string
+        /// after '#'.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10FooErrorUsingCodeAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"code\": \"aws.protocoltests.json10#FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using code, and it might contain a
+        /// namespace. It also might contain a URI. Clients should just take
+        /// the last part of the string after '#' and before ":". This is a
+        /// pathalogical case that might not occur in any deployed AWS
+        /// service.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10FooErrorUsingCodeUriAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"code\": \"aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using __type.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10FooErrorWithDunderTypeErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using __type, and it might contain
+        /// a namespace. Clients should just take the last part of the string
+        /// after '#'.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10FooErrorWithDunderTypeAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"aws.protocoltests.json10#FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using __type, and it might contain
+        /// a namespace. It also might contain a URI. Clients should just
+        /// take the last part of the string after '#' and before ":". This
+        /// is a pathalogical case that might not occur in any deployed AWS
+        /// service.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10FooErrorWithDunderTypeUriAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Parses a complex error with no message member
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10ComplexErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"aws.protocoltests.json10#ComplexError\",\n    \"TopLevel\": \"Top level\",\n    \"Nested\": {\n        \"Foo\": \"bar\"\n    }\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(ComplexErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
+        /// <summary>
+        /// Parses a complex error with an empty body
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonRpc10")]
+        public void AwsJson10EmptyComplexErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"aws.protocoltests.json10#ComplexError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(ComplexErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
     }
 }

--- a/sdk/test/ProtocolTests/Generated/JsonProtocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
+++ b/sdk/test/ProtocolTests/Generated/JsonProtocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
@@ -32,6 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 
 namespace AWSSDK.ProtocolTests.JsonProtocol
@@ -39,5 +40,302 @@ namespace AWSSDK.ProtocolTests.JsonProtocol
     [TestClass]
     public class GreetingWithErrors
     {
+        /// <summary>
+        /// Parses simple JSON errors
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11InvalidGreetingErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.1";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"InvalidGreeting\",\n    \"Message\": \"Hi\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(InvalidGreetingException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
+        /// <summary>
+        /// Parses a complex error with no message member
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11ComplexErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.1";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"ComplexError\",\n    \"TopLevel\": \"Top level\",\n    \"Nested\": {\n        \"Foo\": \"bar\"\n    }\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(ComplexErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11EmptyComplexErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.1";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"ComplexError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(ComplexErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
+        /// <summary>
+        /// Serializes the X-Amzn-ErrorType header. For an example service,
+        /// see Amazon EKS.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11FooErrorUsingXAmznErrorTypeErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["X-Amzn-Errortype"] = "FooError";
+            byte[] bytes = Encoding.ASCII.GetBytes("");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some X-Amzn-Errortype headers contain URLs. Clients need to split
+        /// the URL on ':' and take only the first half of the string. For
+        /// example,
+        /// 'ValidationException:http://internal.amazon.com/coral/com.amazon.coral.validate/'
+        /// is to be interpreted as 'ValidationException'.  For an example
+        /// service see Amazon Polly.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11FooErrorUsingXAmznErrorTypeWithUriErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["X-Amzn-Errortype"] = "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/";
+            byte[] bytes = Encoding.ASCII.GetBytes("");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// X-Amzn-Errortype might contain a URL and a namespace. Client
+        /// should extract only the shape name. This is a pathalogical case
+        /// that might not actually happen in any deployed AWS service.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11FooErrorUsingXAmznErrorTypeWithUriAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["X-Amzn-Errortype"] = "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/";
+            byte[] bytes = Encoding.ASCII.GetBytes("");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// This example uses the 'code' property in the output rather than
+        /// X-Amzn-Errortype. Some services do this though it's preferable to
+        /// send the X-Amzn-Errortype. Client implementations must first
+        /// check for the X-Amzn-Errortype and then check for a top-level
+        /// 'code' property.  For example service see Amazon S3 Glacier.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11FooErrorUsingCodeErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.1";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"code\": \"FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using code, and it might contain a
+        /// namespace. Clients should just take the last part of the string
+        /// after '#'.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11FooErrorUsingCodeAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.1";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"code\": \"aws.protocoltests.restjson#FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using code, and it might contain a
+        /// namespace. It also might contain a URI. Clients should just take
+        /// the last part of the string after '#' and before ":". This is a
+        /// pathalogical case that might not occur in any deployed AWS
+        /// service.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11FooErrorUsingCodeUriAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.1";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"code\": \"aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using __type.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11FooErrorWithDunderTypeErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.1";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using __type, and it might contain
+        /// a namespace. Clients should just take the last part of the string
+        /// after '#'.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11FooErrorWithDunderTypeAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.1";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"aws.protocoltests.restjson#FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using __type, and it might contain
+        /// a namespace. It also might contain a URI. Clients should just
+        /// take the last part of the string after '#' and before ":". This
+        /// is a pathalogical case that might not occur in any deployed AWS
+        /// service.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("JsonProtocol")]
+        public void AwsJson11FooErrorWithDunderTypeUriAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.1";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
     }
 }

--- a/sdk/test/ProtocolTests/Generated/QueryProtocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
+++ b/sdk/test/ProtocolTests/Generated/QueryProtocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
@@ -69,5 +69,71 @@ namespace AWSSDK.ProtocolTests.AwsQuery
             Assert.AreEqual((HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200), context.ResponseData.StatusCode);
         }
 
+        /// <summary>
+        /// Parses simple XML errors
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("AwsQuery")]
+        public void QueryInvalidGreetingErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "text/xml";
+            byte[] bytes = Encoding.ASCII.GetBytes("<ErrorResponse>\n   <Error>\n      <Type>Sender</Type>\n      <Code>InvalidGreeting</Code>\n      <Message>Hi</Message>\n   </Error>\n   <RequestId>foo-id</RequestId>\n</ErrorResponse>\n");
+            var stream = new MemoryStream(bytes);
+            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(InvalidGreetingException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
+        /// <summary>
+        /// Parses customized XML errors
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("AwsQuery")]
+        public void QueryCustomizedErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 402);
+            webResponseData.Headers["Content-Type"] = "text/xml";
+            byte[] bytes = Encoding.ASCII.GetBytes("<ErrorResponse>\n   <Error>\n      <Type>Sender</Type>\n      <Code>Customized</Code>\n      <Message>Hi</Message>\n   </Error>\n   <RequestId>foo-id</RequestId>\n</ErrorResponse>\n");
+            var stream = new MemoryStream(bytes);
+            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 402));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(CustomCodeErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 402));
+        }
+
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("AwsQuery")]
+        public void QueryComplexErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "text/xml";
+            byte[] bytes = Encoding.ASCII.GetBytes("<ErrorResponse>\n   <Error>\n      <Type>Sender</Type>\n      <Code>ComplexError</Code>\n      <TopLevel>Top level</TopLevel>\n      <Nested>\n          <Foo>bar</Foo>\n      </Nested>\n   </Error>\n   <RequestId>foo-id</RequestId>\n</ErrorResponse>\n");
+            var stream = new MemoryStream(bytes);
+            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(ComplexErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
     }
 }

--- a/sdk/test/ProtocolTests/Generated/RestJsonProtocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
+++ b/sdk/test/ProtocolTests/Generated/RestJsonProtocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
@@ -105,5 +105,306 @@ namespace AWSSDK.ProtocolTests.RestJson
             Assert.AreEqual((HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200), context.ResponseData.StatusCode);
         }
 
+        /// <summary>
+        /// Serializes the X-Amzn-ErrorType header. For an example service,
+        /// see Amazon EKS.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonFooErrorUsingXAmznErrorTypeErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["X-Amzn-Errortype"] = "FooError";
+            byte[] bytes = Encoding.ASCII.GetBytes("");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some X-Amzn-Errortype headers contain URLs. Clients need to split
+        /// the URL on ':' and take only the first half of the string. For
+        /// example,
+        /// 'ValidationException:http://internal.amazon.com/coral/com.amazon.coral.validate/'
+        /// is to be interpreted as 'ValidationException'.  For an example
+        /// service see Amazon Polly.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonFooErrorUsingXAmznErrorTypeWithUriErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["X-Amzn-Errortype"] = "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/";
+            byte[] bytes = Encoding.ASCII.GetBytes("");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// X-Amzn-Errortype might contain a URL and a namespace. Client
+        /// should extract only the shape name. This is a pathalogical case
+        /// that might not actually happen in any deployed AWS service.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonFooErrorUsingXAmznErrorTypeWithUriAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["X-Amzn-Errortype"] = "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/";
+            byte[] bytes = Encoding.ASCII.GetBytes("");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// This example uses the 'code' property in the output rather than
+        /// X-Amzn-Errortype. Some services do this though it's preferable to
+        /// send the X-Amzn-Errortype. Client implementations must first
+        /// check for the X-Amzn-Errortype and then check for a top-level
+        /// 'code' property.  For example service see Amazon S3 Glacier.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonFooErrorUsingCodeErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/json";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"code\": \"FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using code, and it might contain a
+        /// namespace. Clients should just take the last part of the string
+        /// after '#'.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonFooErrorUsingCodeAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/json";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"code\": \"aws.protocoltests.restjson#FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using code, and it might contain a
+        /// namespace. It also might contain a URI. Clients should just take
+        /// the last part of the string after '#' and before ":". This is a
+        /// pathalogical case that might not occur in any deployed AWS
+        /// service.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonFooErrorUsingCodeUriAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/json";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"code\": \"aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using __type.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonFooErrorWithDunderTypeErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/json";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using __type, and it might contain
+        /// a namespace. Clients should just take the last part of the string
+        /// after '#'.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonFooErrorWithDunderTypeAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/json";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"aws.protocoltests.restjson#FooError\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Some services serialize errors using __type, and it might contain
+        /// a namespace. It also might contain a URI. Clients should just
+        /// take the last part of the string after '#' and before ":". This
+        /// is a pathalogical case that might not occur in any deployed AWS
+        /// service.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonFooErrorWithDunderTypeUriAndNamespaceErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500);
+            webResponseData.Headers["Content-Type"] = "application/json";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"__type\": \"aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(FooErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 500));
+        }
+
+        /// <summary>
+        /// Serializes a complex error with no message member
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonComplexErrorWithNoMessageErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 403);
+            webResponseData.Headers["Content-Type"] = "application/json";
+            webResponseData.Headers["X-Amzn-Errortype"] = "ComplexError";
+            webResponseData.Headers["X-Header"] = "Header";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"TopLevel\": \"Top level\",\n    \"Nested\": {\n        \"Fooooo\": \"bar\"\n    }\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 403));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(ComplexErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 403));
+        }
+
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonEmptyComplexErrorWithNoMessageErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 403);
+            webResponseData.Headers["Content-Type"] = "application/json";
+            webResponseData.Headers["X-Amzn-Errortype"] = "ComplexError";
+            byte[] bytes = Encoding.ASCII.GetBytes("{}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 403));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(ComplexErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 403));
+        }
+
+        /// <summary>
+        /// Parses simple JSON errors
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestJson")]
+        public void RestJsonInvalidGreetingErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "application/json";
+            webResponseData.Headers["X-Amzn-Errortype"] = "InvalidGreeting";
+            byte[] bytes = Encoding.ASCII.GetBytes("{\n    \"Message\": \"Hi\"\n}");
+            var stream = new MemoryStream(bytes);
+            var context = new JsonUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(InvalidGreetingException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
     }
 }

--- a/sdk/test/ProtocolTests/Generated/RestXmlProtocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
+++ b/sdk/test/ProtocolTests/Generated/RestXmlProtocol/dotnet-protocol-test-codegen/GreetingWithErrors.cs
@@ -71,5 +71,49 @@ namespace AWSSDK.ProtocolTests.RestXml
             Assert.AreEqual((HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200), context.ResponseData.StatusCode);
         }
 
+        /// <summary>
+        /// Parses simple XML errors
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestXml")]
+        public void InvalidGreetingErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400);
+            webResponseData.Headers["Content-Type"] = "application/xml";
+            byte[] bytes = Encoding.ASCII.GetBytes("<ErrorResponse>\n   <Error>\n      <Type>Sender</Type>\n      <Code>InvalidGreeting</Code>\n      <Message>Hi</Message>\n      <AnotherSetting>setting</AnotherSetting>\n   </Error>\n   <RequestId>foo-id</RequestId>\n</ErrorResponse>\n");
+            var stream = new MemoryStream(bytes);
+            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(InvalidGreetingException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 400));
+        }
+
+        [TestMethod]
+        [TestCategory("ProtocolTest")]
+        [TestCategory("ErrorTest")]
+        [TestCategory("RestXml")]
+        public void ComplexErrorErrorResponse()
+        {
+            // Arrange
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 403);
+            webResponseData.Headers["Content-Type"] = "application/xml";
+            webResponseData.Headers["X-Header"] = "Header";
+            byte[] bytes = Encoding.ASCII.GetBytes("<ErrorResponse>\n   <Error>\n      <Type>Sender</Type>\n      <Code>ComplexError</Code>\n      <Message>Hi</Message>\n      <TopLevel>Top level</TopLevel>\n      <Nested>\n          <Foo>bar</Foo>\n      </Nested>\n   </Error>\n   <RequestId>foo-id</RequestId>\n</ErrorResponse>\n");
+            var stream = new MemoryStream(bytes);
+            var context = new XmlUnmarshallerContext(stream,true,webResponseData);
+            // Act
+            var errorResponse = new GreetingWithErrorsResponseUnmarshaller().UnmarshallException(context, null, (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 403));
+            // Assert
+            Assert.IsInstanceOfType(errorResponse, typeof(ComplexErrorException));
+            Assert.AreEqual(errorResponse.StatusCode,(HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 403));
+        }
+
     }
 }

--- a/sdk/test/UnitTests/Custom/TestTools/WebResponseData.cs
+++ b/sdk/test/UnitTests/Custom/TestTools/WebResponseData.cs
@@ -30,7 +30,8 @@ namespace AWSSDK_DotNet.UnitTests.TestTools
             this.ContentType = "application/xml";
             this.StatusCode = HttpStatusCode.OK;
             this.IsSuccessStatusCode = true;
-            this.Headers = new Dictionary<string, string>();
+            // RFC 9110 states headers must be case insensitive
+            this.Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public Dictionary<string,string> Headers { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The protocol test generator takes advantage of `WebResponseData` in `sdk/test/UnitTests/Custom/TestTools/WebResponseData.cs`, and unlike the `WebResponseData` in the SDK header comparisons are done in a case-sensitive manner which goes against RFC. This PR updates the header dictionary to do case insensitive header lookups and uncomments error response tests so that we have more test coverage via protocol tests for error responses.


Originally, I had thought we were doing case-sensitive header lookups in the SDK but [here](https://github.com/aws/aws-sdk-net/blob/v4-development/sdk/src/Core/Amazon.Runtime/Internal/Transform/_bcl/HttpWebRequestResponseData.cs#L79-L88) is where we create the dictionary for the headers and it is case insensitive so only the test project was updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Internal ticket


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
DRY_RUN-c567c945-62dd-4708-ba86-e37a95e02aa0 succeeds. 


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement