### PR TITLE
implement expression builders

### DIFF
--- a/generator/.DevConfigs/e94630b4-0543-487b-b46c-24e52a8676aa.json
+++ b/generator/.DevConfigs/e94630b4-0543-487b-b46c-24e52a8676aa.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Introduce a fluent ExpressionBuilder to the Document Model that uses method chaining to construct type-safe, readable condition and update expressions."
+            ]
+        }
+    ]
+}

--- a/generator/.DevConfigs/e94630b4-0543-487b-b46c-24e52a8676aa.json
+++ b/generator/.DevConfigs/e94630b4-0543-487b-b46c-24e52a8676aa.json
@@ -2,7 +2,7 @@
     "services": [
         {
             "serviceName": "DynamoDBv2",
-            "type": "patch",
+            "type": "minor",
             "changeLogMessages": [
                 "Introduce a fluent ExpressionBuilder to the Document Model that uses method chaining to construct type-safe, readable condition and update expressions."
             ]

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
@@ -320,8 +320,10 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">Type of object.</typeparam>
-        /// <param name="hashKey">Hash key element of the object to delete.</param>
+        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
+        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// </typeparam>
+        /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
         Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, CancellationToken cancellationToken = default);
@@ -334,8 +336,10 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">Type of object.</typeparam>
-        /// <param name="hashKey">Hash key element of the object to delete.</param>
+        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
+        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// </typeparam>
+        /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
@@ -350,8 +354,10 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">Type of object.</typeparam>
-        /// <param name="hashKey">Hash key element of the object to delete.</param>
+        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
+        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// </typeparam>
+        /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="deleteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
@@ -365,8 +371,10 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">Type of object.</typeparam>
-        /// <param name="hashKey">Hash key element of the object to delete.</param>
+        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
+        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// </typeparam>
+        /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="rangeKey">Range key element of the object to delete.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
         /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
@@ -380,8 +388,10 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">Type of object.</typeparam>
-        /// <param name="hashKey">Hash key element of the object to delete.</param>
+        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
+        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// </typeparam>
+        /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="rangeKey">Range key element of the object to delete.</param>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
@@ -397,8 +407,10 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">Type of object.</typeparam>
-        /// <param name="hashKey">Hash key element of the object to delete.</param>
+        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
+        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// </typeparam>
+        /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="rangeKey">Range key element of the object to delete.</param>
         /// <param name="deleteConfig">Config object that can be used to override properties on the table's context for this request.</param>
         /// <param name="cancellationToken">Token which can be used to cancel the task.</param>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
@@ -313,19 +313,21 @@ namespace Amazon.DynamoDBv2.DataModel
         Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(T value, DeleteConfig deleteConfig, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Deletes an item in DynamoDB corresponding to given hash key.
+        /// Deletes an item in DynamoDB corresponding to the given hash key.
         /// </summary>
         /// <remarks>
-        /// If SkipVersionCheck if false, it will check the version of object before deleting.
-        /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
-        /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
+        /// If <paramref name="SkipVersionCheck"/> is false, the method will check the version of the object before deleting.
+        /// The type must include enough schema metadata to resolve the target table and key.
+        /// This can be done through attributes (e.g., <see cref="DynamoDBTableAttribute" />, <see cref="DynamoDBHashKeyAttribute" />),
+        /// or through explicit configuration via <c>TableBuilder</c> or <c>DynamoDBContextConfig</c>.
         /// </remarks>
-        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
-        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// <typeparam name="T">
+        /// The type representing the item stored in DynamoDB. It must be resolvable via table metadata, 
+        /// either from attributes or via configuration.
         /// </typeparam>
         /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
-        /// <param name="cancellationToken">Token which can be used to cancel the task.</param>
-        /// <returns>A Task that can be used to poll or wait for results, or both.</returns>
+        /// <param name="cancellationToken">Token that can be used to cancel the operation.</param>
+        /// <returns>A <see cref="Task"/> that can be awaited for operation completion.</returns>
         Task DeleteAsync<[DynamicallyAccessedMembers(InternalConstants.DataModelModeledType)] T>(object hashKey, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -336,8 +338,9 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
-        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// <typeparam name="T">
+        /// The type representing the item stored in DynamoDB. It must be resolvable via table metadata, 
+        /// either from attributes or via configuration.
         /// </typeparam>
         /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="operationConfig">Config object which can be used to override that table used.</param>
@@ -354,8 +357,9 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
-        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// <typeparam name="T">
+        /// The type representing the item stored in DynamoDB. It must be resolvable via table metadata, 
+        /// either from attributes or via configuration.
         /// </typeparam>
         /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="deleteConfig">Config object that can be used to override properties on the table's context for this request.</param>
@@ -371,8 +375,9 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
-        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// <typeparam name="T">
+        /// The type representing the item stored in DynamoDB. It must be resolvable via table metadata, 
+        /// either from attributes or via configuration.
         /// </typeparam>
         /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="rangeKey">Range key element of the object to delete.</param>
@@ -388,8 +393,9 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
-        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// <typeparam name="T">
+        /// The type representing the item stored in DynamoDB. It must be resolvable via table metadata, 
+        /// either from attributes or via configuration.
         /// </typeparam>
         /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="rangeKey">Range key element of the object to delete.</param>
@@ -407,8 +413,9 @@ namespace Amazon.DynamoDBv2.DataModel
         /// The type must be marked up with <see cref="DynamoDBTableAttribute" /> and at least
         /// one public field/property with <see cref="DynamoDBHashKeyAttribute" />.
         /// </remarks>
-        /// <typeparam name="T">The type representing the item stored in DynamoDB. This must be a modeled type
-        /// decorated with <see cref="DynamoDBTableAttribute" />, and have a hash key field or property.
+        /// <typeparam name="T">
+        /// The type representing the item stored in DynamoDB. It must be resolvable via table metadata, 
+        /// either from attributes or via configuration.
         /// </typeparam>
         /// <param name="hashKey">The value of the hash (partition) key identifying the item to delete.</param>
         /// <param name="rangeKey">Range key element of the object to delete.</param>

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/_async/IDynamoDBContext.Async.cs
@@ -315,12 +315,6 @@ namespace Amazon.DynamoDBv2.DataModel
         /// <summary>
         /// Deletes an item in DynamoDB corresponding to the given hash key.
         /// </summary>
-        /// <remarks>
-        /// If <paramref name="SkipVersionCheck"/> is false, the method will check the version of the object before deleting.
-        /// The type must include enough schema metadata to resolve the target table and key.
-        /// This can be done through attributes (e.g., <see cref="DynamoDBTableAttribute" />, <see cref="DynamoDBHashKeyAttribute" />),
-        /// or through explicit configuration via <c>TableBuilder</c> or <c>DynamoDBContextConfig</c>.
-        /// </remarks>
         /// <typeparam name="T">
         /// The type representing the item stored in DynamoDB. It must be resolvable via table metadata, 
         /// either from attributes or via configuration.

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
@@ -135,7 +135,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <param name="nameBuilder">The <see cref="NameBuilder"/> representing the attribute name.</param>
         /// <param name="setExpressionBuilder">The <see cref="SetValueBuilder"/> representing the value to set.</param>
         /// <returns>The current <see cref="UpdateExpressionBuilder"/> instance for chaining additional operations.</returns>
-        public UpdateExpressionBuilder Set(NameBuilder nameBuilder, SetValueBuilder setExpressionBuilder)
+        public UpdateExpressionBuilder Set(NameBuilder nameBuilder, OperandBuilder setExpressionBuilder)
         {
             if (!OperationBuilders.TryGetValue(OperationModeSet, out var ops))
             {
@@ -292,7 +292,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
             if (node.FormatedExpression.EndsWith(", "))
             {
                 node.FormatedExpression = node.FormatedExpression.Substring(0, node.FormatedExpression.Length - 2);
-
             }
 
             return node;
@@ -593,21 +592,12 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 ConditionMode.Contains =>
                     ContainsBuildCondition(node),
 
-                ConditionMode.Parentheses =>
-                    ParenthesesBuildCondition(node),
-
                 ConditionMode.Unset =>
                     throw new InvalidOperationException("ConditionBuilder"),
 
                 _ =>
                     throw new InvalidOperationException($"Build condition error: unsupported mode: {_conditionMode}")
             };
-        }
-
-        private ExpressionNode ParenthesesBuildCondition(ExpressionNode node)
-        {
-            node.FormatedExpression = "( $c )";
-            return node;
         }
 
         private Queue<ExpressionNode> BuildChildNodes()
@@ -1077,9 +1067,19 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// Default constructor for ValueBuilder.
         /// </summary>
         /// <param name="value"></param>
-        public ValueBuilder(DynamoDBEntry value)
+        internal ValueBuilder(DynamoDBEntry value)
         {
             _value = value;
+        }
+
+        /// <summary>
+        /// Creates a new instance of ValueBuilder with the specified value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ValueBuilder New(DynamoDBEntry value)
+        {
+            return new ValueBuilder(value);
         }
 
         /// <summary>
@@ -1282,7 +1282,6 @@ namespace Amazon.DynamoDBv2.DocumentModel
         And,
         Or,
         Not,
-        Parentheses,
 
         // Function-based Conditions
         Between,

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
@@ -760,9 +760,20 @@ namespace Amazon.DynamoDBv2.DocumentModel
     /// for DynamoDB expressions. It allows the creation of conditions based on attribute names
     /// and supports various comparison, logical, and function-based operations.
     /// </summary>
-    public class NameBuilder : OperandBuilder
+    public partial class NameBuilder : OperandBuilder
     {
         private readonly IEnumerable<string> _names;
+
+        private const string BracketPattern = @"\[(\d+)\]";
+
+#if NET8_0_OR_GREATER
+
+        [GeneratedRegex(BracketPattern)]
+        private static partial Regex BracketPatternRegex();
+#else
+        private static Regex BracketPatternRegex() => _bracketPatternRegex;
+        private static readonly Regex _bracketPatternRegex = new Regex(BracketPattern, RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NameBuilder"/> class with the specified attribute name.
@@ -1020,9 +1031,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 var word = originalWord;
                 var substr = string.Empty;
 
-                // Ensure brackets are matched and contain only digits
-                var bracketPattern = new Regex(@"\[(\d+)\]");
-                var bracketMatches = bracketPattern.Matches(word);
+                var bracketMatches = BracketPatternRegex().Matches(word);
 
                 if (word.Count(c => c == '[') != word.Count(c => c == ']'))
                     throw new InvalidOperationException("Invalid parameter Name");

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
@@ -1,0 +1,1590 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * This file contains classes and utilities for building expressions used in DynamoDB operations.
+ * It provides a flexible and extensible framework for constructing conditional, filter, and query expressions
+ * using attribute names, values, and logical operators.
+ */
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Amazon.Runtime;
+
+namespace Amazon.DynamoDBv2.DocumentModel
+{
+    /// <summary>
+    /// Interface for building expressions used in DynamoDB operations.
+    /// </summary>
+    public interface IExpressionBuilder
+    {
+        /// <summary>
+        /// Builds the expression based on the conditions and operands provided.
+        /// </summary>
+        /// <returns>An <see cref="Expression"/> object representing the constructed expression.</returns>
+        Expression Build();
+    }
+
+    /// <summary>
+    /// Abstract base class for building expressions used in DynamoDB operations.
+    /// Provides a structure for managing conditions and operands that form the basis of an expression.
+    /// </summary>
+    public abstract class ExpressionBuilder: IExpressionBuilder
+    {
+        /// <summary>
+        /// Builds the expression based on provided.
+        /// </summary>
+        /// <returns>An <see cref="Expression"/> object representing the constructed expression.</returns>
+        public Expression Build()
+        {
+            var expressionTree = BuildExpressionTree();
+
+            var aliasList = new KeyAttributeAliasList();
+
+            var expression = new Expression()
+            {
+                ExpressionStatement = expressionTree.BuildExpressionString(aliasList)
+            };
+
+            if (aliasList.NamesList != null && aliasList.NamesList.Count != 0)
+            {
+                var namesDictionary = new Dictionary<string, string>();
+                for (int i = 0; i < aliasList.NamesList.Count; i++)
+                {
+                    namesDictionary[$"#{i}"] = aliasList.NamesList[i];
+                }
+
+                expression.ExpressionAttributeNames = namesDictionary;
+            }
+
+            if (aliasList.ValuesList != null && aliasList.ValuesList.Count != 0)
+            {
+                var values = new Dictionary<string, DynamoDBEntry>();
+                for (int i = 0; i < aliasList.ValuesList.Count; i++)
+                {
+                    values[$":{i}"] = aliasList.ValuesList[i];
+                }
+
+                expression.ExpressionAttributeValues = values;
+            }
+
+            return expression;
+        }
+
+        /// <summary>
+        /// Builds the expression tree for the current expression builder. 
+        /// </summary>
+        /// <returns></returns>
+        internal abstract ExpressionNode BuildExpressionTree();
+    }
+
+    /// <summary>
+    /// The <see cref="UpdateExpressionBuilder"/> class is used to construct update expressions for DynamoDB operations.
+    /// An update expression consists of one or more clauses. Each clause begins with a SET, REMOVE, ADD, or DELETE keyword. 
+    /// You can include any of these clauses in an update expression, in any order.
+    /// </summary>
+    public class UpdateExpressionBuilder : ExpressionBuilder
+    {
+
+        private const string OperationModeSet = "SET";
+        private const string OperationModeRemove = "REMOVE";
+        private const string OperationModeAdd = "ADD";
+        private const string OperationModeDelete = "DELETE";
+
+        /// <summary>
+        /// The list of operations that will be used in the update expression.
+        /// </summary>
+        private Dictionary<string,List<OperationBuilder>> OperationBuilders { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateExpressionBuilder"/> class with default settings.
+        /// </summary>
+        protected UpdateExpressionBuilder()
+        {
+            OperationBuilders = new Dictionary<string, List<OperationBuilder>>();
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="UpdateExpressionBuilder"/> class.
+        /// </summary>
+        /// <returns>A new <see cref="UpdateExpressionBuilder"/> instance for building update expressions.</returns>
+        public static UpdateExpressionBuilder New()
+        {
+            return new UpdateExpressionBuilder();
+        }
+
+        /// <summary>
+        /// Adds a "SET" operation to the update expression, which sets the value of an attribute.
+        /// </summary>
+        /// <param name="nameBuilder">The <see cref="NameBuilder"/> representing the attribute name.</param>
+        /// <param name="setExpressionBuilder">The <see cref="SetValueBuilder"/> representing the value to set.</param>
+        /// <returns>The current <see cref="UpdateExpressionBuilder"/> instance for chaining additional operations.</returns>
+        public UpdateExpressionBuilder Set(NameBuilder nameBuilder, SetValueBuilder setExpressionBuilder)
+        {
+            if (!OperationBuilders.TryGetValue(OperationModeSet, out var ops))
+            {
+                ops = new List<OperationBuilder>();
+                OperationBuilders[OperationModeSet] = ops;
+            }
+
+            ops.Add(new OperationBuilder(OperationMode.Set)
+            {
+                Name = nameBuilder,
+                Value = setExpressionBuilder
+            });
+
+            return this;
+        }
+        
+        /// <summary>
+        /// Adds a "REMOVE" operation to the update expression, which removes one or more attributes from an item.
+        /// </summary>
+        /// <param name="nameBuilder">The <see cref="NameBuilder"/> representing the attribute name to remove.</param>
+        /// <returns>The current <see cref="UpdateExpressionBuilder"/> instance for chaining additional operations.</returns>
+        public UpdateExpressionBuilder Remove(NameBuilder nameBuilder)
+        {
+            if (!OperationBuilders.TryGetValue(OperationModeRemove, out var ops))
+            {
+                ops = new List<OperationBuilder>();
+                OperationBuilders[OperationModeRemove] = ops;
+            }
+
+            ops.Add(new OperationBuilder(OperationMode.Remove)
+            {
+                Name = nameBuilder
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a "DELETE" operation to the update expression, which removes one or more elements from a set attribute.
+        /// </summary>
+        /// <param name="nameBuilder">The <see cref="NameBuilder"/> representing the attribute name.</param>
+        /// <param name="valueBuilder">The <see cref="ValueBuilder"/> representing the value to delete from the set.</param>
+        /// <returns>The current <see cref="UpdateExpressionBuilder"/> instance for chaining additional operations.</returns>
+        public UpdateExpressionBuilder Delete(NameBuilder nameBuilder, ValueBuilder valueBuilder)
+        {
+            if (!OperationBuilders.TryGetValue(OperationModeDelete, out var ops))
+            {
+                ops = new List<OperationBuilder>();
+                OperationBuilders[OperationModeDelete] = ops;
+            }
+
+            ops.Add(new OperationBuilder(OperationMode.Delete)
+            {
+                Name = nameBuilder,
+                Value = valueBuilder
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an "ADD" operation to the update expression, which adds a new attribute or modifies an existing one.
+        /// If the attribute is a number, the value is added or subtracted. If the attribute is a set, the value is appended.
+        /// </summary>
+        /// <param name="nameBuilder">The <see cref="NameBuilder"/> representing the attribute name.</param>
+        /// <param name="valueBuilder">The <see cref="ValueBuilder"/> representing the value to add.</param>
+        /// <returns>The current <see cref="UpdateExpressionBuilder"/> instance for chaining additional operations.</returns>
+        public UpdateExpressionBuilder Add(NameBuilder nameBuilder, ValueBuilder valueBuilder)
+        {
+            if (!OperationBuilders.TryGetValue(OperationModeAdd, out var ops))
+            {
+                ops = new List<OperationBuilder>();
+                OperationBuilders[OperationModeAdd] = ops;
+            }
+
+            ops.Add(new OperationBuilder(OperationMode.Add)
+            {
+                Name = nameBuilder,
+                Value = valueBuilder
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the expression tree for the update expression based on the operations provided.
+        /// </summary>
+        /// <returns>An <see cref="ExpressionNode"/> representing the constructed update expression tree.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if no operations are defined in the update expression.</exception>
+        internal override ExpressionNode BuildExpressionTree()
+        {
+            var resultNode = new ExpressionNode
+            {
+                Children = new Queue<ExpressionNode>()
+            };
+
+            if (OperationBuilders.TryGetValue(OperationModeSet, out var setOps))
+            {
+                var childNode = BuildChildNodes(setOps);
+                resultNode.Children.Enqueue(childNode);
+                resultNode.FormatedExpression += $"{OperationModeSet} $c\n";
+            }
+
+            if (OperationBuilders.TryGetValue(OperationModeRemove, out var removeOps))
+            {
+                var childNode = BuildChildNodes(removeOps);
+                resultNode.Children.Enqueue(childNode);
+                resultNode.FormatedExpression += $"{OperationModeRemove} $c\n";
+            }
+
+            if (OperationBuilders.TryGetValue(OperationModeAdd, out var addOps))
+            {
+                var childNode = BuildChildNodes(addOps);
+                resultNode.Children.Enqueue(childNode);
+                resultNode.FormatedExpression += $"{OperationModeAdd} $c\n";
+            }
+
+            if (OperationBuilders.TryGetValue(OperationModeDelete, out var deleteOps))
+            {
+                var childNode = BuildChildNodes(deleteOps);
+                resultNode.Children.Enqueue(childNode);
+                resultNode.FormatedExpression += $"{OperationModeDelete} $c\n";
+            }
+
+            if (resultNode.Children.Count == 0)
+            {
+                throw new InvalidOperationException("Cannot build update expression tree: operation list is empty.");
+            }
+
+            return resultNode;
+        }
+
+        private ExpressionNode BuildChildNodes(List<OperationBuilder> builders)
+        {
+            if (builders == null || builders.Count == 0)
+            {
+                throw new InvalidOperationException("Cannot build update expression tree: operation list is empty.");
+            }
+
+            var node = new ExpressionNode
+            {
+                Children = new Queue<ExpressionNode>()
+            };
+
+            foreach (var builder in builders)
+            {
+                var expr = builder.Build();
+
+                node.Children.Enqueue(expr);
+                node.FormatedExpression += "$c, ";
+            }
+
+            // Remove trailing comma and space, if any
+            if (node.FormatedExpression.EndsWith(", "))
+            {
+                node.FormatedExpression = node.FormatedExpression.Substring(0, node.FormatedExpression.Length - 2);
+
+            }
+
+            return node;
+        }
+
+    }
+
+    /// <summary>
+    /// Class for building conditions used in DynamoDB expressions.
+    /// Supports comparison, logical, and function-based conditions.
+    /// </summary>
+    public class ConditionExpressionBuilder : ExpressionBuilder
+    {
+        private readonly ConditionMode _conditionMode;
+
+        /// <summary>
+        /// The list of conditions that will be used in the expression.
+        /// </summary>
+        internal List<ExpressionBuilder> Conditions { get; set; }
+
+        /// <summary>
+        /// The list of operands that will be used in the expression.
+        /// </summary>
+        internal List<OperandBuilder> Operands { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConditionExpressionBuilder"/> class with default settings.
+        /// </summary>
+        protected ConditionExpressionBuilder()
+        {
+            _conditionMode = ConditionMode.Unset;
+            Operands = new List<OperandBuilder>();
+            Conditions = new List<ExpressionBuilder>();
+        }
+
+        private ConditionExpressionBuilder(List<OperandBuilder> operandBuilders, ConditionMode mode) : this()
+        {
+
+            _conditionMode = mode;
+            Operands = operandBuilders;
+        }
+
+        private ConditionExpressionBuilder(List<ExpressionBuilder> conditionBuilders, ConditionMode mode) : this()
+        {
+            _conditionMode = mode;
+            Conditions = conditionBuilders;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ConditionExpressionBuilder"/>.
+        /// </summary>
+        /// <returns>A new <see cref="ConditionExpressionBuilder"/> instance.</returns>
+        public static ConditionExpressionBuilder New()
+        {
+            return new ConditionExpressionBuilder();
+        }
+
+        /// <summary>
+        /// Adds a condition to the current condition builder.
+        /// </summary>
+        /// <param name="condition">The condition to add.</param>
+        /// <returns>The current <see cref="ConditionExpressionBuilder"/> instance for chaining.</returns>
+        public ConditionExpressionBuilder WithCondition(ConditionExpressionBuilder condition)
+        {
+            Conditions.Add(condition);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an attribute name to the condition.
+        /// </summary>
+        /// <param name="path">The attribute name or path.</param>
+        /// <returns>A <see cref="NameBuilder"/> for further configuration.</returns>
+        public NameBuilder WithName(string path)
+        {
+            return new NameBuilder(path);
+        }
+
+        /// <summary>
+        /// Combines multiple conditions using the logical "AND" operator.
+        /// </summary>
+        /// <param name="left">The first <see cref="ConditionExpressionBuilder"/> instance to combine.</param>
+        /// <param name="right">The second <see cref="ConditionExpressionBuilder"/> instance to combine.</param>
+        /// <param name="others">Additional <see cref="ConditionExpressionBuilder"/> instances to include in the combination.</param>
+        /// <returns>A new <see cref="ConditionExpressionBuilder"/> instance representing the combined "AND" condition.</returns>
+        public static ConditionExpressionBuilder And(ConditionExpressionBuilder left, ConditionExpressionBuilder right,
+            params ConditionExpressionBuilder[] others)
+        {
+            var allConditions = new List<ExpressionBuilder> { left, right };
+            if (others is { Length: > 0 })
+            {
+                allConditions.AddRange(others);
+            }
+
+            return new ConditionExpressionBuilder(allConditions, ConditionMode.And);
+        }
+
+        /// <summary>
+        /// Combines the current condition with additional conditions using the logical "AND" operator.
+        /// </summary>
+        /// <param name="right">The <see cref="ConditionExpressionBuilder"/> instance to combine with the current condition.</param>
+        /// <param name="others">Additional <see cref="ConditionExpressionBuilder"/> instances to include in the combination.</param>
+        /// <returns>A new <see cref="ConditionExpressionBuilder"/> instance representing the combined "AND" condition.</returns>
+        public ConditionExpressionBuilder And(ConditionExpressionBuilder right, params ConditionExpressionBuilder[] others)
+        {
+            var allConditions = new List<ExpressionBuilder> { this, right };
+            if (others is { Length: > 0 })
+            {
+                allConditions.AddRange(others);
+            }
+
+            return new ConditionExpressionBuilder(allConditions, ConditionMode.And);
+        }
+
+        /// <summary>
+        /// Combines multiple conditions using the logical "OR" operator.
+        /// </summary>
+        /// <param name="left">The first <see cref="ConditionExpressionBuilder"/> instance to combine.</param>
+        /// <param name="right">The second <see cref="ConditionExpressionBuilder"/> instance to combine.</param>
+        /// <param name="others">Additional <see cref="ConditionExpressionBuilder"/> instances to include in the combination.</param>
+        /// <returns>A new <see cref="ConditionExpressionBuilder"/> instance representing the combined "OR" condition.</returns>
+        public static ConditionExpressionBuilder Or(ConditionExpressionBuilder left, ConditionExpressionBuilder right,
+            params ConditionExpressionBuilder[] others)
+        {
+            var allConditions = new List<ExpressionBuilder> { left, right };
+            if (others is { Length: > 0 })
+            {
+                allConditions.AddRange(others);
+            }
+
+            return new ConditionExpressionBuilder(allConditions, ConditionMode.Or);
+        }
+
+        /// <summary>
+        /// Combines the current condition with additional conditions using the logical "OR" operator.
+        /// </summary>
+        /// <param name="right">The <see cref="ConditionExpressionBuilder"/> instance to combine with the current condition.</param>
+        /// <param name="others">Additional <see cref="ConditionExpressionBuilder"/> instances to include in the combination.</param>
+        /// <returns>A new <see cref="ConditionExpressionBuilder"/> instance representing the combined "OR" condition.</returns>
+        public ConditionExpressionBuilder Or(ConditionExpressionBuilder right, params ConditionExpressionBuilder[] others)
+        {
+            var allConditions = new List<ExpressionBuilder> { this, right };
+            if (others is { Length: > 0 })
+            {
+                allConditions.AddRange(others);
+            }
+
+            return new ConditionExpressionBuilder(allConditions, ConditionMode.Or);
+        }
+
+        /// <summary>
+        /// Negates a condition using the logical "NOT" operator.
+        /// </summary>
+        /// <param name="condition">The <see cref="ConditionExpressionBuilder"/> instance to negate.</param>
+        /// <returns>A new <see cref="ConditionExpressionBuilder"/> instance representing the negated condition.</returns>
+        public static ConditionExpressionBuilder Not(ConditionExpressionBuilder condition)
+        {
+            var allConditions = new List<ExpressionBuilder> { condition };
+            return new ConditionExpressionBuilder(allConditions, ConditionMode.Not);
+        }
+
+        /// <summary>
+        /// Negates the current condition using the logical "NOT" operator.
+        /// </summary>
+        /// <returns>A new <see cref="ConditionExpressionBuilder"/> instance representing the negated condition.</returns>
+        public ConditionExpressionBuilder Not()
+        {
+            var allConditions = new List<ExpressionBuilder> { this };
+            return new ConditionExpressionBuilder(allConditions, ConditionMode.Not);
+        }
+
+        internal static ConditionExpressionBuilder Equal(OperandBuilder left, OperandBuilder right)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.Equal);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder NotEqual(OperandBuilder left, OperandBuilder right)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.NotEqual);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder LesThan(OperandBuilder left, OperandBuilder right)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.LessThan);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder LessThanOrEqual(OperandBuilder left, OperandBuilder right)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.LessThanOrEqual);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder GreaterThan(OperandBuilder left, OperandBuilder right)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.GreaterThan);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder GreaterThanOrEqual(OperandBuilder left, OperandBuilder right)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.GreaterThanOrEqual);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder Between(OperandBuilder left, OperandBuilder lowerOperand, OperandBuilder upperOperand)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, lowerOperand, upperOperand }, ConditionMode.Between);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder In(OperandBuilder left, OperandBuilder rightOperand, params OperandBuilder[] otherOperands)
+        {
+            var operands = new List<OperandBuilder> { left, rightOperand };
+            if (otherOperands is { Length: > 0 })
+            {
+                operands.AddRange(otherOperands);
+            }
+            var condition = new ConditionExpressionBuilder(operands, ConditionMode.In);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder AttributeExists(OperandBuilder nameOperand)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { nameOperand }, ConditionMode.AttributeExists);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder AttributeNotExists(OperandBuilder nameOperand)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { nameOperand }, ConditionMode.AttributeNotExists);
+            return condition;
+        }
+        internal static ConditionExpressionBuilder AttributeType(OperandBuilder left, OperandBuilder right)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.AttributeType);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder Contains(OperandBuilder left, OperandBuilder right)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.Contains);
+            return condition;
+        }
+
+        internal static ConditionExpressionBuilder BeginsWith(OperandBuilder left, OperandBuilder right)
+        {
+            var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.BeginsWith);
+            return condition;
+        }
+
+        ///<inheritdoc/>
+        internal override ExpressionNode BuildExpressionTree()
+        {
+            var childNodes = BuildChildNodes();
+
+            var node = new ExpressionNode
+            {
+                Children = childNodes,
+            };
+
+            return _conditionMode switch
+            {
+                ConditionMode.Equal or
+                    ConditionMode.NotEqual or
+                    ConditionMode.LessThan or
+                    ConditionMode.LessThanOrEqual or
+                    ConditionMode.GreaterThan or
+                    ConditionMode.GreaterThanOrEqual =>
+                    CompareBuildCondition(_conditionMode, node),
+
+                ConditionMode.And or ConditionMode.Or =>
+                    CompoundBuildCondition(this, node),
+
+                ConditionMode.Not =>
+                    NotBuildCondition(node),
+
+                ConditionMode.Between =>
+                    BetweenBuildCondition(node),
+
+                ConditionMode.In =>
+                    InBuildCondition(this, node),
+
+                ConditionMode.AttributeExists =>
+                    AttributeExistsBuildCondition(node),
+
+                ConditionMode.AttributeNotExists =>
+                    AttributeNotExistsBuildCondition(node),
+
+                ConditionMode.AttributeType =>
+                    AttributeTypeBuildCondition(node),
+
+                ConditionMode.BeginsWith =>
+                    BeginsWithBuildCondition(node),
+
+                ConditionMode.Contains =>
+                    ContainsBuildCondition(node),
+
+                ConditionMode.Parentheses =>
+                    ParenthesesBuildCondition(node),
+
+                ConditionMode.Unset =>
+                    throw new InvalidOperationException("ConditionBuilder"),
+
+                _ =>
+                    throw new InvalidOperationException($"Build condition error: unsupported mode: {_conditionMode}")
+            };
+        }
+
+        private ExpressionNode ParenthesesBuildCondition(ExpressionNode node)
+        {
+            node.FormatedExpression = "( $c )";
+            return node;
+        }
+
+        private Queue<ExpressionNode> BuildChildNodes()
+        {
+            var childNodes = new Queue<ExpressionNode>();
+
+            foreach (var condition in Conditions)
+            {
+                ExpressionNode node;
+                try
+                {
+                    node = condition.BuildExpressionTree();
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException("Failed to build condition tree", ex);
+                }
+
+                childNodes.Enqueue(node);
+            }
+
+            foreach (var operand in Operands)
+            {
+                ExpressionNode node;
+                try
+                {
+                    node = operand.Build();
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException("Failed to build operand", ex);
+                }
+
+                childNodes.Enqueue(node);
+            }
+
+            return childNodes;
+        }
+
+        #region statement_build
+
+        private ExpressionNode NotBuildCondition(ExpressionNode node)
+        {
+            node.FormatedExpression = "NOT ($c)";
+            return node;
+        }
+
+        private ExpressionNode CompoundBuildCondition(ConditionExpressionBuilder conditionBuilder, ExpressionNode node)
+        {
+            var mode = conditionBuilder._conditionMode switch
+            {
+                ConditionMode.And => "AND",
+                ConditionMode.Or => "OR",
+                _ => throw new InvalidOperationException(
+                    $"Unsupported condition operator: {conditionBuilder._conditionMode}")
+            };
+            node.FormatedExpression = string.Join($" {mode} ",
+                node.Children.Select(c => "($c)"));
+            return node;
+        }
+
+        private ExpressionNode CompareBuildCondition(ConditionMode conditionMode, ExpressionNode node)
+        {
+            switch (conditionMode)
+            {
+                case ConditionMode.Equal:
+                    node.FormatedExpression =
+                        $"$c = $c";
+                    break;
+                case ConditionMode.NotEqual:
+                    node.FormatedExpression =
+                        $"$c <> $c";
+                    break;
+                case ConditionMode.LessThan:
+                    node.FormatedExpression =
+                        $"$c < $c";
+                    break;
+                case ConditionMode.LessThanOrEqual:
+                    node.FormatedExpression =
+                        $"$c <= $c";
+                    break;
+                case ConditionMode.GreaterThan:
+                    node.FormatedExpression =
+                        $"$c > $c";
+                    break;
+                case ConditionMode.GreaterThanOrEqual:
+                    node.FormatedExpression =
+                        $"$c >= $c";
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unsupported mode: {conditionMode}");
+            }
+
+            return node;
+        }
+
+        private ExpressionNode ContainsBuildCondition(ExpressionNode node)
+        {
+            node.FormatedExpression = "contains ($c, $c)";
+            return node;
+        }
+
+        private ExpressionNode BeginsWithBuildCondition(ExpressionNode node)
+        {
+            node.FormatedExpression = "begins_with ($c, $c)";
+            return node;
+        }
+
+        private ExpressionNode AttributeTypeBuildCondition(ExpressionNode node)
+        {
+            node.FormatedExpression = "attribute_type ($c, $c)";
+            return node;
+        }
+
+        private ExpressionNode AttributeNotExistsBuildCondition(ExpressionNode node)
+        {
+            node.FormatedExpression = "attribute_not_exists ($c)";
+            return node;
+        }
+
+        private ExpressionNode AttributeExistsBuildCondition(ExpressionNode node)
+        {
+            node.FormatedExpression = "attribute_exists ($c)";
+            return node;
+        }
+
+        private ExpressionNode InBuildCondition(ConditionExpressionBuilder conditionBuilder, ExpressionNode node)
+        {
+            node.FormatedExpression = "$c IN (";
+
+            for(int i = 1; i < node.Children.Count; i++){
+                node.FormatedExpression += "$c, ";
+            }
+            // Remove trailing comma and space, if any
+            if (node.FormatedExpression.EndsWith(", "))
+            {
+                node.FormatedExpression = node.FormatedExpression.Substring(0, node.FormatedExpression.Length - 2);
+            }
+            node.FormatedExpression += ")";
+            return node;
+        }
+
+        private ExpressionNode BetweenBuildCondition(ExpressionNode node)
+        {
+            node.FormatedExpression = "$c BETWEEN $c AND $c";
+            return node;
+        }
+
+        #endregion
+
+    }
+
+    /// <summary>
+    /// The <see cref="NameBuilder"/> class is responsible for building attribute names
+    /// for DynamoDB expressions. It allows the creation of conditions based on attribute names
+    /// and supports various comparison, logical, and function-based operations.
+    /// </summary>
+    public class NameBuilder : OperandBuilder
+    {
+        private readonly IEnumerable<string> _names;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NameBuilder"/> class with the specified attribute name.
+        /// </summary>
+        /// <param name="name">
+        /// The attribute name to be used in the expression. Supports nested attributes using dot notation
+        /// (e.g., "Parent.Child[0].Grandchild").
+        /// </param>
+        internal NameBuilder(string name)
+        {
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                _names = name.Split('.');
+            }
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="NameBuilder"/> class with the specified attribute name.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static NameBuilder New(string name)
+        {
+            return new NameBuilder(name);
+        }
+
+        #region ConditionExpressionBuilder
+
+        /// <summary>
+        /// Adds an attribute name to the condition.
+        /// </summary>
+        /// <param name="path">The attribute name or path.</param>
+        /// <returns>A <see cref="NameBuilder"/> for further configuration.</returns>
+        public NameBuilder WithName(string path)
+        {
+            return new NameBuilder(path);
+        }
+
+        /// <summary>
+        /// Creates an equal condition between the current attribute and the specified value.
+        /// </summary>
+        /// <param name="right">The value to compare against.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the not-equal condition.</returns>
+        public ConditionExpressionBuilder Equal(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return ConditionExpressionBuilder.Equal(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a not-equal condition between the current attribute and the specified value.
+        /// </summary>
+        /// <param name="right">The value to compare against.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the not-equal condition.</returns>
+        public ConditionExpressionBuilder NotEqual(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return ConditionExpressionBuilder.NotEqual(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a less-than condition between the current attribute and the specified value.
+        /// </summary>
+        /// <param name="right">The value to compare against.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the less-than condition.</returns>
+        public ConditionExpressionBuilder LessThan(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return ConditionExpressionBuilder.LesThan(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a less-than-or-equal condition between the current attribute and the specified value.
+        /// </summary>
+        /// <param name="right">The value to compare against.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the less-than-or-equal condition.</returns>
+        public ConditionExpressionBuilder LessThanOrEqual(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return ConditionExpressionBuilder.LessThanOrEqual(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a greater-than condition between the current attribute and the specified value.
+        /// </summary>
+        /// <param name="right">The value to compare against.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the greater-than condition.</returns>
+        public ConditionExpressionBuilder GreaterThan(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return ConditionExpressionBuilder.GreaterThan(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a greater-than-or-equal condition between the current attribute and the specified value.
+        /// </summary>
+        /// <param name="right">The value to compare against.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the greater-than-or-equal condition.</returns>
+        public ConditionExpressionBuilder GreaterThanOrEqual(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return ConditionExpressionBuilder.GreaterThanOrEqual(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a condition to check if the current attribute's value is between two specified values.
+        /// </summary>
+        /// <param name="lower">The lower bound of the range.</param>
+        /// <param name="upper">The upper bound of the range.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the between condition.</returns>
+        public ConditionExpressionBuilder Between(DynamoDBEntry lower, DynamoDBEntry upper)
+        {
+            var lowerOperand = new ValueBuilder(lower);
+            var upperOperand = new ValueBuilder(upper);
+            return ConditionExpressionBuilder.Between(this, lowerOperand,upperOperand);
+        }
+
+        /// <summary>
+        /// Creates a condition to check if the current attribute's value is in a specified set of values.
+        /// </summary>
+        /// <param name="right">The first value in the set.</param>
+        /// <param name="others">Additional values in the set.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the in condition.</returns>
+        public ConditionExpressionBuilder In(DynamoDBEntry right, params DynamoDBEntry[] others)
+        {
+            var rightOperand = new ValueBuilder(right);
+            var otherOperands = others?.Select(other => new ValueBuilder(other)).Cast<OperandBuilder>().ToArray();
+            return ConditionExpressionBuilder.In(this, rightOperand, otherOperands);
+        }
+
+        /// <summary>
+        /// Creates a condition to check if the current attribute exists in the DynamoDB item.
+        /// </summary>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the attribute exists condition.</returns>
+        public ConditionExpressionBuilder AttributeExists()
+        {
+            return ConditionExpressionBuilder.AttributeExists(this);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public ConditionExpressionBuilder AttributeNotExists()
+        {
+            return ConditionExpressionBuilder.AttributeNotExists(this);
+        }
+
+        /// <summary>
+        /// Creates a condition to check if the current attribute has a specific DynamoDB attribute type.
+        /// </summary>
+        /// <param name="type">The expected DynamoDB attribute type.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the attribute type condition.</returns>
+        public ConditionExpressionBuilder AttributeType(DynamoDBAttributeType type)
+        {
+            var rightOperand = new ValueBuilder(type.Value);
+            return ConditionExpressionBuilder.AttributeType(this,rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a condition to check if the current attribute's value begins with a specified prefix.
+        /// </summary>
+        /// <param name="right">The prefix to check for.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the begins with condition.</returns>
+        public ConditionExpressionBuilder BeginsWith(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return ConditionExpressionBuilder.BeginsWith(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a condition to check if the current attribute's value contains a specified substring or value.
+        /// </summary>
+        /// <param name="right">The substring or value to check for.</param>
+        /// <returns>A <see cref="ConditionExpressionBuilder"/> representing the contains condition.</returns>
+        public ConditionExpressionBuilder Contains(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return ConditionExpressionBuilder.Contains(this, rightOperand);
+        }
+
+        #endregion
+
+        #region UpdateExpressionBuilder
+
+        /// <summary>
+        /// Creates a "Plus" operation for the current attribute, which adds the specified value to the attribute.
+        /// </summary>
+        /// <param name="right">The value to add to the current attribute.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "Plus" operation.</returns>
+        public SetValueBuilder Plus(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return SetValueBuilder.Plus(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a "Minus" operation for the current attribute, which subtracts the specified value from the attribute.
+        /// </summary>
+        /// <param name="right">The value to subtract from the current attribute.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "Minus" operation.</returns>
+        public SetValueBuilder Minus(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return SetValueBuilder.Minus(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a "ListAppend" operation for the current attribute, which appends the specified value to a list attribute.
+        /// </summary>
+        /// <param name="right">The value to append to the list attribute.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "ListAppend" operation.</returns>
+        public SetValueBuilder ListAppend(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return SetValueBuilder.ListAppend(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates an "IfNotExists" operation for the current attribute, which sets the attribute to the specified value
+        /// if it does not already exist.
+        /// </summary>
+        /// <param name="setValue">The value to set if the attribute does not exist.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "IfNotExists" operation.</returns>
+        public SetValueBuilder IfNotExists(DynamoDBEntry setValue)
+        {
+            var rightOperand = new ValueBuilder(setValue);
+            return SetValueBuilder.IfNotExists(this, rightOperand);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Builds the expression node for the current attribute name.
+        /// </summary>
+        /// <returns>An <see cref="ExpressionNode"/> representing the attribute name in the expression.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the attribute name is invalid or unset.</exception>
+        internal override ExpressionNode Build()
+        {
+            if (_names==null || !_names.Any())
+                throw new InvalidOperationException($"Unset name parameter");
+
+            var node = new ExpressionNode
+            {
+                Names = new Stack<string>()
+            };
+
+            var fmtNames = new List<string>(_names.Count());
+
+            foreach (var originalWord in _names)
+            {
+                if (string.IsNullOrEmpty(originalWord))
+                    throw new InvalidOperationException("Invalid parameter Name");
+
+                var word = originalWord;
+                var substr = string.Empty;
+
+                // Ensure brackets are matched and contain only digits
+                var bracketPattern = new Regex(@"\[(\d+)\]");
+                var bracketMatches = bracketPattern.Matches(word);
+
+                if (word.Count(c => c == '[') != word.Count(c => c == ']'))
+                    throw new InvalidOperationException("Invalid parameter Name");
+
+                foreach (Match match in bracketMatches)
+                {
+                    if (!match.Success || match.Groups[1].Length == 0)
+                        throw new InvalidOperationException("Invalid parameter Name");
+                }
+
+                // Extract suffix like [0][1] if present
+                if (word.EndsWith("]"))
+                {
+                    for (int j = 0; j < word.Length; j++)
+                    {
+                        if (word[j] == '[')
+                        {
+                            substr = word.Substring(j);
+                            word = word.Substring(0, j);
+                            break;
+                        }
+                    }
+                }
+
+                if (string.IsNullOrEmpty(word))
+                    throw new InvalidOperationException("Invalid parameter Name");
+
+                node.Names.Push(word);
+                fmtNames.Add($"$n{substr}");
+            }
+
+            node.FormatedExpression = string.Join(".", fmtNames);
+
+            return node;
+        }
+
+    }
+
+    /// <summary>
+    /// ValueBuilder is used to build attribute values for expressions.
+    /// </summary>
+    public class ValueBuilder : OperandBuilder
+    {
+        private DynamoDBEntry _value;
+
+        /// <summary>
+        /// Default constructor for ValueBuilder.
+        /// </summary>
+        /// <param name="value"></param>
+        public ValueBuilder(DynamoDBEntry value)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// Creates a "Plus" operation which adds the specified value to the current value.
+        /// </summary>
+        /// <param name="rightOperand"></param>
+        /// <returns></returns>
+        public SetValueBuilder Plus(OperandBuilder rightOperand)
+        {
+            return SetValueBuilder.Plus(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a "Plus" operation which adds the specified value to the current value.
+        /// </summary>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public SetValueBuilder Plus(DynamoDBEntry right)
+        {
+            var rightOperand = new ValueBuilder(right);
+            return SetValueBuilder.Plus(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a "Minus" operation which subtracts the specified value from the current value. 
+        /// </summary>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public SetValueBuilder Minus(DynamoDBEntry right)
+        {
+            var rightOperand=new ValueBuilder(right);
+            return SetValueBuilder.Minus(this, rightOperand);
+        }
+
+        /// <summary>
+        /// Creates a "Minus" operation which subtracts the specified value from the current value. 
+        /// </summary>
+        /// <param name="rightOperand"></param>
+        /// <returns></returns>
+        public SetValueBuilder Minus(OperandBuilder rightOperand)
+        {
+            return SetValueBuilder.Minus(this, rightOperand);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public SetValueBuilder ListAppend(DynamoDBEntry right)
+        {
+            var rightOperand=new ValueBuilder(right);
+            return SetValueBuilder.ListAppend(this, rightOperand);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="rightOperand"></param>
+        /// <returns></returns>
+        public SetValueBuilder ListAppend(OperandBuilder rightOperand)
+        {
+            return SetValueBuilder.ListAppend(this, rightOperand);
+        }
+
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns></returns>
+        internal override ExpressionNode Build()
+        {
+            var values = new Stack<DynamoDBEntry>();
+            values.Push(_value);
+            return new ExpressionNode
+            {
+                Values = values,
+                FormatedExpression = "$v"
+            };
+        }
+    }
+
+
+    /// <summary>
+    /// Abstract base class for building operands used in DynamoDB expressions.
+    /// Operands represent attribute names or values in an expression.
+    /// </summary>
+    public abstract class OperandBuilder
+    {
+        /// <summary>
+        /// Builds the operand into an <see cref="ExpressionNode"/> for use in an expression.
+        /// </summary>
+        /// <returns>An <see cref="ExpressionNode"/> representing the operand.</returns>
+        internal abstract ExpressionNode Build();
+    }
+
+    /// <summary>
+    /// Constants used for properties of type DynamoDB AttributeType.
+    /// </summary>
+    public class DynamoDBAttributeType : ConstantClass
+    {
+        /// <summary>
+        /// Constant S for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType S = new("S");
+
+        /// <summary>
+        /// Constant SS for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType SS = new("SS");
+
+        /// <summary>
+        /// Constant N for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType N = new("N");
+
+        /// <summary>
+        /// Constant NS for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType NS = new("NS");
+
+        /// <summary>
+        /// Constant B for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType B = new("B");
+
+        /// <summary>
+        /// Constant BS for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType BS = new("BS");
+
+        /// <summary>
+        /// Constant BOOL for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType BOOL = new("BOOL");
+
+        /// <summary>
+        /// Constant NULL for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType NULL = new("NULL");
+
+        /// <summary>
+        /// Constant L for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType L = new("L");
+
+        /// <summary>
+        /// Constant M for DynamoDBAttributeType
+        /// </summary>
+        public static readonly DynamoDBAttributeType M = new("M");
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="value"></param>
+        protected DynamoDBAttributeType(string value)
+            : base(value)
+        {
+        }
+
+        /// <summary>
+        /// Finds the constant for the unique value.
+        /// </summary>
+        /// <param name="value">The unique value for the constant</param>
+        /// <returns>The constant for the unique value</returns>
+        public static DynamoDBAttributeType FindValue(string value)
+        {
+            return FindValue<DynamoDBAttributeType>(value);
+        }
+
+        /// <summary>
+        /// Utility method to convert strings to the constant class.
+        /// </summary>
+        /// <param name="value">The string value to convert to the constant class.</param>
+        /// <returns></returns>
+        public static implicit operator DynamoDBAttributeType(string value)
+        {
+            return FindValue(value);
+        }
+    }
+
+    /// <summary>
+    /// Enumeration of condition modes used in DynamoDB expressions.
+    /// Defines comparison, logical, and function-based conditions.
+    /// </summary>
+    internal enum ConditionMode
+    {
+        // Catches errors for unset ConditionBuilder structs
+        Unset = 0,
+
+        // Comparison Conditions
+        Equal,
+        NotEqual,
+        LessThan,
+        LessThanOrEqual,
+        GreaterThan,
+        GreaterThanOrEqual,
+
+        // Logical Conditions
+        And,
+        Or,
+        Not,
+        Parentheses,
+
+        // Function-based Conditions
+        Between,
+        In,
+        AttributeExists,
+        AttributeNotExists,
+        AttributeType,
+        BeginsWith,
+        Contains
+    }
+
+    internal enum OperationMode
+    {
+        Unset = 0,
+        Set,
+        Remove,
+        Add,
+        Delete
+    }
+
+    /// <summary>
+    /// Abstract base class for building operands used in DynamoDB expressions.
+    /// Operands represent attribute names or values in an expression.
+    /// </summary>
+    internal class OperationBuilder
+    {
+        /// <summary>
+        /// Builds the operand into an <see cref="ExpressionNode"/> for use in an expression.
+        /// </summary>
+        /// <returns>An <see cref="ExpressionNode"/> representing the operand.</returns>
+        internal ExpressionNode Build()
+        {
+            var pathChild = Name.Build();
+
+            var node = new ExpressionNode
+            {
+                Children = new Queue<ExpressionNode>(),
+                FormatedExpression = "$c"
+            };
+
+            node.Children.Enqueue(pathChild);
+
+            if (Mode == OperationMode.Remove)
+            {
+                return node;
+            }
+
+            var valueChild = Value.Build();
+
+            node.Children.Enqueue(valueChild);
+
+            node.FormatedExpression += Mode switch
+            {
+                OperationMode.Set => " = $c",
+                OperationMode.Add or OperationMode.Delete => " $c",
+                _ => throw new InvalidOperationException(
+                    $"Update expression construction failed: unsupported update operation mode: {Mode}")
+            };
+
+            return node;
+        }
+
+        internal OperandBuilder Value { get; set; }
+        internal NameBuilder Name { get; set; }
+        internal OperationMode Mode { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mode"></param>
+        internal OperationBuilder(OperationMode mode)
+        {
+            Mode = mode;
+        }
+    }
+
+    /// <summary>
+    /// Class for building set value expressions used in DynamoDB.
+    /// </summary>
+    public class SetValueBuilder: OperandBuilder
+    {
+        private OperandBuilder _leftOperand;
+        private OperandBuilder _rightOperand;
+        private SetValueMode _mode;
+
+        private SetValueBuilder()
+        {
+            _mode = SetValueMode.Unset;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public static SetValueBuilder New()
+        {
+            return new SetValueBuilder();
+        }
+
+        /// <summary>
+        /// Adds an attribute name to the condition.
+        /// </summary>
+        /// <param name="path">The attribute name or path.</param>
+        /// <returns>A <see cref="NameBuilder"/> for further configuration.</returns>
+        public NameBuilder WithName(string path)
+        {
+            return new NameBuilder(path);
+        }
+
+        /// <summary>
+        /// Creates a new ValueBuilder with the specified value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ValueBuilder WithValue(DynamoDBEntry value)
+        {
+            return new ValueBuilder(value);
+        }
+
+        internal static SetValueBuilder Plus(OperandBuilder left, OperandBuilder right)
+        {
+            return new SetValueBuilder()
+            {
+                _leftOperand = left,
+                _rightOperand = right,
+                _mode = SetValueMode.Plus
+            };
+        }
+        internal static SetValueBuilder Minus(OperandBuilder left, OperandBuilder right)
+        {
+            return new SetValueBuilder()
+            {
+                _leftOperand = left,
+                _rightOperand = right,
+                _mode = SetValueMode.Minus
+            };
+        }
+
+        internal static SetValueBuilder ListAppend(OperandBuilder left, OperandBuilder right)
+        {
+            return new SetValueBuilder()
+            {
+                _leftOperand = left,
+                _rightOperand = right,
+                _mode = SetValueMode.ListAppend
+            };
+        }
+
+        internal static SetValueBuilder IfNotExists(OperandBuilder nameBuilder, OperandBuilder setValue)
+        {
+            return new SetValueBuilder()
+            {
+                _leftOperand = nameBuilder,
+                _rightOperand = setValue,
+                _mode = SetValueMode.IfNotExists
+            };
+        }
+
+        internal override ExpressionNode Build()
+        {
+            if (_mode == SetValueMode.Unset)
+            {
+                throw new ArgumentException("Cannot build operand: SetValueBuilder is in UnsetValue mode.");
+            }
+
+            var left  = _leftOperand.Build();
+
+            var right = _rightOperand.Build();
+
+            var node = new ExpressionNode() 
+            {
+                Children = new Queue<ExpressionNode>()
+            };
+            node.Children.Enqueue(left);
+            node.Children.Enqueue(right);
+
+            node.FormatedExpression = _mode switch
+            {
+                SetValueMode.Plus => "$c + $c",
+                SetValueMode.Minus => "$c - $c",
+                SetValueMode.ListAppend=> "list_append($c, $c)",
+                SetValueMode.IfNotExists => "if_not_exists($c, $c)",
+                _ => throw new InvalidOperationException($"Unsupported SetValueMode: '{_mode}'.")
+            };
+
+            return node;
+        }
+    }
+
+    internal enum SetValueMode
+    {
+        Unset = 0,
+        Plus = 1,
+        Minus = 2,
+        ListAppend = 3,
+        IfNotExists = 4,
+    }
+    /// <summary>
+    /// Represents a node in an expression tree.    
+    /// Used to construct the final expression string and manage attribute names and values.
+    /// </summary>
+    internal class ExpressionNode
+    {
+        /// <summary>
+        /// Stack of attribute names used in the expression.
+        /// </summary>
+        public Stack<string> Names { get; set; } = new();
+
+        /// <summary>
+        /// Stack of attribute values used in the expression.
+        /// </summary>
+        public Stack<DynamoDBEntry> Values { get; set; } = new();
+
+        /// <summary>
+        /// The formatted expression string for this node.
+        /// </summary>
+        public string FormatedExpression { get; set; }
+
+        /// <summary>
+        /// Stack of child nodes representing sub-expressions.
+        /// </summary>
+        public Queue<ExpressionNode> Children { get; set; } = new();
+
+        /// <summary>
+        /// Builds the final expression string for this node, including attribute aliases.
+        /// </summary>
+        /// <param name="aliasList">A list of attribute aliases for names and values.</param>
+        /// <returns>The constructed expression string.</returns>
+        internal string BuildExpressionString(KeyAttributeAliasList aliasList)
+        {
+            var result = new StringBuilder();
+            int i = 0;
+
+            while (i < FormatedExpression.Length)
+            {
+                if (FormatedExpression[i] == '$' && i + 1 < FormatedExpression.Length)
+                {
+                    var next = FormatedExpression[i + 1];
+                    switch (next)
+                    {
+                        case 'n':
+                            {
+                                if (Names.Count == 0)
+                                    throw new InvalidOperationException("Missing name for $n");
+
+                                string name = Names.Pop();
+                                string alias = $"#{aliasList.NamesList.Count}";
+                                aliasList.NamesList.Add(name);
+                                result.Append(alias);
+                                break;
+                            }
+                        case 'v':
+                            {
+                                if (Values.Count == 0)
+                                    throw new InvalidOperationException("Missing value for $v");
+
+                                var val = Values.Pop();
+                                string alias = $":{aliasList.ValuesList.Count}";
+                                aliasList.ValuesList.Add(val);
+                                result.Append(alias);
+                                break;
+                            }
+                        case 'c':
+                            {
+                                if (Children.Count == 0)
+                                    throw new InvalidOperationException("Missing child for $c");
+
+                                var child = Children.Dequeue();
+                                string subExpr = child.BuildExpressionString(aliasList);
+                                result.Append(subExpr);
+                                break;
+                            }
+                        default:
+                            result.Append(FormatedExpression[i]); // not a known placeholder
+                            break;
+                    }
+                    i += 2; // skip the placeholder
+                }
+                else
+                {
+                    result.Append(FormatedExpression[i]);
+                    i++;
+                }
+            }
+
+            return result.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Represents a list of attribute aliases for names and values used in DynamoDB expressions.
+    /// </summary>
+    internal class KeyAttributeAliasList
+    {
+        /// <summary>
+        /// List of attribute names aliases used in the expression.
+        /// </summary>
+        public List<string> NamesList { get; set; } = new();
+
+        /// <summary>
+        /// List of attribute values aliases used in the expression.
+        /// </summary>
+        public List<DynamoDBEntry> ValuesList { get; set; } = new();
+    }
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
@@ -239,28 +239,28 @@ namespace Amazon.DynamoDBv2.DocumentModel
             {
                 var childNode = BuildChildNodes(setOps);
                 resultNode.Children.Enqueue(childNode);
-                resultNode.FormatedExpression += $"{OperationModeSet} $c\n";
+                resultNode.FormatedExpression += $"{OperationModeSet} #c\n";
             }
 
             if (OperationBuilders.TryGetValue(OperationModeRemove, out var removeOps))
             {
                 var childNode = BuildChildNodes(removeOps);
                 resultNode.Children.Enqueue(childNode);
-                resultNode.FormatedExpression += $"{OperationModeRemove} $c\n";
+                resultNode.FormatedExpression += $"{OperationModeRemove} #c\n";
             }
 
             if (OperationBuilders.TryGetValue(OperationModeAdd, out var addOps))
             {
                 var childNode = BuildChildNodes(addOps);
                 resultNode.Children.Enqueue(childNode);
-                resultNode.FormatedExpression += $"{OperationModeAdd} $c\n";
+                resultNode.FormatedExpression += $"{OperationModeAdd} #c\n";
             }
 
             if (OperationBuilders.TryGetValue(OperationModeDelete, out var deleteOps))
             {
                 var childNode = BuildChildNodes(deleteOps);
                 resultNode.Children.Enqueue(childNode);
-                resultNode.FormatedExpression += $"{OperationModeDelete} $c\n";
+                resultNode.FormatedExpression += $"{OperationModeDelete} #c\n";
             }
 
             if (resultNode.Children.Count == 0)
@@ -288,7 +288,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 var expr = builder.Build();
 
                 node.Children.Enqueue(expr);
-                node.FormatedExpression += "$c, ";
+                node.FormatedExpression += "#c, ";
             }
 
             // Remove trailing comma and space, if any
@@ -646,7 +646,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         private ExpressionNode NotBuildCondition(ExpressionNode node)
         {
-            node.FormatedExpression = "NOT ($c)";
+            node.FormatedExpression = "NOT (#c)";
             return node;
         }
 
@@ -660,7 +660,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                     $"Unsupported condition operator: {conditionBuilder._conditionMode}")
             };
             node.FormatedExpression = string.Join($" {mode} ",
-                node.Children.Select(c => "($c)"));
+                node.Children.Select(c => "(#c)"));
             return node;
         }
 
@@ -670,27 +670,27 @@ namespace Amazon.DynamoDBv2.DocumentModel
             {
                 case ConditionMode.Equal:
                     node.FormatedExpression =
-                        $"$c = $c";
+                        $"#c = #c";
                     break;
                 case ConditionMode.NotEqual:
                     node.FormatedExpression =
-                        $"$c <> $c";
+                        $"#c <> #c";
                     break;
                 case ConditionMode.LessThan:
                     node.FormatedExpression =
-                        $"$c < $c";
+                        $"#c < #c";
                     break;
                 case ConditionMode.LessThanOrEqual:
                     node.FormatedExpression =
-                        $"$c <= $c";
+                        $"#c <= #c";
                     break;
                 case ConditionMode.GreaterThan:
                     node.FormatedExpression =
-                        $"$c > $c";
+                        $"#c > #c";
                     break;
                 case ConditionMode.GreaterThanOrEqual:
                     node.FormatedExpression =
-                        $"$c >= $c";
+                        $"#c >= #c";
                     break;
                 default:
                     throw new InvalidOperationException($"Unsupported mode: {conditionMode}");
@@ -701,40 +701,40 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         private ExpressionNode ContainsBuildCondition(ExpressionNode node)
         {
-            node.FormatedExpression = "contains ($c, $c)";
+            node.FormatedExpression = "contains (#c, #c)";
             return node;
         }
 
         private ExpressionNode BeginsWithBuildCondition(ExpressionNode node)
         {
-            node.FormatedExpression = "begins_with ($c, $c)";
+            node.FormatedExpression = "begins_with (#c, #c)";
             return node;
         }
 
         private ExpressionNode AttributeTypeBuildCondition(ExpressionNode node)
         {
-            node.FormatedExpression = "attribute_type ($c, $c)";
+            node.FormatedExpression = "attribute_type (#c, #c)";
             return node;
         }
 
         private ExpressionNode AttributeNotExistsBuildCondition(ExpressionNode node)
         {
-            node.FormatedExpression = "attribute_not_exists ($c)";
+            node.FormatedExpression = "attribute_not_exists (#c)";
             return node;
         }
 
         private ExpressionNode AttributeExistsBuildCondition(ExpressionNode node)
         {
-            node.FormatedExpression = "attribute_exists ($c)";
+            node.FormatedExpression = "attribute_exists (#c)";
             return node;
         }
 
         private ExpressionNode InBuildCondition(ConditionExpressionBuilder conditionBuilder, ExpressionNode node)
         {
-            node.FormatedExpression = "$c IN (";
+            node.FormatedExpression = "#c IN (";
 
             for(int i = 1; i < node.Children.Count; i++){
-                node.FormatedExpression += "$c, ";
+                node.FormatedExpression += "#c, ";
             }
             // Remove trailing comma and space, if any
             if (node.FormatedExpression.EndsWith(", "))
@@ -747,7 +747,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         private ExpressionNode BetweenBuildCondition(ExpressionNode node)
         {
-            node.FormatedExpression = "$c BETWEEN $c AND $c";
+            node.FormatedExpression = "#c BETWEEN #c AND #c";
             return node;
         }
 
@@ -1060,7 +1060,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                     throw new InvalidOperationException("Invalid parameter Name");
 
                 node.Names.Enqueue(word);
-                fmtNames.Add($"$n{substr}");
+                fmtNames.Add($"#n{substr}");
             }
 
             node.FormatedExpression = string.Join(".", fmtNames);
@@ -1184,7 +1184,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
             return new ExpressionNode
             {
                 Values = values,
-                FormatedExpression = "$v"
+                FormatedExpression = "#v"
             };
         }
     }
@@ -1346,7 +1346,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
             var node = new ExpressionNode
             {
                 Children = new Queue<ExpressionNode>(),
-                FormatedExpression = "$c"
+                FormatedExpression = "#c"
             };
 
             node.Children.Enqueue(pathChild);
@@ -1362,8 +1362,8 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
             node.FormatedExpression += Mode switch
             {
-                OperationMode.Set => " = $c",
-                OperationMode.Add or OperationMode.Delete => " $c",
+                OperationMode.Set => " = #c",
+                OperationMode.Add or OperationMode.Delete => " #c",
                 _ => throw new InvalidOperationException(
                     $"Update expression construction failed: unsupported update operation mode: {Mode}")
             };
@@ -1487,10 +1487,10 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
             node.FormatedExpression = _mode switch
             {
-                SetValueMode.Plus => "$c + $c",
-                SetValueMode.Minus => "$c - $c",
-                SetValueMode.ListAppend=> "list_append($c, $c)",
-                SetValueMode.IfNotExists => "if_not_exists($c, $c)",
+                SetValueMode.Plus => "#c + #c",
+                SetValueMode.Minus => "#c - #c",
+                SetValueMode.ListAppend=> "list_append(#c, #c)",
+                SetValueMode.IfNotExists => "if_not_exists(#c, #c)",
                 _ => throw new InvalidOperationException($"Unsupported SetValueMode: '{_mode}'.")
             };
 
@@ -1545,7 +1545,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
             while (i < FormatedExpression.Length)
             {
-                if (FormatedExpression[i] == '$' && i + 1 < FormatedExpression.Length)
+                if (FormatedExpression[i] == '#' && i + 1 < FormatedExpression.Length)
                 {
                     var next = FormatedExpression[i + 1];
                     switch (next)
@@ -1553,7 +1553,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                         case 'n':
                             {
                                 if (Names.Count == 0)
-                                    throw new InvalidOperationException("Missing name for $n");
+                                    throw new InvalidOperationException("Missing name for #n");
 
                                 string name = Names.Dequeue();
                                 string alias = $"#{expressionType}{aliasList.NamesList.Count}";
@@ -1564,7 +1564,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                         case 'v':
                             {
                                 if (Values.Count == 0)
-                                    throw new InvalidOperationException("Missing value for $v");
+                                    throw new InvalidOperationException("Missing value for #v");
 
                                 var val = Values.Dequeue();
                                 string alias = $":{expressionType}{aliasList.ValuesList.Count}";
@@ -1575,7 +1575,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                         case 'c':
                             {
                                 if (Children.Count == 0)
-                                    throw new InvalidOperationException("Missing child for $c");
+                                    throw new InvalidOperationException("Missing child for #c");
 
                                 var child = Children.Dequeue();
                                 string subExpr = child.BuildExpressionString(aliasList, expressionType);

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/ExpressionBuilder.cs
@@ -478,7 +478,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
             return condition;
         }
 
-        internal static ConditionExpressionBuilder LesThan(OperandBuilder left, OperandBuilder right)
+        internal static ConditionExpressionBuilder LessThan(OperandBuilder left, OperandBuilder right)
         {
             var condition = new ConditionExpressionBuilder(new List<OperandBuilder> { left, right }, ConditionMode.LessThan);
             return condition;
@@ -831,7 +831,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
         public ConditionExpressionBuilder LessThan(DynamoDBEntry right)
         {
             var rightOperand = new ValueBuilder(right);
-            return ConditionExpressionBuilder.LesThan(this, rightOperand);
+            return ConditionExpressionBuilder.LessThan(this, rightOperand);
         }
 
         /// <summary>
@@ -1007,7 +1007,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
             var node = new ExpressionNode
             {
-                Names = new Stack<string>()
+                Names = new Queue<string>()
             };
 
             var fmtNames = new List<string>(_names.Count());
@@ -1050,7 +1050,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 if (string.IsNullOrEmpty(word))
                     throw new InvalidOperationException("Invalid parameter Name");
 
-                node.Names.Push(word);
+                node.Names.Enqueue(word);
                 fmtNames.Add($"$n{substr}");
             }
 
@@ -1088,10 +1088,10 @@ namespace Amazon.DynamoDBv2.DocumentModel
         }
 
         /// <summary>
-        /// Creates a "Plus" operation which adds the specified value to the current value.
+        /// Creates a "Plus" operation which adds the specified operand to the current value.
         /// </summary>
-        /// <param name="rightOperand"></param>
-        /// <returns></returns>
+        /// <param name="rightOperand">The <see cref="OperandBuilder"/> representing the operand to add.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "Plus" operation.</returns>
         public SetValueBuilder Plus(OperandBuilder rightOperand)
         {
             return SetValueBuilder.Plus(this, rightOperand);
@@ -1100,8 +1100,8 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <summary>
         /// Creates a "Plus" operation which adds the specified value to the current value.
         /// </summary>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <param name="right">The <see cref="DynamoDBEntry"/> representing the value to add.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "Plus" operation.</returns>
         public SetValueBuilder Plus(DynamoDBEntry right)
         {
             var rightOperand = new ValueBuilder(right);
@@ -1109,10 +1109,10 @@ namespace Amazon.DynamoDBv2.DocumentModel
         }
 
         /// <summary>
-        /// Creates a "Minus" operation which subtracts the specified value from the current value. 
+        /// Creates a "Minus" operation which subtracts the specified value from the current value.
         /// </summary>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <param name="right">The <see cref="DynamoDBEntry"/> representing the value to subtract.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "Minus" operation.</returns>
         public SetValueBuilder Minus(DynamoDBEntry right)
         {
             var rightOperand=new ValueBuilder(right);
@@ -1120,20 +1120,24 @@ namespace Amazon.DynamoDBv2.DocumentModel
         }
 
         /// <summary>
-        /// Creates a "Minus" operation which subtracts the specified value from the current value. 
+        /// Creates a "Minus" operation which subtracts the specified operand from the current value.
         /// </summary>
-        /// <param name="rightOperand"></param>
-        /// <returns></returns>
+        /// <param name="rightOperand">The <see cref="OperandBuilder"/> representing the operand to subtract.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "Minus" operation.</returns>
         public SetValueBuilder Minus(OperandBuilder rightOperand)
         {
             return SetValueBuilder.Minus(this, rightOperand);
         }
 
         /// <summary>
-        /// 
+        /// Creates a "ListAppend" operation for the current value, which appends the specified DynamoDB entry to a list attribute.
         /// </summary>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <param name="right">The <see cref="DynamoDBEntry"/> to append to the list attribute.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "ListAppend" operation.</returns>
+        /// <remarks>
+        /// This operation is used to append a value to an existing list attribute in DynamoDB.
+        /// If the attribute does not exist, it will be created as a list with the specified value.
+        /// </remarks>
         public SetValueBuilder ListAppend(DynamoDBEntry right)
         {
             var rightOperand=new ValueBuilder(right);
@@ -1141,10 +1145,14 @@ namespace Amazon.DynamoDBv2.DocumentModel
         }
 
         /// <summary>
-        /// 
+        /// Creates a "ListAppend" operation for the current value, which appends the specified operand to a list attribute.
         /// </summary>
-        /// <param name="rightOperand"></param>
-        /// <returns></returns>
+        /// <param name="rightOperand">The <see cref="OperandBuilder"/> representing the operand to append to the list attribute.</param>
+        /// <returns>A <see cref="SetValueBuilder"/> representing the "ListAppend" operation.</returns>
+        /// <remarks>
+        /// This operation is used to append an operand to an existing list attribute in DynamoDB.
+        /// If the attribute does not exist, it will be created as a list with the specified operand.
+        /// </remarks>
         public SetValueBuilder ListAppend(OperandBuilder rightOperand)
         {
             return SetValueBuilder.ListAppend(this, rightOperand);
@@ -1152,13 +1160,18 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
 
         /// <summary>
-        ///
+        /// Builds the current value into an <see cref="ExpressionNode"/> for use in a DynamoDB expression.
         /// </summary>
-        /// <returns></returns>
-        internal override ExpressionNode Build()
+        /// <returns>An <see cref="ExpressionNode"/> representing the current value in the expression.</returns>
+        /// <remarks>
+        /// This method converts the internal value of the `ValueBuilder` into an expression node
+        /// that can be used in DynamoDB operations. The resulting node includes the value and its
+        /// formatted representation for inclusion in the final expression.
+        /// </remarks>
+         internal override ExpressionNode Build()
         {
-            var values = new Stack<DynamoDBEntry>();
-            values.Push(_value);
+            var values = new Queue<DynamoDBEntry>();
+            values.Enqueue(_value);
             return new ExpressionNode
             {
                 Values = values,
@@ -1493,12 +1506,12 @@ namespace Amazon.DynamoDBv2.DocumentModel
         /// <summary>
         /// Stack of attribute names used in the expression.
         /// </summary>
-        public Stack<string> Names { get; set; } = new();
+        public Queue<string> Names { get; set; } = new();
 
         /// <summary>
         /// Stack of attribute values used in the expression.
         /// </summary>
-        public Stack<DynamoDBEntry> Values { get; set; } = new();
+        public Queue<DynamoDBEntry> Values { get; set; } = new();
 
         /// <summary>
         /// The formatted expression string for this node.
@@ -1533,7 +1546,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                                 if (Names.Count == 0)
                                     throw new InvalidOperationException("Missing name for $n");
 
-                                string name = Names.Pop();
+                                string name = Names.Dequeue();
                                 string alias = $"#{expressionType}{aliasList.NamesList.Count}";
                                 aliasList.NamesList.Add(name);
                                 result.Append(alias);
@@ -1544,7 +1557,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
                                 if (Values.Count == 0)
                                     throw new InvalidOperationException("Missing value for $v");
 
-                                var val = Values.Pop();
+                                var val = Values.Dequeue();
                                 string alias = $":{expressionType}{aliasList.ValuesList.Count}";
                                 aliasList.ValuesList.Add(val);
                                 result.Append(alias);

--- a/sdk/test/Services/DynamoDBv2/UnitTests/AWSSDK.UnitTests.DynamoDBv2.NetFramework.csproj
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/AWSSDK.UnitTests.DynamoDBv2.NetFramework.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
    <RunAnalyzersDuringBuild Condition="'$(RunAnalyzersDuringBuild)'==''">true</RunAnalyzersDuringBuild>
     <TargetFramework>net472</TargetFramework>
@@ -34,6 +34,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
+	
   <ItemGroup>
     <Compile Remove="**/obj/**"/>
     <None Remove="**/obj/**" />

--- a/sdk/test/Services/DynamoDBv2/UnitTests/AWSSDK.UnitTests.DynamoDBv2.NetFramework.csproj
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/AWSSDK.UnitTests.DynamoDBv2.NetFramework.csproj
@@ -34,7 +34,6 @@
   <PropertyGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
-	
   <ItemGroup>
     <Compile Remove="**/obj/**"/>
     <None Remove="**/obj/**" />

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ExpressionBuilderTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ExpressionBuilderTests.cs
@@ -47,7 +47,7 @@ namespace AWSSDK_DotNet.UnitTests
         public void BuildForAddOperation_ShouldReturnExpression()
         {
             var builder = UpdateExpressionBuilder.New();
-            builder.Add(NameBuilder.New("test"), new ValueBuilder(10));
+            builder.Add(NameBuilder.New("Garbage"), ValueBuilder.New("asdf"));
 
             var expressionTree = builder.Build();
 
@@ -60,7 +60,7 @@ namespace AWSSDK_DotNet.UnitTests
         public void BuildForDeleteOperation_ShouldReturnExpression()
         {
             var builder = UpdateExpressionBuilder.New();
-            builder.Delete(NameBuilder.New("test"), new ValueBuilder(10));
+            builder.Delete(NameBuilder.New("test"), ValueBuilder.New(10));
 
             var expressionTree = builder.Build();
 
@@ -75,7 +75,6 @@ namespace AWSSDK_DotNet.UnitTests
         {
             var builder = UpdateExpressionBuilder.New();
             builder.Remove(NameBuilder.New(""));
-
             builder.Build();
         }
 
@@ -89,6 +88,7 @@ namespace AWSSDK_DotNet.UnitTests
                 Set(NameBuilder.New("test2"),
                     SetValueBuilder.New().WithValue(20).Minus(30)).
                 Build();
+
             Assert.AreEqual("SET #0 = :0 + :1, #1 = :2 - :3\n", updateExpression.ExpressionStatement);
             Assert.AreEqual(2, updateExpression.ExpressionAttributeNames.Count);
             Assert.AreEqual("test", updateExpression.ExpressionAttributeNames["#0"]);
@@ -105,6 +105,7 @@ namespace AWSSDK_DotNet.UnitTests
                     SetValueBuilder.New().WithValue(10).Plus(20)).
                 Remove(NameBuilder.New("test2")).
                 Build();
+
             Assert.AreEqual(updateExpression.ExpressionStatement, "SET #0 = :0 + :1\nREMOVE #1\n");
             Assert.AreEqual(2, updateExpression.ExpressionAttributeNames.Count);
             Assert.AreEqual(2, updateExpression.ExpressionAttributeValues.Count);
@@ -128,9 +129,8 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void NameBuilderConstructor_WhenCalled_CreatesValidInstance()
         {
-
             var nameBuilder = NameBuilder.New("test");
-            // Assert
+
             Assert.IsNotNull(nameBuilder);
             Assert.IsInstanceOfType(nameBuilder, typeof(OperandBuilder));
         }
@@ -139,11 +139,9 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void Complex_Attribute_Paths_Should_Build_Correctly()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("parent.child[0].attribute");
-
-            // Act & Assert
             var node = nameBuilder.AttributeExists().Build();
+
             Assert.AreEqual("attribute_exists (#0.#1[0].#2)", node.ExpressionStatement);
             Assert.AreEqual(0, node.ExpressionAttributeValues.Count);
             Assert.AreEqual(3, node.ExpressionAttributeNames.Count);
@@ -153,15 +151,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_WithSpecialCharacters_Should_Build_Correctly()
         {
-            // Arrange
-            string attributeName = "Test#Attribute-Name.123";
-
+            var attributeName = "Test#Attribute-Name.123";
             var nameBuilder = NameBuilder.New(attributeName);
 
-            // Act
             var result = nameBuilder.AttributeExists().Build();
 
-            // Assert
             Assert.IsNotNull(result);
             Assert.AreEqual("attribute_exists (#0.#1)", result.ExpressionStatement);
         }
@@ -170,14 +164,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_Equal_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
 
-            // Act
             var result = nameBuilder.Equal(10);
             var resultNode = result.Build();
 
-            // Assert
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("#0 = :0", resultNode.ExpressionStatement);
         }
@@ -186,14 +177,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_NotEqual_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
 
-            // Act
             var result = nameBuilder.NotEqual(10);
             var resultNode = result.Build();
 
-            // Assert
             Assert.IsNotNull(result);
             Assert.AreEqual("#0 <> :0", resultNode.ExpressionStatement);
         }
@@ -202,14 +190,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_GreaterThan_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
 
-            // Act
             var result = nameBuilder.GreaterThan(10);
             var resultNode = result.Build();
 
-            // Assert
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("#0 > :0", resultNode.ExpressionStatement);
         }
@@ -218,12 +203,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_GreaterThanOrEqual_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+
             var result = nameBuilder.GreaterThanOrEqual(10);
             var resultNode = result.Build();
-            // Assert
+
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("#0 >= :0", resultNode.ExpressionStatement);
         }
@@ -232,12 +216,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_LessThan_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+
             var result = nameBuilder.LessThan(10);
             var resultNode = result.Build();
-            // Assert
+
             Assert.IsNotNull(result);
             Assert.AreEqual("#0 < :0", resultNode.ExpressionStatement);
         }
@@ -246,12 +229,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_LessThanOrEqual_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+
             var result = nameBuilder.LessThanOrEqual(10);
             var resultNode = result.Build();
-            // Assert
+
             Assert.IsNotNull(result);
             Assert.AreEqual("#0 <= :0", resultNode.ExpressionStatement);
         }
@@ -260,14 +242,12 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_Between_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+
             var result = nameBuilder.Between(10, 20);
             var resultNode = result.Build();
-            // Assert
-            Assert.IsNotNull(result);
 
+            Assert.IsNotNull(result);
             Assert.AreEqual("#0 BETWEEN :0 AND :1", resultNode.ExpressionStatement);
         }
 
@@ -275,12 +255,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_In_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+
             var result = nameBuilder.In(10, 20, 30);
             var resultNode = result.Build();
-            // Assert
+
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("#0 IN (:0, :1, :2)", resultNode.ExpressionStatement);
         }
@@ -289,12 +268,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_BeginsWith_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+
             var result = nameBuilder.BeginsWith("test");
             var resultNode = result.Build();
-            // Assert
+
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("begins_with (#0, :0)", resultNode.ExpressionStatement);
         }
@@ -303,12 +281,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_Contains_WithValue_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+
             var result = nameBuilder.Contains("test");
             var resultNode = result.Build();
-            // Assert
+
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("contains (#0, :0)", resultNode.ExpressionStatement);
         }
@@ -317,12 +294,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_AttributeExists_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+            
             var result = nameBuilder.AttributeExists();
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("attribute_exists (#0)", resultNode.ExpressionStatement);
         }
@@ -331,12 +307,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_AttributeNotExists_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+            
             var result = nameBuilder.AttributeNotExists();
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("attribute_not_exists (#0)", resultNode.ExpressionStatement);
         }
@@ -345,12 +320,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void BuildNameBuilder_AttributeType_ReturnsCondition()
         {
-            // Arrange
             var nameBuilder = NameBuilder.New("TestAttribute");
-            // Act
+            
             var result = nameBuilder.AttributeType(DynamoDBAttributeType.B);
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("attribute_type (#0, :0)", resultNode.ExpressionStatement);
         }
@@ -359,12 +333,12 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void ConditionExpressionBuilder_And_ReturnsCondition()
         {
-            // Act
-            var result = ConditionExpressionBuilder.And(NameBuilder.New("Attribute1").Equal(10),
+            var result = ConditionExpressionBuilder.
+                And(NameBuilder.New("Attribute1").Equal(10),
                 NameBuilder.New("Attribute2").Equal(10));
 
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(result);
             Assert.AreEqual("(#0 = :0) AND (#1 = :1)", resultNode.ExpressionStatement);
         }
@@ -373,14 +347,14 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void ConditionExpressionBuilder_And_Multiple_ReturnsCondition()
         {
-            // Act
+            
             var result = ConditionExpressionBuilder.And(NameBuilder.New("Attribute1").Equal(10),
                 NameBuilder.New("Attribute2").Equal(10),
                 NameBuilder.New("Attribute3").Equal(10),
                 NameBuilder.New("Attribute4").Equal(10));
 
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("(#0 = :0) AND (#1 = :1) AND (#2 = :2) AND (#3 = :3)", resultNode.ExpressionStatement);
         }
@@ -389,12 +363,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void ConditionExpressionBuilder_Or_ReturnsCondition()
         {
-            // Act
             var result = ConditionExpressionBuilder.Or(NameBuilder.New("Attribute1").Equal(10),
                 NameBuilder.New("Attribute2").Equal(20));
 
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(result);
             Assert.AreEqual("(#0 = :0) OR (#1 = :1)", resultNode.ExpressionStatement);
         }
@@ -403,13 +376,13 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void ConditionExpressionBuilder_Or_Multiple_ReturnsCondition()
         {
-            // Act
             var result = ConditionExpressionBuilder.Or(NameBuilder.New("Attribute1").Equal(10),
                 NameBuilder.New("Attribute2").Equal(20),
                 NameBuilder.New("Attribute3").Equal(30),
                 NameBuilder.New("Attribute4").Equal(40));
+
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("(#0 = :0) OR (#1 = :1) OR (#2 = :2) OR (#3 = :3)", resultNode.ExpressionStatement);
         }
@@ -418,13 +391,13 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void ConditionExpressionBuilder_AndNestedOr_ReturnsCondition()
         {
-            // Act
-            var result = ConditionExpressionBuilder.And(NameBuilder.New("Attribute1").Equal(10),
+            var result = ConditionExpressionBuilder.
+                And(NameBuilder.New("Attribute1").Equal(10),
                 ConditionExpressionBuilder.Or(NameBuilder.New("Attribute2").Equal(20),
                     NameBuilder.New("Attribute3").Equal(30)));
 
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("(#0 = :0) AND ((#1 = :1) OR (#2 = :2))", resultNode.ExpressionStatement);
         }
@@ -433,13 +406,13 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void ConditionExpressionBuilder_AndOr_ReturnsCondition()
         {
-            // Act
-            var result = ConditionExpressionBuilder.And(NameBuilder.New("Attribute1").Equal(10),
+            var result = ConditionExpressionBuilder.
+                And(NameBuilder.New("Attribute1").Equal(10),
                 NameBuilder.New("Attribute2").Equal(20)).Or(
                     NameBuilder.New("Attribute3").Equal(30));
 
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("((#0 = :0) AND (#1 = :1)) OR (#2 = :2)", resultNode.ExpressionStatement);
         }
@@ -448,10 +421,11 @@ namespace AWSSDK_DotNet.UnitTests
         [TestCategory("DynamoDBv2")]
         public void ConditionExpressionBuilder_Not_ReturnsCondition()
         {
-            // Act
-            var result = ConditionExpressionBuilder.Not(NameBuilder.New("Attribute1").Equal(10));
+            var result = ConditionExpressionBuilder.
+                Not(NameBuilder.New("Attribute1").Equal(10));
+            
             var resultNode = result.Build();
-            // Assert
+            
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("NOT (#0 = :0)", resultNode.ExpressionStatement);
         }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ExpressionBuilderTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ExpressionBuilderTests.cs
@@ -89,10 +89,10 @@ namespace AWSSDK_DotNet.UnitTests
                     SetValueBuilder.New().WithValue(20).Minus(30)).
                 Build();
 
-            Assert.AreEqual("SET #0 = :0 + :1, #1 = :2 - :3\n", updateExpression.ExpressionStatement);
+            Assert.AreEqual("SET #U0 = :U0 + :U1, #U1 = :U2 - :U3\n", updateExpression.ExpressionStatement);
             Assert.AreEqual(2, updateExpression.ExpressionAttributeNames.Count);
-            Assert.AreEqual("test", updateExpression.ExpressionAttributeNames["#0"]);
-            Assert.AreEqual("test2", updateExpression.ExpressionAttributeNames["#1"]);
+            Assert.AreEqual("test", updateExpression.ExpressionAttributeNames["#U0"]);
+            Assert.AreEqual("test2", updateExpression.ExpressionAttributeNames["#U1"]);
             Assert.AreEqual(4, updateExpression.ExpressionAttributeValues.Count);
         }
 
@@ -106,7 +106,7 @@ namespace AWSSDK_DotNet.UnitTests
                 Remove(NameBuilder.New("test2")).
                 Build();
 
-            Assert.AreEqual(updateExpression.ExpressionStatement, "SET #0 = :0 + :1\nREMOVE #1\n");
+            Assert.AreEqual("SET #U0 = :U0 + :U1\nREMOVE #U1\n" ,updateExpression.ExpressionStatement);
             Assert.AreEqual(2, updateExpression.ExpressionAttributeNames.Count);
             Assert.AreEqual(2, updateExpression.ExpressionAttributeValues.Count);
         }
@@ -118,10 +118,10 @@ namespace AWSSDK_DotNet.UnitTests
             var conditionExpression = ConditionExpressionBuilder.New().WithName("Age").Equal(21).
                 And(ConditionExpressionBuilder.New().WithName("Status").GreaterThan(1)).Build();
 
-            Assert.AreEqual("(#0 = :0) AND (#1 > :1)", conditionExpression.ExpressionStatement);
+            Assert.AreEqual("(#C0 = :C0) AND (#C1 > :C1)", conditionExpression.ExpressionStatement);
             Assert.AreEqual(2, conditionExpression.ExpressionAttributeNames.Count);
-            Assert.AreEqual("Age", conditionExpression.ExpressionAttributeNames["#0"]);
-            Assert.AreEqual("Status", conditionExpression.ExpressionAttributeNames["#1"]);
+            Assert.AreEqual("Age", conditionExpression.ExpressionAttributeNames["#C0"]);
+            Assert.AreEqual("Status", conditionExpression.ExpressionAttributeNames["#C1"]);
             Assert.AreEqual(2, conditionExpression.ExpressionAttributeValues.Count);
         }
 
@@ -142,7 +142,7 @@ namespace AWSSDK_DotNet.UnitTests
             var nameBuilder = NameBuilder.New("parent.child[0].attribute");
             var node = nameBuilder.AttributeExists().Build();
 
-            Assert.AreEqual("attribute_exists (#0.#1[0].#2)", node.ExpressionStatement);
+            Assert.AreEqual("attribute_exists (#C0.#C1[0].#C2)", node.ExpressionStatement);
             Assert.AreEqual(0, node.ExpressionAttributeValues.Count);
             Assert.AreEqual(3, node.ExpressionAttributeNames.Count);
         }
@@ -157,7 +157,7 @@ namespace AWSSDK_DotNet.UnitTests
             var result = nameBuilder.AttributeExists().Build();
 
             Assert.IsNotNull(result);
-            Assert.AreEqual("attribute_exists (#0.#1)", result.ExpressionStatement);
+            Assert.AreEqual("attribute_exists (#C0.#C1)", result.ExpressionStatement);
         }
 
         [TestMethod]
@@ -170,7 +170,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("#0 = :0", resultNode.ExpressionStatement);
+            Assert.AreEqual("#C0 = :C0", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -183,7 +183,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(result);
-            Assert.AreEqual("#0 <> :0", resultNode.ExpressionStatement);
+            Assert.AreEqual("#C0 <> :C0", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -196,7 +196,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("#0 > :0", resultNode.ExpressionStatement);
+            Assert.AreEqual("#C0 > :C0", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -209,7 +209,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("#0 >= :0", resultNode.ExpressionStatement);
+            Assert.AreEqual("#C0 >= :C0", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -222,7 +222,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(result);
-            Assert.AreEqual("#0 < :0", resultNode.ExpressionStatement);
+            Assert.AreEqual("#C0 < :C0", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -235,7 +235,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(result);
-            Assert.AreEqual("#0 <= :0", resultNode.ExpressionStatement);
+            Assert.AreEqual("#C0 <= :C0", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -248,7 +248,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(result);
-            Assert.AreEqual("#0 BETWEEN :0 AND :1", resultNode.ExpressionStatement);
+            Assert.AreEqual("#C0 BETWEEN :C0 AND :C1", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -261,7 +261,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("#0 IN (:0, :1, :2)", resultNode.ExpressionStatement);
+            Assert.AreEqual("#C0 IN (:C0, :C1, :C2)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -274,7 +274,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("begins_with (#0, :0)", resultNode.ExpressionStatement);
+            Assert.AreEqual("begins_with (#C0, :C0)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -287,7 +287,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
 
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("contains (#0, :0)", resultNode.ExpressionStatement);
+            Assert.AreEqual("contains (#C0, :C0)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -300,7 +300,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("attribute_exists (#0)", resultNode.ExpressionStatement);
+            Assert.AreEqual("attribute_exists (#C0)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -313,7 +313,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("attribute_not_exists (#0)", resultNode.ExpressionStatement);
+            Assert.AreEqual("attribute_not_exists (#C0)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -326,7 +326,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("attribute_type (#0, :0)", resultNode.ExpressionStatement);
+            Assert.AreEqual("attribute_type (#C0, :C0)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -340,7 +340,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(result);
-            Assert.AreEqual("(#0 = :0) AND (#1 = :1)", resultNode.ExpressionStatement);
+            Assert.AreEqual("(#C0 = :C0) AND (#C1 = :C1)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -356,7 +356,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("(#0 = :0) AND (#1 = :1) AND (#2 = :2) AND (#3 = :3)", resultNode.ExpressionStatement);
+            Assert.AreEqual("(#C0 = :C0) AND (#C1 = :C1) AND (#C2 = :C2) AND (#C3 = :C3)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -369,7 +369,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(result);
-            Assert.AreEqual("(#0 = :0) OR (#1 = :1)", resultNode.ExpressionStatement);
+            Assert.AreEqual("(#C0 = :C0) OR (#C1 = :C1)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -384,7 +384,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("(#0 = :0) OR (#1 = :1) OR (#2 = :2) OR (#3 = :3)", resultNode.ExpressionStatement);
+            Assert.AreEqual("(#C0 = :C0) OR (#C1 = :C1) OR (#C2 = :C2) OR (#C3 = :C3)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -399,7 +399,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("(#0 = :0) AND ((#1 = :1) OR (#2 = :2))", resultNode.ExpressionStatement);
+            Assert.AreEqual("(#C0 = :C0) AND ((#C1 = :C1) OR (#C2 = :C2))", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -414,7 +414,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("((#0 = :0) AND (#1 = :1)) OR (#2 = :2)", resultNode.ExpressionStatement);
+            Assert.AreEqual("((#C0 = :C0) AND (#C1 = :C1)) OR (#C2 = :C2)", resultNode.ExpressionStatement);
         }
 
         [TestMethod]
@@ -427,7 +427,7 @@ namespace AWSSDK_DotNet.UnitTests
             var resultNode = result.Build();
             
             Assert.IsNotNull(resultNode);
-            Assert.AreEqual("NOT (#0 = :0)", resultNode.ExpressionStatement);
+            Assert.AreEqual("NOT (#C0 = :C0)", resultNode.ExpressionStatement);
         }
     }
 

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ExpressionBuilderTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ExpressionBuilderTests.cs
@@ -145,6 +145,10 @@ namespace AWSSDK_DotNet.UnitTests
             Assert.AreEqual("attribute_exists (#C0.#C1[0].#C2)", node.ExpressionStatement);
             Assert.AreEqual(0, node.ExpressionAttributeValues.Count);
             Assert.AreEqual(3, node.ExpressionAttributeNames.Count);
+            Assert.AreEqual("parent", node.ExpressionAttributeNames["#C0"]);
+            Assert.AreEqual("child", node.ExpressionAttributeNames["#C1"]);
+            Assert.AreEqual("attribute", node.ExpressionAttributeNames["#C2"]);
+
         }
 
         [TestMethod]
@@ -158,6 +162,9 @@ namespace AWSSDK_DotNet.UnitTests
 
             Assert.IsNotNull(result);
             Assert.AreEqual("attribute_exists (#C0.#C1)", result.ExpressionStatement);
+            Assert.AreEqual(2, result.ExpressionAttributeNames.Count);
+            Assert.AreEqual("Test#Attribute-Name", result.ExpressionAttributeNames["#C0"]);
+            Assert.AreEqual("123", result.ExpressionAttributeNames["#C1"]);
         }
 
         [TestMethod]
@@ -249,6 +256,11 @@ namespace AWSSDK_DotNet.UnitTests
 
             Assert.IsNotNull(result);
             Assert.AreEqual("#C0 BETWEEN :C0 AND :C1", resultNode.ExpressionStatement);
+            Assert.AreEqual(1, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual(2, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C0"]);
+            Assert.AreEqual(20, resultNode.ExpressionAttributeValues[":C1"]);
+            
         }
 
         [TestMethod]
@@ -262,6 +274,17 @@ namespace AWSSDK_DotNet.UnitTests
 
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("#C0 IN (:C0, :C1, :C2)", resultNode.ExpressionStatement);
+
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(1, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("TestAttribute", resultNode.ExpressionAttributeNames["#C0"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(3, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C0"]);
+            Assert.AreEqual(20, resultNode.ExpressionAttributeValues[":C1"]);
+            Assert.AreEqual(30, resultNode.ExpressionAttributeValues[":C2"]);
+
         }
 
         [TestMethod]
@@ -275,6 +298,14 @@ namespace AWSSDK_DotNet.UnitTests
 
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("begins_with (#C0, :C0)", resultNode.ExpressionStatement);
+
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(1, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("TestAttribute", resultNode.ExpressionAttributeNames["#C0"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(1, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual("test", resultNode.ExpressionAttributeValues[":C0"].AsString());
         }
 
         [TestMethod]
@@ -288,6 +319,14 @@ namespace AWSSDK_DotNet.UnitTests
 
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("contains (#C0, :C0)", resultNode.ExpressionStatement);
+
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(1, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("TestAttribute", resultNode.ExpressionAttributeNames["#C0"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(1, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual("test", resultNode.ExpressionAttributeValues[":C0"].AsString());
         }
 
         [TestMethod]
@@ -301,6 +340,12 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("attribute_exists (#C0)", resultNode.ExpressionStatement);
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(1, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("TestAttribute", resultNode.ExpressionAttributeNames["#C0"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(0, resultNode.ExpressionAttributeValues.Count);
         }
 
         [TestMethod]
@@ -314,6 +359,12 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("attribute_not_exists (#C0)", resultNode.ExpressionStatement);
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(1, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("TestAttribute", resultNode.ExpressionAttributeNames["#C0"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(0, resultNode.ExpressionAttributeValues.Count);
         }
 
         [TestMethod]
@@ -327,6 +378,13 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("attribute_type (#C0, :C0)", resultNode.ExpressionStatement);
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(1, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("TestAttribute", resultNode.ExpressionAttributeNames["#C0"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(1, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(DynamoDBAttributeType.B.Value, resultNode.ExpressionAttributeValues[":C0"].AsString());
         }
 
         [TestMethod]
@@ -341,6 +399,15 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(result);
             Assert.AreEqual("(#C0 = :C0) AND (#C1 = :C1)", resultNode.ExpressionStatement);
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(2, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("Attribute1", resultNode.ExpressionAttributeNames["#C0"]);
+            Assert.AreEqual("Attribute2", resultNode.ExpressionAttributeNames["#C1"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(2, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C0"]);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C1"]);
         }
 
         [TestMethod]
@@ -357,6 +424,20 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("(#C0 = :C0) AND (#C1 = :C1) AND (#C2 = :C2) AND (#C3 = :C3)", resultNode.ExpressionStatement);
+
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(4, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("Attribute1", resultNode.ExpressionAttributeNames["#C0"]);
+            Assert.AreEqual("Attribute2", resultNode.ExpressionAttributeNames["#C1"]);
+            Assert.AreEqual("Attribute3", resultNode.ExpressionAttributeNames["#C2"]);
+            Assert.AreEqual("Attribute4", resultNode.ExpressionAttributeNames["#C3"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(4, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C0"]);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C1"]);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C2"]);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C3"]);
         }
 
         [TestMethod]
@@ -370,6 +451,16 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(result);
             Assert.AreEqual("(#C0 = :C0) OR (#C1 = :C1)", resultNode.ExpressionStatement);
+
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(2, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("Attribute1", resultNode.ExpressionAttributeNames["#C0"]);
+            Assert.AreEqual("Attribute2", resultNode.ExpressionAttributeNames["#C1"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(2, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C0"]);
+            Assert.AreEqual(20, resultNode.ExpressionAttributeValues[":C1"]);
         }
 
         [TestMethod]
@@ -385,6 +476,20 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("(#C0 = :C0) OR (#C1 = :C1) OR (#C2 = :C2) OR (#C3 = :C3)", resultNode.ExpressionStatement);
+
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(4, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("Attribute1", resultNode.ExpressionAttributeNames["#C0"]);
+            Assert.AreEqual("Attribute2", resultNode.ExpressionAttributeNames["#C1"]);
+            Assert.AreEqual("Attribute3", resultNode.ExpressionAttributeNames["#C2"]);
+            Assert.AreEqual("Attribute4", resultNode.ExpressionAttributeNames["#C3"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(4, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C0"]);
+            Assert.AreEqual(20, resultNode.ExpressionAttributeValues[":C1"]);
+            Assert.AreEqual(30, resultNode.ExpressionAttributeValues[":C2"]);
+            Assert.AreEqual(40, resultNode.ExpressionAttributeValues[":C3"]);
         }
 
         [TestMethod]
@@ -400,6 +505,18 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("(#C0 = :C0) AND ((#C1 = :C1) OR (#C2 = :C2))", resultNode.ExpressionStatement);
+
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(3, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("Attribute1", resultNode.ExpressionAttributeNames["#C0"]);
+            Assert.AreEqual("Attribute2", resultNode.ExpressionAttributeNames["#C1"]);
+            Assert.AreEqual("Attribute3", resultNode.ExpressionAttributeNames["#C2"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(3, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C0"]);
+            Assert.AreEqual(20, resultNode.ExpressionAttributeValues[":C1"]);
+            Assert.AreEqual(30, resultNode.ExpressionAttributeValues[":C2"]);
         }
 
         [TestMethod]
@@ -415,6 +532,18 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("((#C0 = :C0) AND (#C1 = :C1)) OR (#C2 = :C2)", resultNode.ExpressionStatement);
+
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(3, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("Attribute1", resultNode.ExpressionAttributeNames["#C0"]);
+            Assert.AreEqual("Attribute2", resultNode.ExpressionAttributeNames["#C1"]);
+            Assert.AreEqual("Attribute3", resultNode.ExpressionAttributeNames["#C2"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(3, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C0"]);
+            Assert.AreEqual(20, resultNode.ExpressionAttributeValues[":C1"]);
+            Assert.AreEqual(30, resultNode.ExpressionAttributeValues[":C2"]);
         }
 
         [TestMethod]
@@ -428,6 +557,13 @@ namespace AWSSDK_DotNet.UnitTests
             
             Assert.IsNotNull(resultNode);
             Assert.AreEqual("NOT (#C0 = :C0)", resultNode.ExpressionStatement);
+            // Assert ExpressionAttributeNames
+            Assert.AreEqual(1, resultNode.ExpressionAttributeNames.Count);
+            Assert.AreEqual("Attribute1", resultNode.ExpressionAttributeNames["#C0"]);
+
+            // Assert ExpressionAttributeValues
+            Assert.AreEqual(1, resultNode.ExpressionAttributeValues.Count);
+            Assert.AreEqual(10, resultNode.ExpressionAttributeValues[":C0"]);
         }
     }
 

--- a/sdk/test/UnitTests/Custom/AWSSDK.UnitTestUtilities.NetFramework.csproj
+++ b/sdk/test/UnitTests/Custom/AWSSDK.UnitTestUtilities.NetFramework.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-
+	  
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/sdk/test/UnitTests/Custom/AWSSDK.UnitTestUtilities.NetFramework.csproj
+++ b/sdk/test/UnitTests/Custom/AWSSDK.UnitTestUtilities.NetFramework.csproj
@@ -15,7 +15,6 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-	  
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
Add an expression builder for DynamoDB conditional expressions, akin to the Go SDK’s dynamodb/expression package and Boto3’s dynamodb.conditions, to streamline expression creation.

## Description
In Document Model add support for fluent ExpressionBuilder similar to the GO SDK. The implementation will follow a design pattern comparable to the Go SDK's expression package, using method chaining to define update actions and condition expressions in a type-safe and readable way.

Create condition expressions examples:

Equal
```csharp
//existing 
var conditionalExpression = new Expression
{
    ExpressionStatement = "#price = :price",
    ExpressionAttributeNames = { ["#price"] = "Price" },
    ExpressionAttributeValues = { [":price"] = 50 }
};

//build 
var expression = ConditionExpressionBuilder.New().WithName("Price").Equal(50).Build();
```

And

```csharp
//existing 
var conditionalExpression = new Expression
                    {
                        ExpressionStatement = "attribute_not_exists(#id) AND #price <> :price",
                        ExpressionAttributeNames = { ["#id"] = "Id", ["#price"] = "Price" },
                        ExpressionAttributeValues = { [":price"] = 500 }
                    };

//build 
var expression = ConditionExpressionBuilder.New().WithName("Id").AttributeExists().
                And(ConditionExpressionBuilder.New().WithName("Price").Equal(50)).Build();
```

Update actions expression:

Set
```csharp
//existing 
var updateExpression = new Expression
{
    ExpressionStatement = "SET #garbage = :garbage",
    ExpressionAttributeNames = { ["#garbage"] = "Garbage" },
    ExpressionAttributeValues = { [":garbage"] = "asdf" }
};

//build 
var expression = UpdateExpressionBuilder.New().
    Set(NameBuilder.New("Garbage"), SetValueBuilder.New().WithValue("asdf")).Build();
```

Set increment
```csharp
//existing 
var updateExpression = new Expression
{
    ExpressionStatement = "SET #price = #price + :inc",
    ExpressionAttributeNames = { ["#price"] = "Price" },
    ExpressionAttributeValues = { [":inc"] = 1 }
}

//build 
var expression = UpdateExpressionBuilder.New().
    Set(NameBuilder.New("Price"), SetValueBuilder.New().WithName("Price").Plus(1))
    .Build(); 
```


## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/2602
update the generic parameter documentation for DeleteAsync https://github.com/aws/aws-sdk-net/issues/2615

## Testing
Unit tests added
![image](https://github.com/user-attachments/assets/1c5beb96-ab8d-4249-bb70-ec1662e820cd)

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement