### PR TITLE
[V4] Add the ConnectTimeout property for .NET 8 target

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.NETCore.Setup</id>
     <title>AWSSDK - Extensions for NETCore Setup</title>
-    <version>4.0.0.0</version>
+    <version>4.0.1.0</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with .NET Core configuration and dependency injection frameworks.</description>
     <language>en-US</language>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
@@ -339,6 +339,12 @@ namespace Amazon.Extensions.NETCore.Setup
             {
                 config.Timeout = defaultConfig.Timeout.Value;
             }
+#if NET8_0_OR_GREATER
+            if (defaultConfig.ConnectTimeout.HasValue)
+            {
+                config.ConnectTimeout = defaultConfig.ConnectTimeout.Value;
+            }
+#endif
             if (defaultConfig.UseAlternateUserAgentHeader.HasValue)
             {
                 config.UseAlternateUserAgentHeader = defaultConfig.UseAlternateUserAgentHeader.Value;

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
@@ -313,6 +313,17 @@ namespace Microsoft.Extensions.Configuration
 
                     options.DefaultClientConfig.Timeout = TimeSpan.FromMilliseconds(timeout);
                 }
+#if NET8_0_OR_GREATER
+                else if (string.Equals(element.Key, nameof(DefaultClientConfig.ConnectTimeout), StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!int.TryParse(element.Value, out var connectTimeout))
+                    {
+                        throw new ArgumentException($"Invalid integer value for {nameof(DefaultClientConfig.ConnectTimeout)}.");
+                    }
+
+                    options.DefaultClientConfig.ConnectTimeout = TimeSpan.FromMilliseconds(connectTimeout);
+                }
+#endif
                 else if (string.Equals(element.Key, nameof(DefaultClientConfig.UseAlternateUserAgentHeader), StringComparison.OrdinalIgnoreCase))
                 {
                     if (!bool.TryParse(element.Value, out var useAlternateUserAgentHeader))

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/DefaultClientConfig.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/DefaultClientConfig.cs
@@ -214,6 +214,15 @@ namespace Amazon.Extensions.NETCore.Setup
         /// </summary>
         public TimeSpan? Timeout { get; set; }
 
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Gets and sets the connection timeout that will be set on the HttpClient used by the service client to make requests.
+        /// The connection timeout is used control the wait time for the connection to be established to the service. The default
+        /// connection timeout for the HttpClient infinite waiting period.
+        /// </summary>
+        public TimeSpan? ConnectTimeout { get; set; }
+#endif
+
         /// <summary>
         /// When set to true, the service client will use the x-amz-user-agent
         /// header instead of the User-Agent header to report version and

--- a/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
+++ b/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
@@ -127,6 +127,11 @@ namespace NETCore.SetupTests
             var clientConfig = client.Config as AmazonS3Config;
             Assert.NotNull(clientConfig);
             Assert.True(clientConfig.ForcePathStyle);
+
+#if NET8_0_OR_GREATER
+            Assert.Equal(TimeSpan.FromMilliseconds(500), options.DefaultClientConfig.ConnectTimeout);
+            Assert.Equal(TimeSpan.FromMilliseconds(500), clientConfig.ConnectTimeout);
+#endif
         }
 
         [Fact]

--- a/extensions/test/NETCore.SetupTests/TestFiles/GetClientConfigSettingsTest.json
+++ b/extensions/test/NETCore.SetupTests/TestFiles/GetClientConfigSettingsTest.json
@@ -3,10 +3,11 @@
     "UseHttp": true,
     "MaxErrorRetry": 6,
     "Timeout": 1000,
+    "ConnectTimeout": 500,
     "AuthenticationRegion": "us-east-1",
     "Region": "us-west-2",
     "DefaultsMode": "Standard",
-    "ForcePathStyle":  true,
+    "ForcePathStyle": true,
     "RetryMode": "Standard"
   }
 }

--- a/generator/.DevConfigs/A78BAE5D-9864-4E0F-853F-BBA0ACD3F60D.json
+++ b/generator/.DevConfigs/A78BAE5D-9864-4E0F-853F-BBA0ACD3F60D.json
@@ -6,7 +6,8 @@
             "Add the ConnectTimeout property on the service client config for the .NET 8 target of the SDK."
         ],
 		"backwardIncompatibilitiesToIgnore": [
-			"Amazon.Runtime.ClientConfig/MethodAdded"
+			"Amazon.Runtime.ClientConfig/MethodAdded",
+			"Amazon.Runtime.IClientConfig/MethodAbstractMethodAdded"
 		]
     }
 }

--- a/generator/.DevConfigs/A78BAE5D-9864-4E0F-853F-BBA0ACD3F60D.json
+++ b/generator/.DevConfigs/A78BAE5D-9864-4E0F-853F-BBA0ACD3F60D.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "updateMinimum": true,
+        "type": "Patch",
+        "changeLogMessages": [
+            "Add the ConnectTimeout property on the service client config for the .NET 8 target of the SDK."
+        ]
+    }
+}

--- a/generator/.DevConfigs/A78BAE5D-9864-4E0F-853F-BBA0ACD3F60D.json
+++ b/generator/.DevConfigs/A78BAE5D-9864-4E0F-853F-BBA0ACD3F60D.json
@@ -4,6 +4,9 @@
         "type": "Patch",
         "changeLogMessages": [
             "Add the ConnectTimeout property on the service client config for the .NET 8 target of the SDK."
-        ]
+        ],
+		"backwardIncompatibilitiesToIgnore": [
+			"Amazon.Runtime.ClientConfig/MethodAdded"
+		]
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -742,7 +742,31 @@ namespace Amazon.Runtime
             }
         }
 
-#if AWS_ASYNC_API
+#if NET8_0_OR_GREATER
+        TimeSpan? _connectTimeout;
+
+        /// <summary>
+        /// Gets and sets the connection timeout that will be set on the HttpClient used by the service client to make requests.
+        /// The connection timeout is used control the wait time for the connection to be established to the service. The default
+        /// connection timeout for the HttpClient is infinite waiting period.
+        /// </summary>
+        public TimeSpan? ConnectTimeout
+        {
+            get
+            {
+                if (!this._connectTimeout.HasValue)
+                    return null;
+
+                return this._connectTimeout.Value;
+            }
+            set
+            {
+                ValidateTimeout(value);
+                this._connectTimeout = value;
+            }
+        }
+#endif
+
         /// <summary>
         /// Generates a <see cref="CancellationToken"/> based on the value
         /// for <see cref="DefaultConfiguration.TimeToFirstByteTimeout"/>.
@@ -758,7 +782,6 @@ namespace Amazon.Runtime
                 ? new CancellationTokenSource(cancelTimeout.Value).Token
                 : default(CancellationToken);
         }
-#endif
 
         /// <summary>
         /// Configures the endpoint calculation for a service to go to a dual stack (ipv6 enabled) endpoint

--- a/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
@@ -260,6 +260,13 @@ namespace Amazon.Runtime
         /// </remarks>
         TimeSpan? Timeout { get; }
 
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Gets the connection timeout that will be set on the HttpClient used by the service client to make requests.
+        /// The connection timeout is used control the wait time for the connection to be established to the service.
+        /// </summary>
+        TimeSpan? ConnectTimeout { get; }
+#endif
         /// <summary>
         /// Configures the endpoint calculation for a service to go to a dual stack (ipv6 enabled) endpoint
         /// for the configured region.

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
@@ -255,6 +255,11 @@ namespace Amazon.Runtime
                 // is going to be required.
                 EnableMultipleHttp2Connections = true
             };
+
+            if (clientConfig.ConnectTimeout.HasValue)
+            {
+                httpMessageHandler.ConnectTimeout = clientConfig.ConnectTimeout.Value;
+            }
 #else
             var httpMessageHandler = new HttpClientHandler();
 #endif

--- a/sdk/src/Core/Amazon.Runtime/_netstandard/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/_netstandard/ClientConfig.cs
@@ -168,6 +168,11 @@ namespace Amazon.Runtime
             if (clientConfig.MaxConnectionsPerServer.HasValue)
                 uniqueString = string.Concat(uniqueString, "MaxConnectionsPerServer:", clientConfig.MaxConnectionsPerServer.Value.ToString());
 
+#if NET8_0_OR_GREATER
+            if (clientConfig.ConnectTimeout.HasValue)
+                uniqueString = string.Concat(uniqueString, "ConnectTimeout:", clientConfig.ConnectTimeout.Value.ToString());
+#endif
+
             return uniqueString;
         }
 

--- a/sdk/test/NetStandard/UnitTests/ClientConfigTests.cs
+++ b/sdk/test/NetStandard/UnitTests/ClientConfigTests.cs
@@ -37,6 +37,9 @@ namespace UnitTests
             "DisableLogging",
             "ProxyCredentials",
             "Timeout",
+#if NET8_0_OR_GREATER
+            "ConnectTimeout",
+#endif
             "UseDualstackEndpoint",
             "UseFIPSEndpoint",
             "ProxyHost",


### PR DESCRIPTION
## Description
In the .NET 8 target we have access to the [ConnectTimeout](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler.connecttimeout). This PR exposes the ability to set the `ConnectTimeout` on the service client.

## Motivation and Context
This will help in scenario the SDK is trying to connect to a bad host and gets stuck trying to create the connection for a long period. If the user sets the connect timeout the `SendAsync` will timeout after the connect timeout has expired and since it is an IO exception the SDK will retry possibly to a different host.

## Testing
Running dry run
Manually confirmed by setting a low connect timeout that the SDK does do a retry when the connect timeout happens.

