### PR TITLE
Update auth resolver async flow to add user agent details after resolving identity

### DIFF
--- a/generator/.DevConfigs/9c63240f-0f30-4c8e-b0a7-e434529126fd.json
+++ b/generator/.DevConfigs/9c63240f-0f30-4c8e-b0a7-e434529126fd.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "fix: Update auth resolver async flow to add user agent details after resolving identity"
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
@@ -162,7 +162,7 @@ namespace Amazon.Runtime.Internal
                     {
                         // We can use DefaultAWSCredentials if it was set by the user for these schemes.
                         executionContext.RequestContext.Identity = clientConfig.DefaultAWSCredentials;
-                        return;
+                        break;
                     }
 
                     if (scheme is BearerAuthScheme && clientConfig.AWSTokenProvider != null)
@@ -178,7 +178,7 @@ namespace Amazon.Runtime.Internal
                         }
 
                         executionContext.RequestContext.Identity = resolvedToken.Value;
-                        return;
+                        break;
                     }
 
                     var identityResolver = scheme.GetIdentityResolver(clientConfig.IdentityResolverConfiguration);
@@ -188,7 +188,7 @@ namespace Amazon.Runtime.Internal
 
                     if (executionContext.RequestContext.Identity != null)
                     {
-                        return;
+                        break;
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes an issue in auth resolver async flow where it skips updating the request context feature IDs.

<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-7592`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
 * `DRY_RUN-7138d387-82fa-40ca-9e9f-f37165cd7540`
 * Ran an async operation manually and validated that the user agent feature id for the resolved credential is added correctly.
 <!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement