### PR TITLE
Fix async waiting in `DynamoDBRetryPolicy`.

### DIFF
--- a/generator/.DevConfigs/1cecd29e-66f5-4ac7-be16-2df3ba18f3d2.json
+++ b/generator/.DevConfigs/1cecd29e-66f5-4ac7-be16-2df3ba18f3d2.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "DynamoDBv2",
+      "type": "patch",
+      "changeLogMessages": [
+        "Add DynamoDBRetryPolicy.WaitBeforeRetryAsync override method in order to use the updated retry logic for async retries."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/Internal/DynamoDBRetryPolicy.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Internal/DynamoDBRetryPolicy.cs
@@ -14,7 +14,6 @@
  */
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
@@ -55,7 +54,7 @@ namespace Amazon.DynamoDBv2.Internal
         /// <param name="executionContext"></param>
         public override void WaitBeforeRetry(IExecutionContext executionContext)
         {
-            Thread.Sleep(CalculateRetryDelay(executionContext.RequestContext.Retries));
+            Amazon.Util.AWSSDKUtils.Sleep(CalculateRetryDelay(executionContext.RequestContext.Retries));
         }
 
         /// <summary>

--- a/sdk/src/Services/DynamoDBv2/Custom/Internal/DynamoDBRetryPolicy.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/Internal/DynamoDBRetryPolicy.cs
@@ -1,12 +1,12 @@
-﻿/*
+/*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -14,10 +14,8 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
 
@@ -38,12 +36,12 @@ namespace Amazon.DynamoDBv2.Internal
             base(config)
         {
             ThrottlingErrorCodes.Add("TransactionInProgressException");
-               
-            //When derived from DefaultRetryPolicy, we are in legacy retry 
+
+            //When derived from DefaultRetryPolicy, we are in legacy retry
             //mode. When in legacy retry mode MaxErrorRetry used to be set
             //to 10 in the DynamoDB and DynamoDBStreams configs. This
             //can no longer be set in the configs because the retry mode
-            //may not be known at that point where standard and adaptive 
+            //may not be known at that point where standard and adaptive
             //retry modes are not to have this default.
             if(!config.IsMaxErrorRetrySet)
             {
@@ -57,24 +55,32 @@ namespace Amazon.DynamoDBv2.Internal
         /// <param name="executionContext"></param>
         public override void WaitBeforeRetry(IExecutionContext executionContext)
         {
-            pauseExponentially(executionContext.RequestContext.Retries);
+            Thread.Sleep(CalculateRetryDelay(executionContext.RequestContext.Retries));
+        }
+
+        /// <summary>
+        /// Overriden to cause a pause between retries.
+        /// </summary>
+        /// <param name="executionContext"></param>
+        public override Task WaitBeforeRetryAsync(IExecutionContext executionContext)
+        {
+            return Task.Delay(CalculateRetryDelay(executionContext.RequestContext.Retries), executionContext.RequestContext.CancellationToken);
         }
 
         /// <summary>
         /// Override the pausing function so retries would happen more frequent then the default operation.
         /// </summary>
-        /// <param name="retries">Current number of retries.</param>
-        private void pauseExponentially(int retries)
+        private int CalculateRetryDelay(int retries)
         {
             int delay;
-               
+
             if (retries <= 0)       delay = 0;
             else if (retries < 20)  delay = Convert.ToInt32(Math.Pow(2, retries - 1) * 50.0);
             else                    delay = Int32.MaxValue;
 
             if (retries > 0 && (delay > MaxBackoffInMilliseconds || delay <= 0))
                 delay = MaxBackoffInMilliseconds;
-            Amazon.Util.AWSSDKUtils.Sleep(delay);
+            return delay;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates `DynamoDBRetryPolicy` to override the `WaitBeforeRetryAsync` method in order to use the updated retry logic for async retries in addition to sync ones.

## Motivation and Context
Noticed as part of a larger clean-up effort, and split into its own branch.

## Testing
N/A

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement