### PR TITLE
Improve CborStreamReader Logic to Handle Nesting and End-of-Buffer Corner Cases

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CborProtocol/Internal/CborStreamReader.cs
+++ b/extensions/src/AWSSDK.Extensions.CborProtocol/Internal/CborStreamReader.cs
@@ -134,6 +134,14 @@ namespace Amazon.Extensions.CborProtocol.Internal
                 }
                 catch (Exception ex) when (ex is InvalidOperationException || ex is CborContentException)
                 {
+                    // Both InvalidOperationException and CborContentException can occur when the reader
+                    // runs out of buffered data mid-item or encounters an incomplete CBOR structure.
+                    // - CborContentException: typically thrown when encountering invalid CBOR content,
+                    //   such as a premature break or truncated container.
+                    // - InvalidOperationException: can happen when the reader attempts to interpret data
+                    //   as a different type due to hitting a buffer boundary before the full item is available.
+                    // We catch both, trigger a buffer refill, and retry before deciding if it is a genuine error.
+
                     if (_currentChunkSize == 0 && _internalCborReader.BytesRemaining == 0)
                     {
                         // Fail fast if we’ve already consumed all input and nothing remains to refill.
@@ -193,11 +201,30 @@ namespace Amazon.Extensions.CborProtocol.Internal
 
                 if (state == CborReaderState.Finished)
                 {
+                    // We got CborReaderState.Finished which means the reader has exhausted the bytes currently
+                    // given to it and the next token may live in the next chunk that we haven't read yet.
+                    //
+                    // For indefinite-length containers the end of the container is a break marker byte (0xFF).
+                    // If that break byte is the next byte in the stream, we must consume it, otherwise the reader
+                    // will become desynchronized (it will still think we're inside a container while removed the
+                    // container from the _nestingStack).
+                    // This byte can exist in the next chunk, so when we hit Finished we first attempt to refill
+                    // the buffer (no skip) so the reader can see the next byte(s). Only after refilling can we safely
+                    // determine whether the next byte is a break byte that terminates the current container.
+
                     // Try to refill first, maybe the break marker is in the next chunk.
                     RefillBuffer(0);
 
                     if (IsNextByteEndOfContainer())
                     {
+                        // If the next raw byte after refill is the CBOR "break" (0xFF), that indicates an
+                        // indefinite-length container terminator. We must explicitly consume that break byte
+                        // so we can remove the item from the _nestingStack and parsing can continue correctly.
+                        //
+                        // We call RefillBuffer(1) to skip the break byte and  rebuild the internal reader.
+                        // It consumes the break byte from the leftover buffer so subsequent calls to the CborReader
+                        // see the next item.
+
                         RefillBuffer(1); // Skip the break marker (0xFF)
                     }
                     _nestingStack.Pop();
@@ -239,7 +266,7 @@ namespace Amazon.Extensions.CborProtocol.Internal
         {
             return ExecuteRead(r =>
             {
-                // We need to Peek twice incase the first time failed because we are near the end of the current chunk and we just need to refill.
+                // We need to Peek twice in case the first time failed because we are near the end of the current chunk and we just need to refill.
                 for (int attempt = 0; attempt < 2; attempt++)
                 {
                     try
@@ -256,7 +283,7 @@ namespace Amazon.Extensions.CborProtocol.Internal
                     }
                     catch (CborContentException ex)
                     {
-                        // PeekState threw an exception, we will attempt to refill incase we aren't at the end of the stream.
+                        // PeekState threw an exception, we will attempt to refill in case we aren't at the end of the stream.
                         _logger.Debug(ex, "PeekState threw exception (attempt #{0}). Attempting refill.", attempt + 1);
                         RefillBuffer(0);
                     }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the `CborStreamReader` streaming logic to correctly handle scenarios where the buffer ends just after an item was read, particularly when working with nested containers.

Previously, the streaming CBOR reader could incorrectly signal completion when the current buffer segment ended but nested containers were still open. This caused issues with large or segmented CBOR payloads where container boundaries did not align with buffer boundaries.

* Avoids prematurely treating `PeekState() == Finished` as a final read state when there are still open containers in the nesting stack.
* Ensures containers are only closed when the corresponding `EndArray` or `EndMap` is explicitly read when end-of-current-buffer-part scenarios.

<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-8252`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
- `DRY_RUN-08c395ab-328f-4d34-8928-282cecedfd90`
- Added unit tests to cover when the buffer ends close to the end of containers.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement