### PR TITLE
Fixed incorrect datatype for AWSSDK.Extensions.NETCore.Setup configuration schema

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.NETCore.Setup</id>
     <title>AWSSDK - Extensions for NETCore Setup</title>
-    <version>4.0.2.1</version>
+    <version>4.0.2.2</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with .NET Core configuration and dependency injection frameworks.</description>
     <language>en-US</language>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/Schema/ConfigurationSchema.json
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/Schema/ConfigurationSchema.json
@@ -121,7 +121,7 @@
           "description": "If set this role will be assumed using the resolved AWS credentials."
         },
         "ThrottleRetries": {
-          "type": "bool",
+          "type": "boolean",
           "description": "Enables the SDK to use intelligent throttle retry logic."
         },
         "Timeout": {


### PR DESCRIPTION
## Description
The schema used for creating the intelisense in appsettings.json was incorrectly using `bool` instead of `boolean` for the dataype of the `ThrottleRetries` property. All the other boolean properties in the schema were already using `boolean` for the datatype.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3970

