### PR TITLE
Fix User-Agent duplication and support case-sensitive constant classes for feature IDs

### DIFF
--- a/generator/.DevConfigs/6ea8698f-8d5d-4a79-8648-42451415f12e.json
+++ b/generator/.DevConfigs/6ea8698f-8d5d-4a79-8648-42451415f12e.json
@@ -1,0 +1,10 @@
+
+{
+ "core": {
+    "changeLogMessages": [
+      "fix: User-Agent header is growing when reusing the request object"
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentDetails.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentDetails.cs
@@ -58,6 +58,14 @@ namespace Amazon.Runtime.Internal.UserAgent
         }
 
         /// <summary>
+        /// Returns the user agent components that were explicitly added via AddUserAgentComponent,
+        /// </summary>
+        public string GetCustomUserAgentComponents()
+        {
+            return _userAgentBuilder.ToString().Trim();
+        }
+
+        /// <summary>
         /// Appends the metrics user-agent to the existing user-agent and returns the full string.
         /// </summary>
         /// <returns>The final user-agent string including metrics data.</returns>

--- a/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentFeatureId.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentFeatureId.cs
@@ -18,6 +18,7 @@ namespace Amazon.Runtime.Internal.UserAgent
     /// <summary>
     /// Represents the unique metric identifiers for SDK features tracked under User Agent 2.1 (UA2.1).
     /// </summary>
+    [ConstantClassComparer(ConstantClassComparerKind.Ordinal)]
     public class UserAgentFeatureId : ConstantClass
     {
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
@@ -75,7 +75,8 @@ namespace Amazon.Runtime.Internal
     public class RequestContext : IRequestContext
     {
         private IServiceMetadata _serviceMetadata;
-        IDictionary<string, object> _contextAttributes;
+        private IDictionary<string, object> _contextAttributes;
+        private UserAgentDetails _userAgentDetails;
 
         public RequestContext(bool enableMetric)
             : this(enableMetric, null)
@@ -104,7 +105,24 @@ namespace Amazon.Runtime.Internal
         public InvokeOptionsBase Options { get; set; }
         public ISigner Signer { get; set; }
         public BaseIdentity Identity { get; set; }
-        public UserAgentDetails UserAgentDetails { get => ((IAmazonWebServiceRequest)OriginalRequest).UserAgentDetails; }
+        public UserAgentDetails UserAgentDetails
+        {
+            get
+            {
+                if (_userAgentDetails != null)
+                    return _userAgentDetails;
+
+                _userAgentDetails = new UserAgentDetails();
+
+                _userAgentDetails.AddUserAgentComponent(((IAmazonWebServiceRequest)OriginalRequest).UserAgentDetails.GetCustomUserAgentComponents());
+                foreach (var featureId in ((IAmazonWebServiceRequest)OriginalRequest).UserAgentDetails.TrackedFeatureIds)
+                {
+                    _userAgentDetails.AddFeature(featureId);
+                }
+
+                return _userAgentDetails;
+            }
+        }
 
         public System.Threading.CancellationToken CancellationToken { get; set; }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Resolved an issue where the User-Agent header would grow on each request when reusing the same request object, this was caused by reusing the same `UserAgentDetails` instance attached to the request.
Fixed this by creating a copy of the request’s `UserAgentDetails` in the `RequestContext` instead of reusing the request instance.

Also found an issue where `ConstantClass` defaulted to case-insensitive comparisons, which caused conflicts with similarly named feature IDs.
For example when copying `PAGINATOR ("C")` feature id from the request to  the `RequestContext`  the `FLEXIBLE_CHECKSUMS_RES_WHEN_REQUIRED ("c")` feature id gets added instead.


Added `ConstantClassComparerAttribute` that allows derived ConstantClass types to specify the desired comparer type (OrdinalIgnoreCase, Ordinal.), and default behavior remains `OrdinalIgnoreCase` to preserve existing behavior.
Updated the feature ID constant class to use `Ordinal` to support case-sensitive identifiers.


<!--- Describe your changes in detail -->

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3759
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
* `DRY_RUN-20271a23-b168-4004-b640-ec5a77fb847b`
* Tested invoking multiple operations using the same request object and validated that the user agent stays constant.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement