### PR TITLE
Update PersistenceManager not to fail when used in a read-only file system

### DIFF
--- a/generator/.DevConfigs/2cd7f333-8fa0-4666-9ad9-375ff5a7e780.json
+++ b/generator/.DevConfigs/2cd7f333-8fa0-4666-9ad9-375ff5a7e780.json
@@ -1,0 +1,10 @@
+{
+    "core": {
+        "updateMinimum": true,
+        "type": "Patch",
+        "changeLogMessages": [
+            "Update `PersistenceManager` not to throw an exception when the SDK is used with a read-only file system (https://github.com/aws/aws-sdk-net/issues/3801)",
+            "Add `AWSConfigs.DisableLegacyPersistenceStore` option to instruct the SDK not to use the [SDK Store](https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/sdk-store.html) in its default profile resolution search"
+        ]
+    }
+}

--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using Amazon.Runtime;
 using Amazon.Runtime.Telemetry;
 using Amazon.Runtime.Credentials;
+using Amazon.Runtime.CredentialManagement;
 
 namespace Amazon
 {
@@ -81,6 +82,7 @@ namespace Amazon
         internal static string _awsAccountsLocation = GetConfig(AWSProfilesLocationKey);
         internal static bool _useSdkCache = GetConfigBool(UseSdkCacheKey, defaultValue: true);
         internal static bool _initializeCollections = GetConfigBool(InitializeCollectionsKey, defaultValue: false);
+        internal static bool _disableLegacyPersistenceStore = GetConfigBool(DisableLegacyPersistenceStoreKey, defaultValue: false);
         private static TelemetryProvider _telemetryProvider = new DefaultTelemetryProvider();
 
 #if NET8_0_OR_GREATER
@@ -214,6 +216,7 @@ namespace Amazon
         }
 
         #endregion
+        
         #region StreamingUtf8JsonReaderBufferSize
 
         /// <summary>
@@ -296,7 +299,7 @@ namespace Amazon
 #if NET8_0_OR_GREATER
         /// <summary>
         /// Key for the DisableDangerousDisablePathAndQueryCanonicalization property.
-        /// <seealso cref="Amazon.AWSConfigs.InitializeCollections"/>
+        /// <seealso cref="Amazon.AWSConfigs.DisableDangerousDisablePathAndQueryCanonicalization"/>
         /// </summary>
         public const string DisableDangerousDisablePathAndQueryCanonicalizationKey = "AWSDisableDangerousDisablePathAndQueryCanonicalization";
 
@@ -340,7 +343,35 @@ namespace Amazon
             get { return _rootConfig.AWSCredentialsGenerators; }
             set { _rootConfig.AWSCredentialsGenerators = value; }
         }
-        
+
+        #endregion
+
+        #region DisableLegacyPersistenceStore
+
+        /// <summary>
+        /// Key for the <seealso cref="Amazon.AWSConfigs.DisableLegacyPersistenceStore"/> property.
+        /// </summary>
+        public const string DisableLegacyPersistenceStoreKey = "AWSDisableLegacyPersistenceStore";
+
+        /// <summary>
+        /// When attempting to retrieve configuration options for a given profile, the AWS SDK for .NET will look at both 
+        /// the shared config file and the SDK Store by default - via the <see cref="CredentialProfileStoreChain"/>.
+        /// <para />
+        /// The SDK Store has a few limitations, such as only being available on Windows and being specific to a particular user on a particular host. 
+        /// <para />
+        /// Setting this property to <c>true</c> will instruct the SDK not to check the legacy persistence store when interacting with
+        /// profiles (this setting is only applicable to the <see cref="CredentialProfileStoreChain"/> and it's not considered when 
+        /// interacting with the <see cref="NetSDKCredentialsFile"/> class directly).
+        /// </summary>
+        /// <remarks>
+        /// The default value is <c>false</c>.
+        /// </remarks>
+        public static bool DisableLegacyPersistenceStore
+        {
+            get { return _rootConfig.DisableLegacyPersistenceStore; }
+            set { _rootConfig.DisableLegacyPersistenceStore = value; }
+        }
+
         #endregion
 
         #region AWS Config Sections

--- a/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfileStoreChain.cs
+++ b/sdk/src/Core/Amazon.Runtime/CredentialManagement/CredentialProfileStoreChain.cs
@@ -99,12 +99,15 @@ namespace Amazon.Runtime.CredentialManagement
         /// <returns>True if the profile was found, false otherwise.</returns>
         public bool TryGetProfile(string profileName, out CredentialProfile profile)
         {
-            if (string.IsNullOrEmpty(ProfilesLocation) && UserCrypto.IsUserCryptAvailable)
+            if (!AWSConfigs.DisableLegacyPersistenceStore)
             {
-                var netCredentialsFile = new NetSDKCredentialsFile();
-                if (netCredentialsFile.TryGetProfile(profileName, out profile))
+                if (string.IsNullOrEmpty(ProfilesLocation) && UserCrypto.IsUserCryptAvailable)
                 {
-                    return true;
+                    var netCredentialsFile = new NetSDKCredentialsFile();
+                    if (netCredentialsFile.TryGetProfile(profileName, out profile))
+                    {
+                        return true;
+                    }
                 }
             }
 
@@ -140,11 +143,15 @@ namespace Amazon.Runtime.CredentialManagement
         {
             var profiles = new List<CredentialProfile>();
 
-            if (string.IsNullOrEmpty(ProfilesLocation) && UserCrypto.IsUserCryptAvailable)
+            if (!AWSConfigs.DisableLegacyPersistenceStore)
             {
-                var netSdkFile = new NetSDKCredentialsFile();
-                profiles.AddRange(netSdkFile.ListProfiles());
+                if (string.IsNullOrEmpty(ProfilesLocation) && UserCrypto.IsUserCryptAvailable)
+                {
+                    var netSdkFile = new NetSDKCredentialsFile();
+                    profiles.AddRange(netSdkFile.ListProfiles());
+                }
             }
+
             var sharedFile = new SharedCredentialsFile(ProfilesLocation);
             profiles.AddRange(sharedFile.ListProfiles());
 
@@ -171,7 +178,7 @@ namespace Amazon.Runtime.CredentialManagement
         /// <param name="profile">The profile to register.</param>
         public void RegisterProfile(CredentialProfile profile)
         {
-            if (string.IsNullOrEmpty(ProfilesLocation) && UserCrypto.IsUserCryptAvailable)
+            if (!AWSConfigs.DisableLegacyPersistenceStore && string.IsNullOrEmpty(ProfilesLocation) && UserCrypto.IsUserCryptAvailable)
             {
                 new NetSDKCredentialsFile().RegisterProfile(profile);
             }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Settings/PersistenceManager.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Settings/PersistenceManager.cs
@@ -88,27 +88,26 @@ namespace Amazon.Runtime.Internal.Settings
 
             try
             {
-#if BCL
+#if NETFRAMEWORK
                 SettingsStoreFolder = System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData) + "/AWSToolkit";
 #else
                 SettingsStoreFolder = System.Environment.GetEnvironmentVariable("HOME");
                 if (string.IsNullOrEmpty(SettingsStoreFolder))
                     SettingsStoreFolder = System.Environment.GetEnvironmentVariable("USERPROFILE");
 
-                SettingsStoreFolder = Path.Combine(SettingsStoreFolder, "AppData/Local/AWSToolkit");
+                SettingsStoreFolder = Path.Combine(SettingsStoreFolder, "AppData", "Local", "AWSToolkit");
 #endif
                 if (!Directory.Exists(SettingsStoreFolder))
                     Directory.CreateDirectory(SettingsStoreFolder);
 
                 Instance = new PersistenceManager();
             }
-            catch (UnauthorizedAccessException ex)
+            catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
             {
                 _logger.Error(ex, $"Unable to initialize '{nameof(PersistenceManager)}'. Falling back to '{nameof(InMemoryPersistenceManager)}'.");
-
                 Instance = new InMemoryPersistenceManager();
             }
-        }
+       }
 
         #endregion
 

--- a/sdk/src/Core/Amazon.Util/Internal/RootConfig.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/RootConfig.cs
@@ -52,6 +52,8 @@ namespace Amazon.Util.Internal
 
         public List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator> AWSCredentialsGenerators { get; set; }
 
+        public bool DisableLegacyPersistenceStore { get; set; }
+
         private const string _rootAwsSectionName = "aws";
         public RootConfig()
         {
@@ -65,6 +67,7 @@ namespace Amazon.Util.Internal
             UseSdkCache = AWSConfigs._useSdkCache;
             InitializeCollections = AWSConfigs._initializeCollections;
             CorrectForClockSkew = true;
+            DisableLegacyPersistenceStore = AWSConfigs._disableLegacyPersistenceStore;
 
 #if NET8_0_OR_GREATER
             DisableDangerousDisablePathAndQueryCanonicalization = AWSConfigs._disableDangerousDisablePathAndQueryCanonicalization;
@@ -105,5 +108,4 @@ namespace Amazon.Util.Internal
             return null;
         }
     }
-
 }


### PR DESCRIPTION
Fixes #3801 

## Description
Updates the SDK's `PersistenceManager` not to fail when running on a read-only file system. 

I also included the suggested new option to ignore the legacy persistence store when the SDK is going through the default profile resolution search (via the `CredentialProfileStoreChain`).

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3801 and `DOTNET-8123`

## Testing
- Dry-run: `DRY_RUN-5960c79f-a0e7-4dad-97c9-61374e1d2324`
- I also created a console app using the `PersistenceManager` class directly and confirmed running it in a read-only file system does not throw a terminating error anymore:

```csharp
using Amazon;
using Amazon.Runtime.Internal.Settings;

AWSConfigs.LoggingConfig.LogTo = LoggingOptions.Console;
AWSConfigs.LoggingConfig.LogMetricsFormat = LogMetricsFormatOption.JSON;
AWSConfigs.LoggingConfig.LogResponses = ResponseLoggingOption.Always;
AWSConfigs.LoggingConfig.LogMetrics = true;

var instance = PersistenceManager.Instance;
Console.WriteLine($"Got here! Instance type is {instance.GetType()}");
```

Before:
```
PS> docker run --read-only --rm my-dotnet-app
Unhandled exception. System.TypeInitializationException: The type initializer for 'Amazon.Runtime.Internal.Settings.PersistenceManager' threw an exception.
 ---> System.IO.IOException: Read-only file system : '/root/AppData'
```

After:
```
PS> docker run --read-only --rm my-dotnet-app
PersistenceManager 1|2025-07-10T23:52:15.244Z|ERROR|Unable to initialize 'PersistenceManager'. Falling back to 'InMemoryPersistenceManager'. --> System.IO.IOException: Read-only file system : '/root/AppData'
Got here! Instance type is Amazon.Runtime.Internal.Settings.InMemoryPersistenceManager
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license