### PR TITLE
Update the nuspec for AWSSDK.Extensions.Bedrock.MEAI for GA release

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.Bedrock.MEAI</id>
     <title>AWSSDK - Bedrock integration with Microsoft.Extensions.AI.</title>
-    <version>4.0.0.0-preview.17</version>
+    <version>4.0.1.0</version>
     <authors>Amazon Web Services</authors>
     <description>Implementations of Microsoft.Extensions.AI's abstractions for Bedrock.</description>
     <language>en-US</language>
@@ -13,18 +13,18 @@
     <icon>images\AWSLogo.png</icon>
     <dependencies>
       <group targetFramework="net472">
-        <dependency id="AWSSDK.Core" version="4.0.0.2" />
-        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.1" />
+        <dependency id="AWSSDK.Core" version="4.0.0.4" />
+        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.5.0" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.2" />
-        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.1" />
+        <dependency id="AWSSDK.Core" version="4.0.0.4" />
+        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.5.0" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.2" />
-        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.1" />
+        <dependency id="AWSSDK.Core" version="4.0.0.4" />
+        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.5.0" />
       </group>
     </dependencies>


### PR DESCRIPTION
Update the AWSSDK.Extensions.Bedrock.MEAI for the GA release now that the dependencies are now GA. I set the version to `4.0.1.0` instead of `4.0.0.0` because we have an unlisted `4.0.0.0` version when we accidently released the package is GA when the dependency was not GA. 