### PR TITLE
Fix: Allow some sso properties to be used in conjunction with source_profile and credential_source

### DIFF
--- a/generator/.DevConfigs/b24980c4-b6f6-4181-9789-fda85df054a3.json
+++ b/generator/.DevConfigs/b24980c4-b6f6-4181-9789-fda85df054a3.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "[Breaking Change] Allow source_profile to be used in conjunction with sso_session. If the profile specified via source_profile has sso_session, and the sso_session section is correctly configured, credentials will be retrieved from sso. The sso credentials will then be used to assume the role specified in the original profile. Previous behavior was that it assumed the role specified in source_profile, which does not follow the assume role profile chaining pattern."
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/Internal/CredentialProfileTypeDetector.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/Internal/CredentialProfileTypeDetector.cs
@@ -101,43 +101,62 @@ namespace Amazon.Runtime.CredentialManagement.Internal
                     {
                         new HashSet<string> { RoleArn, SourceProfile },
                         new HashSet<string> { RoleArn, SourceProfile, AwsAccountId },
+                        new HashSet<string> { RoleArn, SourceProfile, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
+                        new HashSet<string> { RoleArn, SourceProfile, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                     } 
                 },
                 { 
                     CredentialProfileType.AssumeRoleCredentialSource, new List<HashSet<string>>() 
                     { 
                         new HashSet<string> { RoleArn, CredentialSource },
-                        new HashSet<string> { RoleArn, CredentialSource, AwsAccountId }
+                        new HashSet<string> { RoleArn, CredentialSource, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
+                        new HashSet<string> { RoleArn, CredentialSource, AwsAccountId },
+                        new HashSet<string> { RoleArn, CredentialSource, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl }
                     } 
                 },
                 {
                     CredentialProfileType.AssumeRoleExternal, new List<HashSet<string>>() 
                     { 
                         new HashSet<string> { ExternalID, RoleArn, SourceProfile },
+                        new HashSet<string> { ExternalID, RoleArn, SourceProfile, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                         new HashSet<string> { ExternalID, RoleArn, SourceProfile, AwsAccountId },
+                        new HashSet<string> { ExternalID, RoleArn, SourceProfile, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl}
                     } 
                 },
-                { CredentialProfileType.AssumeRoleExternalMFA, new List<HashSet<string>>() { new HashSet<string> { ExternalID, RoleArn, SourceProfile, MfaSerial } } },
+                { 
+                    CredentialProfileType.AssumeRoleExternalMFA, new List<HashSet<string>>() 
+                    { 
+                        new HashSet<string> { ExternalID, RoleArn, SourceProfile, MfaSerial },
+                        new HashSet<string> { ExternalID, RoleArn, SourceProfile, MfaSerial, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl }
+                    } 
+                },
                 { 
                     CredentialProfileType.AssumeRoleWithWebIdentity, new List<HashSet<string>>() 
                     {
                         new HashSet<string> { RoleArn, WebIdentityTokenFile },
+                        new HashSet<string> { RoleArn, WebIdentityTokenFile, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                         new HashSet<string> { RoleArn, WebIdentityTokenFile, CredentialSource },
+                        new HashSet<string> { RoleArn, WebIdentityTokenFile, CredentialSource, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                         new HashSet<string> { RoleArn, WebIdentityTokenFile, CredentialSource, AwsAccountId },
+                        new HashSet<string> { RoleArn, WebIdentityTokenFile, CredentialSource, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                     } 
                 },
                 { 
                     CredentialProfileType.AssumeRoleWithWebIdentitySessionName, new List<HashSet<string>>() 
                     { 
                         new HashSet<string> { RoleArn, WebIdentityTokenFile, RoleSessionName },
-                        new HashSet<string> { RoleArn, WebIdentityTokenFile, RoleSessionName, AwsAccountId } ,
+                        new HashSet<string> { RoleArn, WebIdentityTokenFile, RoleSessionName, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
+                        new HashSet<string> { RoleArn, WebIdentityTokenFile, RoleSessionName, AwsAccountId },
+                        new HashSet<string> { RoleArn, WebIdentityTokenFile, RoleSessionName, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl } ,
                     } 
                 },
                 { 
                     CredentialProfileType.AssumeRoleMFA, new List<HashSet<string>>() 
                     { 
                         new HashSet<string> { MfaSerial, RoleArn, SourceProfile },
+                        new HashSet<string> { MfaSerial, RoleArn, SourceProfile, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                         new HashSet<string> { MfaSerial, RoleArn, SourceProfile, AwsAccountId },
+                        new HashSet<string> { MfaSerial, RoleArn, SourceProfile, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                     } 
                 },
                 { CredentialProfileType.Basic, new List<HashSet<string>>() 
@@ -165,28 +184,36 @@ namespace Amazon.Runtime.CredentialManagement.Internal
                     CredentialProfileType.AssumeRoleSessionName, new List<HashSet<string>>() 
                     { 
                         new HashSet<string> { RoleArn, SourceProfile, RoleSessionName },
+                        new HashSet<string> { RoleArn, SourceProfile, RoleSessionName, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl},
                         new HashSet<string> { RoleArn, SourceProfile, RoleSessionName, AwsAccountId },
+                        new HashSet<string> { RoleArn, SourceProfile, RoleSessionName, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                     } 
                 },
                 { 
                     CredentialProfileType.AssumeRoleCredentialSourceSessionName, new List<HashSet<string>>() 
                     {
                         new HashSet<string> { RoleArn, CredentialSource, RoleSessionName },
+                        new HashSet<string> { RoleArn, CredentialSource, RoleSessionName, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                         new HashSet<string> { RoleArn, CredentialSource, RoleSessionName, AwsAccountId},
+                        new HashSet<string> { RoleArn, CredentialSource, RoleSessionName, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                     } 
                 },
                 { 
                     CredentialProfileType.AssumeRoleExternalSessionName, new List<HashSet<string>>() 
                     { 
                         new HashSet<string> { ExternalID, RoleArn, SourceProfile, RoleSessionName },
+                        new HashSet<string> { ExternalID, RoleArn, SourceProfile, RoleSessionName, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                         new HashSet<string> { ExternalID, RoleArn, SourceProfile, RoleSessionName, AwsAccountId },
+                        new HashSet<string> { ExternalID, RoleArn, SourceProfile, RoleSessionName, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                     } 
                 },
                 { 
                     CredentialProfileType.AssumeRoleExternalMFASessionName, new List<HashSet<string>>() 
                     { 
                         new HashSet<string> { ExternalID, MfaSerial, RoleArn, SourceProfile, RoleSessionName },
+                        new HashSet<string> { ExternalID, MfaSerial, RoleArn, SourceProfile, RoleSessionName, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                         new HashSet<string> { ExternalID, MfaSerial, RoleArn, SourceProfile, RoleSessionName, AwsAccountId },
+                        new HashSet<string> { ExternalID, MfaSerial, RoleArn, SourceProfile, RoleSessionName, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                     } 
                 },
                 { CredentialProfileType.SSO, new List<HashSet<string>>() { new HashSet<string> { SsoAccountId, SsoRegion, SsoRegistrationScopes, SsoRoleName, SsoStartUrl, SsoSession } } },
@@ -194,7 +221,9 @@ namespace Amazon.Runtime.CredentialManagement.Internal
                     CredentialProfileType.AssumeRoleMFASessionName, new List<HashSet<string>>() 
                     { 
                         new HashSet<string> { MfaSerial, RoleArn, SourceProfile, RoleSessionName },
+                        new HashSet<string> { MfaSerial, RoleArn, SourceProfile, RoleSessionName, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl },
                         new HashSet<string> { MfaSerial, RoleArn, SourceProfile, RoleSessionName, AwsAccountId },
+                        new HashSet<string> { MfaSerial, RoleArn, SourceProfile, RoleSessionName, AwsAccountId, SsoSession, SsoRegion, SsoRegistrationScopes, SsoStartUrl }
                     } 
                 },
             };
@@ -238,11 +267,9 @@ namespace Amazon.Runtime.CredentialManagement.Internal
 
             HashSet<string> propertyNames = GetPropertyNames(profileOptions);
 
-            // Spec: If one or more of the SSO properties is present, the profile MUST be resolved by the SSO credential provider.
-            if (propertyNames.Any(propertyName => SsoProperties.Contains(propertyName)))
-            {
+            //SPEC: if sso_account_id or sso_role_name exist credentials MUST be resolved by the sso credential provider.
+            if (propertyNames.Contains(SsoAccountId) || propertyNames.Contains(SsoRoleName))
                 return CredentialProfileType.SSO;
-            }
 
             // brute force algorithm - but it's a very small set
             foreach (var pair in TypePropertyDictionary)

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/AWSCredentialsFactoryTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/AWSCredentialsFactoryTest.cs
@@ -493,7 +493,7 @@ namespace AWSSDK.UnitTests
 
             AssertExtensions.ExpectException(() =>
                     AWSCredentialsFactory.GetAWSCredentials(SsoProfileMissingFields, ProfileStore),
-                typeof(ArgumentNullException)); 
+                typeof(InvalidDataException)); 
         }
 
         [TestMethod]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
~~I reordered the list of credential profile types based on the credential-provider-chain SEP. This doesn't affect the functionality of the PR it was just for logical reordering.~~

This PR allows a setup like the following to work correctly:
```
[profile test-profile]
role_arn=arn:aws:iam::<account_id>:role/s3-read-only-role
source_profile=source-profile
role_session_name=testing
sso_session=my-sso-2
region=us-east-1
[profile source-profile]
sso_session = my-sso-2
sso_account_id = <account_id>
sso_role_name = AdministratorAccess
region = us-east-1
[sso-session my-sso-2]
sso_start_url = https://***
sso_region = us-east-1
sso_registration_scopes = sso:account:access

```

where test-profile will be looked at as an assume role profile instead of an sso profile like it was previously. This is the correct behavior as the SEP states:
```
If either the sso_account_id or sso_role_name configurations values are present the profile MUST be resolved by the SSO credential provider.

```
We weren't following the SEP and were assuming that if *any* sso property is set then it is an SSO profile. Now we only resolve credentials via SSO if the profile contains `sso_account_id` or `sso_role_name`. 

This then allows a user to login via SSO in powershell or the cli
```
Invoke-AWSSSOLogin -profileName test-profie
```
which will start the SSOLogin process and then assume the role `arn:aws:iam::<account_id>:role/s3-read-only-role` specified in the original profile.

And then the user can call 
```
aws sts-get-caller-identity --profile test-profile

{
    "UserId": "****:testing",
    "Account": "<account_id>",
    "Arn": "arn:aws:sts::<account_id>:assumed-role/s3-read-only-role/testing"
}
```

I also added the sso properties (not including sso_account_id and sso_role_name) to the other assume role/ credential source credential profile type in accordance with the credentials-provider-chain SEP.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
internal ticket: dotnet-8049
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
DRY_RUN-ed9ce705-b59d-4b7a-847b-ae15c0fbceb4
## Screenshots (if appropriate)
The following console app works
```
Amazon.AWSConfigs.LoggingConfig.LogResponses = Amazon.ResponseLoggingOption.Always;
Amazon.AWSConfigs.LoggingConfig.LogTo = Amazon.LoggingOptions.Console;
Amazon.AWSConfigs.LoggingConfig.LogMetrics = true;
var profileName = "test-profile";
Environment.SetEnvironmentVariable("AWS_PROFILE", profileName);
var config = new AmazonSecurityTokenServiceConfig
{
    RegionEndpoint = RegionEndpoint.USEast1
};
var s3Config = new AmazonS3Config
{
    RegionEndpoint = RegionEndpoint.USEast1
};
using (var stsClient = new AmazonSecurityTokenServiceClient(config))
using (var s3Client = new AmazonS3Client(s3Config))
{
    var stsResponse = await stsClient.GetCallerIdentityAsync(new GetCallerIdentityRequest());
    Console.WriteLine("Caller identity is {0}", stsResponse.Arn);
    var s3Response = await s3Client.ListBucketsAsync(new ListBucketsRequest { });
    s3Response.Buckets.ForEach(x => Console.WriteLine(x.BucketName));
//call below will correctly fail because the test-profile only has read-only access.
    await s3Client.PutObjectAsync(new PutObjectRequest
    {
        BucketName = "aws-net-sdk-1625686759",
        Key = "testing123",
        ContentBody = " hello world"
    }).ConfigureAwait(false);
}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement