### PR TITLE
Avoid setting config properties that don't exist in .NET Framework variant

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.NETCore.Setup</id>
     <title>AWSSDK - Extensions for NETCore Setup</title>
-    <version>4.0.2.0</version>
+    <version>4.0.2.1</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with .NET Core configuration and dependency injection frameworks.</description>
     <language>en-US</language>
@@ -14,19 +14,19 @@
 	
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.12" />
+        <dependency id="AWSSDK.Core" version="4.0.0.18" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="AWSSDK.Core" version="4.0.0.12" />
+        <dependency id="AWSSDK.Core" version="4.0.0.18" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.12" />
+        <dependency id="AWSSDK.Core" version="4.0.0.18" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Xml.Linq;
 using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
@@ -377,6 +378,7 @@ namespace Amazon.Extensions.NETCore.Setup
             return config;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private void SetNETStandardAndAboveSettings(DefaultClientConfig defaultConfig, ClientConfig config)
         {
             if (defaultConfig.HttpClientCacheSize.HasValue)

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
@@ -21,6 +21,7 @@ using System.Xml.Linq;
 using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
 using Amazon.Runtime.Credentials.Internal;
+using Amazon.Util;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -295,10 +296,6 @@ namespace Amazon.Extensions.NETCore.Setup
             {
                 config.FastFailRequests = defaultConfig.FastFailRequests.Value;
             }
-            if (defaultConfig.HttpClientCacheSize.HasValue)
-            {
-                config.HttpClientCacheSize = defaultConfig.HttpClientCacheSize.Value;
-            }
             if (defaultConfig.IgnoreConfiguredEndpointUrls.HasValue)
             {
                 config.IgnoreConfiguredEndpointUrls = defaultConfig.IgnoreConfiguredEndpointUrls.Value;
@@ -367,7 +364,25 @@ namespace Amazon.Extensions.NETCore.Setup
                 ProcessServiceSpecificSettings(config, defaultConfig.ServiceSpecificSettings);
             }
 
+            // It is possible that this library might be used in .NET Framework application. In that
+            // case the SDK used at runtime will be the .NET Framework variant. To avoid getting
+            // MissingMethodException exceptions for config properties that don't exist in 
+            // .NET Framework variant put the set calls in a separate method only called
+            // if the SDK is not the .NET Framework variant.
+            if (!AWSSDKUtils.IsNETFramework())
+            {
+                SetNETStandardAndAboveSettings(defaultConfig, config);
+            }
+
             return config;
+        }
+
+        private void SetNETStandardAndAboveSettings(DefaultClientConfig defaultConfig, ClientConfig config)
+        {
+            if (defaultConfig.HttpClientCacheSize.HasValue)
+            {
+                config.HttpClientCacheSize = defaultConfig.HttpClientCacheSize.Value;
+            }
         }
 
 #if NET8_0_OR_GREATER


### PR DESCRIPTION

## Description
This is the part 2 of PR https://github.com/aws/aws-sdk-net/pull/3934 that makes it so AWSSDK.Extensions.NETCore.Setup does not attempt to set service client config properties that do not exist in the .NET Framework variant of the SDK.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3932

## Testing
Built a .NET Framework console application using `AWSSDK.Extensions.NETCore.Setup` and confirmed I got the reported `MissingMethodException`. Then built a new package version with this change and used that and confirmed the exception went away.