### PR TITLE
[V3] Update HTTP handler to handle scenario where content stream position is not zero

### DIFF
--- a/generator/.DevConfigs/083f2f8d-4b63-4b95-a272-1be2843814e2.json
+++ b/generator/.DevConfigs/083f2f8d-4b63-4b95-a272-1be2843814e2.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Update HTTP handler to handle scenario where content stream position is not zero (https://github.com/aws/aws-sdk-net/issues/3941)"
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
@@ -445,7 +445,17 @@ namespace Amazon.Runtime.Internal
                 }
                 else
                 {
-                    originalStream = wrappedRequest.ContentStream;
+                    // If the current position for the ContentStream is not at the beginning, we need to handle it
+                    // before wrapping it during GetInputStream.
+                    if (wrappedRequest.ContentStream.CanSeek && wrappedRequest.ContentStream.Position != 0)
+                    {
+                        var size = wrappedRequest.ContentStream.Length - wrappedRequest.ContentStream.Position;
+                        originalStream = new PartialReadOnlyWrapperStream(wrappedRequest.ContentStream, size);
+                    }
+                    else
+                    {
+                        originalStream = wrappedRequest.ContentStream;
+                    }
                 }
 
                 var callback = ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)wrappedRequest.OriginalRequest).StreamUploadProgressCallback;
@@ -492,7 +502,17 @@ namespace Amazon.Runtime.Internal
                 }
                 else
                 {
-                    originalStream = wrappedRequest.ContentStream;
+                    // If the current position for the ContentStream is not at the beginning, we need to handle it
+                    // before wrapping it during GetInputStream.
+                    if (wrappedRequest.ContentStream.CanSeek && wrappedRequest.ContentStream.Position != 0)
+                    {
+                        var size = wrappedRequest.ContentStream.Length - wrappedRequest.ContentStream.Position;
+                        originalStream = new PartialReadOnlyWrapperStream(wrappedRequest.ContentStream, size);
+                    }
+                    else
+                    {
+                        originalStream = wrappedRequest.ContentStream;
+                    }
                 }
 
                 var callback = ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)wrappedRequest.OriginalRequest).StreamUploadProgressCallback;

--- a/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
+++ b/sdk/test/NetStandard/IntegrationTests/IntegrationTests/S3/PutObjectTests.cs
@@ -187,6 +187,55 @@ namespace Amazon.DNXCore.IntegrationTests.S3
         }
 
         /// <summary>
+        /// Reported in https://github.com/aws/aws-sdk-net/issues/3941
+        /// </summary>
+        [Fact]
+        public async Task HandlesFileStreamWithoutAutoReset()
+        {
+            using (var writeFs = new FileStream("sample.bin", FileMode.Create, FileAccess.Write))
+            {
+                var data = new byte[]
+                {
+                    0x01, 0x00, 0x0D, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x01, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                };
+
+                await writeFs.WriteAsync(data, 0, data.Length);
+            }
+
+            using var fileStream = File.Open("sample.bin", FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new BinaryReader(fileStream);
+
+            fileStream.Position = 10;
+            var compression = reader.ReadInt16();
+            
+            fileStream.Seek(8, SeekOrigin.Current);
+            var bIsLast = reader.ReadBoolean();
+            
+            fileStream.Seek(4, SeekOrigin.Current);
+
+            var putRequest = new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = "upload-test/0D-0",
+                ContentType = "application/octet-stream",
+                InputStream = fileStream,
+                AutoResetStreamPosition = false,
+            };
+            putRequest.Metadata.Add("compression", compression.ToString());
+            putRequest.Metadata.Add("islast", bIsLast ? "T" : "F");
+
+            var putResponse = await Client.PutObjectAsync(putRequest);
+            Assert.Equal(HttpStatusCode.OK, putResponse.HttpStatusCode);
+
+            var getResponse = await Client.GetObjectMetadataAsync(bucketName, putRequest.Key);
+            Assert.Equal(HttpStatusCode.OK, getResponse.HttpStatusCode);
+            Assert.NotNull(getResponse.Metadata);
+            Assert.True(getResponse.Metadata.Count > 0);
+        }
+
+        /// <summary>
         /// Reported in https://github.com/aws/aws-sdk-net/issues/3629
         /// </summary>
         [Theory]


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-net/issues/3941 for V3

## Description
Prior to the S3's default data integrity change, any streams passed into `PutObject` / `UploadPart` would be wrapped into a [MD5Stream](https://github.com/aws/aws-sdk-net/blob/32933d593014977245226d19bdc8d89c95899f3e/sdk/src/Core/Amazon.Runtime/Internal/Util/HashStream.cs#L447) that would handle a non-zero starting position.

After the change, the customer's stream is passed directly into one of our wrappers (e.g. `ChunkedUploadWrapperStream`) which was not taking the current position when calculating the value to be sent in the `Content-Length` header.

This PR updates the HTTP handler to, prior to creating our wrappers, check if the content stream has a non-zero starting position (guaranteeing that the calculations only take into account the correct data range being uploaded).

## Testing
- Dry-run: `DRY_RUN-5485a153-e9eb-471b-ab82-8b7f7d31a9f7`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license