### PR TITLE
[V3] Update JSON error unmarshaller not to check for nested properties

### DIFF
--- a/generator/.DevConfigs/c54f4070-ef42-43e1-a0ca-dd6a527690dc.json
+++ b/generator/.DevConfigs/c54f4070-ef42-43e1-a0ca-dd6a527690dc.json
@@ -1,0 +1,18 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Update `JsonErrorResponseUnmarshaller` not to check nested properties when trying to populate details for operations that failed."
+        ],
+        "type": "patch",
+        "updateMinimum": true
+    },
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fix issue where `ReturnValuesOnConditionCheckFailure` could not be used if the provided document included properties that ended with `code` or `message` (https://github.com/aws/aws-sdk-net/issues/3764)."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
@@ -148,6 +148,14 @@ namespace Amazon.Runtime.Internal.Transform
 
             while (TryReadContext(context))
             {
+                // Do not attempt to process nested properties, as for DynamoDB the error response may contain
+                // extra values that end with one of the prefixes we're looking.
+                // Issue reported in: https://github.com/aws/aws-sdk-net/issues/3764
+                if (context.CurrentDepth > 1)
+                {
+                    continue;
+                }
+
                 if (context.TestExpression("__type"))
                 {
                     type = StringUnmarshaller.GetInstance().Unmarshall(context);

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ErrorMarshallerTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/ErrorMarshallerTests.cs
@@ -1,0 +1,60 @@
+﻿using Amazon.DynamoDBv2.Model;
+using Amazon.DynamoDBv2.Model.Internal.MarshallTransformations;
+using Amazon.Runtime.Internal.Transform;
+using AWSSDK_DotNet35.UnitTests.TestTools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace AWSSDK_DotNet35.UnitTests
+{
+    [TestClass]
+    public class ErrorMarshallerTests
+    {
+        /// <summary>
+        /// Reported in https://github.com/aws/aws-sdk-net/issues/3764
+        /// </summary>
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public void ErrorMarshaller_IgnoresNestedPropertiesForException()
+        {
+            var content = @"{
+                ""__type"": ""com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException"",
+                ""Item"": {
+                    ""Dictionary"": {
+                        ""M"": {
+                            ""keyThatEndsWithCode"": {
+                                ""M"": {
+                                    ""Foo"": {
+                                        ""S"": ""bar""
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    ""Key"": {
+                        ""S"": ""Key""
+                    }
+                },
+                ""Message"": ""The conditional request failed""
+            }";
+
+            var webResponseData = new WebResponseData();
+            webResponseData.StatusCode = HttpStatusCode.BadRequest;
+            webResponseData.Headers["Content-Type"] = "application/x-amz-json-1.0";
+
+            var stream = new MemoryStream(Encoding.ASCII.GetBytes(content));
+            var context = new JsonUnmarshallerContext(stream, true, webResponseData);
+
+            var response = new PutItemResponseUnmarshaller().UnmarshallException(context, null, HttpStatusCode.BadRequest);
+            var actualException = response as ConditionalCheckFailedException;
+            Assert.IsNotNull(actualException);
+
+            Assert.IsNotNull(actualException.Item);
+            Assert.AreEqual(2, actualException.Item.Count);
+            Assert.IsNotNull(actualException.Item["Dictionary"].M["keyThatEndsWithCode"]);
+            Assert.IsNotNull(actualException.Item["Key"].S);
+        }
+    }
+}


### PR DESCRIPTION
V3 port of https://github.com/aws/aws-sdk-net/pull/3888

## Testing
- Dry-runs: `DRY_RUN-71c4704b-59f9-46e6-a525-ed2f2476ebed` (.NET) and `DRY_RUN-2f2c6345-3c28-41a5-bdd0-a10567377167` (PowerShell) 

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
