### PR TITLE
Do not overwrite content-type header if set explicitly in MPU scenarios

### DIFF
--- a/generator/.DevConfigs/c07cc471-4e94-42cf-9c2f-c8c3fa906465.json
+++ b/generator/.DevConfigs/c07cc471-4e94-42cf-9c2f-c8c3fa906465.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fix: Fixed a bug where Content-Type header was being overwritten in multipart upload scenarios."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
@@ -348,8 +348,22 @@ namespace Amazon.S3.Transfer.Internal
             if (this._fileTransporterRequest.Metadata != null && this._fileTransporterRequest.Metadata.Count > 0)
                 initRequest.Metadata = this._fileTransporterRequest.Metadata;
             if (this._fileTransporterRequest.Headers != null && this._fileTransporterRequest.Headers.Count > 0)
-                initRequest.Headers = this._fileTransporterRequest.Headers;
-
+            {
+                foreach (var headerKey in this._fileTransporterRequest.Headers.Keys)
+                {
+                    // InitiateMultipartUploadRequest already has its content-type header set.
+                    // don't copy the Content-Type if it's set already as to not overwrite the original content-type
+                    if (string.Equals(headerKey, HeaderKeys.ContentTypeHeader) && this._fileTransporterRequest.IsSetContentType())
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        initRequest.Headers[headerKey] = this._fileTransporterRequest.Headers[headerKey];
+                    }
+                }
+            }
+                
             return initRequest;
         }
 

--- a/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
@@ -11,6 +11,8 @@ using Amazon.S3.Transfer;
 using Amazon.S3.Util;
 using AWSSDK_DotNet.IntegrationTests.Utils;
 using Amazon.Util;
+using System.Net.Mime;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 {
@@ -1029,6 +1031,33 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             });
 
             Assert.IsTrue(File.Exists(filePath));
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void TestMultipartUploadWithSetContentTypeNotOverwritten()
+        {
+            // 20 MB stream
+            var fileName = UtilityMethods.GenerateName(@"SetContentType");
+            var path = Path.Combine(BasePath, fileName);
+            var fileSize = 20 * MEG_SIZE;
+            UtilityMethods.GenerateFile(path, 20 * MEG_SIZE);
+            var transferUtilityRequest = new TransferUtilityUploadRequest
+            {
+                BucketName = bucketName,
+                FilePath = path,
+                Key = "test-content-type",
+                ContentType = MediaTypeNames.Text.Plain,
+                Headers =
+                {
+                    ContentEncoding = "gzip",
+                },
+            };
+            var tu = new TransferUtility(Client);
+            tu.Upload(transferUtilityRequest);
+            var downloadPath = path + ".download";
+            var metadata = Client.GetObjectMetadata(new GetObjectMetadataRequest { BucketName = bucketName, Key = "test-content-type" });
+            Assert.IsTrue(metadata.Headers.ContentType.Equals(MediaTypeNames.Text.Plain));
         }
 
 #if ASYNC_AWAIT


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When copying the headers from the TransferUtilitityUploadRequest to InitiateMultipartUploadRequest, do not overwrite content-type header if it is set. I have also verified that Content-Type is the only property that modifies the headers for `InitiateMultipartUploadRequest`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes https://github.com/aws/aws-sdk-net/issues/3783
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Dry run passes DRY_RUN-224d2c50-c2a5-456d-91b5-202d148ee748
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement