### PR TITLE
Decorated AnalyticsConfiguration property in PutBucketAnalyticsConfigurationRequest class with [AWSProperty(Required = true)] attribute per S3 service API model.

### DIFF
--- a/generator/.DevConfigs/72b8712b-b032-45be-bec6-91a2ba19d96c.json
+++ b/generator/.DevConfigs/72b8712b-b032-45be-bec6-91a2ba19d96c.json
@@ -1,0 +1,9 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [ "Decorated AnalyticsConfiguration property in PutBucketAnalyticsConfigurationRequest class with [AWSProperty(Required = true)] attribute per S3 service API model." ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/PutBucketAnalyticsConfigurationRequest.cs
+++ b/sdk/src/Services/S3/Custom/Model/PutBucketAnalyticsConfigurationRequest.cs
@@ -12,12 +12,12 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
 using System;
 using System.Collections.Generic;
-using System.Xml.Serialization;
 using System.Text;
-
-using Amazon.Runtime;
+using System.Xml.Serialization;
 
 namespace Amazon.S3.Model
 {
@@ -162,6 +162,7 @@ namespace Amazon.S3.Model
         /// <summary>
         /// The configuration and any analyses for the analytics filter.
         /// </summary>
+        [AWSProperty(Required = true)]
         public AnalyticsConfiguration AnalyticsConfiguration
         {
             get { return this.analyticsConfiguration; }


### PR DESCRIPTION
## Description
Decorated `AnalyticsConfiguration` property in `PutBucketAnalyticsConfigurationRequest` class with `[AWSProperty(Required = true)]` attribute per S3 service API model.

## Motivation and Context
PowerShell issue **PowerShell-53**.

- In S3 service API documentation for [PutBucketAnalyticsConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html), it is specified that [AnalyticsConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html#API_PutBucketAnalyticsConfiguration_RequestSyntax) is a required parameter.
- However, while debugging CmdLet generation for `WriteS3BucketAnalyticsConfigurationCmdlet` the `IsRequired` flag for property `AnalyticsConfiguration` is set as `false`.
- In SDK(s), [s3-2006-03-01.api.json](https://github.com/aws/aws-sdk-net/blob/a0e9d9a0fa45798da8037f898174311f63d2c90d/generator/ServiceModels/s3/s3-2006-03-01.api.json#L7192C6-L7192C44), `AnalyticsConfiguration` is in the `required` key list.
- The `IsRequired` field for `SimplePropertyInfo` is populated [here](https://github.com/aws/PRIVATE-aws-tools-for-powershell-staging/blob/9563eef5bfba68bb0d04e7d11d84ba3988043bf8/generator/AWSPSGeneratorLib/Generators/SimplePropertyInfo.cs#L408). It inspects .NET attribute `Amazon.Runtime.Internal.AWSPropertyAttribute`, if any, that is present for the property and checks if `IsRequired` at .NET attribute level is set.
- Currently, most of the S3 models are hand-written. Looks like in [PutBucketAnalyticsConfigurationRequest](https://github.com/aws/aws-sdk-net/blob/a0e9d9a0fa45798da8037f898174311f63d2c90d/sdk/src/Services/S3/Custom/Model/PutBucketAnalyticsConfigurationRequest.cs#L165), `AnalyticsConfiguration` is not decorated with `Amazon.Runtime.Internal.AWSPropertyAttribute[IsRequired= true]` attribute.

## Testing
- Dry-run `DRY_RUN-2a42e26c-2721-4094-88b4-df8a567bcb9d` pending.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement