### PR TITLE
Set assembly version for all targets to fixed 4.0 version number

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/Properties/AssemblyInfo.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/Properties/AssemblyInfo.cs
@@ -15,9 +15,5 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-#if NETFRAMEWORK
 [assembly: AssemblyVersion("4.0")]
-#else
-[assembly: AssemblyVersion("4.0.0.0")]
-#endif
 [assembly: AssemblyFileVersion("4.0.0.0")]

--- a/extensions/src/AWSSDK.Extensions.CloudFront.Signers/Properties/AssemblyInfo.cs
+++ b/extensions/src/AWSSDK.Extensions.CloudFront.Signers/Properties/AssemblyInfo.cs
@@ -15,9 +15,5 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-#if NETFRAMEWORK
 [assembly: AssemblyVersion("4.0")]
-#else
-[assembly: AssemblyVersion("4.0.0.0")]
-#endif
 [assembly: AssemblyFileVersion("4.0.0.0")]

--- a/extensions/src/AWSSDK.Extensions.CrtIntegration/Properties/AssemblyInfo.cs
+++ b/extensions/src/AWSSDK.Extensions.CrtIntegration/Properties/AssemblyInfo.cs
@@ -15,9 +15,5 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-#if NETFRAMEWORK
 [assembly: AssemblyVersion("4.0")]
-#else
-[assembly: AssemblyVersion("4.0.0.0")]
-#endif
 [assembly: AssemblyFileVersion("4.0.0.0")]

--- a/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/Properties/AssemblyInfo.cs
+++ b/extensions/src/AWSSDK.Extensions.EC2.DecryptPassword/Properties/AssemblyInfo.cs
@@ -15,9 +15,5 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-#if NETFRAMEWORK
 [assembly: AssemblyVersion("4.0")]
-#else
-[assembly: AssemblyVersion("4.0.0.0")]
-#endif
 [assembly: AssemblyFileVersion("4.0.0.0")]

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/Properties/AssemblyInfo.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyVersion("4.0")]
 [assembly: AssemblyFileVersion("4.0.0.0")]

--- a/generator/.DevConfigs/FFEEA749-5916-4B6D-A546-48A887CED3EB.json
+++ b/generator/.DevConfigs/FFEEA749-5916-4B6D-A546-48A887CED3EB.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Set assembly version for all targets to fixed 4.0 version number to avoid binding issues. The assembly file version should be used to understand the version of the assembly."
+        ],
+		"type": "Patch",
+        "updateMinimum": true
+    }
+}

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/AssemblyInfo.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/AssemblyInfo.cs
@@ -15,7 +15,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+    #line 1 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class AssemblyInfo : BaseGenerator
     {
@@ -36,35 +36,35 @@ using System.Runtime.CompilerServices;
 // associated with an assembly.
 [assembly: AssemblyTitle(""");
             
-            #line 12 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 12 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyTitle));
             
             #line default
             #line hidden
             this.Write("\")]\r\n#if BCL\r\n[assembly: AssemblyDescription(\"");
             
-            #line 14 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 14 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyDescription(versionIdentifier: "4.7.2")));
             
             #line default
             #line hidden
             this.Write("\")]\r\n#elif NETSTANDARD20\r\n[assembly: AssemblyDescription(\"");
             
-            #line 16 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 16 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyDescription(versionIdentifier: "NetStandard 2.0")));
             
             #line default
             #line hidden
             this.Write("\")]\r\n#elif NETCOREAPP3_1\r\n[assembly: AssemblyDescription(\"");
             
-            #line 18 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 18 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyDescription(versionIdentifier: ".NET Core 3.1")));
             
             #line default
             #line hidden
             this.Write("\")]\r\n#elif NET8_0\r\n[assembly: AssemblyDescription(\"");
             
-            #line 20 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 20 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.AssemblyDescription(versionIdentifier: ".NET 8.0")));
             
             #line default
@@ -96,24 +96,16 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion(""1.0.*"")]
-#if BCL
 [assembly: AssemblyVersion(""");
             
-            #line 48 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 47 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceVersion));
             
             #line default
             #line hidden
-            this.Write("\")]\r\n#else\r\n[assembly: AssemblyVersion(\"");
+            this.Write("\")]\r\n[assembly: AssemblyFileVersion(\"");
             
-            #line 50 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceFileVersion));
-            
-            #line default
-            #line hidden
-            this.Write("\")]\r\n#endif\r\n[assembly: AssemblyFileVersion(\"");
-            
-            #line 52 "C:\Projects\aws-sdk-net\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
+            #line 48 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\AssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Config.ServiceFileVersion));
             
             #line default

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/AssemblyInfo.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/AssemblyInfo.tt
@@ -44,9 +44,5 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-#if BCL
 [assembly: AssemblyVersion("<#=this.Config.ServiceVersion #>")]
-#else
-[assembly: AssemblyVersion("<#=this.Config.ServiceFileVersion #>")]
-#endif
 [assembly: AssemblyFileVersion("<#=this.Config.ServiceFileVersion #>")]

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/CoreAssemblyInfo.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/CoreAssemblyInfo.cs
@@ -15,7 +15,7 @@ namespace ServiceClientGenerator.Generators.SourceFiles
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
+    #line 1 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class CoreAssemblyInfo : BaseGenerator
     {
@@ -83,23 +83,16 @@ namespace ServiceClientGenerator.Generators.SourceFiles
                     "lowing four values:\r\n//\r\n//      Major Version\r\n//      Minor Version \r\n//      " +
                     "Build Number\r\n//      Revision\r\n//\r\n// You can specify all the values or you can" +
                     " default the Build and Revision Numbers \r\n// by using the \'*\' as shown below:\r\n/" +
-                    "/ [assembly: AssemblyVersion(\"1.0.*\")]\r\n#if BCL\r\n[assembly: AssemblyVersion(\"");
+                    "/ [assembly: AssemblyVersion(\"1.0.*\")]\r\n\r\n[assembly: AssemblyVersion(\"");
             
-            #line 56 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
+            #line 56 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Session["Version"]));
             
             #line default
             #line hidden
-            this.Write("\")]\r\n#else\r\n[assembly: AssemblyVersion(\"");
+            this.Write("\")]\r\n[assembly: AssemblyFileVersion(\"");
             
-            #line 58 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(this.Session["FileVersion"]));
-            
-            #line default
-            #line hidden
-            this.Write("\")]\r\n#endif\r\n[assembly: AssemblyFileVersion(\"");
-            
-            #line 60 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
+            #line 57 "C:\codebase\v4\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\SourceFiles\CoreAssemblyInfo.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(this.Session["FileVersion"]));
             
             #line default

--- a/generator/ServiceClientGeneratorLib/Generators/SourceFiles/CoreAssemblyInfo.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/SourceFiles/CoreAssemblyInfo.tt
@@ -52,11 +52,8 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-#if BCL
+
 [assembly: AssemblyVersion("<#=this.Session["Version"]#>")]
-#else
-[assembly: AssemblyVersion("<#=this.Session["FileVersion"] #>")]
-#endif
 [assembly: AssemblyFileVersion("<#=this.Session["FileVersion"] #>")]
 
 #if BCL


### PR DESCRIPTION
https://github.com/aws/aws-sdk-net/issues/3776#issuecomment-2841265248

## Description
Set the assembly version for all targets 4.0 to avoid binding issues. We made an incorrect decision in V4 thinking that for .NET Core targets the assembly version was not included as part of the identity. So we thought we could have the full assembly version in those targets to avoid the common versioning confusion we get with error messages. This was incorrect in that .NET Core still does include version as part of identity there are just some relaxed rules with allowing to load newer assemblies. This still leaves open many scenarios of upgrading packages that cause binding issues.

We are updating all assembly packages versions to reset all packages to now have a `4.0` assembly version.

## Motivation and Context
Remove binding issues.

## Testing
Ran the generator and confirmed the assembly info for core and service packages were correct.

Compiled the framework and netstandard solution.

