### PR TITLE
Remove unnecessary dependencies.

### DIFF
--- a/generator/ServiceClientGeneratorLib/ServiceClientGeneratorLib.csproj
+++ b/generator/ServiceClientGeneratorLib/ServiceClientGeneratorLib.csproj
@@ -735,7 +735,7 @@
       <LastGenOutput>AmazonS3RetryPolicy.cs</LastGenOutput>
     </None>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 	<PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net45'">

--- a/sdk/test/NetStandard/UnitTests/AWSSDK.UnitTests.Custom.NetStandard.csproj
+++ b/sdk/test/NetStandard/UnitTests/AWSSDK.UnitTests.Custom.NetStandard.csproj
@@ -56,7 +56,6 @@ This project file should not be used as part of a release pipeline.
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="Moq" Version="4.18.4" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
## Description
This PR removes two unnecessary dependencies from non-shipping projects. In one case the dependency was entirely removed, and in the other it was restricted only to .NET Standard 2.0.

## Motivation and Context
When building with the .NET 10 SDK, I am getting [`NU1510`](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/nu1510-pruned-references) warnings-as-errors because of unnecessary dependencies.

## Testing
N/A

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement