### PR TITLE
Add utility method to detect .NET Framework version of SDK

### DIFF
--- a/generator/.DevConfigs/91bbaabd-8a52-43d9-ae0b-410bfb215318.json
+++ b/generator/.DevConfigs/91bbaabd-8a52-43d9-ae0b-410bfb215318.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "Add utility method for allowing .NET Standard 2.0 libraries using the SDK to know whether they are using the .NET Framework version of the SDK."
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -946,6 +946,21 @@ namespace Amazon.Util
 #endif
         }
 
+        /// <summary>
+        /// This method returns true if the variant of the SDK being used is the .NET Framework target. This allows
+        /// libraries using .NET Standard 2.0 like AWSSDK.Extensions.NETCore.Setup to know at runtime if they are
+        /// using the .NET Framework version and if so make decisions on what APIs it should call.
+        /// </summary>
+        /// <returns>True if the version of the SDK is .NET Framework variant.</returns>
+        public static bool IsNETFramework()
+        {
+#if NETFRAMEWORK
+            return true;
+#else
+            return false;
+#endif
+        }
+
         #region The code in this region has been minimally adapted from Microsoft's PathInternal.Windows.cs class as of 11/19/2019.  The logic remains the same.
         /// <summary>
         /// Returns true if the path specified is relative to the current drive or working directory.
@@ -1018,7 +1033,7 @@ namespace Amazon.Util
         /// URL encodes a string per the specified RFC. If the path property is specified,
         /// the accepted path characters {/+:} are not encoded.
         /// </summary>
-        /// <param name="rfcNumber">RFC number determing safe characters</param>
+        /// <param name="rfcNumber">RFC number determining safe characters</param>
         /// <param name="data">The string to encode</param>
         /// <param name="path">Whether the string is a URL path or not</param>
         /// <returns>The encoded string</returns>


### PR DESCRIPTION
## Description
.NET Standard 2.0 libraries like AWSSDK.Extensions.NETCore.Setup might find at runtime that it is using the .NET Framework version of the SDK. If it is uses the .NET Framework variant it might have to choose to call or not call APIs on the SDK due to the methods not existing.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3932

