### PR TITLE
Fixed trim warnings in DDB High Level

### DIFF
--- a/generator/.DevConfigs/FD891AA9-310E-4F80-B97A-00C8B7B97BA3.json
+++ b/generator/.DevConfigs/FD891AA9-310E-4F80-B97A-00C8B7B97BA3.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fixed trim warnings in Object Persistence high level library introduced by PR adding polymorphic support."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -57,17 +57,39 @@ namespace Amazon.DynamoDBv2.DataModel
         // Converter, if one is present
         public IPropertyConverter Converter { get; protected set; }
 
-        public void AddDerivedType(string typeDiscriminator, Type type)
+        public void AddDerivedType(string typeDiscriminator, [DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type type)
         {
-            DerivedTypesDictionary[type] = typeDiscriminator;
-            DerivedTypeKeysDictionary[typeDiscriminator] = type;
+            _derivedTypesDictionary[type] = typeDiscriminator;
+            _derivedTypeKeysDictionary[typeDiscriminator] = type;
         }
 
         // derived type information used for polymorphic serialization
-        public Dictionary<Type, string> DerivedTypesDictionary { get; private set; }
+        private Dictionary<Type, string> _derivedTypesDictionary;
 
         // derived type information used for polymorphic deserialization
-        public Dictionary<string, Type> DerivedTypeKeysDictionary { get; private set; }
+        private Dictionary<string, Type> _derivedTypeKeysDictionary;
+
+        public bool TryGetDerivedTypeDiscriminator([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type type, out string typeDiscriminator)
+        {
+            if (_derivedTypesDictionary.TryGetValue(type, out typeDiscriminator))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
+            Justification = "The user's type has been annotated with InternalConstants.DataModelModeledType with the public API into the library. At this point the type will not be trimmed.")]
+        public bool TryGetDerivedType(string typeDiscriminator, [DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] out Type deriviedType)
+        {
+            if (_derivedTypeKeysDictionary.TryGetValue(typeDiscriminator, out deriviedType))
+            {
+                return true;
+            }
+
+            return false;
+        }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072",
             Justification = "The user's type has been annotated with DynamicallyAccessedMemberTypes.All with the public API into the library. At this point the type will not be trimmed.")]
@@ -81,18 +103,15 @@ namespace Amazon.DynamoDBv2.DataModel
         internal SimplePropertyStorage([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type memberType)
         {
             MemberType = memberType;
-            DerivedTypesDictionary = new Dictionary<Type, string>();
-            DerivedTypeKeysDictionary = new Dictionary<string,Type>();
+            _derivedTypesDictionary = new Dictionary<Type, string>();
+            _derivedTypeKeysDictionary = new Dictionary<string,Type>();
         }
-        internal SimplePropertyStorage([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type memberType, Dictionary<Type, string> derivedTypesDictionary)
+
+        internal SimplePropertyStorage([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type memberType, SimplePropertyStorage parentProeprtyStorage)
         {
             MemberType = memberType;
-            DerivedTypesDictionary = derivedTypesDictionary;
-        }
-        internal SimplePropertyStorage([DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] Type memberType, Dictionary<string, Type> derivedTypeKeysDictionary)
-        {
-            MemberType = memberType;
-            DerivedTypeKeysDictionary = derivedTypeKeysDictionary;
+            _derivedTypesDictionary = parentProeprtyStorage._derivedTypesDictionary;
+            _derivedTypeKeysDictionary = parentProeprtyStorage._derivedTypeKeysDictionary;
         }
 
         public override string ToString()


### PR DESCRIPTION
## Issue
https://github.com/aws/aws-sdk-net/issues/3362#issuecomment-2728710929

## Description
Awhile back we took in  [PR #346](https://github.com/aws/aws-sdk-net/pull/3643) that added support for polymorphic types. This created new collections maintained by the DDB high level library for the derived types and these new collection caused trim warnings only when doing an actual aot build. The new collections of types didn't have the required annotations and the fact the fact that calling code was directly interacting with these collections made it hard to annotate.

I refactored the internals to keep access to the collections and only accessible through `TryGet` methods that had the required annotations. Given all types representing user data have the annotations to say keep all metadata the suppressions added in the PR should be safe. All of the derived types will be registered with the with the HLL using the `AddDerivedType` method which has the annotations that says don't trim anything from the type.


## Testing
Dry Run: Pending
Build and ran Native AOT application exercising code paths and confirmed no trim warnings

