### PR TITLE
Fix issue of not passing in the explicit credentials when an internal S3 client

### DIFF
--- a/generator/.DevConfigs/323d1a5a-a907-4c7f-8624-b441d389e7ea.json
+++ b/generator/.DevConfigs/323d1a5a-a907-4c7f-8624-b441d389e7ea.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fix issue of not passing in the explicit credentials when an internal instance of the S3 client is created for detecting bucket region."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Util/BucketRegionDetector.cs
+++ b/sdk/src/Services/S3/Custom/Util/BucketRegionDetector.cs
@@ -113,7 +113,7 @@ namespace Amazon.S3.Util
         private static string GetHeadBucketPreSignedUrl(string bucketName, IRequestContext requestContext)
         {
             // all buckets accessible via USEast1
-            using (var s3Client = GetUsEast1ClientFromCredentials(requestContext.ClientConfig.DefaultAWSCredentials))
+            using (var s3Client = GetUsEast1ClientFromCredentials(requestContext.ExplicitAWSCredentials ?? requestContext.ClientConfig.DefaultAWSCredentials))
             {
                 // IMPORTANT:
                 // This method is called as part of the request pipeline.

--- a/sdk/src/Services/S3/Custom/Util/_async/BucketRegionDetector.cs
+++ b/sdk/src/Services/S3/Custom/Util/_async/BucketRegionDetector.cs
@@ -61,7 +61,7 @@ namespace Amazon.S3.Util
         private static async Task<string> GetBucketRegionNoPipelineAsync(string bucketName, IRequestContext requestContext)
         {
             var headBucketPreSignedUrl = GetHeadBucketPreSignedUrl(bucketName, requestContext);
-            using (var s3Client = GetUsEast1ClientFromCredentials(requestContext.ClientConfig.DefaultAWSCredentials))
+            using (var s3Client = GetUsEast1ClientFromCredentials(requestContext.ExplicitAWSCredentials ?? requestContext.ClientConfig.DefaultAWSCredentials))
             {
                 return (await AmazonS3HttpUtil.GetHeadAsync(s3Client, s3Client.Config, headBucketPreSignedUrl,
                     HeaderKeys.XAmzBucketRegion).ConfigureAwait(false)).HeaderValue;


### PR DESCRIPTION
## Description
During an S3 retry handling the SDK will attempt to check if the bucket is going to right region. To do that it creates an internal S3 service client configured to us-east-1. The creation of that client was not updated in PR https://github.com/aws/aws-sdk-net/issues/3950 where we introduced the new `ExplicitAWSCredentials` property. Because of that if credentials were given directly via the S3 constructor they would not be used for the internal S3 client.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3971

## Testing
Pending Dry Run

