### PR TITLE
Fix ProtocolSelectionTests and skip cbor protocol for arc-region-switch service

### DIFF
--- a/generator/ServiceClientGeneratorLib/ServiceModel.cs
+++ b/generator/ServiceClientGeneratorLib/ServiceModel.cs
@@ -300,6 +300,14 @@ namespace ServiceClientGenerator
             "ec2",
         };
 
+        /// <summary>
+        /// Dictionary of services that should skip a specific protocol.
+        /// </summary>
+        private readonly Dictionary<string, string> _skipProtocolForService = new Dictionary<string, string>()
+        {
+            { "ARC Region switch", "smithy-rpc-v2-cbor" }
+        };
+
         private string _preferredProtocol;
 
         /// <summary>
@@ -321,7 +329,8 @@ namespace ServiceClientGenerator
                         var serviceProtocols = modelProtocols.Cast<JsonData>().Select(x => x.ToString());
                         foreach (var supportedProtocol in _supportedProtocols)
                         {
-                            if (serviceProtocols.Contains(supportedProtocol))
+                            if (serviceProtocols.Contains(supportedProtocol) && 
+                                !(_skipProtocolForService.ContainsKey(ServiceId) && _skipProtocolForService[ServiceId] == supportedProtocol))
                             {
                                 _preferredProtocol = supportedProtocol;
                                 break;

--- a/generator/ServiceClientGeneratorTests/ProtocolSelectionTests.cs
+++ b/generator/ServiceClientGeneratorTests/ProtocolSelectionTests.cs
@@ -9,29 +9,26 @@ namespace ServiceClientGeneratorTests
     public class ProtocolSelectionTests
     {
         [Fact]
-        public void TestSkipsCborProtocol()
+        public void TestDoesNotSkipsCborProtocol()
         {
             var model = GetServiceModel("ModelWithCborAndJson.json");
-            Assert.Equal("json", model.Protocol);
+            Assert.Equal("smithy-rpc-v2-cbor", model.Protocol);
         }
 
         [Fact]
-        public void TestDoesNotSupportCbor()
+        public void TestDoesSupportCbor()
         {
             var model = GetServiceModel("ModelWithCborOnly.json");
-            Assert.Equal(string.Empty, model.Protocol);
-
-            var exception = Assert.Throws<Exception>(() => model.Type);
-            Assert.Contains("TestService does not support any of the protocols available in the .NET SDK", exception.Message);
+            Assert.Equal("smithy-rpc-v2-cbor", model.Protocol);
         }
 
         [Theory]
-        [InlineData("ModelWithMultipleProtocols.json")]
-        [InlineData("ModelWithJsonAndQuery.json")]
-        public void TestPicksProtocolByPriority(string fileName)
+        [InlineData("ModelWithMultipleProtocols.json", "smithy-rpc-v2-cbor")]
+        [InlineData("ModelWithJsonAndQuery.json", "json")]
+        public void TestPicksProtocolByPriority(string fileName, string expectedProtocol)
         {
             var model = GetServiceModel(fileName);
-            Assert.Equal("json", model.Protocol);
+            Assert.Equal(expectedProtocol, model.Protocol);
         }
 
         [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- We have a few tests in `ProtocolSelectionTests` that started failing after we supported `CBOR`, this PR updates them to account for `smithy-rpc-v2-cbor` support.
- This PR also skips the `CBOR` protocol for the `arc-region-switch` service to prevent sudden protocol changes during the release of `CBOR` updates.

<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-7384`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
* `DRY_RUN-aa656b0a-883a-469d-99c3-b3f8bf84aace`.
* Validated that `ProtocolSelectionTests` passes.
* Ran the generator and validated that  `arc-region-switch` keeps using `JSON` protocol. 
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement