### PR TITLE
[V4] Update JSON error unmarshaller not to check for nested properties

### DIFF
--- a/generator/.DevConfigs/c54f4070-ef42-43e1-a0ca-dd6a527690dc.json
+++ b/generator/.DevConfigs/c54f4070-ef42-43e1-a0ca-dd6a527690dc.json
@@ -1,0 +1,18 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Update `JsonErrorResponseUnmarshaller` not to check nested properties when trying to populate details for operations that failed."
+        ],
+        "type": "patch",
+        "updateMinimum": true
+    },
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fix issue where `ReturnValuesOnConditionCheckFailure` could not be used if the provided document included properties that ended with `code` or `message` (https://github.com/aws/aws-sdk-net/issues/3764)."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
@@ -162,6 +162,14 @@ namespace Amazon.Runtime.Internal.Transform
 
             while (TryReadContext(context, ref reader))
             {
+                // Do not attempt to process nested properties, as for DynamoDB the error response may contain
+                // extra values that end with one of the prefixes we're looking.
+                // Issue reported in: https://github.com/aws/aws-sdk-net/issues/3764
+                if (context.CurrentDepth > 1)
+                {
+                    continue;
+                }
+
                 if (context.TestExpression("__type"))
                 {
                     type = StringUnmarshaller.GetInstance().Unmarshall(context, ref reader);

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ErrorMarshallerTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ErrorMarshallerTests.cs
@@ -1,0 +1,60 @@
+﻿using Amazon.DynamoDBv2.Model;
+using Amazon.DynamoDBv2.Model.Internal.MarshallTransformations;
+using Amazon.Runtime.Internal.Transform;
+using AWSSDK_DotNet.UnitTests.TestTools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace AWSSDK_DotNet.UnitTests
+{
+    [TestClass]
+    public class ErrorMarshallerTests
+    {
+        /// <summary>
+        /// Reported in https://github.com/aws/aws-sdk-net/issues/3764
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void ErrorMarshaller_IgnoresNestedPropertiesForException() 
+        {
+            var content = @"{
+                ""__type"": ""com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException"",
+                ""Item"": {
+                    ""Dictionary"": {
+                        ""M"": {
+                            ""keyThatEndsWithCode"": {
+                                ""M"": {
+                                    ""Foo"": {
+                                        ""S"": ""bar""
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    ""Key"": {
+                        ""S"": ""Key""
+                    }
+                },
+                ""Message"": ""The conditional request failed""
+            }";
+
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = HttpStatusCode.BadRequest;
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+
+            var stream = new MemoryStream(Encoding.ASCII.GetBytes(content));
+            var context = new JsonUnmarshallerContext(stream, true, webResponseData);
+            
+            var response = new PutItemResponseUnmarshaller().UnmarshallException(context, null, HttpStatusCode.BadRequest);
+            var actualException = response as ConditionalCheckFailedException;
+            Assert.IsNotNull(actualException);
+            
+            Assert.IsNotNull(actualException.Item);
+            Assert.AreEqual(2, actualException.Item.Count);
+            Assert.IsNotNull(actualException.Item["Dictionary"].M["keyThatEndsWithCode"]);
+            Assert.IsNotNull(actualException.Item["Key"].S);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3764 

## Description
The SDK JSON (`aws-restjson1` ) error unmarshaller checks for properties that end in certain values (the original spec is in the `sdk-unmarshal-errors` SEP). However, customers can request that DynamoDB return values whenever a PUT item fails due to a condition not being met.

If any properties in the customer model (which we don't control) also end with one of those suffixes, our unmarshaller fails. I updated it to only check for the values at the root level of the response.

This PR is for V4 as we have better coverage regarding protocol tests, but let me know if fixing it in V3 makes sense (from what I saw the logic has been in the SDK for quite some time and it's not a regression in V4).

## Testing
- Dry-runs: `DRY_RUN-77340fa6-b014-4138-9335-df03b1fad2c0` (.NET) and `DRY_RUN-ef8c7677-19a9-4078-ae35-1027e13e061b` (PowerShell)
- Ran the reproduction from the original issue and confirmed `ConditionalCheckFailedException` was thrown as expected

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
