### PR TITLE
Changed example S3 bucket names to use approved value.

### DIFF
--- a/generator/.DevConfigs/02307d99-dc6c-4ae1-8529-d7394f1493cb.json
+++ b/generator/.DevConfigs/02307d99-dc6c-4ae1-8529-d7394f1493cb.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Changing S3 bucket names to preferred values in example documentation."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/S3/Custom/Model/DeleteBucketEncryptionRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteBucketEncryptionRequest.cs
@@ -44,7 +44,7 @@ namespace Amazon.S3.Model
         /// 
         /// Virtual-hosted-style requests aren't supported. 
         /// Directory bucket names must be unique in the chosen Availability Zone. 
-        /// Bucket names must also follow the format <c><i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c><i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</c>). 
+        /// Bucket names must also follow the format <c><i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c><i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</c>). 
         /// 
         /// For information about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming rules</a> 
         /// in the <i>Amazon S3 User Guide</i>.

--- a/sdk/src/Services/S3/Custom/Model/DeleteBucketPolicyRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteBucketPolicyRequest.cs
@@ -113,7 +113,7 @@ namespace Amazon.S3.Model
         /// you must use path-style requests in the format <c>https://s3express-control.<i>region_code</i>.amazonaws.com/<i>bucket-name</i>
         /// </c>. Virtual-hosted-style requests aren't supported. Directory bucket names must
         /// be unique in the chosen Availability Zone. Bucket names must also follow the format
-        /// <c> <i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c> <i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</c>).
+        /// <c> <i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c> <i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</c>).
         /// For information about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory
         /// bucket naming rules</a> in the <i>Amazon S3 User Guide</i> 
         /// </para>

--- a/sdk/src/Services/S3/Custom/Model/DeleteBucketRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/DeleteBucketRequest.cs
@@ -96,7 +96,7 @@ namespace Amazon.S3.Model
         /// you must use path-style requests in the format <c>https://s3express-control.<i>region_code</i>.amazonaws.com/<i>bucket-name</i>
         /// </c>. Virtual-hosted-style requests aren't supported. Directory bucket names must
         /// be unique in the chosen Availability Zone. Bucket names must also follow the format
-        /// <c> <i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c> <i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</c>).
+        /// <c> <i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c> <i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</c>).
         /// For information about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory
         /// bucket naming rules</a> in the <i>Amazon S3 User Guide</i> 
         /// </para>

--- a/sdk/src/Services/S3/Custom/Model/GetBucketEncryptionRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetBucketEncryptionRequest.cs
@@ -77,7 +77,7 @@ namespace Amazon.S3.Model
         /// 
         /// Virtual-hosted-style requests aren't supported. 
         /// Directory bucket names must be unique in the chosen Availability Zone. 
-        /// Bucket names must also follow the format <c><i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c><i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</c>). 
+        /// Bucket names must also follow the format <c><i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c><i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</c>). 
         /// 
         /// For information about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming rules</a> 
         /// in the <i>Amazon S3 User Guide</i>.

--- a/sdk/src/Services/S3/Custom/Model/GetBucketPolicyRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetBucketPolicyRequest.cs
@@ -114,7 +114,7 @@ namespace Amazon.S3.Model
         /// <b>Directory buckets </b> - When you use this operation with a directory bucket, you must use path-style 
         /// requests in the format <c>https://s3express-control.<i>region-code</i>.amazonaws.com/<i>bucket-name</i> </c>. Virtual-hosted-style 
         /// requests aren't supported. Directory bucket names must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket 
-        /// names must also follow the format <c> <i>bucket-base-name</i>--<i>zone-id</i>--x-s3</c> (for example, <c> <i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</c>). For 
+        /// names must also follow the format <c> <i>bucket-base-name</i>--<i>zone-id</i>--x-s3</c> (for example, <c> <i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</c>). For 
         /// information about bucket naming restrictions, see 
         /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming rules</a> in 
         /// the <i>Amazon S3 User Guide</i> </para> <para> <b>Access points</b> - When you use this API operation with an access point, provide the 

--- a/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectMetadataRequest.cs
@@ -208,7 +208,7 @@ namespace Amazon.S3.Model
         /// must use virtual-hosted-style requests in the format <c> <i>Bucket_name</i>.s3express-<i>az_id</i>.<i>region</i>.amazonaws.com</c>.
         /// Path-style requests are not supported. Directory bucket names must be unique in the
         /// chosen Availability Zone. Bucket names must follow the format <c> <i>bucket_base_name</i>--<i>az-id</i>--x-s3</c>
-        /// (for example, <c> <i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</c>). For information
+        /// (for example, <c> <i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</c>). For information
         /// about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory
         /// bucket naming rules</a> in the <i>Amazon S3 User Guide</i>.
         /// </para>

--- a/sdk/src/Services/S3/Custom/Model/PutBucketEncryptionRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutBucketEncryptionRequest.cs
@@ -95,7 +95,7 @@ namespace Amazon.S3.Model
         /// 
         /// Virtual-hosted-style requests aren't supported. 
         /// Directory bucket names must be unique in the chosen Availability Zone. 
-        /// Bucket names must also follow the format <c><i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c><i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</c>). 
+        /// Bucket names must also follow the format <c><i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c><i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</c>). 
         /// 
         /// For information about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming rules</a> 
         /// in the <i>Amazon S3 User Guide</i>.

--- a/sdk/src/Services/S3/Custom/Model/PutBucketPolicyRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutBucketPolicyRequest.cs
@@ -124,7 +124,7 @@ namespace Amazon.S3.Model
         /// you must use path-style requests in the format <c>https://s3express-control.<i>region_code</i>.amazonaws.com/<i>bucket-name</i>
         /// </c>. Virtual-hosted-style requests aren't supported. Directory bucket names must
         /// be unique in the chosen Availability Zone. Bucket names must also follow the format
-        /// <c> <i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c> <i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</c>).
+        /// <c> <i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c> <i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</c>).
         /// For information about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory
         /// bucket naming rules</a> in the <i>Amazon S3 User Guide</i> 
         /// </para>

--- a/sdk/src/Services/S3/Custom/Model/PutBucketRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutBucketRequest.cs
@@ -230,7 +230,7 @@ namespace Amazon.S3.Model
         /// you must use path-style requests in the format <c>https://s3express-control.<i>region_code</i>.amazonaws.com/<i>bucket-name</i>
         /// </c>. Virtual-hosted-style requests aren't supported. Directory bucket names must
         /// be unique in the chosen Availability Zone. Bucket names must also follow the format
-        /// <c> <i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c> <i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</c>).
+        /// <c> <i>bucket_base_name</i>--<i>az_id</i>--x-s3</c> (for example, <c> <i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</c>).
         /// For information about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory
         /// bucket naming rules</a> in the <i>Amazon S3 User Guide</i> 
         /// </para>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I have updated bucket names defined in the source code of this repo which are used to publish example documentation to use a preferred value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
DRY_RUN-36c637a3-3e7e-4d71-a5aa-2267be9ca906

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement