### PR TITLE
S3 DeleteObjects Key Validation Fix

### DIFF
--- a/generator/.DevConfigs/a5cb7525-8e50-4583-ae7b-36180442d7e3.json
+++ b/generator/.DevConfigs/a5cb7525-8e50-4583-ae7b-36180442d7e3.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+      {
+        "serviceName": "S3",
+        "type": "patch",
+        "changeLogMessages": [
+          "Fixed a bug in DeleteObjects where valid objects would not be deleted when the request included invalid keys"
+        ]
+      }
+    ]
+  }

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/DeleteObjectsRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/DeleteObjectsRequestMarshaller.cs
@@ -68,36 +68,52 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 xmlWriter.WriteStartElement("Delete", S3Constants.S3RequestXmlNamespace);
 
                 var deleteDeleteobjectsList = deleteObjectsRequest.Objects;
-                if (deleteDeleteobjectsList != null && deleteDeleteobjectsList.Count > 0)
+                if (deleteDeleteobjectsList == null || deleteDeleteobjectsList.Count == 0)
                 {
-                    foreach (var deleteDeleteobjectsListValue in deleteDeleteobjectsList)
+                    if (deleteObjectsRequest.ValidationErrors?.Count > 0)
                     {
-                        xmlWriter.WriteStartElement("Object", "");
-                        if (deleteDeleteobjectsListValue.IsSetKey())
-                        {
-                            xmlWriter.WriteElementString("Key", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.Key));
-                        }
-                        if (deleteDeleteobjectsListValue.IsSetVersionId())
-                        {
-                            xmlWriter.WriteElementString("VersionId", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.VersionId));
-                        }
-
-                        if (deleteDeleteobjectsListValue.IsSetETag())
-                        {
-                            xmlWriter.WriteElementString("ETag", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.ETag));
-                        }
-                        if (deleteDeleteobjectsListValue.IsSetLastModifiedTime())
-                        {
-                            xmlWriter.WriteElementString("LastModifiedTime", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.LastModifiedTime.Value));
-                        }
-                        if (deleteDeleteobjectsListValue.IsSetSize())
-                        {
-                            xmlWriter.WriteElementString("Size", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.Size.Value));
-                        }
-
-                        xmlWriter.WriteEndElement();
+                        // All keys were invalid - provide clear error with validation details
+                        throw new AmazonS3Exception(
+                            $"DeleteObjects operation failed: All {deleteObjectsRequest.ValidationErrors.Count} keys were invalid. See ValidationErrors for details."
+                        );
+                    }
+                    else
+                    {
+                        // No keys were provided
+                        throw new AmazonS3Exception(
+                            "DeleteObjects operation requires at least one valid key, but none were provided."
+                        );
                     }
                 }
+                
+                foreach (var deleteDeleteobjectsListValue in deleteDeleteobjectsList)
+                {
+                    xmlWriter.WriteStartElement("Object", "");
+                    if (deleteDeleteobjectsListValue.IsSetKey())
+                    {
+                        xmlWriter.WriteElementString("Key", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.Key));
+                    }
+                    if (deleteDeleteobjectsListValue.IsSetVersionId())
+                    {
+                        xmlWriter.WriteElementString("VersionId", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.VersionId));
+                    }
+
+                    if (deleteDeleteobjectsListValue.IsSetETag())
+                    {
+                        xmlWriter.WriteElementString("ETag", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.ETag));
+                    }
+                    if (deleteDeleteobjectsListValue.IsSetLastModifiedTime())
+                    {
+                        xmlWriter.WriteElementString("LastModifiedTime", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.LastModifiedTime.Value));
+                    }
+                    if (deleteDeleteobjectsListValue.IsSetSize())
+                    {
+                        xmlWriter.WriteElementString("Size", "", S3Transforms.ToXmlStringValue(deleteDeleteobjectsListValue.Size.Value));
+                    }
+
+                    xmlWriter.WriteEndElement();
+                }
+                
                 if (deleteObjectsRequest.IsSetQuiet())
                 {
                     xmlWriter.WriteElementString("Quiet", "", S3Transforms.ToXmlStringValue(deleteObjectsRequest.Quiet.Value));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modified the S3 client's `DeleteObjects` operation to properly handle invalid keys in batch delete requests. Instead of failing the entire operation when any single key is invalid, the client now skips invalid keys and proceeds with deleting valid objects. If all keys in a request are invalid, a clear exception is thrown with an appropriate message.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Addresses open issue #3828
---
This change is required because the current implementation prevents valid keys from being deleted when any key in the batch is invalid (e.g., too long). The S3 DeleteObjects API is designed to support partial successes, but the client-side validation was preventing this behavior by throwing an `AmazonS3Exception` before the request reached the service.

This fix allows the DeleteObjects operation to behave as expected, processing all valid keys even when some invalid keys are present in the same batch.
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes were tested with the following scenarios:
- Request with only valid keys (verified all objects deleted)
- Request with mix of valid and invalid keys (verified valid objects deleted)
- Request with all invalid keys (verified appropriate exception thrown)
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement