### PR TITLE
Update SDK not to mutate credentials in config object

### DIFF
--- a/generator/.DevConfigs/dd64ba29-2cea-4bd3-bcf3-775156c740f8.json
+++ b/generator/.DevConfigs/dd64ba29-2cea-4bd3-bcf3-775156c740f8.json
@@ -4,6 +4,9 @@
         "type": "Patch",
         "changeLogMessages": [
             "Update SDK not to mutate credentials in provided config object (https://github.com/aws/aws-sdk-net/issues/3950)"
+        ],
+        "backwardIncompatibilitiesToIgnore": [
+            "Amazon.Runtime.IRequestContext/MethodAbstractMethodAdded"
         ]
     }
 }

--- a/generator/.DevConfigs/dd64ba29-2cea-4bd3-bcf3-775156c740f8.json
+++ b/generator/.DevConfigs/dd64ba29-2cea-4bd3-bcf3-775156c740f8.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "updateMinimum": true,
+        "type": "Patch",
+        "changeLogMessages": [
+            "Update SDK not to mutate credentials in provided config object (https://github.com/aws/aws-sdk-net/issues/3950)"
+        ]
+    }
+}

--- a/generator/ServiceClientGeneratorLib/DefaultConfiguration/SdkDefaultConfigurationJsonDataModel.cs
+++ b/generator/ServiceClientGeneratorLib/DefaultConfiguration/SdkDefaultConfigurationJsonDataModel.cs
@@ -8,7 +8,7 @@ namespace ServiceClientGenerator.DefaultConfiguration
 {
     /// <summary>
     /// Represents the sdk-default-configuration.json file so that it be serialized with
-    /// <see cref="JsonMapper.ToObject{T}(string)"/>
+    /// <see cref="JsonMapper.ToObject{T}(string, bool)"/>
     ///
     /// Also contains some helper conversions for navigating the deserialized model.
     /// </summary>

--- a/generator/ServiceModels/docdb/docdb.customizations.json
+++ b/generator/ServiceModels/docdb/docdb.customizations.json
@@ -5,7 +5,7 @@
                 "operation": "addBefore",
                 "newType": "Amazon.DocDB.Internal.PreSignedUrlRequestHandler",
                 "targetType": "Amazon.Runtime.Internal.Marshaller",
-                "constructorInput": "this.Config.DefaultAWSCredentials"
+                "constructorInput": "this.DefaultAWSCredentials ?? this.Config.DefaultAWSCredentials"
             }
         ]
     }  

--- a/generator/ServiceModels/docdb/docdb.customizations.json
+++ b/generator/ServiceModels/docdb/docdb.customizations.json
@@ -5,7 +5,7 @@
                 "operation": "addBefore",
                 "newType": "Amazon.DocDB.Internal.PreSignedUrlRequestHandler",
                 "targetType": "Amazon.Runtime.Internal.Marshaller",
-                "constructorInput": "this.DefaultAWSCredentials ?? this.Config.DefaultAWSCredentials"
+                "constructorInput": "this.ExplicitAWSCredentials ?? this.Config.DefaultAWSCredentials"
             }
         ]
     }  

--- a/generator/ServiceModels/ec2/ec2.customizations.json
+++ b/generator/ServiceModels/ec2/ec2.customizations.json
@@ -5,7 +5,7 @@
                 "operation": "addBefore",
                 "newType": "Amazon.EC2.Internal.AmazonEC2PreMarshallHandler",
                 "targetType": "Amazon.Runtime.Internal.Marshaller",
-                "constructorInput": "this.DefaultAWSCredentials ?? this.Config.DefaultAWSCredentials"
+                "constructorInput": "this.ExplicitAWSCredentials ?? this.Config.DefaultAWSCredentials"
             },
             {
                 "operation": "addAfter",

--- a/generator/ServiceModels/ec2/ec2.customizations.json
+++ b/generator/ServiceModels/ec2/ec2.customizations.json
@@ -5,7 +5,7 @@
                 "operation": "addBefore",
                 "newType": "Amazon.EC2.Internal.AmazonEC2PreMarshallHandler",
                 "targetType": "Amazon.Runtime.Internal.Marshaller",
-                "constructorInput": "this.Config.DefaultAWSCredentials"
+                "constructorInput": "this.DefaultAWSCredentials ?? this.Config.DefaultAWSCredentials"
             },
             {
                 "operation": "addAfter",

--- a/generator/ServiceModels/neptune/neptune.customizations.json
+++ b/generator/ServiceModels/neptune/neptune.customizations.json
@@ -29,7 +29,7 @@
                 "operation": "addBefore",
                 "newType": "Amazon.Neptune.Internal.PreSignedUrlRequestHandler",
                 "targetType": "Amazon.Runtime.Internal.Marshaller",
-                "constructorInput": "this.Config.DefaultAWSCredentials"
+                "constructorInput": "this.DefaultAWSCredentials ?? this.Config.DefaultAWSCredentials"
             }
         ]
     }  

--- a/generator/ServiceModels/neptune/neptune.customizations.json
+++ b/generator/ServiceModels/neptune/neptune.customizations.json
@@ -29,7 +29,7 @@
                 "operation": "addBefore",
                 "newType": "Amazon.Neptune.Internal.PreSignedUrlRequestHandler",
                 "targetType": "Amazon.Runtime.Internal.Marshaller",
-                "constructorInput": "this.DefaultAWSCredentials ?? this.Config.DefaultAWSCredentials"
+                "constructorInput": "this.ExplicitAWSCredentials ?? this.Config.DefaultAWSCredentials"
             }
         ]
     }  

--- a/generator/ServiceModels/rds/rds.customizations.json
+++ b/generator/ServiceModels/rds/rds.customizations.json
@@ -20,7 +20,7 @@
                 "operation": "addBefore",
                 "newType": "Amazon.RDS.Internal.PreSignedUrlRequestHandler",
                 "targetType": "Amazon.Runtime.Internal.Marshaller",
-                "constructorInput": "this.Config.DefaultAWSCredentials"
+                "constructorInput": "this.DefaultAWSCredentials ?? this.Config.DefaultAWSCredentials"
             }
         ]
     }

--- a/generator/ServiceModels/rds/rds.customizations.json
+++ b/generator/ServiceModels/rds/rds.customizations.json
@@ -20,7 +20,7 @@
                 "operation": "addBefore",
                 "newType": "Amazon.RDS.Internal.PreSignedUrlRequestHandler",
                 "targetType": "Amazon.Runtime.Internal.Marshaller",
-                "constructorInput": "this.DefaultAWSCredentials ?? this.Config.DefaultAWSCredentials"
+                "constructorInput": "this.ExplicitAWSCredentials ?? this.Config.DefaultAWSCredentials"
             }
         ]
     }

--- a/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
+++ b/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
@@ -167,11 +167,7 @@ namespace Amazon.Runtime
             config.Validate();
             _config = config;
 
-            if (credentials != null)
-            {
-                ExplicitAWSCredentials = credentials;
-            }
-
+            ExplicitAWSCredentials = credentials;
             EndpointDiscoveryResolver = new EndpointDiscoveryResolver(config, _logger);
             Initialize();
             UpdateSecurityProtocol();

--- a/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
+++ b/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
@@ -45,6 +45,12 @@ namespace Amazon.Runtime
         protected RuntimePipeline RuntimePipeline { get; set; }
         public IClientConfig Config => _config;
         private readonly ClientConfig _config;
+
+        /// <summary>
+        /// Credentials explicitly specified when constructing the client.
+        /// </summary>
+        protected internal AWSCredentials DefaultAWSCredentials { get; private set; }
+
         protected virtual IServiceMetadata ServiceMetadata { get; } = new ServiceMetadata();
         protected virtual bool SupportResponseLogging
         {
@@ -159,11 +165,13 @@ namespace Amazon.Runtime
                 _logger = Logger.GetLogger(this.GetType());
 
             config.Validate();
-
-            if(credentials != null)
-                config.DefaultAWSCredentials = credentials;
-
             _config = config;
+
+            if (credentials != null)
+            {
+                DefaultAWSCredentials = credentials;
+            }
+
             EndpointDiscoveryResolver = new EndpointDiscoveryResolver(config, _logger);
             Initialize();
             UpdateSecurityProtocol();
@@ -205,6 +213,7 @@ namespace Amazon.Runtime
                 new RequestContext(this.Config.LogMetrics)
                 {
                     ClientConfig = this.Config,
+                    DefaultAWSCredentials = this.DefaultAWSCredentials,
                     Marshaller = options.RequestMarshaller,
                     OriginalRequest = request,
                     Unmarshaller = options.ResponseUnmarshaller,
@@ -234,6 +243,7 @@ namespace Amazon.Runtime
                 new RequestContext(this.Config.LogMetrics)
                 {
                     ClientConfig = this.Config,
+                    DefaultAWSCredentials = this.DefaultAWSCredentials,
                     Marshaller = options.RequestMarshaller,
                     OriginalRequest = request,
                     Unmarshaller = options.ResponseUnmarshaller,

--- a/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
+++ b/sdk/src/Core/Amazon.Runtime/AmazonServiceClient.cs
@@ -49,7 +49,7 @@ namespace Amazon.Runtime
         /// <summary>
         /// Credentials explicitly specified when constructing the client.
         /// </summary>
-        protected internal AWSCredentials DefaultAWSCredentials { get; private set; }
+        protected internal AWSCredentials ExplicitAWSCredentials { get; private set; }
 
         protected virtual IServiceMetadata ServiceMetadata { get; } = new ServiceMetadata();
         protected virtual bool SupportResponseLogging
@@ -169,7 +169,7 @@ namespace Amazon.Runtime
 
             if (credentials != null)
             {
-                DefaultAWSCredentials = credentials;
+                ExplicitAWSCredentials = credentials;
             }
 
             EndpointDiscoveryResolver = new EndpointDiscoveryResolver(config, _logger);
@@ -213,7 +213,7 @@ namespace Amazon.Runtime
                 new RequestContext(this.Config.LogMetrics)
                 {
                     ClientConfig = this.Config,
-                    DefaultAWSCredentials = this.DefaultAWSCredentials,
+                    ExplicitAWSCredentials = this.ExplicitAWSCredentials,
                     Marshaller = options.RequestMarshaller,
                     OriginalRequest = request,
                     Unmarshaller = options.ResponseUnmarshaller,
@@ -243,7 +243,7 @@ namespace Amazon.Runtime
                 new RequestContext(this.Config.LogMetrics)
                 {
                     ClientConfig = this.Config,
-                    DefaultAWSCredentials = this.DefaultAWSCredentials,
+                    ExplicitAWSCredentials = this.ExplicitAWSCredentials,
                     Marshaller = options.RequestMarshaller,
                     OriginalRequest = request,
                     Unmarshaller = options.ResponseUnmarshaller,

--- a/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/IClientConfig.cs
@@ -65,15 +65,15 @@ namespace Amazon.Runtime
         /// <summary> 
         /// <para> 
         /// The AWS credentials used for authenticating calls to AWS for services using AWS signature version 4 (SigV4). 
-        /// SigV4 is the most common authentication mechanism used for AWS service calls. If AWSCredentials are used as a 
-        /// parameter to the service client's constructor the value will be set on this property. 
+        /// SigV4 is the most common authentication mechanism used for AWS service calls. 
         /// </para> 
         /// <para> 
         /// Common instances of AWSCredentials are <see cref="Amazon.Runtime.BasicAWSCredentials" /> for static credentials and 
         /// <see cref="Amazon.Runtime.AssumeRoleAWSCredentials" /> for getting credentials by assuming an IAM role. 
         /// </para> 
         /// <para> 
-        /// If null, the SDK will determine which credentials to use at request time using information from the source service model. 
+        /// If null, the SDK will determine which credentials to use at request time using information from the source service model.
+        /// Credentials passed as a parameter to the service client's constructor take precedence over these default credentials.
         /// </para> 
         /// </summary>
         AWSCredentials DefaultAWSCredentials { get; }

--- a/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
@@ -32,7 +32,7 @@ namespace Amazon.Runtime.Internal
             where TConfig : ClientConfig, new ()
             where TClient : AmazonServiceClient
         {
-            var credentials = originalServiceClient.Config.DefaultAWSCredentials;
+            var credentials = originalServiceClient.DefaultAWSCredentials ?? originalServiceClient.Config.DefaultAWSCredentials;
             var newConfig = originalServiceClient.CloneConfig<TConfig>();
 
             var newServiceClientTypeInfo = typeof(TClient);
@@ -116,7 +116,8 @@ namespace Amazon.Runtime.Internal
                     config.GetType()
                 });
 
-            var newServiceClient = constructor.Invoke(new object[] { originalServiceClient.Config.DefaultAWSCredentials, config }) as TClient;
+            var credentials = originalServiceClient.DefaultAWSCredentials ?? originalServiceClient.Config.DefaultAWSCredentials;
+            var newServiceClient = constructor.Invoke(new object[] { credentials, config }) as TClient;
 
             return newServiceClient;
         }

--- a/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/ServiceClientHelpers.cs
@@ -32,7 +32,7 @@ namespace Amazon.Runtime.Internal
             where TConfig : ClientConfig, new ()
             where TClient : AmazonServiceClient
         {
-            var credentials = originalServiceClient.DefaultAWSCredentials ?? originalServiceClient.Config.DefaultAWSCredentials;
+            var credentials = originalServiceClient.ExplicitAWSCredentials ?? originalServiceClient.Config.DefaultAWSCredentials;
             var newConfig = originalServiceClient.CloneConfig<TConfig>();
 
             var newServiceClientTypeInfo = typeof(TClient);
@@ -116,7 +116,7 @@ namespace Amazon.Runtime.Internal
                     config.GetType()
                 });
 
-            var credentials = originalServiceClient.DefaultAWSCredentials ?? originalServiceClient.Config.DefaultAWSCredentials;
+            var credentials = originalServiceClient.ExplicitAWSCredentials ?? originalServiceClient.Config.DefaultAWSCredentials;
             var newServiceClient = constructor.Invoke(new object[] { credentials, config }) as TClient;
 
             return newServiceClient;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/SdkCache.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/SdkCache.cs
@@ -227,7 +227,7 @@ namespace Amazon.Runtime.Internal.Util
 
                 var key = new CacheKey();
 
-                var credentials = client.DefaultAWSCredentials ?? client.Config.DefaultAWSCredentials;
+                var credentials = client.ExplicitAWSCredentials ?? client.Config.DefaultAWSCredentials;
                 key.ImmutableCredentials = credentials?.GetCredentials();
                 key.RegionEndpoint = client.Config.RegionEndpoint;
                 key.ServiceUrl = client.Config.ServiceURL;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/SdkCache.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/SdkCache.cs
@@ -227,9 +227,8 @@ namespace Amazon.Runtime.Internal.Util
 
                 var key = new CacheKey();
 
-                var credentials = client.Config.DefaultAWSCredentials;
-                key.ImmutableCredentials = credentials == null ?
-                    null : credentials.GetCredentials();
+                var credentials = client.DefaultAWSCredentials ?? client.Config.DefaultAWSCredentials;
+                key.ImmutableCredentials = credentials?.GetCredentials();
                 key.RegionEndpoint = client.Config.RegionEndpoint;
                 key.ServiceUrl = client.Config.ServiceURL;
                 key.CacheType = cacheType;

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
@@ -34,7 +34,7 @@ namespace Amazon.Runtime
         RequestMetrics Metrics { get; }
         ISigner Signer { get; set; }
         BaseIdentity Identity { get; set; }
-        AWSCredentials DefaultAWSCredentials { get; }
+        AWSCredentials ExplicitAWSCredentials { get; }
         IClientConfig ClientConfig { get; }
         IRequest Request { get; set; }
         bool IsSigned { get; set; }
@@ -106,7 +106,7 @@ namespace Amazon.Runtime.Internal
         public InvokeOptionsBase Options { get; set; }
         public ISigner Signer { get; set; }
         public BaseIdentity Identity { get; set; }
-        public AWSCredentials DefaultAWSCredentials { get; set; }
+        public AWSCredentials ExplicitAWSCredentials { get; set; }
         public UserAgentDetails UserAgentDetails
         {
             get

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
@@ -34,6 +34,7 @@ namespace Amazon.Runtime
         RequestMetrics Metrics { get; }
         ISigner Signer { get; set; }
         BaseIdentity Identity { get; set; }
+        AWSCredentials DefaultAWSCredentials { get; }
         IClientConfig ClientConfig { get; }
         IRequest Request { get; set; }
         bool IsSigned { get; set; }
@@ -105,6 +106,7 @@ namespace Amazon.Runtime.Internal
         public InvokeOptionsBase Options { get; set; }
         public ISigner Signer { get; set; }
         public BaseIdentity Identity { get; set; }
+        public AWSCredentials DefaultAWSCredentials { get; set; }
         public UserAgentDetails UserAgentDetails
         {
             get

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
@@ -57,6 +57,7 @@ namespace Amazon.Runtime.Internal
             }
 
             var clientConfig = executionContext.RequestContext.ClientConfig;
+            var defaultCredentials = executionContext.RequestContext.DefaultAWSCredentials ?? clientConfig.DefaultAWSCredentials;
 
             for (int i = 0; i < authOptions.Count; i++)
             {
@@ -72,10 +73,10 @@ namespace Amazon.Runtime.Internal
                 {
                     executionContext.RequestContext.Signer = GetSigner(scheme);
 
-                    if ((scheme is AwsV4aAuthScheme || scheme is AwsV4AuthScheme) && clientConfig.DefaultAWSCredentials != null)
+                    if ((scheme is AwsV4aAuthScheme || scheme is AwsV4AuthScheme) && defaultCredentials != null)
                     {
                         // We can use DefaultAWSCredentials if it was set by the user for these schemes.
-                        executionContext.RequestContext.Identity = clientConfig.DefaultAWSCredentials;
+                        executionContext.RequestContext.Identity = defaultCredentials;
                         break;
                     }
 
@@ -143,6 +144,7 @@ namespace Amazon.Runtime.Internal
 
             var clientConfig = executionContext.RequestContext.ClientConfig;
             var cancellationToken = executionContext.RequestContext.CancellationToken;
+            var defaultCredentials = executionContext.RequestContext.DefaultAWSCredentials ?? clientConfig.DefaultAWSCredentials;
 
             for (int i = 0; i < authOptions.Count; i++)
             {
@@ -158,10 +160,10 @@ namespace Amazon.Runtime.Internal
                 {
                     executionContext.RequestContext.Signer = GetSigner(scheme);
 
-                    if ((scheme is AwsV4aAuthScheme || scheme is AwsV4AuthScheme) && clientConfig.DefaultAWSCredentials != null)
+                    if ((scheme is AwsV4aAuthScheme || scheme is AwsV4AuthScheme) && defaultCredentials != null)
                     {
                         // We can use DefaultAWSCredentials if it was set by the user for these schemes.
-                        executionContext.RequestContext.Identity = clientConfig.DefaultAWSCredentials;
+                        executionContext.RequestContext.Identity = defaultCredentials;
                         break;
                     }
 

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs
@@ -57,7 +57,7 @@ namespace Amazon.Runtime.Internal
             }
 
             var clientConfig = executionContext.RequestContext.ClientConfig;
-            var defaultCredentials = executionContext.RequestContext.DefaultAWSCredentials ?? clientConfig.DefaultAWSCredentials;
+            var defaultCredentials = executionContext.RequestContext.ExplicitAWSCredentials ?? clientConfig.DefaultAWSCredentials;
 
             for (int i = 0; i < authOptions.Count; i++)
             {
@@ -144,7 +144,7 @@ namespace Amazon.Runtime.Internal
 
             var clientConfig = executionContext.RequestContext.ClientConfig;
             var cancellationToken = executionContext.RequestContext.CancellationToken;
-            var defaultCredentials = executionContext.RequestContext.DefaultAWSCredentials ?? clientConfig.DefaultAWSCredentials;
+            var defaultCredentials = executionContext.RequestContext.ExplicitAWSCredentials ?? clientConfig.DefaultAWSCredentials;
 
             for (int i = 0; i < authOptions.Count; i++)
             {

--- a/sdk/src/Services/DocDB/Custom/Internal/PreSignedUrlRequestHandler.cs
+++ b/sdk/src/Services/DocDB/Custom/Internal/PreSignedUrlRequestHandler.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using Amazon.Runtime;
+using Amazon.Runtime.Credentials.Internal;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Runtime.Internal.Util;
@@ -41,7 +42,7 @@ namespace Amazon.DocDB.Internal
         /// <param name="credentials"></param>
         public PreSignedUrlRequestHandler(AWSCredentials credentials)
         {
-            _credentials = credentials;
+            _credentials = credentials ?? DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
         }
 
         /// <summary>

--- a/sdk/src/Services/EC2/Custom/Internal/AmazonEC2PreMarshallHandler.cs
+++ b/sdk/src/Services/EC2/Custom/Internal/AmazonEC2PreMarshallHandler.cs
@@ -18,6 +18,7 @@ using System.Globalization;
 using Amazon.EC2.Model.Internal.MarshallTransformations;
 using Amazon.Runtime;
 using Amazon.EC2.Model;
+using Amazon.Runtime.Credentials.Internal;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Runtime.Internal.Util;
@@ -38,7 +39,7 @@ namespace Amazon.EC2.Internal
         /// <param name="credentials"></param>
         public AmazonEC2PreMarshallHandler(AWSCredentials credentials)
         {
-            this._credentials = credentials;
+            this._credentials = credentials ?? DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
         }
 
         /// <summary>

--- a/sdk/src/Services/Neptune/Custom/Internal/PreSignedUrlRequestHandler.cs
+++ b/sdk/src/Services/Neptune/Custom/Internal/PreSignedUrlRequestHandler.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using Amazon.Runtime;
+using Amazon.Runtime.Credentials.Internal;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Runtime.Internal.Util;
@@ -41,7 +42,7 @@ namespace Amazon.Neptune.Internal
         /// <param name="credentials"></param>
         public PreSignedUrlRequestHandler(AWSCredentials credentials)
         {
-            _credentials = credentials;
+            _credentials = credentials ?? DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
         }
 
         /// <summary>

--- a/sdk/src/Services/RDS/Custom/Internal/PreSignedUrlRequestHandler.cs
+++ b/sdk/src/Services/RDS/Custom/Internal/PreSignedUrlRequestHandler.cs
@@ -14,6 +14,7 @@
  */
 
 using Amazon.Runtime;
+using Amazon.Runtime.Credentials.Internal;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Runtime.Internal.Util;
@@ -41,7 +42,7 @@ namespace Amazon.RDS.Internal
         /// <param name="credentials"></param>
         public PreSignedUrlRequestHandler(AWSCredentials credentials)
         {
-            _credentials = credentials;
+            _credentials = credentials ?? DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
@@ -718,7 +718,7 @@ namespace Amazon.S3
             var credentials =
                 DefaultAWSCredentials ??
                 Config.DefaultAWSCredentials ??
-                DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>(); 
+                DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
             
             if (credentials == null)
                 throw new AmazonS3Exception("Credentials must be specified, cannot call method anonymously");

--- a/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
@@ -103,7 +103,10 @@ namespace Amazon.S3
         /// <exception cref="T:System.ArgumentNullException" />
         internal string GetPreSignedURLInternal(GetPreSignedUrlRequest request)
         {
-            var credentials = Config.DefaultAWSCredentials ?? DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
+            var credentials = 
+                DefaultAWSCredentials ??
+                Config.DefaultAWSCredentials ?? 
+                DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
 
             if(credentials == null)
                 throw new AmazonS3Exception("Credentials must be specified, cannot call method anonymously");
@@ -171,7 +174,10 @@ namespace Amazon.S3
         [SuppressMessage("AWSSDKRules", "CR1004")]
         internal async Task<string> GetPreSignedURLInternalAsync(GetPreSignedUrlRequest request)
         {
-            var credentials = Config.DefaultAWSCredentials ?? DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
+            var credentials = 
+                DefaultAWSCredentials ??
+                Config.DefaultAWSCredentials ?? 
+                DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
 
             if (credentials == null)
                 throw new AmazonS3Exception("Credentials must be specified, cannot call method anonymously");
@@ -709,7 +715,11 @@ namespace Amazon.S3
         {
             ValidateCreatePresignedPostRequest(request);
 
-            var credentials = Config.DefaultAWSCredentials ?? DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
+            var credentials =
+                DefaultAWSCredentials ??
+                Config.DefaultAWSCredentials ??
+                DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>(); 
+            
             if (credentials == null)
                 throw new AmazonS3Exception("Credentials must be specified, cannot call method anonymously");
 
@@ -730,7 +740,11 @@ namespace Amazon.S3
         {
             ValidateCreatePresignedPostRequest(request);
 
-            var credentials = Config.DefaultAWSCredentials ?? DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
+            var credentials =
+                DefaultAWSCredentials ??
+                Config.DefaultAWSCredentials ??
+                DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
+
             if (credentials == null)
                 throw new AmazonS3Exception("Credentials must be specified, cannot call method anonymously");
 

--- a/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
+++ b/sdk/src/Services/S3/Custom/AmazonS3Client.Extensions.cs
@@ -104,7 +104,7 @@ namespace Amazon.S3
         internal string GetPreSignedURLInternal(GetPreSignedUrlRequest request)
         {
             var credentials = 
-                DefaultAWSCredentials ??
+                ExplicitAWSCredentials ??
                 Config.DefaultAWSCredentials ?? 
                 DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
 
@@ -175,7 +175,7 @@ namespace Amazon.S3
         internal async Task<string> GetPreSignedURLInternalAsync(GetPreSignedUrlRequest request)
         {
             var credentials = 
-                DefaultAWSCredentials ??
+                ExplicitAWSCredentials ??
                 Config.DefaultAWSCredentials ?? 
                 DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
 
@@ -716,7 +716,7 @@ namespace Amazon.S3
             ValidateCreatePresignedPostRequest(request);
 
             var credentials =
-                DefaultAWSCredentials ??
+                ExplicitAWSCredentials ??
                 Config.DefaultAWSCredentials ??
                 DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
             
@@ -741,7 +741,7 @@ namespace Amazon.S3
             ValidateCreatePresignedPostRequest(request);
 
             var credentials =
-                DefaultAWSCredentials ??
+                ExplicitAWSCredentials ??
                 Config.DefaultAWSCredentials ??
                 DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
 


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-net/issues/3950

## Description
In V4, we moved the `DefaultAWSCredentials` property from the service client to the client config (the reason was that other credentials related properties - such as configuring the SSO token provider - were already there). However, this created an issue when a) credentials are explicitly specified when creating a service client, and b) the same config object is shared across multiple clients (see original issue for an example).

This PR re-introduces the property so that we don't mutate the customer's config object. If set the explicit credentials will take preference, but customers can still use `s3Config.DefaultAWSCredentials = new ...` to share the same set of credentials across multiple clients.

## Testing
- Dry-run (in progress): `DRY_RUN-7a35fc89-b550-4a38-9a19-85832da65598`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
