### PR TITLE
[V4] Update DocumentModel to handle expressions without variables

### DIFF
--- a/generator/.DevConfigs/6d15fac7-b782-42ab-a6b8-e2ff4c240df3.json
+++ b/generator/.DevConfigs/6d15fac7-b782-42ab-a6b8-e2ff4c240df3.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fix regression where an `Expression` could not be used without `ExpressionAttributeValues` (https://github.com/aws/aws-sdk-net/issues/3802)"
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
@@ -218,27 +218,29 @@ namespace Amazon.DynamoDBv2.DocumentModel
         internal static Dictionary<string, AttributeValue> ConvertToAttributeValues(
             Dictionary<string, DynamoDBEntry> valueMap, Table table)
         {
-            var convertedValues = new Dictionary<string, AttributeValue>();
-            if (valueMap != null)
+            if (valueMap == null || valueMap.Count == 0)
             {
-                foreach (var kvp in valueMap)
+                return null;
+            }
+
+            var convertedValues = new Dictionary<string, AttributeValue>();
+            foreach (var kvp in valueMap)
+            {
+                var attributeName = kvp.Key;
+                var entry = kvp.Value;
+
+                if (entry == null)
+                    convertedValues[attributeName] = new AttributeValue { NULL = true };
+                else
                 {
-                    var attributeName = kvp.Key;
-                    var entry = kvp.Value;
+                    if (table.StoreAsEpoch.Contains(attributeName))
+                        entry = Document.DateTimeToEpochSeconds(entry, attributeName);
 
-                    if (entry == null)
-                        convertedValues[attributeName] = new AttributeValue { NULL = true };
-                    else
-                    {
-                        if (table.StoreAsEpoch.Contains(attributeName))
-                            entry = Document.DateTimeToEpochSeconds(entry, attributeName);
+                    if (table.StoreAsEpochLong.Contains(attributeName))
+                        entry = Document.DateTimeToEpochSecondsLong(entry, attributeName);
 
-                        if (table.StoreAsEpochLong.Contains(attributeName))
-                            entry = Document.DateTimeToEpochSecondsLong(entry, attributeName);
-
-                        var attributeConversionConfig = new DynamoDBEntry.AttributeConversionConfig(table.Conversion, table.IsEmptyStringValueEnabled);
-                        convertedValues[attributeName] = entry.ConvertToAttributeValue(attributeConversionConfig);
-                    }
+                    var attributeConversionConfig = new DynamoDBEntry.AttributeConversionConfig(table.Conversion, table.IsEmptyStringValueEnabled);
+                    convertedValues[attributeName] = entry.ConvertToAttributeValue(attributeConversionConfig);
                 }
             }
 

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DocumentTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DocumentTests.cs
@@ -58,6 +58,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
                 // Test expressions for put
                 TestExpressionPut(hashTable);
+                TestExpressionPutWithoutValues(hashTable);
 
                 // Test expressions for delete
                 TestExpressionsOnDelete(hashTable);
@@ -137,6 +138,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
                 // Test expressions for put
                 TestExpressionPut(hashTable);
+                TestExpressionPutWithoutValues(hashTable);
 
                 // Test expressions for delete
                 TestExpressionsOnDelete(hashTable);
@@ -1752,6 +1754,27 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             doc["update-test"] = 3;
             Assert.IsFalse(hashTable.TryPutItem(doc, config));
 
+            hashTable.DeleteItem(doc);
+        }
+
+        private void TestExpressionPutWithoutValues(ITable hashTable)
+        {
+            var doc = new Document
+            {
+                ["Id"] = DateTime.UtcNow.Ticks
+            };
+
+            var expression = new Expression
+            {
+                ExpressionStatement = "attribute_not_exists(Id)"
+            };
+
+            var config = new PutItemOperationConfig
+            {
+                ConditionalExpression = expression
+            };
+
+            Assert.IsTrue(hashTable.TryPutItem(doc, config));
             hashTable.DeleteItem(doc);
         }
 


### PR DESCRIPTION
Fixes #3802 

## Motivation and Context
Fixes a regression introduced in V4 where an expression without variables would throw an `AmazonDynamoDBException: ExpressionAttributeValues must not be empty`. For example, this operation:
```csharp
var ddb = new AmazonDynamoDBClient();
var table = new TableBuilder(ddb, "TestTable").AddHashKey("pk", DynamoDBEntryType.String).Build();
var doc = new Document { ["pk"] = Guid.NewGuid().ToString() };

await table.PutItemAsync(doc, new PutItemOperationConfig
{
    ConditionalExpression = new Expression { ExpressionStatement = "attribute_not_exists(pk)" },
});
```

Would result in the following request body:
```json
{"ConditionExpression":"attribute_not_exists(pk)","ExpressionAttributeValues":{},"Item":{"pk":{"S":"386ba1d5-5b18-47e5-9c22-3b73e0f1ddd1"}},"TableName":"TestTable"}
```

This PR updates the document model to match the request sent by V3:
```json
{"ConditionExpression":"attribute_not_exists(pk)","Item":{"pk":{"S":"75fbb295-a11c-4447-ac1a-bacc2baacd0c"}},"TableName":"TestTable"}
```

## Testing
- Dry-run: `DRY_RUN-c628983c-fa45-42c4-a4d0-81921c146e4f`
- Also confirmed this works when `AWSConfigs.InitializeCollections` is set to `true`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license