### PR TITLE
Update HttpRequestMessageFactory to correctly set the Content-Length header

### DIFF
--- a/generator/.DevConfigs/1505438c-c9a6-422f-85d8-0fa7258698f6.json
+++ b/generator/.DevConfigs/1505438c-c9a6-422f-85d8-0fa7258698f6.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Update HttpRequestMessageFactory to correctly set the Content-Length header"
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
@@ -625,13 +625,12 @@ namespace Amazon.Runtime
             if ((isChunkedUploadWrapperStreamWithLength || isTrailingHeadersWrapperStreamWithLength || isCompressionWrapperStreamWithLength)
                 || (chunkedUploadWrapperStream == null && trailingHeadersWrapperStream == null && compressionWrapperStream == null))
             {
-                long position = 0;
+                long position;
                 try
                 {
-                    if (contentStream.CanSeek)
-                    {
-                        position = contentStream.Position;
-                    }
+                    // Even in cases where the stream is unseekable the position may still be tracked due to special
+                    // circumstances of ChunkedUploadWrapperStream.
+                    position = contentStream.Position;
                 }
                 catch (NotSupportedException)
                 {

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
@@ -189,8 +189,10 @@ namespace Amazon.DNXCore.IntegrationTests.S3
         /// <summary>
         /// Reported in https://github.com/aws/aws-sdk-net/issues/3629
         /// </summary>
-        [Fact]
-        public async Task TestResetStreamPosition()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestResetStreamPosition(bool useChunkEncoding)
         {
             var memoryStream = new MemoryStream();
             long offset;
@@ -214,7 +216,7 @@ namespace Amazon.DNXCore.IntegrationTests.S3
                 AutoResetStreamPosition = false,
                 AutoCloseStream = !memoryStream.CanSeek,
                 InputStream = memoryStream.CanSeek ? memoryStream : AmazonS3Util.MakeStreamSeekable(memoryStream),
-                UseChunkEncoding = false,
+                UseChunkEncoding = useChunkEncoding,
             };
 
             var putResponse = await Client.PutObjectAsync(putRequest);


### PR DESCRIPTION
## Description

This PR updates the .NET Standard implementation of the `HttpRequestMessageFactory` to correctly set the Content-Length header, particularly for non-seekable streams, by taking the current stream position into account.

The issue being addressed was originally fixed in #3631. However, due to the test coverage only verifying behavior when `UseChunkEncoding = false`, the regression was reintroduced when the position adjustment was moved behind a check that only applies to seekable streams.

This update ensures that the stream position is correctly accounted for when setting Content-Length, regardless of the stream's seekability.


## Motivation and Context
#3629
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
 * `DRY_RUN-05ce4689-5754-4c4b-afd9-b0119f943459`.
 * Updated `TestResetStreamPosition` test to run with and without `ChunkEncoding`.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement