### PR TITLE
[V4] Update generator to handle paginators where the token is a collection

### DIFF
--- a/generator/.DevConfigs/50736c58-f72b-4e62-8cc1-b7b7b8f11f0a.json
+++ b/generator/.DevConfigs/50736c58-f72b-4e62-8cc1-b7b7b8f11f0a.json
@@ -1,0 +1,18 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Update documentation for the `AWSConfigs.InitializeCollections` property to specify the correct default value for V4 (and how to restore the V3 behavior)"
+        ],
+        "type": "patch",
+        "updateMinimum": true
+    },
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Update paginators to handle scenarios where the token is a collection (that's null by default in V4)"
+            ]
+        }
+    ]
+}

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.cs
@@ -18,7 +18,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+    #line 1 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class BasePaginator : BaseGenerator
     {
@@ -29,7 +29,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
         public override string TransformText()
         {
             
-            #line 6 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 6 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 	AddLicenseHeader();
 
@@ -40,49 +40,49 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "tem.Collections;\r\nusing System.Threading;\r\nusing System.Threading.Tasks;\r\nusing " +
                     "Amazon.Runtime;\r\n\r\n#pragma warning disable CS0612,CS0618\r\nnamespace ");
             
-            #line 19 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 19 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.Namespace));
             
             #line default
             #line hidden
             this.Write(".Model\r\n{\r\n    /// <summary>\r\n    /// Base class for ");
             
-            #line 22 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 22 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write(" paginators.\r\n    /// </summary>\r\n    internal sealed partial class ");
             
-            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 24 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Paginator : IPaginator<");
             
-            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 24 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response>, I");
             
-            #line 24 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 24 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Paginator\r\n    {\r\n        private readonly IAmazon");
             
-            #line 26 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 26 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write(" _client;\r\n        private readonly ");
             
-            #line 27 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 27 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
@@ -91,21 +91,21 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "/// <summary>\r\n        /// Enumerable containing all full responses for the oper" +
                     "ation\r\n        /// </summary>\r\n        public IPaginatedEnumerable<");
             
-            #line 33 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 33 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> Responses => new PaginatedResponse<");
             
-            #line 33 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 33 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response>(this);\r\n");
             
-            #line 34 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 34 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListItemType != null))
 {
@@ -115,56 +115,56 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
             #line hidden
             this.Write("\r\n        /// <summary>\r\n        /// Enumerable containing all of the ");
             
-            #line 40 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 40 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.Member.PropertyName));
             
             #line default
             #line hidden
             this.Write("\r\n        /// </summary>\r\n        public IPaginatedEnumerable<");
             
-            #line 42 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 42 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.ListItemType));
             
             #line default
             #line hidden
             this.Write("> ");
             
-            #line 42 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 42 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.Member.PropertyName));
             
             #line default
             #line hidden
             this.Write(" => \r\n            new PaginatedResultKeyResponse<");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 43 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response, ");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 43 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.ListItemType));
             
             #line default
             #line hidden
             this.Write(">(this, (i) => i.");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 43 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.PropertyName));
             
             #line default
             #line hidden
             this.Write(" ?? new ");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 43 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(resultKey.Member.DetermineType()));
             
             #line default
             #line hidden
             this.Write("());\r\n");
             
-            #line 44 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 44 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -173,21 +173,21 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
             #line hidden
             this.Write("\r\n        internal ");
             
-            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 48 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Paginator(IAmazon");
             
-            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 48 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ClassName));
             
             #line default
             #line hidden
             this.Write(" client, ");
             
-            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 48 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
@@ -195,14 +195,14 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
             this.Write("Request request)\r\n        {\r\n            this._client = client;\r\n            this" +
                     "._request = request;\r\n        }\r\n#if BCL\r\n        IEnumerable<");
             
-            #line 54 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 54 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> IPaginator<");
             
-            #line 54 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 54 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
@@ -216,7 +216,7 @@ foreach(var resultKey in this.Operation.Paginators.ResultKeys.Where(r => r.ListI
             PaginatorUtils.SetUserAgentAdditionOnRequest(_request);
 ");
             
-            #line 61 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 61 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var inputToken in this.Operation.Paginators.InputTokens)
 {
@@ -226,21 +226,21 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("            var ");
             
-            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 65 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" = _request.");
             
-            #line 65 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 65 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.PropertyName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 66 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 66 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -249,14 +249,14 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("            ");
             
-            #line 69 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 69 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response response;\r\n            do\r\n            {\r\n");
             
-            #line 72 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 72 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var inputToken in this.Operation.Paginators.InputTokens)
 {
@@ -266,21 +266,21 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("                _request.");
             
-            #line 76 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 76 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = ");
             
-            #line 76 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 76 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 77 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 77 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -289,14 +289,14 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("                response = _client.");
             
-            #line 80 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 80 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("(_request);\r\n");
             
-            #line 81 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 81 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
 {
@@ -306,21 +306,21 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
             #line hidden
             this.Write("                ");
             
-            #line 85 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 85 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[i].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" = response.");
             
-            #line 85 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 85 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.OutputTokens[i].PropertyName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 86 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 86 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -329,7 +329,7 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
             #line hidden
             this.Write("                yield return response;\r\n            }\r\n");
             
-            #line 91 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 91 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 if (this.Operation.Paginators.MoreResults != null)
 {
@@ -339,14 +339,14 @@ if (this.Operation.Paginators.MoreResults != null)
             #line hidden
             this.Write("            while (response.");
             
-            #line 95 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 95 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.MoreResults.PropertyName));
             
             #line default
             #line hidden
             this.Write(".GetValueOrDefault());\r\n");
             
-            #line 96 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 96 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 } 
 else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
@@ -357,14 +357,14 @@ else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
             #line hidden
             this.Write("            while (");
             
-            #line 101 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 101 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(".Count > 0);\r\n");
             
-            #line 102 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 102 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 else if (this.Operation.StopPaginationOnSameToken)
@@ -375,21 +375,21 @@ else if (this.Operation.StopPaginationOnSameToken)
             #line hidden
             this.Write("            while (");
             
-            #line 107 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 107 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" != _request.");
             
-            #line 107 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 107 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].PropertyName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 108 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 108 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 else
@@ -400,14 +400,14 @@ else
             #line hidden
             this.Write("            while (!string.IsNullOrEmpty(");
             
-            #line 113 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 113 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write("));\r\n");
             
-            #line 114 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 114 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -417,14 +417,14 @@ else
             this.Write("        }\r\n#endif\r\n#if AWS_ASYNC_ENUMERABLES_API\r\n        async IAsyncEnumerable<" +
                     "");
             
-            #line 120 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 120 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response> IPaginator<");
             
-            #line 120 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 120 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
@@ -438,7 +438,7 @@ else
             PaginatorUtils.SetUserAgentAdditionOnRequest(_request);
 ");
             
-            #line 127 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 127 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var inputToken in this.Operation.Paginators.InputTokens)
 {
@@ -448,21 +448,21 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("            var ");
             
-            #line 131 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 131 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" = _request.");
             
-            #line 131 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 131 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.PropertyName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 132 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 132 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -471,14 +471,14 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("            ");
             
-            #line 135 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 135 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Response response;\r\n            do\r\n            {\r\n");
             
-            #line 138 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 138 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 foreach(var inputToken in this.Operation.Paginators.InputTokens)
 {
@@ -488,21 +488,21 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("                _request.");
             
-            #line 142 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 142 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.PropertyName));
             
             #line default
             #line hidden
             this.Write(" = ");
             
-            #line 142 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 142 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(inputToken.Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 143 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 143 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -511,14 +511,14 @@ foreach(var inputToken in this.Operation.Paginators.InputTokens)
             #line hidden
             this.Write("                response = await _client.");
             
-            #line 146 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 146 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Name));
             
             #line default
             #line hidden
             this.Write("Async(_request, cancellationToken).ConfigureAwait(false);\r\n");
             
-            #line 147 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 147 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
 {
@@ -528,21 +528,21 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
             #line hidden
             this.Write("                ");
             
-            #line 151 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 151 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[i].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" = response.");
             
-            #line 151 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 151 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.OutputTokens[i].PropertyName));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 152 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 152 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -552,7 +552,7 @@ for(var i = 0; i < this.Operation.Paginators.InputTokens.Count; i++)
             this.Write("                cancellationToken.ThrowIfCancellationRequested();\r\n              " +
                     "  yield return response;\r\n            }\r\n");
             
-            #line 158 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 158 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 if (this.Operation.Paginators.MoreResults != null)
 {
@@ -562,14 +562,14 @@ if (this.Operation.Paginators.MoreResults != null)
             #line hidden
             this.Write("            while (response.");
             
-            #line 162 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 162 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.MoreResults.PropertyName));
             
             #line default
             #line hidden
             this.Write(".GetValueOrDefault());\r\n");
             
-            #line 163 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 163 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 } 
 else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
@@ -580,14 +580,14 @@ else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
             #line hidden
             this.Write("            while (");
             
-            #line 168 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 168 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
-            this.Write(".Count > 0);\r\n");
+            this.Write("?.Count > 0);\r\n");
             
-            #line 169 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 169 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 else if (this.Operation.StopPaginationOnSameToken)
@@ -598,21 +598,21 @@ else if (this.Operation.StopPaginationOnSameToken)
             #line hidden
             this.Write("            while (");
             
-            #line 174 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 174 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write(" != _request.");
             
-            #line 174 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 174 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].PropertyName));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 175 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 175 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 else
@@ -623,14 +623,14 @@ else
             #line hidden
             this.Write("            while (!string.IsNullOrEmpty(");
             
-            #line 180 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 180 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Operation.Paginators.InputTokens[0].Member.ArgumentName));
             
             #line default
             #line hidden
             this.Write("));\r\n");
             
-            #line 181 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+            #line 181 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
 }
 
@@ -641,7 +641,7 @@ else
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 189 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
+        #line 189 "C:\Projects\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\BasePaginator.tt"
 
     // The operation the marshaller will be used on
 	public Operation Operation { get; set; }	

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/BasePaginator.tt
@@ -165,7 +165,7 @@ if (this.Operation.Paginators.MoreResults != null)
 else if (this.Operation.Paginators.InputTokens[0].IsListOrDict)
 {
 #>
-            while (<#=this.Operation.Paginators.InputTokens[0].Member.ArgumentName#>.Count > 0);
+            while (<#=this.Operation.Paginators.InputTokens[0].Member.ArgumentName#>?.Count > 0);
 <#
 }
 else if (this.Operation.StopPaginationOnSameToken)

--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -277,17 +277,20 @@ namespace Amazon
         public const string InitializeCollectionsKey = "AWSInitializeCollections";
 
         /// <summary>
-        /// When true the collections used on the service API request and response objects are initialized
+        /// When <c>true</c> the collections used on the service API request and response objects are initialized
         /// to an empty collection. The collections are sent as part of requests when a collection is non-empty.
-        /// 
-        /// Setting InitializeCollections to false means all collections used on the service API request and 
+        /// <para />
+        /// Setting InitializeCollections to <c>false</c> means all collections used on the service API request and 
         /// response objects are initialized to null. The collections are sent as part of requests when
         /// the collection non-null including an empty collection.
+        /// <para />
+        /// The default value is <c>false</c>. 
         /// 
-        /// The default value is true. In the next major version of the SDK the default will change to false.
-        /// This will improve performance not creating unnecessary collection instances and provide more
-        /// control when the collection is sent to the service.
+        /// This was changed in V4 of the SDK to improve performance by not creating unnecessary 
+        /// collection instances and provide more control when the collection is sent to the service.
         /// 
+        /// You can set this value to <c>true</c> to revert to the collection initialization behavior of V3.
+        /// <para />
         /// Setting this property is not thread safe and should only be set at application startup.
         /// </summary>
         public static bool InitializeCollections

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/_bcl+netstandard/BatchGetItemPaginator.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/_bcl+netstandard/BatchGetItemPaginator.cs
@@ -85,7 +85,7 @@ namespace Amazon.DynamoDBv2.Model
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return response;
             }
-            while (requestItems.Count > 0);
+            while (requestItems?.Count > 0);
         }
 #endif
     }

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/_bcl+netstandard/QueryPaginator.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/_bcl+netstandard/QueryPaginator.cs
@@ -85,7 +85,7 @@ namespace Amazon.DynamoDBv2.Model
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return response;
             }
-            while (exclusiveStartKey.Count > 0);
+            while (exclusiveStartKey?.Count > 0);
         }
 #endif
     }

--- a/sdk/src/Services/DynamoDBv2/Generated/Model/_bcl+netstandard/ScanPaginator.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Model/_bcl+netstandard/ScanPaginator.cs
@@ -85,7 +85,7 @@ namespace Amazon.DynamoDBv2.Model
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return response;
             }
-            while (exclusiveStartKey.Count > 0);
+            while (exclusiveStartKey?.Count > 0);
         }
 #endif
     }


### PR DESCRIPTION
Fixes #3765  

## Description
See issue for details, but the generator was not considering the fact that DynamoDB includes paginators where the input token is a collection (which is null by default in V4).

I also updated the documentation for the `AWSConfigs.InitializeCollections` property to correctly state the default value in V4.

## Testing
- Dry-run: `DRY_RUN-ccfc378b-fc72-47cd-b8c2-b0d945b98551`
- Ran reproduction application from issue report and confirmed it succeeded.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
