### PR TITLE
Fix Document enumeration for Dictionary types to resolve WebAuthn serialization errors

### DIFF
--- a/generator/.DevConfigs/304ac42f-43cd-4862-bab4-413ad22e17b1.json
+++ b/generator/.DevConfigs/304ac42f-43cd-4862-bab4-413ad22e17b1.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+      "changeLogMessages": [
+        "Fixed Document.cs serialization issue that caused WebAuthn operations to fail when response contained Dictionary structures"
+      ],
+      "type": "patch",
+      "updateMinimum": true
+    }
+  }

--- a/sdk/src/Core/Amazon.Runtime/Documents/Document.cs
+++ b/sdk/src/Core/Amazon.Runtime/Documents/Document.cs
@@ -285,7 +285,13 @@ namespace Amazon.Runtime.Documents
         #region Collection Initializers
         IEnumerator<Document> IEnumerable<Document>.GetEnumerator()
         {
-            return AsList().GetEnumerator();
+            if (Type == DocumentType.List)
+                return AsList().GetEnumerator();
+
+            if (Type == DocumentType.Dictionary)
+                return AsDictionary().Values.GetEnumerator();
+
+            return new[]{this}.AsEnumerable().GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed a serialization bug in the Document class where the IEnumerator<Document> IEnumerable<Document>.GetEnumerator() method always attempted to convert Documents to Lists, causing InvalidDocumentTypeConversionException when the Document contained Dictionary structures. Updated the method to handle both Dictionary and List types, matching the pattern already used in the non-generic IEnumerable.GetEnumerator() method.

## Motivation and Context
This change fixes a critical issue where WebAuthn operations like StartWebAuthnRegistrationAsync were failing with serialization errors. The WebAuthn service returns response data as Dictionary structures, but the Document enumeration logic was incorrectly assuming all Documents were Lists during JSON serialization.
Fixes #3837 

## Testing
* Verified that the fix resolves the WebAuthn StartWebAuthnRegistrationAsync serialization error
* Confirmed the implementation follows the existing pattern used in the same class for the non-generic IEnumerable.GetEnumerator() method
* Tested that Dictionary-type Documents can now be properly enumerated during JSON serialization

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement