### PR TITLE
Fix missing OriginalRequest in RequestContext when generating presigned URLs.

### DIFF
--- a/generator/.DevConfigs/e24c3bf6-da22-4935-8303-cdba82a45405.json
+++ b/generator/.DevConfigs/e24c3bf6-da22-4935-8303-cdba82a45405.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fix regression where presigned URLs could not be created when using a custom `ServiceURL`."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
@@ -113,8 +113,15 @@ namespace Amazon.S3
             var immutableCredentials = credentials.GetCredentials();
             var irequest = Marshall(this.Config, request, immutableCredentials.AccessKey, immutableCredentials.Token, signatureVersionToUse);
 
-            var context = new Amazon.Runtime.Internal.ExecutionContext(new Amazon.Runtime.Internal.RequestContext(true, new NullSigner()) { Request = irequest, ClientConfig = this.Config }, null);
-            
+            var context = new Amazon.Runtime.Internal.ExecutionContext(
+                new RequestContext(true, new NullSigner())
+                {
+                    Request = irequest,
+                    ClientConfig = this.Config,
+                    OriginalRequest = request,
+                },
+                null
+            );
             new AmazonS3EndpointResolver().ProcessRequestHandlers(context);
             var expressConfig = this.Config as AmazonS3Config;
             if (context.RequestContext.Request.IsDirectoryBucket() && !expressConfig.DisableS3ExpressSessionAuth)
@@ -176,8 +183,15 @@ namespace Amazon.S3
             var immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
             var irequest = Marshall(this.Config, request, immutableCredentials.AccessKey, immutableCredentials.Token, signatureVersionToUse);
 
-
-            var context = new Amazon.Runtime.Internal.ExecutionContext(new Amazon.Runtime.Internal.RequestContext(true, new NullSigner()) { Request = irequest, ClientConfig = this.Config }, null);
+            var context = new Amazon.Runtime.Internal.ExecutionContext(
+                new RequestContext(true, new NullSigner())
+                {
+                    Request = irequest,
+                    ClientConfig = this.Config,
+                    OriginalRequest = request,
+                },
+                null
+            );
             new AmazonS3EndpointResolver().ProcessRequestHandlers(context);
             var expressConfig = this.Config as AmazonS3Config;
             if (context.RequestContext.Request.IsDirectoryBucket() && !expressConfig.DisableS3ExpressSessionAuth)

--- a/sdk/test/Services/S3/IntegrationTests/GeneratePreSignedUrlTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/GeneratePreSignedUrlTests.cs
@@ -176,6 +176,34 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             });
         }
 
+        [TestMethod]
+        [TestCategory("S3")]
+        public void TestGetPreSignedURL_WithCustomServiceURL()
+        {
+            var serviceUrl = "https://s3-external-1.amazonaws.com";
+            var config = new AmazonS3Config
+            {
+                ServiceURL = serviceUrl,
+                ForcePathStyle = true,
+                AuthenticationRegion = "us-west-2"
+            };
+
+            var credentials = new BasicAWSCredentials("accessKey", "secretKey");
+
+            var s3Client = new AmazonS3Client(credentials, config);
+
+            var request = new GetPreSignedUrlRequest
+            {
+                BucketName = "my-bucket",
+                Key = "my-object-key",
+                Expires = DateTime.UtcNow.AddMinutes(5)
+            };
+
+            var url = s3Client.GetPreSignedURL(request);
+
+            Assert.IsTrue(url.StartsWith(serviceUrl));
+        }
+
         private void TestPreSignedUrlPut(PresignedUrlTestParameters testParams)
         {
             var client = new AmazonS3Client(testParams.Region);


### PR DESCRIPTION
## Description
An exception was thrown when generating a presigned URL using a custom `ServiceURL`.
The `OriginalRequest` property wasn't assigned in the `RequestContext` in `GetPreSignedURLInternal`. Which caused a `NullReferenceException` when trying to set `ENDPOINT_OVERRIDE` feature id in the `UserAgentDetails` (this is why it only happens when `ServiceURL` is set).
The fix was setting the `OriginalRequest` to the `GetPreSignedUrlRequest`.

## Motivation and Context
* #3797 

## Testing
* Ran the code provided in [#3797](https://github.com/aws/aws-sdk-net/issues/3797) and validated that it works after the fix.
* Added a unit test that reproduces the issue using a custom `ServiceURL` and verifies that `GetPreSignedURL` returns a valid URL without throwing an exception.
* `DRY_RUN-ab447d67-0a56-4d7f-983c-24f42f0db70d`.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement