### PR TITLE
Issues/3731 json schema input schema

### DIFF
--- a/extensions/AWSSDK.Extensions.sln
+++ b/extensions/AWSSDK.Extensions.sln
@@ -74,6 +74,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWSSDK.CommonTest", "..\sdk
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWSSDK.S3.NetFramework", "..\sdk\src\Services\S3\AWSSDK.S3.NetFramework.csproj", "{1A313326-988F-4FF2-992E-6D7E50DCF598}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWSSDKExtensionsIntegrationTests", "C:\Users\rbarreto\source\repos\AWSSDKExtensionsIntegrationTests\AWSSDKExtensionsIntegrationTests.csproj", "{87312699-8C48-488B-80DC-0FF8FB4705E6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -204,6 +206,10 @@ Global
 		{1A313326-988F-4FF2-992E-6D7E50DCF598}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A313326-988F-4FF2-992E-6D7E50DCF598}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1A313326-988F-4FF2-992E-6D7E50DCF598}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87312699-8C48-488B-80DC-0FF8FB4705E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87312699-8C48-488B-80DC-0FF8FB4705E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87312699-8C48-488B-80DC-0FF8FB4705E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87312699-8C48-488B-80DC-0FF8FB4705E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/extensions/AWSSDK.Extensions.sln
+++ b/extensions/AWSSDK.Extensions.sln
@@ -74,8 +74,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWSSDK.CommonTest", "..\sdk
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWSSDK.S3.NetFramework", "..\sdk\src\Services\S3\AWSSDK.S3.NetFramework.csproj", "{1A313326-988F-4FF2-992E-6D7E50DCF598}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWSSDKExtensionsIntegrationTests", "C:\Users\rbarreto\source\repos\AWSSDKExtensionsIntegrationTests\AWSSDKExtensionsIntegrationTests.csproj", "{87312699-8C48-488B-80DC-0FF8FB4705E6}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -206,10 +204,6 @@ Global
 		{1A313326-988F-4FF2-992E-6D7E50DCF598}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A313326-988F-4FF2-992E-6D7E50DCF598}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1A313326-988F-4FF2-992E-6D7E50DCF598}.Release|Any CPU.Build.0 = Release|Any CPU
-		{87312699-8C48-488B-80DC-0FF8FB4705E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{87312699-8C48-488B-80DC-0FF8FB4705E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{87312699-8C48-488B-80DC-0FF8FB4705E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{87312699-8C48-488B-80DC-0FF8FB4705E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
@@ -499,6 +499,7 @@ internal sealed partial class BedrockChatClient : IChatClient
                         {
                             ToolUseId = frc.CallId,
                             Content = [new() { Json = new Document(new Dictionary<string, Document>() { ["result"] = result }) }],
+                            
                         },
                     });
                     break;
@@ -592,7 +593,7 @@ internal sealed partial class BedrockChatClient : IChatClient
     /// <summary>Converts a <see cref="Dictionary{String, Object}"/> to a <see cref="Document"/>.</summary>
     private static Document DictionaryToDocument(IDictionary<string, object?>? arguments)
     {
-        Document inputs = default;
+        Document inputs = new Document(new Dictionary<string, Document>());
         if (arguments is not null)
         {
             foreach (KeyValuePair<string, object?> argument in arguments)
@@ -704,20 +705,30 @@ internal sealed partial class BedrockChatClient : IChatClient
                 }
             }
 
+            var schemaDictionary = new Dictionary<string, Document>()
+            {
+                ["type"] = new Document("object"),
+            };
+
+            if (inputs != default)
+            {
+                schemaDictionary["properties"] = inputs;
+            }
+
+            if (required.Count > 0)
+            {
+                schemaDictionary["required"] = new Document(required);
+            }
+
             return new Tool()
             {
                 ToolSpec = new ToolSpecification()
                 {
                     Name = f.Name,
                     Description = !string.IsNullOrEmpty(f.Description) ? f.Description : f.Name,
-                    InputSchema = new()
+                    InputSchema = new ToolInputSchema()
                     {
-                        Json = new(new Dictionary<string, Document>()
-                        {
-                            ["type"] = new Document("object"),
-                            ["properties"] = inputs,
-                            ["required"] = new Document(required),
-                        })
+                        Json = new(schemaDictionary)
                     },
                 },
             };


### PR DESCRIPTION
This pull request introduces changes to improve the handling of `Document` objects and schema generation in the `BedrockChatClient` class within the `AWSSDK.Extensions.Bedrock.MEAI` extension. The updates streamline the creation of input schemas and ensure consistency in `Document` initialization.

- Fix #3731 

### Fix to `Document` default:

This change prevents an error while advertising the function result back to the API, as it says the toolInput cannot be `null`, by setting the default as empty dictionary sorts the error.

### Enhancements to schema generation:

* handling `type`, `properties`, and `required` fields in a more structured manner, this avoid advertising those properties when they are not present. Any execution of a function that has no arguments were failing after this fix.

# Reproduction Bug 

```csharp
using Amazon.BedrockRuntime;
using Microsoft.Extensions.AI;
using Microsoft.Extensions.DependencyInjection;
using System.Globalization;

var services = new ServiceCollection();
services.TryAddAWSService<IAmazonBedrockRuntime>();

var runtime = services.BuildServiceProvider().GetRequiredService<IAmazonBedrockRuntime>();

var chatClient = runtime.AsIChatClient().AsBuilder().UseFunctionInvocation().Build();

var aiFunction = AIFunctionFactory.Create(() => DateTime.UtcNow.ToString("d", CultureInfo.InvariantCulture), "GetCurrentDate", "Returns the current date in UTC format.");

var chatOptions = new ChatOptions
{
    ModelId = "anthropic.claude-3-5-sonnet-20240620-v1:0",
    Tools = [aiFunction],
};

var response = await chatClient.GetResponseAsync([
    new ChatMessage(ChatRole.User, "What is the current date?"),
], chatOptions);

Console.WriteLine($"Response: {response}");
```