### PR TITLE
Fix: Handle null values in JMESPath sub-expressions gracefully

### DIFF
--- a/generator/ServiceClientGeneratorLib/Utils.cs
+++ b/generator/ServiceClientGeneratorLib/Utils.cs
@@ -252,7 +252,7 @@ namespace ServiceClientGenerator
                 if (nestedMember == "[]")
                 {
                     // Flatten the nested lists into a single list using LINQ SelectMany
-                    mainPathBuilder.Append($"SelectMany(element => element)");
+                    mainPathBuilder.Append($"SelectMany(element => element).Where(element => element != null)");
                     continue;
                 }
 

--- a/generator/ServiceClientGeneratorLib/Utils.cs
+++ b/generator/ServiceClientGeneratorLib/Utils.cs
@@ -224,7 +224,7 @@ namespace ServiceClientGenerator
             {
                 if (mainPathBuilder.Length > 0)
                 {
-                    mainPathBuilder.Append('.');
+                    mainPathBuilder.Append("?.");
                 }
 
                 var nestedMember = originalNestedMember;
@@ -271,8 +271,8 @@ namespace ServiceClientGenerator
                     var multiSelectExpressions = SplitMultiSelectExpression(nestedMember.Substring(1, nestedMember.Length - 2));
 
                     // Skip element. since we will create an array rather than selecting a property of the element
-                    if (mainPathBuilder.ToString().EndsWith("element."))
-                        mainPathBuilder.Length -= "element.".Length;
+                    if (mainPathBuilder.ToString().EndsWith("element?."))
+                        mainPathBuilder.Length -= "element?.".Length;
 
                     mainPathBuilder.Append("new [] { ");
                     for (int i = 0; i < multiSelectExpressions.Count; i++)
@@ -281,7 +281,7 @@ namespace ServiceClientGenerator
                         var expressionValue = JMESPathToNativeValue(expr, currentShape);
 
                         // Append the expression as part of the new anonymous object
-                        mainPathBuilder.Append($"element.{expressionValue}");
+                        mainPathBuilder.Append($"element?.{expressionValue}");
 
                         if (i < multiSelectExpressions.Count - 1)
                         {
@@ -309,7 +309,7 @@ namespace ServiceClientGenerator
 
                 if (mapMatch.Success)
                 {
-                    mainPathBuilder.Append(".Keys.ToList()");
+                    mainPathBuilder.Append("?.Keys.ToList()");
                 }
 
                 currentShape = currentMember.Shape;

--- a/generator/ServiceClientGeneratorTests/JMESPathToNativeValueTests.cs
+++ b/generator/ServiceClientGeneratorTests/JMESPathToNativeValueTests.cs
@@ -148,7 +148,7 @@ namespace ServiceClientGeneratorTests
 
             var nativeValue = ServiceClientGenerator.Utils.JMESPathToNativeValue("listOfUnions[*][string, object.key][]", topShape);
 
-            Assert.Equal("ListOfUnions?.Select(element => new [] { element?.String, element?.Object?.Key })?.SelectMany(element => element)", nativeValue);
+            Assert.Equal("ListOfUnions?.Select(element => new [] { element?.String, element?.Object?.Key })?.SelectMany(element => element).Where(element => element != null)", nativeValue);
         }
 
         [Fact]

--- a/generator/ServiceClientGeneratorTests/JMESPathToNativeValueTests.cs
+++ b/generator/ServiceClientGeneratorTests/JMESPathToNativeValueTests.cs
@@ -50,7 +50,7 @@ namespace ServiceClientGeneratorTests
 
             var nativeValue = ServiceClientGenerator.Utils.JMESPathToNativeValue("nested.listOfObjects[*]", topShape);
 
-            Assert.Equal("Nested.ListOfObjects.Select(element => element)", nativeValue);
+            Assert.Equal("Nested?.ListOfObjects?.Select(element => element)", nativeValue);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace ServiceClientGeneratorTests
 
             var nativeValue = ServiceClientGenerator.Utils.JMESPathToNativeValue("nested.map*", topShape);
 
-            Assert.Equal("Nested.Map.Values.Select(element => element)", nativeValue);
+            Assert.Equal("Nested?.Map?.Values.Select(element => element)", nativeValue);
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace ServiceClientGeneratorTests
 
             var nativeValue = ServiceClientGenerator.Utils.JMESPathToNativeValue("nested.keys(map)", topShape);
 
-            Assert.Equal("Nested.Map.Keys.ToList()", nativeValue);
+            Assert.Equal("Nested?.Map?.Keys.ToList()", nativeValue);
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace ServiceClientGeneratorTests
 
             var nativeValue = ServiceClientGenerator.Utils.JMESPathToNativeValue("list[*].inner", topShape);
 
-            Assert.Equal("List.Select(element => element.Inner)", nativeValue);
+            Assert.Equal("List?.Select(element => element?.Inner)", nativeValue);
         }
 
         [Fact]
@@ -148,7 +148,7 @@ namespace ServiceClientGeneratorTests
 
             var nativeValue = ServiceClientGenerator.Utils.JMESPathToNativeValue("listOfUnions[*][string, object.key][]", topShape);
 
-            Assert.Equal("ListOfUnions.Select(element => new [] { element.String, element.Object.Key }).SelectMany(element => element)", nativeValue);
+            Assert.Equal("ListOfUnions?.Select(element => new [] { element?.String, element?.Object?.Key })?.SelectMany(element => element)", nativeValue);
         }
 
         [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR improves the resilience of sub-expression handling in `JMESPathToNativeValue` by adding null-coalescing (?.) support when traversing nested members in sub-expressions. 

Previously, if an intermediate object in the expression was null, the evaluation would fail. With this change, expressions like `foo.bar.baz` are now translated safely as `Foo?.Bar?.Baz`.

Changes
 * Updated `HandleSubExpression` to inject null-safe member access (?.) for each level of the path.
 * Updated unit tests to validate the new behavior with nested paths where intermediate properties can be null.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
DynamoDB new feature was failing where sub-expression were null.


## Testing
* Ran the generator and validated that the changes only affects DynamoDB.
* Executed DyanmoDB tests locally.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement