### PR TITLE
Fix issue #3989. Allow GetLifecycleConfiguration to be called with an empty filter.

### DIFF
--- a/generator/.DevConfigs/69493830-939a-47ba-ae94-e9ae35de6475.json
+++ b/generator/.DevConfigs/69493830-939a-47ba-ae94-e9ae35de6475.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fix issue #3989. If an empty filter was specified, GetLifecycleConfiguration was failing. This fix allows an empty filter to be specified when retrieving lifecycle configurations via GetLifecycleConfiguration."
+      ]
+    }
+  ]
+}

--- a/generator/ServiceModels/s3/s3.customizations.json
+++ b/generator/ServiceModels/s3/s3.customizations.json
@@ -171,14 +171,12 @@
                             "private LifecycleRuleStatus _status = LifecycleRuleStatus.Disabled;"
                         ]
                     }
-                }
-            ],
-            "predicateListUnmarshallers":[
+                },
                 {
                     "Filter": 
                     {
-                        "predicateListUnmarshallerName": "LifecycleFilterPredicateListUnmarshaller",
-                        "filterPredicateName": "LifecycleFilterPredicate"
+                        "skipContextTestExpressionUnmarshallingLogic" : true,
+                        "injectXmlUnmarshallCode": ["FilterCustomUnmarshall(context, unmarshalledObject);"]
                     }
                 }
             ]

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/LifecycleRuleUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/LifecycleRuleUnmarshaller.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Xml.Serialization;
+
+using Amazon.S3.Model;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Transform;
+using Amazon.Runtime.Internal.Util;
+
+#pragma warning disable CS0612,CS0618
+namespace Amazon.S3.Model.Internal.MarshallTransformations
+{
+    public partial class LifecycleRuleUnmarshaller : IXmlUnmarshaller<LifecycleRule, XmlUnmarshallerContext>
+    {
+        private static void FilterCustomUnmarshall(XmlUnmarshallerContext context, LifecycleRule rule)
+        {
+            var predicateList = LifecycleFilterPredicateListUnmarshaller.Instance.Unmarshall(context);
+
+            if (predicateList.Count == 1)
+            {
+                rule.Filter = new LifecycleFilter()
+                {
+                    LifecycleFilterPredicate = predicateList[0]
+                };
+            }
+            else if (predicateList.Count > 1)
+            {
+                var requestId = context.ResponseData.GetHeaderValue("x-amzn-RequestId");
+                var message = "The Filter element must contain at most one 'Prefix', 'Tag', or 'And' predicate.";
+                throw new AmazonUnmarshallingException(requestId, context.CurrentPath, context.ResponseBody, message, null);
+            }
+            return;
+        }
+    }
+}

--- a/sdk/src/Services/S3/Generated/Model/Internal/MarshallTransformations/LifecycleRuleUnmarshaller.cs
+++ b/sdk/src/Services/S3/Generated/Model/Internal/MarshallTransformations/LifecycleRuleUnmarshaller.cs
@@ -70,9 +70,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     }
                     if (context.TestExpression("Filter", targetDepth))
                     {
-                        var predicateList = LifecycleFilterPredicateListUnmarshaller.Instance.Unmarshall(context);
-                        unmarshalledObject.Filter = new LifecycleFilter();
-                        unmarshalledObject.Filter.LifecycleFilterPredicate = predicateList[0];
+                        FilterCustomUnmarshall(context, unmarshalledObject);
                         continue;
                     }
                     if (context.TestExpression("ID", targetDepth))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This regression was introduced via https://github.com/aws/aws-sdk-net/pull/3940 where we started to generate this operation. The original code https://github.com/aws/aws-sdk-net/blob/aws-sdk-net-v3.7/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/RulesItemUnmarshaller.cs#L76-L82

guarded against an empty filter by continuing to unmarshall. I left this out b/c i was unable to call PutLifecycle with no filter, but i forgot the case where an empty filter could be specified like so

```
PS> aws s3api get-bucket-lifecycle-configuration --bucket testing123
{
    "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K",
    "Rules": [
        {
            "Expiration": {
                "Days": 180
            },
            "ID": "test-rule",
            "Filter": {},
            "Status": "Enabled",
            "Transitions": [
                {
                    "Days": 30,
                    "StorageClass": "STANDARD_IA"
                }
            ],
            "AbortIncompleteMultipartUpload": {
                "DaysAfterInitiation": 7
            }
        }
    ]
}
```

This PR adds back the logic from the custom code and adds a test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
dry run is in progress Build id: 05b78bd5-27fc-4b45-80a6-7f3a78c164d3
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement