### PR TITLE
Fix Cbor edge cases when unmarshalling deeply nested maps/arrays and optimized numbers

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CborProtocol/AWSSDK.Extensions.CborProtocol.nuspec
+++ b/extensions/src/AWSSDK.Extensions.CborProtocol/AWSSDK.Extensions.CborProtocol.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.CborProtocol</id>
     <title>AWSSDK - Extensions for Cbor protocol support</title>
-    <version>4.0.0.1</version>
+    <version>4.0.0.2</version>
     <authors>Amazon Web Services</authors>
 	  <description>This package contains shared serialization and deserialization logic for services that use Cbor protocol in the AWS SDK for .NET.</description>
     <language>en-US</language>

--- a/extensions/src/AWSSDK.Extensions.CborProtocol/Internal/CborStreamReader.cs
+++ b/extensions/src/AWSSDK.Extensions.CborProtocol/Internal/CborStreamReader.cs
@@ -28,6 +28,38 @@ namespace Amazon.Extensions.CborProtocol.Internal
     /// </summary>
     public class CborStreamReader : IDisposable
     {
+        private class ContainerFrame
+        {
+            public CborContainerType Type { get; }
+            public int? RemainingItems { get; private set; }
+
+            public ContainerFrame(CborContainerType type, int? remainingItems)
+            {
+                Type = type;
+                RemainingItems = remainingItems;
+                if (RemainingItems.HasValue && type == CborContainerType.Map)
+                {
+                    // Multiply RemainingItems by 2 for maps to account for key value pairs.
+                    RemainingItems *= 2;
+                }
+            }
+
+            public void ConsumeItem()
+            {
+                RemainingItems = RemainingItems.HasValue ? RemainingItems.Value - 1 : (int?)null;
+
+                if (RemainingItems < 0)
+                {
+                    // This should never happen if container boundaries are respected.
+                    // It indicates that more items were read than the container declared.
+                    throw new CborContentException(
+                        $"Too many items read from {Type} container. Expected {RemainingItems + 1} more item(s)."
+                    );
+                }
+            }
+
+            public bool IsComplete => RemainingItems == 0;
+        }
         /// <summary>
         /// Enum to track the type of CBOR container (map or array)
         /// for state management within the CborStreamReader.
@@ -39,7 +71,7 @@ namespace Amazon.Extensions.CborProtocol.Internal
         }
 
         private static readonly ILogger _logger = Logger.GetLogger(typeof(CborStreamReader));
-        private readonly Stack<CborContainerType> _nestingStack = new Stack<CborContainerType>();
+        private readonly Stack<ContainerFrame> _nestingStack = new Stack<ContainerFrame>();
         private readonly Stream _stream;
         private byte[] _buffer;
         private CborReader _internalCborReader;
@@ -174,7 +206,7 @@ namespace Amazon.Extensions.CborProtocol.Internal
         {
             ExecuteRead(r =>
             {
-                if (_nestingStack.Count == 0 || _nestingStack.Peek() != expectedType)
+                if (_nestingStack.Count == 0 || _nestingStack.Peek().Type != expectedType)
                     throw new CborContentException($"Unexpected end of {expectedType.ToString().ToLowerInvariant()}.");
 
                 var state = CborReaderState.Finished;
@@ -230,6 +262,20 @@ namespace Amazon.Extensions.CborProtocol.Internal
                     _nestingStack.Pop();
                     return true;
                 }
+                else if (_nestingStack.Count > 0 && _nestingStack.Peek().IsComplete)
+                {
+                    // Special handling for definite-length containers that are fully consumed:
+                    // For definite-length maps/arrays, the internal CborReader does not provide an explicit
+                    // end token. Once we have read all items (tracked via the _nestingStack frame's RemainingItems),
+                    // PeekState may point to the next item rather than EndArray/EndMap. In that case, we can
+                    // safely consider the container complete, pop the frame, and continue parsing.
+                    //
+                    // This prevents throwing a CborContentException when reading end container of a large
+                    // container that spans multiple buffer chunks and ensures ReadEndContainer returns the correct
+                    // logical end of the container.
+                    _nestingStack.Pop();
+                    return true;
+                }
 
                 throw new CborContentException($"Expected end of {expectedType.ToString().ToLowerInvariant()} but could not parse it.");
             });
@@ -239,26 +285,44 @@ namespace Amazon.Extensions.CborProtocol.Internal
         public void ReadEndMap()
         {
             ReadEndContainer(CborContainerType.Map, CborReaderState.EndMap, (reader) => reader.ReadEndMap());
+            // After reading the end of a container (map/array), we need to mark it as consumed
+            // in the parent container (if any). This ensures that nested arrays/maps count as
+            // a single item in their enclosing container. Without this, the parent container
+            // would incorrectly think there are remaining items, causing PeekState and
+            // item-count tracking to become desynchronized with the actual CBOR stream.
+            if (_nestingStack.Count > 0)
+            {
+                _nestingStack.Peek().ConsumeItem();
+            }
         }
 
         public void ReadEndArray()
         {
             ReadEndContainer(CborContainerType.Array, CborReaderState.EndArray, (r) => r.ReadEndArray());
+            // After reading the end of a container (map/array), we need to mark it as consumed
+            // in the parent container (if any). This ensures that nested arrays/maps count as
+            // a single item in their enclosing container. Without this, the parent container
+            // would incorrectly think there are remaining items, causing PeekState and
+            // item-count tracking to become desynchronized with the actual CBOR stream.
+            if (_nestingStack.Count > 0)
+            {
+                _nestingStack.Peek().ConsumeItem();
+            }
         }
 
 
         public int? ReadStartMap() => ExecuteRead(reader =>
         {
-            var result = reader.ReadStartMap();
-            _nestingStack.Push(CborContainerType.Map);
-            return result;
+            var count = reader.ReadStartMap();
+            _nestingStack.Push(new ContainerFrame(CborContainerType.Map, count));
+            return count;
         });
 
         public int? ReadStartArray() => ExecuteRead(reader =>
         {
-            var result = reader.ReadStartArray();
-            _nestingStack.Push(CborContainerType.Array);
-            return result;
+            var count = reader.ReadStartArray();
+            _nestingStack.Push(new ContainerFrame(CborContainerType.Array, count));
+            return count;
         });
 
 
@@ -266,6 +330,18 @@ namespace Amazon.Extensions.CborProtocol.Internal
         {
             return ExecuteRead(r =>
             {
+                // Handle definite-length containers that silently complete
+                if (_nestingStack.Count > 0)
+                {
+                    var frame = _nestingStack.Peek();
+                    if (frame.IsComplete)
+                    {
+                        return frame.Type == CborContainerType.Map
+                            ? CborReaderState.EndMap
+                            : CborReaderState.EndArray;
+                    }
+                }
+
                 // We need to Peek twice in case the first time failed because we are near the end of the current chunk and we just need to refill.
                 for (int attempt = 0; attempt < 2; attempt++)
                 {
@@ -293,7 +369,7 @@ namespace Amazon.Extensions.CborProtocol.Internal
                 // only then consider inferring the state based on container nesting.
                 if (_nestingStack.Count > 0)
                 {
-                    var inferredState = _nestingStack.Peek() == CborContainerType.Map
+                    var inferredState = _nestingStack.Peek().Type == CborContainerType.Map
                         ? CborReaderState.EndMap
                         : CborReaderState.EndArray;
 
@@ -305,17 +381,38 @@ namespace Amazon.Extensions.CborProtocol.Internal
             });
         }
 
-        public string ReadTextString() => ExecuteRead(r => r.ReadTextString());
-        public int ReadInt32() => ExecuteRead(r => r.ReadInt32());
-        public long ReadInt64() => ExecuteRead(r => r.ReadInt64());
-        public decimal ReadDecimal() => ExecuteRead(r => r.ReadDecimal());
-        public double ReadDouble() => ExecuteRead(r => r.ReadDouble());
-        public bool ReadBoolean() => ExecuteRead(r => r.ReadBoolean());
-        public float ReadSingle() => ExecuteRead(r => r.ReadSingle());
+        /// <summary>
+        /// Executes the provided CBOR read operation and automatically updates the item count
+        /// of the current container (if any) to ensure that whenever an item is read, the parent
+        /// container's RemainingItems count is decremented.
+        /// </summary>
+        private T ExecuteValueRead<T>(Func<CborReader, T> readOperation)
+        {
+            var result = ExecuteRead<T>(readOperation);
+            if (_nestingStack.Count > 0)
+            {
+                _nestingStack.Peek().ConsumeItem();
+            }
+
+            return result;
+        }
+
+        public string ReadTextString() => ExecuteValueRead(r => r.ReadTextString());
+        public int ReadInt32() => ExecuteValueRead(r => r.ReadInt32());
+        public long ReadInt64() => ExecuteValueRead(r => r.ReadInt64());
+        public ulong ReadUInt64() => ExecuteValueRead(r => r.ReadUInt64());
+        public decimal ReadDecimal() => ExecuteValueRead(r => r.ReadDecimal());
+        public double ReadDouble() => ExecuteValueRead(r => r.ReadDouble());
+        public bool ReadBoolean() => ExecuteValueRead(r => r.ReadBoolean());
+        public float ReadSingle() => ExecuteValueRead(r => r.ReadSingle());
+        public byte[] ReadByteString() => ExecuteValueRead(r => r.ReadByteString());
+        public void ReadNull() => ExecuteValueRead(r => { r.ReadNull(); return true; });
+        public void SkipValue() => ExecuteValueRead(r => { r.SkipValue(); return true; });
+
+        // Tags annotate the next CBOR item but are not themselves counted
+        // as items within a definite-length array or map. For this reason,
+        // we do not call ExecuteValueRead() and only use ExecuteRead() here.
         public CborTag ReadTag() => ExecuteRead(r => r.ReadTag());
-        public byte[] ReadByteString() => ExecuteRead(r => r.ReadByteString());
-        public void ReadNull() => ExecuteRead(r => { r.ReadNull(); return true; });
-        public void SkipValue() => ExecuteRead(r => { r.SkipValue(); return true; });
         public int CurrentDepth => _internalCborReader.CurrentDepth;
 
         public void Dispose()

--- a/extensions/src/AWSSDK.Extensions.CborProtocol/Internal/Transform/CborSimpleTypeUnmarshaller.cs
+++ b/extensions/src/AWSSDK.Extensions.CborProtocol/Internal/Transform/CborSimpleTypeUnmarshaller.cs
@@ -56,12 +56,44 @@ namespace Amazon.Extensions.CborProtocol.Internal.Transform
                 value = reader.ReadInt64();
             else if (typeof(T) == typeof(decimal) || typeof(T) == typeof(decimal?))
                 value = reader.ReadDecimal();
-            else if (typeof(T) == typeof(double) || typeof(T) == typeof(double?))
-                value = reader.ReadDouble();
             else if (typeof(T) == typeof(bool) || typeof(T) == typeof(bool?))
                 value = reader.ReadBoolean();
+            else if (typeof(T) == typeof(double) || typeof(T) == typeof(double?))
+            {
+                var state = reader.PeekState();
+                // CBOR values for doubles may sometimes be encoded as integers to save space
+                // (e.g., when the original value was a whole number).
+                if (state == CborReaderState.UnsignedInteger)
+                {
+                    value = (double)reader.ReadUInt64();
+                }
+                else if (state == CborReaderState.NegativeInteger)
+                {
+                    value = (double)reader.ReadInt64();
+                }
+                else
+                {
+                    value = reader.ReadDouble();
+                }
+            }
             else if (typeof(T) == typeof(float) || typeof(T) == typeof(float?))
-                value = reader.ReadSingle();
+            {
+                var state = reader.PeekState();
+                // CBOR values for floats may sometimes be encoded as integers to save space
+                // (e.g., when the original value was a whole number).
+                if (state == CborReaderState.UnsignedInteger)
+                {
+                    value = (float)reader.ReadUInt64();
+                }
+                else if (state == CborReaderState.NegativeInteger)
+                {
+                    value = (float)reader.ReadInt64();
+                }
+                else
+                {
+                    value = reader.ReadSingle();
+                }
+            }
             else if (typeof(T) == typeof(byte))
             {
                 int result = reader.ReadInt32();

--- a/generator/ServiceClientGeneratorLib/GeneratorDriver.cs
+++ b/generator/ServiceClientGeneratorLib/GeneratorDriver.cs
@@ -1173,7 +1173,7 @@ namespace ServiceClientGenerator
 
             if (Configuration.ServiceModel.Type == ServiceType.Cbor)
             {
-                awsDependencies.Add(string.Format("AWSSDK.Extensions.CborProtocol"), "[4.0.0.1, 5.0)");
+                awsDependencies.Add(string.Format("AWSSDK.Extensions.CborProtocol"), "[4.0.0.2, 5.0)");
             }
 
             var nugetAssemblyName = Configuration.AssemblyTitle;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes edge cases in the CBOR protocol reader/unmarshaller:

Added support in `CborSimpleTypeUnmarshaller` for reading CBOR’s smallest numeric representation.

For the nested maps/arrays issue, CBOR has two ways to end arrays/maps:
* Indefinite-length: there’s an explicit break byte 0xFF.
* Definite-length: there is no terminator byte; the container is “over” once you’ve read the declared number of items (for maps, pairs).

Our streaming reader relied on `PeekState()` or break bytes (`0xFF`) to detect container ends. This worked when containers ended at the stream boundary or stayed within a single chunk, but failed for deeply nested, definite-length containers that spanned multiple chunks.
After reading the last item, `PeekState()` would return the next item’s state instead of EndArray/EndMap, since there was no on-wire terminator. This caused desync issues when calling ReadEndArray/Map.

We now track containers explicitly:
* Push a frame on ReadStartArray/Map with RemainingItems (arrays = count, maps = count × 2).
* Decrement RemainingItems after each item read/skip.
* When RemainingItems == 0, we infer EndArray/EndMap without consuming bytes.
* For indefinite-length containers, we still check for and skip the 0xFF break marker.
* After closing a nested container, the parent’s frame is decremented once.

By maintaining a per-container item counter (arrays: n, maps: 2n) and decrementing on each value, we can know container end precisely, keep `PeekState()` correct, and close containers properly even when the boundary is split across chunks.


<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-8252`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
- `DRY_RUN-c81ddfaa-9196-4bb2-8d89-f35fe9e9b6bf`
- Added unit tests to cover these fixes.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement