### PR TITLE
Fix issue with url encoding bug

### DIFF
--- a/generator/.DevConfigs/4a47973b-5c80-465d-8064-f224697e4182.json
+++ b/generator/.DevConfigs/4a47973b-5c80-465d-8064-f224697e4182.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fix issue with url encoding for request properties with values that have a majority of characters that need to be percent encoded"
+    ]
+  }
+}

--- a/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/AWSSDKUtilsTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Amazon.Util;
 using System.Text;
 using Amazon.Runtime.Internal;
@@ -67,6 +67,8 @@ namespace UnitTests.NetStandard.Core
         [Theory]
         [InlineData("value, with special chars!", "value%2C%20with%20special%20chars%21")]
         [InlineData("value, with special chars and path {/+:}", "value%2C%20with%20special%20chars%20and%20path%20%7B%2F%2B%3A%7D")]
+        [InlineData("紙_一般_児童手当等の受給資格及び児童手当の額についての認定請求公金非対応", "%E7%B4%99_%E4%B8%80%E8%88%AC_%E5%85%90%E7%AB%A5%E6%89%8B%E5%BD%93%E7%AD%89%E3%81%AE%E5%8F%97%E7%B5%A6%E8%B3%87%E6%A0%BC%E5%8F%8A%E3%81%B3%E5%85%90%E7%AB%A5%E6%89%8B%E5%BD%93%E3%81%AE%E9%A1%8D%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6%E3%81%AE%E8%AA%8D%E5%AE%9A%E8%AB%8B%E6%B1%82%E5%85%AC%E9%87%91%E9%9D%9E%E5%AF%BE%E5%BF%9C")]
+
         public void UrlEncodeWithoutPath(string input, string expected)
         {
             var encoded = AWSSDKUtils.UrlEncode(input, path: false);
@@ -78,6 +80,7 @@ namespace UnitTests.NetStandard.Core
         [InlineData("\ud83d\ude02 value, with special chars!", "%F0%9F%98%82%20value,%20with%20special%20chars!")]
         [InlineData("value, with special chars!", "value,%20with%20special%20chars!")]
         [InlineData("value, with special chars and path {/+:}", "value,%20with%20special%20chars%20and%20path%20%7B/+%3A%7D")]
+        [InlineData("紙_一般_児童手当等の受給資格及び児童手当の額についての認定請求公金非対応", "%E7%B4%99_%E4%B8%80%E8%88%AC_%E5%85%90%E7%AB%A5%E6%89%8B%E5%BD%93%E7%AD%89%E3%81%AE%E5%8F%97%E7%B5%A6%E8%B3%87%E6%A0%BC%E5%8F%8A%E3%81%B3%E5%85%90%E7%AB%A5%E6%89%8B%E5%BD%93%E3%81%AE%E9%A1%8D%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6%E3%81%AE%E8%AA%8D%E5%AE%9A%E8%AB%8B%E6%B1%82%E5%85%AC%E9%87%91%E9%9D%9E%E5%AF%BE%E5%BF%9C")]
         public void UrlEncodeWithPath(string input, string expected)
         {
             var encoded = AWSSDKUtils.UrlEncode(input, path: true);


### PR DESCRIPTION
## Description
V4 has memory allocation optimizations when we url encoding request parameters. Essentially we create one span that included the utf 8 data to be encoded at the end and then iterate over the data and url encode the utf 8 data place at the start of the span. By design some of the utf 8 already url encoded in the span will be overwritten in the span to save memory allocations. The optimization did not handle if every utf8 byte had to be percent encoded taking up 3 bytes. In that scenario some of the utf 8 data not encoded yet will be overwritten by the url encoded data.

To handle this we have to allocate the overall span for the worst case scenario and allocate 3 times the utf 8 data instead of 2 times.


## Motivation and Context
Fix regression

## Testing
Added test case
Dry Run: DRY_RUN-a9a82259-fb8a-44b7-b54d-2b989edc0b2b Success

