### PR TITLE
V3: Fixed an issue where IAmazonS3.EnsureBucketExists(Async) was throwing an exception if S3 bucket already exists in the executing account.

### DIFF
--- a/generator/.DevConfigs/ed078ac7-c659-4cce-ad66-d313e8f48ffb.json
+++ b/generator/.DevConfigs/ed078ac7-c659-4cce-ad66-d313e8f48ffb.json
@@ -1,0 +1,9 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [ "Fixed an issue where IAmazonS3.EnsureBucketExists(Async) was throwing an exception if S3 bucket already exists in the executing account." ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/_async/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/_async/AmazonS3Client.Extensions.cs
@@ -143,9 +143,15 @@ namespace Amazon.S3
             return this.PutACLAsync(request);
         }
 
-        Task ICoreAmazonS3.EnsureBucketExistsAsync(string bucketName)
+        async Task ICoreAmazonS3.EnsureBucketExistsAsync(string bucketName)
         {
-            return this.PutBucketAsync(bucketName);
+            try
+            {
+                await this.PutBucketAsync(bucketName).ConfigureAwait(false);
+            }
+            catch (BucketAlreadyOwnedByYouException)
+            {
+            }
         }
 
         [Obsolete("This method is deprecated: its behavior is inconsistent and always uses HTTP. Please use Amazon.S3.Util.AmazonS3Util.DoesS3BucketExistV2Async instead.")]

--- a/sdk/src/Services/S3/Custom/_bcl/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/_bcl/AmazonS3Client.Extensions.cs
@@ -141,7 +141,11 @@ namespace Amazon.S3
 
         void ICoreAmazonS3.EnsureBucketExists(string bucketName)
         {
-            this.PutBucket(bucketName);
+            try
+            {
+                this.PutBucket(bucketName);
+            }
+            catch (BucketAlreadyOwnedByYouException) { }
         }
 
         [Obsolete("This method is obsolete: its behavior is inconsistent and always uses HTTP.")]

--- a/sdk/test/Services/S3/IntegrationTests/S3ExtensionsTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/S3ExtensionsTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Amazon;
+
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Transfer;
+
+using Amazon.S3Control;
+using Amazon.S3Control.Model;
+using Amazon.Runtime.SharedInterfaces;
+
+
+
+namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
+{
+    [TestClass]
+    public class S3ExtensionsTests : TestBase<AmazonS3Client>
+    {
+        static string _bucketName;
+
+        [ClassInitialize]
+        public static void Setup(TestContext context)
+        {
+            _bucketName = S3TestUtils.CreateBucketWithWait(Client);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            Amazon.S3.Util.AmazonS3Util.DeleteS3BucketWithObjects(Client, _bucketName);
+        }
+
+
+        [TestMethod]
+        public void EnsureBucketExists()
+        {
+            IAmazonS3 s3Client = Client;
+            s3Client.EnsureBucketExists(_bucketName);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fixed an issue where `IAmazonS3.EnsureBucketExists`(`Async`) was throwing an exception if S3 bucket already exists in the executing account.

Kindly note below for 1st version:
- Refer [Using the handle method to filter inner exceptions](https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/exception-handling-task-parallel-library#using-the-handle-method-to-filter-inner-exceptions) on how to handle exceptions when using async `Task` based version.
- After handling exception for async version, we return `Task.FromResult(0)`. This is because:
  - If we return the original `Task` object, it re-throws exception in the calling awaited thread.
  - `Task.CompletedTask` doesn't exist in `NET45` target.

## Motivation and Context
Issue #3807 

## Testing
- Added integration test.
- Dry-run `DRY_RUN-32d10e46-52d0-421f-9bc7-943cdd6348cd` completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement