### PR TITLE
Update to Microsoft.Extensions.AI.Abstractions 9.9.0

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetFramework.csproj
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetFramework.csproj
@@ -37,7 +37,7 @@
   </Choose>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.8.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetFramework.csproj
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetFramework.csproj
@@ -37,7 +37,7 @@
   </Choose>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.7.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetStandard.csproj
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetStandard.csproj
@@ -41,7 +41,7 @@
   </Choose>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.7.0" />
+  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetStandard.csproj
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.NetStandard.csproj
@@ -41,7 +41,7 @@
   </Choose>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.8.0" />
+  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
@@ -15,17 +15,17 @@
       <group targetFramework="net472">
         <dependency id="AWSSDK.Core" version="4.0.0.4" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.7.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="AWSSDK.Core" version="4.0.0.4" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.7.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="AWSSDK.Core" version="4.0.0.4" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.7.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
       </group>
     </dependencies>
   </metadata> 

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
@@ -15,17 +15,17 @@
       <group targetFramework="net472">
         <dependency id="AWSSDK.Core" version="4.0.0.4" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.9.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="AWSSDK.Core" version="4.0.0.4" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.9.0" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="AWSSDK.Core" version="4.0.0.4" />
         <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.9.0" />
       </group>
     </dependencies>
   </metadata> 

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AWSSDK.Extensions.Bedrock.MEAI.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.Bedrock.MEAI</id>
     <title>AWSSDK - Bedrock integration with Microsoft.Extensions.AI.</title>
-    <version>4.0.2.0</version>
+    <version>4.0.3.0</version>
     <authors>Amazon Web Services</authors>
     <description>Implementations of Microsoft.Extensions.AI's abstractions for Bedrock.</description>
     <language>en-US</language>
@@ -13,18 +13,18 @@
     <icon>images\AWSLogo.png</icon>
     <dependencies>
       <group targetFramework="net472">
-        <dependency id="AWSSDK.Core" version="4.0.0.4" />
-        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.26" />
+        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.6" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.9.0" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.4" />
-        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.26" />
+        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.6" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.9.0" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.4" />
-        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.3" />
+        <dependency id="AWSSDK.Core" version="4.0.0.26" />
+        <dependency id="AWSSDK.BedrockRuntime" version="4.0.0.6" />
         <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.9.0" />
       </group>
     </dependencies>

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AmazonBedrockRuntimeExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AmazonBedrockRuntimeExtensions.cs
@@ -15,6 +15,7 @@
 
 using Microsoft.Extensions.AI;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Amazon.BedrockRuntime;
 
@@ -52,5 +53,19 @@ public static class AmazonBedrockRuntimeExtensions
     public static IEmbeddingGenerator<string, Embedding<float>> AsIEmbeddingGenerator(
         this IAmazonBedrockRuntime runtime, string? defaultModelId = null, int? defaultModelDimensions = null) =>
         runtime is not null ? new BedrockEmbeddingGenerator(runtime, defaultModelId, defaultModelDimensions) :
+        throw new ArgumentNullException(nameof(runtime));
+
+    /// <summary>Gets an <see cref="IImageGenerator"/> for the specified <see cref="IAmazonBedrockRuntime"/> instance.</summary>
+    /// <param name="runtime">The runtime instance to be represented as an <see cref="IImageGenerator"/>.</param>
+    /// <param name="defaultModelId">
+    /// The default model ID to use when no model is specified in a request. If not specified,
+    /// a model must be provided in the <see cref="ImageGenerationOptions.ModelId"/> passed to <see cref="IImageGenerator.GenerateAsync"/>.
+    /// </param>
+    /// <returns>An <see cref="IImageGenerator"/> instance representing the <see cref="IAmazonBedrockRuntime"/> instance.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="runtime"/> is <see langword="null"/>.</exception>
+    [Experimental("MEAI001")]
+    public static IImageGenerator AsIImageGenerator(
+        this IAmazonBedrockRuntime runtime, string? defaultModelId = null) =>
+        runtime is not null ? new BedrockImageGenerator(runtime, defaultModelId) :
         throw new ArgumentNullException(nameof(runtime));
 }

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
@@ -98,16 +98,18 @@ internal sealed partial class BedrockChatClient : IChatClient
                     result.Contents.Add(new TextContent(text) { RawRepresentation = content });
                 }
 
-                if (content.CitationsContent is { } citations)
+                if (content.CitationsContent is { } citations &&
+                    citations.Citations is { Count: > 0 } &&
+                    citations.Content is { Count: > 0 })
                 {
-                    int count = Math.Min(citations.Citations?.Count ?? 0, citations.Content?.Count ?? 0);
+                    int count = Math.Min(citations.Citations.Count, citations.Content.Count);
                     for (int i = 0; i < count; i++)
                     {
-                        TextContent tc = new(citations.Content![i]?.Text) { RawRepresentation = citations.Content![i] };
+                        TextContent tc = new(citations.Content[i]?.Text) { RawRepresentation = citations.Content[i] };
                         tc.Annotations = [new CitationAnnotation()
                         {
-                            Title = citations.Citations![i].Title,
-                            Snippet = citations.Citations![i].SourceContent?.Select(c => c.Text).FirstOrDefault(),
+                            Title = citations.Citations[i].Title,
+                            Snippet = citations.Citations[i].SourceContent?.Select(c => c.Text).FirstOrDefault(),
                         }];
                         result.Contents.Add(tc);
                     }

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
@@ -726,7 +726,7 @@ internal sealed partial class BedrockChatClient : IChatClient
         {
             foreach (AITool tool in tools)
             {
-                if (tool is not AIFunction f)
+                if (tool is not AIFunctionDeclaration f)
                 {
                     continue;
                 }

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockImageGenerator.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockImageGenerator.cs
@@ -1,0 +1,197 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.BedrockRuntime.Model;
+using Microsoft.Extensions.AI;
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Amazon.BedrockRuntime;
+
+[Experimental("MEAI001")]
+internal sealed partial class BedrockImageGenerator : IImageGenerator
+{
+    /// <summary>The wrapped <see cref="IAmazonBedrockRuntime"/> instance.</summary>
+    private readonly IAmazonBedrockRuntime _runtime;
+    /// <summary>Default model ID to use when no model is specified in the request.</summary>
+    private readonly string? _modelId;
+    /// <summary>Metadata describing the image generator.</summary>
+    private readonly ImageGeneratorMetadata _metadata;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BedrockImageGenerator"/> class.
+    /// </summary>
+    /// <param name="runtime">The <see cref="IAmazonBedrockRuntime"/> instance to wrap.</param>
+    /// <param name="defaultModelId">Model ID to use as the default when no model ID is specified in a request.</param>
+    public BedrockImageGenerator(IAmazonBedrockRuntime runtime, string? defaultModelId)
+    {
+        Debug.Assert(runtime is not null);
+
+        _runtime = runtime!;
+        _modelId = defaultModelId;
+
+        _metadata = new(AmazonBedrockRuntimeExtensions.ProviderName, defaultModelId: defaultModelId);
+    }
+
+    public void Dispose()
+    {
+        // Do not dispose of _runtime, as this instance doesn't own it.
+    }
+
+    /// <inheritdoc />
+
+    /// <inheritdoc />
+    public object? GetService(Type serviceType, object? serviceKey)
+    {
+        if (serviceType is null)
+        {
+            throw new ArgumentNullException(nameof(serviceType));
+        }
+
+        return
+            serviceKey is not null ? null :
+            serviceType == typeof(ImageGeneratorMetadata) ? _metadata :
+            serviceType.IsInstanceOfType(_runtime) ? _runtime :
+            serviceType.IsInstanceOfType(this) ? this :
+            null;
+    }
+
+    public async Task<ImageGenerationResponse> GenerateAsync(
+        ImageGenerationRequest request, ImageGenerationOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        int numImages = options?.Count ?? 1;
+        if (numImages < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "The number of images must be at least 1.");
+        }
+
+        InvokeModelRequest invokeRequest = options?.RawRepresentationFactory?.Invoke(this) as InvokeModelRequest ?? new();
+        invokeRequest.ModelId ??= options?.ModelId ?? _modelId;
+        invokeRequest.Accept ??= "application/json";
+        invokeRequest.ContentType ??= "application/json";
+        if (invokeRequest.Body is null)
+        {
+            JsonObject body = new();
+
+            // Each model has its own way of specifying the prompt and image generation parameters, unfortunately.
+            // The following logic handles the most common cases today, but may need to be extended for
+            // future models.
+
+            if (invokeRequest.ModelId?.IndexOf("stability", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                // Stability AI models
+
+                if (invokeRequest.ModelId?.IndexOf("stable-diffusion", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    JsonArray textPrompts = new();
+                    for (int i = 0; i < numImages; i++)
+                    {
+                        textPrompts.Add((JsonNode)new JsonObject { ["text"] = request.Prompt ?? "" });
+                    }
+                    body["text_prompts"] = textPrompts;
+
+                    if (options?.ImageSize?.Width is int width && options.ImageSize?.Height is int height)
+                    {
+                        body["width"] = width;
+                        body["height"] = height;
+                    }
+                }
+                else
+                {
+                    body["prompt"] = request.Prompt ?? "";
+                }
+            }
+            else
+            {
+                // Amazon models (e.g. Titan, Nova Canvas)
+
+                body["taskType"] = "TEXT_IMAGE";
+                body["textToImageParams"] = new JsonObject { ["text"] = request.Prompt ?? "" };
+
+                JsonObject imageGenerationConfig = new()
+                {
+                    ["seed"] =
+#if NET
+                        Random.Shared.Next(),
+#else
+                        new Random().Next(),
+#endif
+                };
+
+                if (options?.ImageSize?.Width is int width && options.ImageSize?.Height is int height)
+                {
+                    imageGenerationConfig["width"] = width;
+                    imageGenerationConfig["height"] = height;
+                }
+
+                if (numImages > 1)
+                {
+                    imageGenerationConfig["numberOfImages"] = numImages;
+                }
+
+                body["imageGenerationConfig"] = imageGenerationConfig;
+            }
+
+            invokeRequest.Body = new MemoryStream(JsonSerializer.SerializeToUtf8Bytes(body, BedrockJsonContext.Default.JsonNode));
+        }
+
+        InvokeModelResponse rawResponse = await _runtime.InvokeModelAsync(invokeRequest, cancellationToken).ConfigureAwait(false);
+
+        ImageGenerationResponse result = new() { RawRepresentation = rawResponse };
+
+        using JsonDocument doc = JsonDocument.Parse(rawResponse.Body);
+        JsonElement root = doc.RootElement;
+
+        if (root.TryGetProperty("artifacts", out JsonElement artifactElement) && artifactElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var element in artifactElement.EnumerateArray())
+            {
+                if (element.TryGetProperty("base64", out JsonElement base64Element) &&
+                    base64Element.ValueKind == JsonValueKind.String)
+                {
+                    result.Contents.Add(new DataContent(Convert.FromBase64String(base64Element.GetString()!), "image/png"));
+                }
+            }
+        }
+        else if (root.TryGetProperty("images", out JsonElement imagesElement) && imagesElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var image in imagesElement.EnumerateArray())
+            {
+                if (image.ValueKind == JsonValueKind.String)
+                {
+                    result.Contents.Add(new DataContent(Convert.FromBase64String(image.GetString()!), "image/png"));
+                }
+            }
+        }
+
+        if (result.Contents is not { Count: > 0 })
+        {
+            throw new InvalidOperationException("Image generation did not produce any images.");
+        }
+
+        return result;
+    }
+}

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/ExperimentalAttribute.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/ExperimentalAttribute.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#if !NET
+namespace System.Diagnostics.CodeAnalysis;
+
+// Polyfill for [Experimental]
+
+[AttributeUsage(
+    AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct |
+    AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property |
+    AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate, 
+    Inherited = false)]
+internal sealed class ExperimentalAttribute : Attribute
+{
+    public ExperimentalAttribute(string diagnosticId) => DiagnosticId = diagnosticId;
+    public string DiagnosticId { get; }
+    public string? Message { get; set; }
+    public string? UrlFormat { get; set; }
+}
+#endif

--- a/extensions/test/BedrockMEAITests/BedrockMEAITests.NetFramework.csproj
+++ b/extensions/test/BedrockMEAITests/BedrockMEAITests.NetFramework.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.7.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.8.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/extensions/test/BedrockMEAITests/BedrockMEAITests.NetFramework.csproj
+++ b/extensions/test/BedrockMEAITests/BedrockMEAITests.NetFramework.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.8.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
## Description

- Updated to the latest M.E.AI.Abstractions release
- Set new ChatMessage.CreatedAt property
- Set and use new DataContent.Name property
- Added citations to BedrockChatClient
- Added implementation of IImageGenerator (as [Experimental] because the interface is itself [Experimental])

## Motivation and Context

Light-up new surface area in Microsoft.Extensions.AI.Abstractions.

## Testing

Manual testing against various models with basic scenarios.

## Screenshots (if appropriate)

<img width="937" height="605" alt="image" src="https://github.com/user-attachments/assets/e02dff06-5fbd-4e2f-b8c5-e9ae1d7d4e0b" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement