### PR TITLE
Fix DeleteObjects to throw DeleteObjectsException instead of AmazonS3Exception

### DIFF
--- a/generator/.DevConfigs/1f197260-2f36-43db-8312-41be9543531c.json
+++ b/generator/.DevConfigs/1f197260-2f36-43db-8312-41be9543531c.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fixed DeleteObjects to throw DeleteObjectsException instead of AmazonS3Exception for consistent error handling"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added UnmarshallException method override to `DeleteObjectsResponseUnmarshaller` to ensure that all `DeleteObjects` operation failures consistently throw `DeleteObjectsException` instead of the generic `AmazonS3Exception`.
The fix creates a `DeleteObjectsResponse` containing structured error information and wraps it in a `DeleteObjectsException`, preserving all error details (`ErrorCode`, `RequestId`, `StatusCode`) while providing the expected exception type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes issue #3828 reported inconsistent exception handling for `DeleteObjects` operations.
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Tested with invalid keys (too long), confirming `DeleteObjectsException` is now thrown
- Verified that exception contains proper error information in `Response.DeleteErrors` collection
- Validated that `ErrorCode`, `RequestId`, and `StatusCode` are properly preserved
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement