### PR TITLE
Update the nuspec of Extensions.CborProtocol to use the correct AWSSDK.Core

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CborProtocol/AWSSDK.Extensions.CborProtocol.nuspec
+++ b/extensions/src/AWSSDK.Extensions.CborProtocol/AWSSDK.Extensions.CborProtocol.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.CborProtocol</id>
     <title>AWSSDK - Extensions for Cbor protocol support</title>
-    <version>4.0.0.0</version>
+    <version>4.0.0.1</version>
     <authors>Amazon Web Services</authors>
 	  <description>This package contains shared serialization and deserialization logic for services that use Cbor protocol in the AWS SDK for .NET.</description>
     <language>en-US</language>
@@ -13,19 +13,19 @@
     <icon>images\AWSLogo.png</icon>
     <dependencies>
       <group targetFramework="net472">
-        <dependency id="AWSSDK.Core" version="4.0.0.0" />
+        <dependency id="AWSSDK.Core" version="4.0.0.25" />
         <dependency id="System.Formats.Cbor" version="9.0.5" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0" />
+        <dependency id="AWSSDK.Core" version="4.0.0.25" />
         <dependency id="System.Formats.Cbor" version="9.0.5" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="AWSSDK.Core" version="4.0.0.0" />
+        <dependency id="AWSSDK.Core" version="4.0.0.25" />
         <dependency id="System.Formats.Cbor" version="9.0.5" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.0" />
+        <dependency id="AWSSDK.Core" version="4.0.0.25" />
         <dependency id="System.Formats.Cbor" version="9.0.5" />
       </group>
     </dependencies>

--- a/generator/ServiceClientGeneratorLib/GeneratorDriver.cs
+++ b/generator/ServiceClientGeneratorLib/GeneratorDriver.cs
@@ -1173,7 +1173,7 @@ namespace ServiceClientGenerator
 
             if (Configuration.ServiceModel.Type == ServiceType.Cbor)
             {
-                awsDependencies.Add(string.Format("AWSSDK.Extensions.CborProtocol"), "[4.0.0.0, 5.0)");
+                awsDependencies.Add(string.Format("AWSSDK.Extensions.CborProtocol"), "[4.0.0.1, 5.0)");
             }
 
             var nugetAssemblyName = Configuration.AssemblyTitle;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
`AWSSDK.Extensions.CborProtocol` is using `AWSConfigs.CborReaderInitialBufferSize` which was added to `AWSSDK.Core` in version `4.0.0.25`. 
This PR updates the `nuspec` of `AWSSDK.Extensions.CborProtocol`  to use the correct core version.
## Motivation and Context
* `DOTNET-8270`.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
* `DRY_RUN-825181f7-090e-4ad0-b5aa-7020f06cd297`
* Ran the generator and validated that `nuspec` of CBOR services have a dependency on `[4.0.0.1, 5.0)` version of the extension package.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement