### PR TITLE
Update nuspec for AWSSDK.Extensions.Bedrock.MEAI

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.Bedrock.MEAI</id>
     <title>AWSSDK - Bedrock integration with Microsoft.Extensions.AI.</title>
-    <version>4.0.0.0-preview.14</version>
+    <version>4.0.0.0-preview.15</version>
     <authors>Amazon Web Services</authors>
     <description>Implementations of Microsoft.Extensions.AI's abstractions for Bedrock.</description>
     <language>en-US</language>
@@ -13,17 +13,17 @@
     <icon>images\AWSLogo.png</icon>
     <dependencies>
       <group targetFramework="net472">
-        <dependency id="AWSSDK.Core" version="4.0.0.0" />
+        <dependency id="AWSSDK.Core" version="4.0.0.2" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.0" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.4.0-preview.1.25207.5" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0" />
+        <dependency id="AWSSDK.Core" version="4.0.0.2" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.0" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.4.0-preview.1.25207.5" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0" />
+        <dependency id="AWSSDK.Core" version="4.0.0.2" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.0" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.4.0-preview.1.25207.5" />
       </group>


### PR DESCRIPTION
With the previous PR https://github.com/aws/aws-sdk-net/pull/3781 that fixed the assembly version we need to release AWSSDK.Extensions.Bedrock.MEAI to pick up the new core since the current released version is pointing to an AWSSDK.Core that as a bad assembly version.
