### PR TITLE
Skip unknown properties when mapping EndpointTests V3

### DIFF
--- a/generator/.DevConfigs/1e81788b-4e71-4457-9348-d81a456886b7.json
+++ b/generator/.DevConfigs/1e81788b-4e71-4457-9348-d81a456886b7.json
@@ -1,0 +1,8 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Skip unknown properties when mapping EndpointTests"
+    ],
+    "type": "patch"
+  }
+}

--- a/generator/ServiceClientGeneratorLib/GenerationManifest.cs
+++ b/generator/ServiceClientGeneratorLib/GenerationManifest.cs
@@ -288,7 +288,7 @@ namespace ServiceClientGenerator
                     throw new FileNotFoundException($"Endpoints tests are missing. Expected file suffix is .{EndpointRuleSetTestsFile}");
                 }
                 json = File.ReadAllText(testsFileName);
-                config.EndpointTests = JsonMapper.ToObject<EndpointTests>(json);
+                config.EndpointTests = JsonMapper.ToObject<EndpointTests>(json, true);
             }
 
             if (modelNode[ModelsSectionKeys.NugetPackageTitleSuffix] != null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Skip unknown properties when mapping EndpointTests
<!--- Describe your changes in detail -->

## Motivation and Context
This PR change allows the .NET SDKs to ignore unknown properties so the endpoints team can make additive changes and add new endpoint properties without requiring support from the .NET SDK.  
This way they can ship the endpoint rules updates and SDKs will benefit from the addition whenever they decide to implement the feature instead of having to wait for all SDKs to schedule and complete the work.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
* `DRY_RUN-22399aa8-3385-40dd-a5d6-663347c06e65`
* Ran the generator using some models that includes unknown endpoint properties.


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement