### PR TITLE
Fixed an issue where NullReferenceException was thrown when calling AddPartETags() on CompleteMultipartUploadRequest object.

### DIFF
--- a/generator/.DevConfigs/f957e2d8-fa28-425e-878a-fc657dfb625d.json
+++ b/generator/.DevConfigs/f957e2d8-fa28-425e-878a-fc657dfb625d.json
@@ -1,0 +1,9 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [ "Fixed an issue where NullReferenceException was thrown when calling AddPartETags() on CompleteMultipartUploadRequest object." ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/CompleteMultipartUploadRequest.cs
@@ -529,6 +529,11 @@ namespace Amazon.S3.Model
         /// <param name="partETags">PartETags that will added to this request.</param>
         public void AddPartETags(params PartETag[] partETags)
         {
+            if (PartETags == null)
+            {
+                PartETags = new List<PartETag>();
+            }
+
             if (partETags != null)
             {
                 foreach (PartETag part in partETags)
@@ -544,13 +549,17 @@ namespace Amazon.S3.Model
         /// <param name="partETags">PartETags that will added to this request.</param>
         public void AddPartETags(IEnumerable<PartETag> partETags)
         {
-            if (partETags == null)
+            if (PartETags == null)
             {
-                partETags = new List<PartETag>();
+                PartETags = new List<PartETag>();
             }
-            foreach (PartETag part in partETags)
+
+            if (partETags != null)
             {
-                this.PartETags.Add(part);
+                foreach (PartETag part in partETags)
+                {
+                    this.PartETags.Add(part);
+                }
             }
         }
 
@@ -568,9 +577,12 @@ namespace Amazon.S3.Model
                 PartETags = new List<PartETag>();
             }
 
-            foreach (UploadPartResponse response in responses)
+            if (responses != null)
             {
-                this.PartETags.Add(new PartETag(response, copyChecksums: false));
+                foreach (UploadPartResponse response in responses)
+                {
+                    this.PartETags.Add(new PartETag(response, copyChecksums: false));
+                }
             }
         }
 
@@ -588,9 +600,12 @@ namespace Amazon.S3.Model
                 PartETags = new List<PartETag>();
             }
 
-            foreach (UploadPartResponse response in responses)
+            if (responses != null)
             {
-                this.PartETags.Add(new PartETag(response, copyChecksums: false));
+                foreach (UploadPartResponse response in responses)
+                {
+                    this.PartETags.Add(new PartETag(response, copyChecksums: false));
+                }
             }
         }
 
@@ -605,9 +620,12 @@ namespace Amazon.S3.Model
                 PartETags = new List<PartETag>();
             }
 
-            foreach (UploadPartResponse response in responses)
+            if (responses != null)
             {
-                this.PartETags.Add(new PartETag(response, copyChecksums: true));
+                foreach (UploadPartResponse response in responses)
+                {
+                    this.PartETags.Add(new PartETag(response, copyChecksums: true));
+                }
             }
         }
 
@@ -622,9 +640,12 @@ namespace Amazon.S3.Model
                 PartETags = new List<PartETag>();
             }
 
-            foreach (UploadPartResponse response in responses)
+            if (responses != null)
             {
-                this.PartETags.Add(new PartETag(response, copyChecksums: true));
+                foreach (UploadPartResponse response in responses)
+                {
+                    this.PartETags.Add(new PartETag(response, copyChecksums: true));
+                }
             }
         }
 
@@ -642,9 +663,12 @@ namespace Amazon.S3.Model
                 PartETags = new List<PartETag>();
             }
 
-            foreach (CopyPartResponse response in responses)
+            if (responses != null)
             {
-                this.PartETags.Add(new PartETag(response, copyChecksums: false));
+                foreach (CopyPartResponse response in responses)
+                {
+                    this.PartETags.Add(new PartETag(response, copyChecksums: false));
+                }
             }
         }
 
@@ -662,9 +686,12 @@ namespace Amazon.S3.Model
                 PartETags = new List<PartETag>();
             }
 
-            foreach (CopyPartResponse response in responses)
+            if (responses != null)
             {
-                this.PartETags.Add(new PartETag(response, copyChecksums: false));
+                foreach (CopyPartResponse response in responses)
+                {
+                    this.PartETags.Add(new PartETag(response, copyChecksums: false));
+                }
             }
         }
 
@@ -679,9 +706,12 @@ namespace Amazon.S3.Model
                 PartETags = new List<PartETag>();
             }
 
-            foreach (CopyPartResponse response in responses)
+            if (responses != null)
             {
-                this.PartETags.Add(new PartETag(response, copyChecksums: true));
+                foreach (CopyPartResponse response in responses)
+                {
+                    this.PartETags.Add(new PartETag(response, copyChecksums: true));
+                }
             }
         }
 
@@ -696,9 +726,12 @@ namespace Amazon.S3.Model
                 PartETags = new List<PartETag>();
             }
 
-            foreach (CopyPartResponse response in responses)
+            if (responses != null)
             {
-                this.PartETags.Add(new PartETag(response, copyChecksums: true));
+                foreach (CopyPartResponse response in responses)
+                {
+                    this.PartETags.Add(new PartETag(response, copyChecksums: true));
+                }
             }
         }
 


### PR DESCRIPTION
## Description
Fixed an issue where `NullReferenceException` was thrown when calling `AddPartETags()` on `CompleteMultipartUploadRequest` object. This also adds additional check(s) in `AddPartETagsAndChecksums()`.

## Motivation and Context
Issue #3815

## Testing
Dry-run `DRY_RUN-0bd0ea5a-8b20-4c27-89bd-087a47b1b416` completed successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement