### PR TITLE
Fixed an issue in JsonPolicyWriter.WritePolicyToString() method where it was not using prettyPrint parameter for indentation.

### DIFF
--- a/generator/.DevConfigs/31d96afb-c4e2-4057-b0cc-14b36797961d.json
+++ b/generator/.DevConfigs/31d96afb-c4e2-4057-b0cc-14b36797961d.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Fixed an issue in JsonPolicyWriter.WritePolicyToString() method where it was not using prettyPrint parameter for indentation."
+    ],
+    "type": "patch",
+    "updateMinimum": false
+  }
+}

--- a/sdk/src/Core/Amazon.Auth/AccessControlPolicy/Internal/JsonPolicyWriter.cs
+++ b/sdk/src/Core/Amazon.Auth/AccessControlPolicy/Internal/JsonPolicyWriter.cs
@@ -53,7 +53,7 @@ namespace Amazon.Auth.AccessControlPolicy.Internal
                 // indentSize is only available in net8+ and net472
                 JsonWriterOptions options = new JsonWriterOptions
                 {
-                    Indented = true,
+                    Indented = prettyPrint
                 };
                 using (var stream = new MemoryStream())
                 using (var generator = new Utf8JsonWriter(stream, options))

--- a/sdk/test/UnitTests/Custom/PolicyTests.cs
+++ b/sdk/test/UnitTests/Custom/PolicyTests.cs
@@ -249,5 +249,41 @@ namespace AWSSDK_DotNet.UnitTests
             Assert.AreEqual(1, statement.Principals.Count);
             Assert.AreEqual(Principal.Anonymous, statement.Principals.First());
         }
+
+        [TestMethod]
+        public void TestPrettyPrintIndentationDisabled()
+        {
+            string testPolicy = @"{
+                ""Version"": ""2012-10-17"",
+                ""Statement"": [
+                {
+                    ""Sid"": ""AllowS3ListBucket"",
+                    ""Effect"": ""Allow"",
+                    ""Action"": [
+                    ""s3:ListBucket""
+                    ],
+                    ""Resource"": [
+                    ""arn:aws:s3:::your-bucket-name""
+                    ]
+                }
+                ]
+            }";
+
+            var policy = Policy.FromJson(testPolicy);
+            string policyString = policy.ToJson(false);
+
+            Assert.IsFalse(policyString.Contains("\n"));
+        }
+
+        [TestMethod]
+        public void TestPrettyPrintIndentationEnabled()
+        {
+            string testPolicy = @"{""Version"": ""2012-10-17"", ""Statement"": [{""Sid"": ""AllowS3ListBucket"", ""Effect"": ""Allow"", ""Action"": [ ""s3:ListBucket"" ], ""Resource"": [ ""arn:aws:s3:::your-bucket-name""]}]}";
+
+            var policy = Policy.FromJson(testPolicy);
+            string policyString = policy.ToJson(true);
+
+            Assert.IsTrue(policyString.Contains("\n"));
+        }
     }
 }


### PR DESCRIPTION
## Description
Fixed an issue in `JsonPolicyWriter.WritePolicyToString()` method where it was not using `prettyPrint` parameter for indentation.

## Motivation and Context
Issue #3805.

## Testing
- Added unit tests.
- Dry-run `DRY_RUN-4f6f7952-cc98-4d78-922a-44d23aaf629c` completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement