### PR TITLE
[V3] Add the ConnectTimeout property on the service client config for the …

### DIFF
--- a/generator/.DevConfigs/378BAE5D-9864-4E0F-853F-BBA0ACD3F60D.json
+++ b/generator/.DevConfigs/378BAE5D-9864-4E0F-853F-BBA0ACD3F60D.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "updateMinimum": true,
+        "type": "Patch",
+        "changeLogMessages": [
+            "Add the ConnectTimeout property on the service client config for the .NET 8 target of the SDK."
+        ]
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -832,6 +832,31 @@ namespace Amazon.Runtime
             }
         }
 
+#if NET8_0_OR_GREATER
+        TimeSpan? _connectTimeout;
+
+        /// <summary>
+        /// Gets and sets the connection timeout that will be set on the HttpClient used by the service client to make requests.
+        /// The connection timeout is used control the wait time for the connection to be established to the service. The default
+        /// connection timeout for the HttpClient is infinite waiting period.
+        /// </summary>
+        public TimeSpan? ConnectTimeout
+        {
+            get
+            {
+                if (!this._connectTimeout.HasValue)
+                    return null;
+
+                return this._connectTimeout.Value;
+            }
+            set
+            {
+                ValidateTimeout(value);
+                this._connectTimeout = value;
+            }
+        }
+#endif
+
 #if AWS_ASYNC_API
         /// <summary>
         /// Generates a <see cref="CancellationToken"/> based on the value

--- a/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
@@ -245,6 +245,14 @@ namespace Amazon.Runtime
         /// </remarks>
         TimeSpan? Timeout { get; }
 
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Gets the connection timeout that will be set on the HttpClient used by the service client to make requests.
+        /// The connection timeout is used control the wait time for the connection to be established to the service.
+        /// </summary>
+        TimeSpan? ConnectTimeout { get; }
+#endif
+
         /// <summary>
         /// Configures the endpoint calculation for a service to go to a dual stack (ipv6 enabled) endpoint
         /// for the configured region.

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_netstandard/HttpRequestMessageFactory.cs
@@ -245,7 +245,16 @@ namespace Amazon.Runtime
          /// <returns></returns>
         private static HttpClient CreateManagedHttpClient(IClientConfig clientConfig)
         {
+#if NET8_0_OR_GREATER
+            var httpMessageHandler = new SocketsHttpHandler();
+
+            if (clientConfig.ConnectTimeout.HasValue)
+            {
+                httpMessageHandler.ConnectTimeout = clientConfig.ConnectTimeout.Value;
+            }
+#else
             var httpMessageHandler = new HttpClientHandler();
+#endif
 
             if (clientConfig.MaxConnectionsPerServer.HasValue)
                 httpMessageHandler.MaxConnectionsPerServer = clientConfig.MaxConnectionsPerServer.Value;

--- a/sdk/src/Core/Amazon.Runtime/_netstandard/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/_netstandard/ClientConfig.cs
@@ -168,6 +168,11 @@ namespace Amazon.Runtime
             if (clientConfig.MaxConnectionsPerServer.HasValue)
                 uniqueString = string.Concat(uniqueString, "MaxConnectionsPerServer:", clientConfig.MaxConnectionsPerServer.Value.ToString());
 
+#if NET8_0_OR_GREATER
+            if (clientConfig.ConnectTimeout.HasValue)
+                uniqueString = string.Concat(uniqueString, "ConnectTimeout:", clientConfig.ConnectTimeout.Value.ToString());
+#endif
+
             return uniqueString;
         }
 

--- a/sdk/test/NetStandard/UnitTests/ClientConfigTests.cs
+++ b/sdk/test/NetStandard/UnitTests/ClientConfigTests.cs
@@ -38,6 +38,9 @@ namespace UnitTests
             "DisableLogging",
             "ProxyCredentials",
             "Timeout",
+#if NET8_0_OR_GREATER
+            "ConnectTimeout",
+#endif
             "UseDualstackEndpoint",
             "UseFIPSEndpoint",
             "ProxyHost",


### PR DESCRIPTION
## Description
In the .NET 8 target we have access to the [ConnectTimeout](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler.connecttimeout). This PR exposes the ability to set the `ConnectTimeout` on the service client.

In the [V4](https://github.com/aws/aws-sdk-net/pull/3819) version of this AWSSDK.Extensions.NETCore.Setup was also updated but in this V3 PR it was not. That is because in V3 extends from the `ClientConfig` so it automatically inherits the properties. In V4 we removed the inheritance so I need to copy the `ConnectTimeout` to AWSSDK.Extensions.NETCore.Setup and add the logic to copy the setting the service client config.

## Motivation and Context
This will help in scenario the SDK is trying to connect to a bad host and gets stuck trying to create the connection for a long period. If the user sets the connect timeout the `SendAsync` will timeout after the connect timeout has expired and since it is an IO exception the SDK will retry possibly to a different host.

## Testing
Dry run successful: DRY_RUN-394333cd-113a-4bbe-a5f0-a13ba692b64c
Manually confirmed by setting a low connect timeout that the SDK does do a retry when the connect timeout happens.

