### PR TITLE
fix: Update RedShift CRUDSecurityGroups test with the new exception message

### DIFF
--- a/sdk/test/Services/Redshift/IntegrationTests/Redshift.cs
+++ b/sdk/test/Services/Redshift/IntegrationTests/Redshift.cs
@@ -49,7 +49,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             catch (AmazonRedshiftException e)
             {
                 // This test does not work for VPC by default accounts so skip the test.
-                if (!string.Equals(e.Message, "VPC-by-Default customers cannot use cluster security groups"))
+                if (!string.Equals(e.Message, "Amazon Redshift has discontinued cluster security groups. For security group configuration, associate VPC security groups when creating or modifying your cluster."))
                     throw;
             }
             finally


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
RedShift suddenly changed their exception message and caused our test to fail. This PR updates `CRUDSecurityGroups` to the new message.

## Testing
Ran the test locally and it succeeded. 
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
