### PR TITLE
Fixed issue with collection properties with customizations 

### DIFF
--- a/generator/.DevConfigs/dd40b21f-183d-40f2-8508-eba8bdfbec46.json
+++ b/generator/.DevConfigs/dd40b21f-183d-40f2-8508-eba8bdfbec46.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fixed issue when model properties had customization exposing IsSet methods that empty collections would not be sent as part of the request. For example the L and M properties of AttributeValue in DynamoDB."
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
@@ -402,7 +402,7 @@ namespace Amazon.Util.Internal
             if (field == null)
                 return false;
 
-            if (field.Count > 0)
+            if (field.Count > 0 || !AWSConfigs.InitializeCollections)
                 return true;
 
             var sl = field as AlwaysSendList<T>;
@@ -416,7 +416,7 @@ namespace Amazon.Util.Internal
             if (field == null)
                 return false;
 
-            if (field.Count > 0)
+            if (field.Count > 0 || !AWSConfigs.InitializeCollections)
                 return true;
 
             var sd = field as AlwaysSendDictionary<TKey, TVvalue>;

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/ServiceTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/ServiceTests.cs
@@ -206,12 +206,15 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
             var emptyListAV = new AttributeValue();
             emptyListAV.L = null;
-            // call to IsLSet = true sets L to empty list
+            // call to IsLSet = true sets L to empty list. This is testing legacy behavior in V3 where
+            // Users would explicit set IsLSet to confirm an empty array is sent to the request.
             emptyListAV.IsLSet = true;
             Assert.AreEqual(0, emptyListAV.L.Count);
+
+            // Create a new AttributeValue to confirm that the empty collection will be sent even
+            // if IsLSet is not set.
+            emptyListAV = new AttributeValue();
             emptyListAV.L = new List<AttributeValue>();
-            // call to IsLSet = true sets L to empty list
-            emptyListAV.IsLSet = true;
             Assert.AreEqual(0, emptyListAV.L.Count);
 
             var boolAV = new AttributeValue();

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DynamoDBTests.cs
@@ -103,7 +103,7 @@ namespace AWSSDK_DotNet.UnitTests
                         {
                             new AttributeValue
                             {
-                                M = new Dictionary<string, AttributeValue>(),
+                                M = null,
                             }
                         }
                     }
@@ -112,6 +112,24 @@ namespace AWSSDK_DotNet.UnitTests
 
             var document = Document.FromAttributeMap(initialAttributeMap);
             Assert.AreEqual(document["Lists"].AsListOfDocument().Count, 0);
+
+            initialAttributeMap = new Dictionary<string, AttributeValue>
+            {
+                { "Lists", new AttributeValue
+                    {
+                        L = new List<AttributeValue>
+                        {
+                            new AttributeValue
+                            {
+                                M = new Dictionary<string, AttributeValue>(),
+                            }
+                        }
+                    }
+                }
+            };
+
+            document = Document.FromAttributeMap(initialAttributeMap);
+            Assert.AreEqual(document["Lists"].AsListOfDocument().Count, 1);
 
             var jsonString = document.ToJson();
             Assert.IsNotNull(jsonString);


### PR DESCRIPTION
## Description
In V3 we sometimes added customizations to make public `IsSet<property-name>` properties so users could explicit say this property with an empty collection is set and we should send it to the service. The `L` and `M` properties for `AttributeValue` in DynamoDB are common examples of this. The generate public `IsSet<property-name>` properties used a different code path for then the usual internal `IsSet` for checking if a property was set and should be sent. This different code path in V4 wasn't updated to handle the `AWSConfigs.InitializeCollections` property and collection properties being null by default.

## Testing
Adapted an existing DDB integ test to trigger the failing condition and then made the code fix to get the test to pass.
Running Dry Run

