### PR TITLE
Update endpoint resolver to handle anonymous credentials when trying to retrieve account IDs

### DIFF
--- a/generator/.DevConfigs/72b4f8b3-b7e1-496b-a64f-5c4a01528cf0.json
+++ b/generator/.DevConfigs/72b4f8b3-b7e1-496b-a64f-5c4a01528cf0.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Update endpoint resolver to handle anonymous credentials when trying to retrieve account IDs"
+            ]
+        }
+    ]
+}

--- a/generator/ServiceClientGeneratorLib/Generators/Endpoints/EndpointResolver.partial.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Endpoints/EndpointResolver.partial.cs
@@ -25,7 +25,7 @@ namespace ServiceClientGenerator.Generators.Endpoints
                 case "AWS::S3::DisableMultiRegionAccessPoints": return "config.DisableMultiregionAccessPoints";
                 case "AWS::S3::UseGlobalEndpoint": return "config.USEast1RegionalEndpointValue == S3UsEast1RegionalEndpointValue.Legacy";
                 case "AWS::STS::UseGlobalEndpoint": return "false";
-                case "AWS::Auth::AccountId": return "requestContext.Identity is AWSCredentials credentials ? credentials.GetCredentials().AccountId : null";
+                case "AWS::Auth::AccountId": return "requestContext.Identity is AWSCredentials credentials ? credentials.GetCredentials()?.AccountId : null";
                 case "AWS::Auth::AccountIdEndpointMode": return "config.AccountIdEndpointMode.ToString().ToLower()";
                 default: throw new Exception("Unknown builtIn");
             }

--- a/sdk/src/Services/DynamoDBv2/Generated/Internal/AmazonDynamoDBEndpointResolver.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/Internal/AmazonDynamoDBEndpointResolver.cs
@@ -54,7 +54,7 @@ namespace Amazon.DynamoDBv2.Internal
             result.UseDualStack = config.UseDualstackEndpoint;
             result.UseFIPS = config.UseFIPSEndpoint;
             result.Endpoint = config.ServiceURL;
-            result.AccountId = requestContext.Identity is AWSCredentials credentials ? credentials.GetCredentials().AccountId : null;
+            result.AccountId = requestContext.Identity is AWSCredentials credentials ? credentials.GetCredentials()?.AccountId : null;
             result.AccountIdEndpointMode = config.AccountIdEndpointMode.ToString().ToLower();
 
 


### PR DESCRIPTION
Fixes #3776 

## Description
See issue for more details, but the endpoint resolver generated code was not handling the scenario where anonymous credentials are used for the request.

## Testing
- Dry-run: `DRY_RUN-eb92bf48-769e-47bd-ac7f-2c67117ef948`
- Ran console app from issue, 

Before: `System.NullReferenceException: 'Object reference not set to an instance of an object.'`

After (still fails because the actual DDB requires credentials but no NPE anymore):
```
AmazonDynamoDBClient 35|2025-04-29T12:44:29.937Z|ERROR|
    AmazonDynamoDBException making request ScanRequest to https://dynamodb.us-west-2.amazonaws.com/
    Attempt 1. --> Amazon.DynamoDBv2.AmazonDynamoDBException: Request is missing Authentication Token
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license