### PR TITLE
Enable MockHttpRequestFactory in non Net Framework targets

### DIFF
--- a/generator/.DevConfigs/3f30d84d-d6bc-4b07-8d9e-f1356be1d8ac.json
+++ b/generator/.DevConfigs/3f30d84d-d6bc-4b07-8d9e-f1356be1d8ac.json
@@ -1,0 +1,8 @@
+
+{
+  "core": {
+    "changeLogMessages": ["Enable MockHttpRequestFactory in non netframework targets"],
+    "type": "patch",
+    "updateMinimum": false
+  }
+}

--- a/generator/.DevConfigs/3f30d84d-d6bc-4b07-8d9e-f1356be1d8ac.json
+++ b/generator/.DevConfigs/3f30d84d-d6bc-4b07-8d9e-f1356be1d8ac.json
@@ -1,8 +1,0 @@
-
-{
-  "core": {
-    "changeLogMessages": ["Enable MockHttpRequestFactory in non netframework targets"],
-    "type": "patch",
-    "updateMinimum": false
-  }
-}

--- a/sdk/test/UnitTests/Custom/Runtime/CustomResponses.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/CustomResponses.cs
@@ -62,9 +62,13 @@ namespace AWSSDK.UnitTests
             AmazonServiceClient client,
             Func<HttpHandlerTests.MockHttpRequest, HttpWebResponse> responseCreator)
         {
+#if BCL
             var requestFactory = new HttpHandlerTests.MockHttpRequestFactory();
             requestFactory.ResponseCreator = responseCreator;
             ReplaceHttpRequestHandler(client, requestFactory);
+#else
+            throw new NotImplementedException();
+#endif
         }
 
         public static void ReplaceHttpRequestHandler<T>(

--- a/sdk/test/UnitTests/Custom/Runtime/HttpHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/HttpHandlerTests.cs
@@ -10,6 +10,7 @@ using AWSSDK_DotNet.UnitTests;
 using Amazon.Runtime.Internal.Util;
 using System.Net;
 using System.Reflection;
+using System.Net.Http;
 
 using Amazon.S3;
 using Amazon.S3.Model;
@@ -167,7 +168,12 @@ namespace AWSSDK.UnitTests
         public class MockHttpRequestFactory : IHttpRequestFactory<Stream>
         {    
             public Action GetResponseAction { get; set; }
+
+#if BCL
             public Func<MockHttpRequest, HttpWebResponse> ResponseCreator { get; set; }
+#else
+            public Func<MockHttpRequest, HttpResponseMessage> ResponseCreator { get; set; }
+#endif
 
             public MockHttpRequest LastCreatedRequest { get; private set; }
 
@@ -201,23 +207,29 @@ namespace AWSSDK.UnitTests
             public Uri RequestUri { get; set; }
 
             public Action GetResponseAction { get; set; }
-            public Func<MockHttpRequest, HttpWebResponse> ResponseCreator { get; set; }
 
             public Version HttpProtocolVersion { get; set; }
 
+#if BCL
+            public Func<MockHttpRequest, HttpWebResponse> ResponseCreator { get; set; }
+
             public MockHttpRequest(Uri requestUri, Action action, Func<MockHttpRequest, HttpWebResponse> responseCreator = null)
+#else
+            public Func<MockHttpRequest, HttpResponseMessage> ResponseCreator { get; set; }
+
+            public MockHttpRequest(Uri requestUri, Action action, Func<MockHttpRequest, HttpResponseMessage> responseCreator = null)
+#endif
             {
                 this.RequestUri = requestUri;
                 this.GetResponseAction = action;
-#if BCL
                 this.ResponseCreator = responseCreator ?? CreateResponse;
-#else
-                throw new NotImplementedException();
-#endif
             }
 
 #if BCL
             private HttpWebResponse CreateResponse(MockHttpRequest request)
+#else
+            private HttpResponseMessage CreateResponse(MockHttpRequest request)
+#endif
             {
                 // Extract the last segment of the URI, this is the custom URI 
                 // sent by the unit tests.
@@ -227,10 +239,22 @@ namespace AWSSDK.UnitTests
                 if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode <= (HttpStatusCode)299)
                     return response;
                 else                
-                    throw new HttpErrorResponseException(new HttpWebRequestResponseData(response));    
-            }
+#if BCL
+                    throw new HttpErrorResponseException(new HttpWebRequestResponseData(response));
+#else
+                {
+                    var instance = Activator.CreateInstance(
+                               typeof(HttpClientResponseData),
+                               BindingFlags.Instance | BindingFlags.NonPublic,
+                               binder: null,
+                               args: new[] { response },
+                               culture: null
+                           );
+                    throw new HttpErrorResponseException(instance as HttpClientResponseData);
+                }
 #endif
-            
+            }
+
             public void ConfigureRequest(IRequestContext requestContext)
             {
                 this.IsConfigureRequestCalled = true;
@@ -250,14 +274,21 @@ namespace AWSSDK.UnitTests
 
             public Amazon.Runtime.Internal.Transform.IWebResponseData GetResponse()
             {
-#if BCL
                 if (this.GetResponseAction!=null)                
                     this.GetResponseAction();
 
                 var response = ResponseCreator(this);
+#if BCL
                 return new HttpWebRequestResponseData(response);
 #else
-                throw new NotImplementedException();
+                var instance = Activator.CreateInstance(
+                               typeof(HttpClientResponseData),
+                               BindingFlags.Instance | BindingFlags.NonPublic,
+                               binder: null,
+                               args: new[] { response },
+                               culture: null
+                           );
+                return instance as HttpClientResponseData;
 #endif
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently `MockHttpRequestFactory`  only works for .net framework, and since we eventually want to run tests in other targets, this PR enables MockHttpRequestFactory in non Net Framework targets.
This doesn't support custom responses yet.


Currently `MockHttpRequestFactory` is only working on the .NET Framework. To support running tests on additional target frameworks, this PR extends support for `MockHttpRequestFactory` to non-.NET Framework targets.

Note: Custom response handling is not implemented yet .

## Motivation and Context
Running tests for non Net Framework targets.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
* Ran `AWSSDK.Extensions` solution tests locally.
* `DRY_RUN-7ee716c8-84d6-426c-a4fd-f058b3d959a8`.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement