### PR TITLE
Add CborReaderProxy to support process CBOR stream in chunks

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CborProtocol/Internal/CborStreamReader.cs
+++ b/extensions/src/AWSSDK.Extensions.CborProtocol/Internal/CborStreamReader.cs
@@ -1,0 +1,295 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using Amazon.Runtime.Internal.Util;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Formats.Cbor;
+using System.IO;
+
+namespace Amazon.Extensions.CborProtocol.Internal
+{
+    /// <summary>
+    /// A streaming CBOR reader that processes large CBOR data streams in chunks without loading
+    /// the entire payload into memory at once. This class wraps <see cref="CborReader"/>
+    /// to provide streaming capabilities while maintaining the same reading interface.
+    /// </summary>
+    public class CborStreamReader : IDisposable
+    {
+        /// <summary>
+        /// Enum to track the type of CBOR container (map or array)
+        /// for state management within the CborStreamReader.
+        /// </summary>
+        private enum CborContainerType
+        {
+            Map,
+            Array
+        }
+
+        private static readonly ILogger _logger = Logger.GetLogger(typeof(CborStreamReader));
+        private readonly Stack<CborContainerType> _nestingStack = new Stack<CborContainerType>();
+        private readonly Stream _stream;
+        private byte[] _buffer;
+        private CborReader _internalCborReader;
+        private int _currentChunkSize;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CborStreamReader"/> class that reads CBOR data
+        /// from the specified stream.
+        /// </summary>
+        /// <param name="stream">The input stream containing CBOR-formatted data.
+        /// The stream must be readable and remain open for the lifetime of the reader.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the stream parameter is null.</exception>
+        /// <remarks>
+        /// The reader uses a configurable initial buffer size (from <see cref="AWSConfigs.CborReaderInitialBufferSize"/>)
+        /// and will automatically resize the buffer if needed to handle larger CBOR items.
+        /// </remarks>
+        public CborStreamReader(Stream stream)
+        {
+            _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            _buffer = ArrayPool<byte>.Shared.Rent(AWSConfigs.CborReaderInitialBufferSize);
+
+            _currentChunkSize = _stream.Read(_buffer, 0, _buffer.Length);
+            var memorySlice = new ReadOnlyMemory<byte>(_buffer, 0, _currentChunkSize);
+
+            // We must allow multiple root values because when refilling the new chunk is just a fragment of the whole stream.
+            _internalCborReader = new CborReader(memorySlice, allowMultipleRootLevelValues: true);
+        }
+
+        /// <summary>
+        /// This method is called when a read operation fails because it needs more
+        /// data than is currently available in the buffer. It handles stitching leftover
+        /// data with a new chunk from the stream and, if necessary, resizing the buffer.
+        /// </summary>
+        /// <param name="bytesToSkip">Number of bytes to skip before reading new data (e.g., 1 to skip CBOR break byte 0xFF)</param>
+        private void RefillBuffer(int bytesToSkip = 0)
+        {
+            int leftoverBytesCount = _internalCborReader.BytesRemaining;
+
+            // Determine where the leftover bytes start
+            int leftoverStartIndex = _currentChunkSize - leftoverBytesCount;
+
+            // If we are skipping bytes, we need to move the start forward
+            leftoverStartIndex += bytesToSkip;
+            leftoverBytesCount = leftoverBytesCount - bytesToSkip;
+
+            // If the leftover data completely fills the buffer, grow it
+            if (leftoverBytesCount >= _buffer.Length)
+            {
+                int newSize = _buffer.Length * 2;
+                var newBuffer = ArrayPool<byte>.Shared.Rent(newSize);
+
+                Buffer.BlockCopy(_buffer, leftoverStartIndex, newBuffer, 0, leftoverBytesCount);
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _buffer = newBuffer;
+            }
+            else if (leftoverBytesCount > 0)  // Shift leftovers (after skipping) to the beginning of the buffer
+            {
+                Buffer.BlockCopy(_buffer, leftoverStartIndex, _buffer, 0, leftoverBytesCount);
+            }
+
+            // Read from stream into buffer after leftovers
+            int bytesReadFromStream = _stream.Read(_buffer, leftoverBytesCount, _buffer.Length - leftoverBytesCount);
+
+            // Update the total size of valid data in our buffer.
+            _currentChunkSize = leftoverBytesCount + bytesReadFromStream;
+
+            // Check for a malformed stream: if we have leftovers but the stream is empty,
+            // it means the CBOR data was truncated.
+            if (bytesReadFromStream == 0 && leftoverBytesCount > 0)
+            {
+                throw new CborContentException("Stream ended unexpectedly with an incomplete CBOR data item.");
+            }
+
+            var newMemorySlice = new ReadOnlyMemory<byte>(_buffer, 0, _currentChunkSize);
+            _internalCborReader.Reset(newMemorySlice);
+
+            _logger.DebugFormat("Buffer refilled: read {0} byte(s), total in buffer now: {1}.", bytesReadFromStream, _currentChunkSize);
+        }
+
+        /// <summary>
+        /// Executes a CBOR read operation, refilling the buffer and retrying if a CborContentException is thrown.
+        /// </summary>
+        /// <typeparam name="T">The return type of the CBOR read operation.</typeparam>
+        /// <param name="readOperation">A delegate representing the read operation to execute.</param>
+        /// <returns>The result of the read operation.</returns>
+        /// <exception cref="CborContentException">
+        /// Thrown if too many retries are attempted or if the stream ends unexpectedly.
+        /// </exception>
+        private T ExecuteRead<T>(Func<CborReader, T> readOperation)
+        {
+            int maxRetries = 64;
+            int retryCount = 0;
+
+            while (true)
+            {
+                try
+                {
+                    return readOperation(_internalCborReader);
+                }
+                catch (CborContentException ex)
+                {
+                    if (_currentChunkSize == 0 && _internalCborReader.BytesRemaining == 0)
+                    {
+                        // Fail fast if we’ve already consumed all input and nothing remains to refill.
+                        throw;
+                    }
+
+                    if (++retryCount > maxRetries)
+                    {
+                        throw new CborContentException("Too many retries during CBOR stream parsing. Possible malformed or infinite data.", ex);
+                    }
+
+                    _logger.Debug(ex, "CborContentException caught (attempt #{0}), attempting to refill buffer.", retryCount);
+                    // Attempt to refill and retry the operation.
+                    RefillBuffer();
+                }
+            }
+        }
+
+
+        private bool IsNextByteEndOfContainer()
+        {
+            int unreadOffset = _currentChunkSize - _internalCborReader.BytesRemaining;
+            if (unreadOffset < _currentChunkSize)
+                return _buffer[unreadOffset] == 0xFF; // 0xFF indicates "break" in indefinite-length map/array
+
+            return false;
+        }
+
+        private void ReadEndContainer(CborContainerType expectedType, CborReaderState expectedEndState, Action<CborReader> readEndAction)
+        {
+            ExecuteRead(r =>
+            {
+                if (_nestingStack.Count == 0 || _nestingStack.Peek() != expectedType)
+                    throw new CborContentException($"Unexpected end of {expectedType.ToString().ToLowerInvariant()}.");
+
+                var state = CborReaderState.Finished;
+                try
+                {
+                    state = r.PeekState();
+                }
+                catch (CborContentException)
+                {
+                    // This exception is expected in two cases:
+                    // 1. When we've reached the end of the current CBOR buffer chunk and need to refill.
+                    // 2. When the current buffer does not contain the start of the array/map we're trying to end.
+                    // In both cases, the internal CborReader's state will be `Finished` and we will trigger a buffer refill.
+                    // This is not a true error, but logging at Info level can help trace how we arrived at a certain state.
+                    _logger.DebugFormat("CborContentException caught during PeekState while expecting end of {0}", expectedType.ToString().ToLowerInvariant());
+                }
+
+                if (state == expectedEndState)
+                {
+                    readEndAction(r);
+                    _nestingStack.Pop();
+                    return true;
+                }
+
+                if (state == CborReaderState.Finished)
+                {
+                    if (IsNextByteEndOfContainer())
+                    {
+                        RefillBuffer(1); // Skip the break marker (0xFF)
+                    }
+                    else
+                    {
+                        RefillBuffer(0); // This means we are in a definite-length map/array which doesn't end with 0xFF.
+                    }
+                    _nestingStack.Pop();
+                    return true;
+                }
+
+                throw new CborContentException($"Expected end of {expectedType.ToString().ToLowerInvariant()} but could not parse it.");
+            });
+        }
+
+
+        public void ReadEndMap()
+        {
+            ReadEndContainer(CborContainerType.Map, CborReaderState.EndMap, (reader) => reader.ReadEndMap());
+        }
+
+        public void ReadEndArray()
+        {
+            ReadEndContainer(CborContainerType.Array, CborReaderState.EndArray, (r) => r.ReadEndArray());
+        }
+
+
+        public int? ReadStartMap() => ExecuteRead(reader =>
+        {
+            var result = reader.ReadStartMap();
+            _nestingStack.Push(CborContainerType.Map);
+            return result;
+        });
+
+        public int? ReadStartArray() => ExecuteRead(reader =>
+        {
+            var result = reader.ReadStartArray();
+            _nestingStack.Push(CborContainerType.Array);
+            return result;
+        });
+
+
+        public CborReaderState PeekState()
+        {
+            return ExecuteRead(r =>
+            {
+                try
+                {
+                    return r.PeekState();
+                }
+                catch (CborContentException ex)
+                {
+                    // Translate a Break code to the appropriate container end state
+                    // based on our own nesting stack.
+                    if (_nestingStack.Count > 0)
+                    {
+                        var inferredState = _nestingStack.Peek() == CborContainerType.Map
+                            ? CborReaderState.EndMap
+                            : CborReaderState.EndArray;
+
+                        _logger.Debug(ex, "CborContentException during PeekState interpreted as {0} due to nesting stack.", inferredState);
+                        return inferredState;
+                    }
+                    // If our stack is empty, it's a genuine error.
+                    throw;
+                }
+            });
+        }
+
+        public string ReadTextString() => ExecuteRead(r => r.ReadTextString());
+        public int ReadInt32() => ExecuteRead(r => r.ReadInt32());
+        public long ReadInt64() => ExecuteRead(r => r.ReadInt64());
+        public decimal ReadDecimal() => ExecuteRead(r => r.ReadDecimal());
+        public double ReadDouble() => ExecuteRead(r => r.ReadDouble());
+        public bool ReadBoolean() => ExecuteRead(r => r.ReadBoolean());
+        public float ReadSingle() => ExecuteRead(r => r.ReadSingle());
+        public CborTag ReadTag() => ExecuteRead(r => r.ReadTag());
+        public byte[] ReadByteString() => ExecuteRead(r => r.ReadByteString());
+        public void ReadNull() => ExecuteRead(r => { r.ReadNull(); return true; });
+        public void SkipValue() => ExecuteRead(r => { r.SkipValue(); return true; });
+        public int CurrentDepth => _internalCborReader.CurrentDepth;
+
+        public void Dispose()
+        {
+            if (_buffer != null)
+            {
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _buffer = null;
+            }
+        }
+    }
+}

--- a/extensions/test/CborProtocol.Tests/CborStreamReaderTests.cs
+++ b/extensions/test/CborProtocol.Tests/CborStreamReaderTests.cs
@@ -1,0 +1,408 @@
+﻿using Amazon.Extensions.CborProtocol;
+using Amazon.Extensions.CborProtocol.Internal;
+using System;
+using System.Formats.Cbor;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Amazon.CborProtocol.Tests;
+
+
+public class BufferSizeConfigFixture : IDisposable
+{
+    private readonly int _originalValue;
+
+    public BufferSizeConfigFixture()
+    {
+        // Save original value
+        _originalValue = AWSConfigs.CborReaderInitialBufferSize;
+
+        // Set a small buffer size to easily test larger streams.
+        AWSConfigs.CborReaderInitialBufferSize = 100;
+    }
+
+    public void Dispose()
+    {
+        // Restore original value
+        AWSConfigs.CborReaderInitialBufferSize = _originalValue;
+    }
+}
+
+public class CborStreamReaderTests : IClassFixture<BufferSizeConfigFixture>
+{
+
+    [Fact]
+    public void Unmarshall_SimpleObject_FitsInInitialBuffer()
+    {
+        var writer = new CborWriter();
+        writer.WriteStartMap(2);
+        writer.WriteTextString("Key1");
+        writer.WriteTextString("Value1");
+        writer.WriteTextString("Key2");
+        writer.WriteInt32(123);
+        writer.WriteEndMap();
+
+        byte[] bytes = writer.Encode();
+        var stream = new MemoryStream(bytes);
+
+        using var reader = new CborStreamReader(stream);
+
+        reader.ReadStartMap();
+        Assert.Equal("Key1", reader.ReadTextString());
+        Assert.Equal("Value1", reader.ReadTextString());
+        Assert.Equal("Key2", reader.ReadTextString());
+        reader.SkipValue(); // Skip integer
+        reader.ReadEndMap();
+        Assert.Equal(CborReaderState.Finished, reader.PeekState());
+
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(4)]
+    [InlineData(8)]
+    public void Unmarshall_ItemLargerThanBuffer_ResizesMultipleTimes(int multiplier)
+    {
+        // Create a string that will force multiple buffer resizes.
+        int stringSize = (AWSConfigs.CborReaderInitialBufferSize * multiplier) + 50;
+        var veryLargeString = new string('B', stringSize);
+
+        var writer = new CborWriter();
+        writer.WriteTextString(veryLargeString);
+        byte[] bytes = writer.Encode();
+        var stream = new MemoryStream(bytes);
+
+        using var reader = new CborStreamReader(stream);
+
+        string result = reader.ReadTextString();
+        Assert.Equal(veryLargeString, result);
+
+    }
+
+    [Fact]
+    public void Unmarshall_ObjectCrossesBufferBoundary_RefillsCorrectly()
+    {
+        var writer = new CborWriter();
+        writer.WriteStartMap(null);
+        writer.WriteTextString("key1");
+        writer.WriteTextString(new string('A', 90));
+        writer.WriteTextString("key2");
+        writer.WriteStartMap(null);
+        writer.WriteTextString("key3");
+        writer.WriteTextString("value2");
+        writer.WriteEndMap();
+        writer.WriteEndMap();
+
+        byte[] bytes = writer.Encode();
+        var stream = new MemoryStream(bytes);
+
+        using var reader = new CborStreamReader(stream);
+
+        reader.ReadStartMap();
+        Assert.Equal("key1", reader.ReadTextString());
+        string value1 = reader.ReadTextString(); // This read will consume most of the first chunk.
+        Assert.Equal(90, value1.Length);
+        Assert.Equal("key2", reader.ReadTextString());
+        reader.ReadStartMap();
+
+        Assert.Equal("key3", reader.ReadTextString());
+        Assert.Equal("value2", reader.ReadTextString());
+        reader.ReadEndMap();
+        reader.ReadEndMap();
+
+    }
+
+    [Fact]
+    public void SkipValue_OnLargeNestedMap_Succeeds()
+    {
+        var writer = new CborWriter();
+        writer.WriteStartArray(2);
+
+        // Start the large nested map
+        writer.WriteStartMap(1);
+        writer.WriteTextString("large_key");
+        writer.WriteTextString(new string('X', 300)); // This will force refills
+        writer.WriteEndMap();
+
+        // The value we want to read after the skip
+        writer.WriteInt32(99);
+        writer.WriteEndArray();
+
+        var stream = new MemoryStream(writer.Encode());
+
+        using var reader = new CborStreamReader(stream);
+
+        reader.ReadStartArray();
+
+        // Skip the entire large map object
+        reader.SkipValue();
+
+        // Assert that we can correctly read the next item
+        Assert.Equal(99, reader.ReadInt32());
+
+        reader.ReadEndArray();
+        Assert.Equal(CborReaderState.Finished, reader.PeekState());
+
+    }
+
+    [Fact]
+    public void ReadEndArray_WhenInMap_ThrowsCborContentException()
+    {
+        // Arrange: A simple map
+        var writer = new CborWriter();
+        writer.WriteStartMap(0);
+        writer.WriteEndMap();
+        var stream = new MemoryStream(writer.Encode());
+
+        // Act & Assert
+        using var reader = new CborStreamReader(stream);
+
+        reader.ReadStartMap();
+        Assert.Throws<CborContentException>(() => reader.ReadEndArray());
+
+    }
+
+    [Fact]
+    public void Unmarshall_IncompleteStream_ThrowsCborContentException()
+    {
+        // CBOR header for a string of length 20, but we only provide 10 bytes of data.
+        byte[] bytes = Convert.FromBase64String("eBQKCgoKCgoKCg==");
+        var stream = new MemoryStream(bytes);
+
+        using var reader = new CborStreamReader(stream);
+
+        // The reader will attempt to read the string, realize it's incomplete,
+        // try to refill, find no more data, and then throw an exception.
+        Assert.Throws<CborContentException>(() => reader.ReadTextString());
+
+    }
+
+
+    [Fact]
+    public void Unmarshall_EmptyStream_ThrowsOnRead()
+    {
+        byte[] bytes = new byte[0];
+        var stream = new MemoryStream(bytes);
+
+        using var reader = new CborStreamReader(stream);
+
+        // Attempting to read from a finished reader should throw.
+        Assert.Throws<CborContentException>(() => reader.ReadStartMap());
+
+    }
+
+    [Fact]
+    public void Unmarshall_ComplexObject_SpansMultipleBuffers()
+    {
+        // Create a single map object with three large items.
+        var writer = new CborWriter();
+        writer.WriteStartMap(3);
+
+        writer.WriteTextString("item1");
+        writer.WriteTextString(new string('A', 80)); // Item 1
+
+        writer.WriteTextString("item2");
+        writer.WriteTextString(new string('B', 80)); // Item 2 (will cross boundary)
+
+        writer.WriteTextString("item3");
+        writer.WriteTextString(new string('C', 80)); // Item 3 (in second and third chunk)
+
+        writer.WriteEndMap();
+        byte[] bytes = writer.Encode();
+        var stream = new MemoryStream(bytes);
+
+        using var reader = new CborStreamReader(stream);
+
+        reader.ReadStartMap();
+
+        Assert.Equal("item1", reader.ReadTextString());
+        Assert.Equal(80, reader.ReadTextString().Length);
+
+        Assert.Equal("item2", reader.ReadTextString());
+        Assert.Equal(80, reader.ReadTextString().Length);
+
+        Assert.Equal("item3", reader.ReadTextString());
+        Assert.Equal(80, reader.ReadTextString().Length);
+
+        reader.ReadEndMap();
+        Assert.Equal(CborReaderState.Finished, reader.PeekState());
+
+    }
+
+    [Fact]
+    public void Unmarshall_DefiniteLength_NestedMapAndArray()
+    {
+        var writer = new CborWriter();
+        writer.WriteStartMap(1);
+        writer.WriteTextString("nestedArray");
+        writer.WriteStartArray(2);
+        writer.WriteInt32(1);
+        writer.WriteInt32(2);
+        writer.WriteEndArray();
+        writer.WriteEndMap();
+
+        var stream = new MemoryStream(writer.Encode());
+
+        using var reader = new CborStreamReader(stream);
+        reader.ReadStartMap();
+        Assert.Equal("nestedArray", reader.ReadTextString());
+        reader.ReadStartArray();
+        Assert.Equal(1, reader.ReadInt32());
+        Assert.Equal(2, reader.ReadInt32());
+        reader.ReadEndArray();
+        reader.ReadEndMap();
+    }
+
+    [Fact]
+    public void Unmarshall_IndefiniteLengthArray_CrossesBuffer_EndsWithBreak()
+    {
+        var writer = new CborWriter();
+        writer.WriteStartArray(null);
+        writer.WriteTextString(new string('X', 90)); // Fills buffer
+        writer.WriteTextString("done");
+        writer.WriteEndArray();
+
+        var stream = new MemoryStream(writer.Encode());
+
+        using var reader = new CborStreamReader(stream);
+        reader.ReadStartArray();
+        Assert.Equal(90, reader.ReadTextString().Length);
+        Assert.Equal("done", reader.ReadTextString());
+        reader.ReadEndArray();
+    }
+
+    [Fact]
+    public void Unmarshall_NestedIndefinite_MapArrayStructure()
+    {
+        var writer = new CborWriter();
+        writer.WriteStartMap(null);
+        writer.WriteTextString("array");
+        writer.WriteStartArray(null);
+        writer.WriteTextString("one");
+        writer.WriteTextString("two");
+        writer.WriteEndArray();
+        writer.WriteEndMap();
+
+        var stream = new MemoryStream(writer.Encode());
+
+        using var reader = new CborStreamReader(stream);
+        reader.ReadStartMap();
+        Assert.Equal("array", reader.ReadTextString());
+        reader.ReadStartArray();
+        Assert.Equal("one", reader.ReadTextString());
+        Assert.Equal("two", reader.ReadTextString());
+        reader.ReadEndArray();
+        reader.ReadEndMap();
+    }
+
+    [Fact]
+    public void Unmarshall_EmptyIndefiniteArray()
+    {
+        var writer = new CborWriter();
+        writer.WriteStartArray(null);
+        writer.WriteEndArray();
+
+        var stream = new MemoryStream(writer.Encode());
+
+        using var reader = new CborStreamReader(stream);
+        reader.ReadStartArray();
+        reader.ReadEndArray();
+    }
+
+    [Fact]
+    public void Unmarshall_IncompleteMap_ThrowsCborContentException()
+    {
+        var writer = new CborWriter();
+        writer.WriteStartMap(1);
+        writer.WriteTextString("key");
+        writer.WriteTextString("value");
+        writer.WriteEndMap();
+
+        var bytes = writer.Encode().Take(5).ToArray(); // Truncate it
+        var stream = new MemoryStream(bytes);
+
+        using var reader = new CborStreamReader(stream);
+        reader.ReadStartMap();
+        Assert.Equal("key", reader.ReadTextString());
+        Assert.Throws<CborContentException>(() => reader.ReadTextString());
+    }
+
+    [Fact]
+    public void Unmarshall_SkipValue_CrossesBufferBoundary()
+    {
+        var writer = new CborWriter();
+        writer.WriteStartArray(2);
+        writer.WriteTextString(new string('X', 200));
+        writer.WriteInt32(42);
+        writer.WriteEndArray();
+
+        var stream = new MemoryStream(writer.Encode());
+
+        using var reader = new CborStreamReader(stream);
+        reader.ReadStartArray();
+        reader.SkipValue(); // This string skip will require buffer refill
+        Assert.Equal(42, reader.ReadInt32());
+        reader.ReadEndArray();
+    }
+
+    [Fact]
+    public void Unmarshall_ByteString_CrossingBuffer()
+    {
+        var writer = new CborWriter();
+        byte[] largeByteArray = new byte[150]; // Larger than buffer size
+        new Random().NextBytes(largeByteArray);
+
+        writer.WriteByteString(largeByteArray);
+
+        using var reader = new CborStreamReader(new MemoryStream(writer.Encode()));
+        byte[] result = reader.ReadByteString();
+
+        Assert.Equal(largeByteArray, result);
+    }
+
+    [Fact]
+    public void Unmarshall_CborTags()
+    {
+        var writer = new CborWriter();
+        writer.WriteTag(CborTag.DateTimeString);
+        writer.WriteTextString("2025-07-29T00:00:00Z");
+
+        using var reader = new CborStreamReader(new MemoryStream(writer.Encode()));
+        CborTag tag = reader.ReadTag();
+        string dateStr = reader.ReadTextString();
+
+        Assert.Equal(CborTag.DateTimeString, tag);
+        Assert.Equal("2025-07-29T00:00:00Z", dateStr);
+    }
+
+    [Fact]
+    public void Unmarshall_DeeplyNestedStructure()
+    {
+        var writer = new CborWriter();
+        // Create a deeply nested structure
+        for (int i = 0; i < 10; i++)
+        {
+            writer.WriteStartMap(1);
+            writer.WriteTextString($"level{i}");
+        }
+        writer.WriteTextString("value");
+        for (int i = 0; i < 10; i++)
+        {
+            writer.WriteEndMap();
+        }
+
+        using var reader = new CborStreamReader(new MemoryStream(writer.Encode()));
+        for (int i = 0; i < 10; i++)
+        {
+            reader.ReadStartMap();
+            Assert.Equal($"level{i}", reader.ReadTextString());
+        }
+        Assert.Equal("value", reader.ReadTextString());
+        for (int i = 0; i < 10; i++)
+        {
+            reader.ReadEndMap();
+        }
+    }
+}
+

--- a/sdk/src/Core/AWSConfigs.cs
+++ b/sdk/src/Core/AWSConfigs.cs
@@ -80,6 +80,7 @@ namespace Amazon
         internal static string _awsProfileName = GetConfig(AWSProfileNameKey);
         internal static string _awsAccountsLocation = GetConfig(AWSProfilesLocationKey);
         internal static bool _useSdkCache = GetConfigBool(UseSdkCacheKey, defaultValue: true);
+        internal static int _cborReaderInitialBufferSize = GetConfigInt(CborReaderInitialBufferSizeKey, defaultValue: 1024 * 4); //4KB
         internal static bool _initializeCollections = GetConfigBool(InitializeCollectionsKey, defaultValue: false);
         private static TelemetryProvider _telemetryProvider = new DefaultTelemetryProvider();
 
@@ -257,6 +258,33 @@ namespace Amazon
         {
             get { return _rootConfig.UseSdkCache; }
             set { _rootConfig.UseSdkCache = value; }
+        }
+
+        #endregion
+
+        #region CborReader Initial Buffer Size
+
+        /// <summary>
+        /// Key for the CborReaderInitialBufferSize property.
+        /// <seealso cref="Amazon.AWSConfigs.CborReaderInitialBufferSize"/>
+        /// </summary>
+        public const string CborReaderInitialBufferSizeKey = "CborReaderInitialBufferSize";
+
+        /// <summary>
+        /// Configures the initial buffer size in bytes for the streaming CBOR reader.
+        /// If this value isn't set, a default size of 4,096 bytes (4 KB) will be used.
+        /// <para />
+        /// Setting this property is not thread safe and should only be set at application startup.
+        /// <para />
+        /// <remarks>
+        /// Note that the buffer will automatically resize if it encounters a single data item larger
+        /// than this initial size.
+        /// </remarks>
+        /// </summary>
+        public static int CborReaderInitialBufferSize
+        {
+            get { return _rootConfig.CborReaderInitialBufferSize; }
+            set { _rootConfig.CborReaderInitialBufferSize = value; }
         }
 
         #endregion
@@ -475,6 +503,15 @@ namespace Amazon
             string value = GetConfig(name);
             bool result;
             if (bool.TryParse(value, out result))
+                return result;
+            return defaultValue;
+        }
+
+        private static int GetConfigInt(string name, int defaultValue = 0)
+        {
+            string value = GetConfig(name);
+            int result;
+            if (int.TryParse(value, out result))
                 return result;
             return defaultValue;
         }

--- a/sdk/src/Core/Amazon.Util/Internal/RootConfig.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/RootConfig.cs
@@ -34,6 +34,7 @@ namespace Amazon.Util.Internal
         public bool UseSdkCache { get; set; }
 
         public bool InitializeCollections { get; set; }
+        public int CborReaderInitialBufferSize { get; set; }
 
         public bool CorrectForClockSkew { get; set; }
 
@@ -64,6 +65,7 @@ namespace Amazon.Util.Internal
             ProfilesLocation = AWSConfigs._awsAccountsLocation;
             UseSdkCache = AWSConfigs._useSdkCache;
             InitializeCollections = AWSConfigs._initializeCollections;
+            CborReaderInitialBufferSize = AWSConfigs._cborReaderInitialBufferSize;
             CorrectForClockSkew = true;
 
 #if NET8_0_OR_GREATER


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The current code loads the whole response stream in memory before start the unmarshalling process. This works for small payloads but may cause issues for large response payloads.
The `System.Formats.Cbor.CborReader` doesn't accept stream and requires in memory byte array for deserialization.

This PR adds `CborReaderProxy` that wraps `System.Formats.Cbor.CborReader` to support processing the stream in chunks without ever holding the whole payload in memory, feeding the chunks into `CborReader` and process them one by one.


The default `CborReader.ReadEndMap()`/`CborReader.ReadEndArray()` methods assume the full map is already present in the input buffer and cannot continue reading if the buffer ends in the middle of a container.
This means the reader will fail to advance if the next token is a container break (0xFF) but the start wasn't read into the current buffer (it was read in a previous part of the stream).

To support maps/arrays across multiple refills I did the following:
* Implement custom `ReadStartMap`, `ReadEndMap`, `ReadStartArray`, `ReadEndArray`.
* Detect and skip container break markers `0xFF` as needed.
* Added `_nestingStack` to track when reading a nested CBOR structure (e.g., an array of maps), and correctly match calls to `ReadStartMap` with `ReadEndMap`, and `ReadStartArray` with `ReadEndArray`.


## Motivation and Context
`#DOTNET-8252`

## Testing
* Added `CborReaderProxyTests.cs` to cover the new changes.
* Tested various `CloudWatch` and `SecretsManager` operations with CBOR.
* `DRY_RUN-4ff92fab-9e40-46cc-88d0-746023de37cf`.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement