### PR TITLE
Added MaxConnectionsPerServer to AWSSDK.Extensions.NETCore.Setup

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/AWSSDK.Extensions.NETCore.Setup.nuspec
@@ -3,7 +3,7 @@
   <metadata> 
     <id>AWSSDK.Extensions.NETCore.Setup</id>
     <title>AWSSDK - Extensions for NETCore Setup</title>
-    <version>4.0.2.2</version>
+    <version>4.0.3.0</version>
     <authors>Amazon Web Services</authors>
     <description>Extensions for the AWS SDK for .NET to integrate with .NET Core configuration and dependency injection frameworks.</description>
     <language>en-US</language>
@@ -14,19 +14,19 @@
 	
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.18" />
+        <dependency id="AWSSDK.Core" version="4.0.0.26" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="AWSSDK.Core" version="4.0.0.18" />
+        <dependency id="AWSSDK.Core" version="4.0.0.26" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="AWSSDK.Core" version="4.0.0.18" />
+        <dependency id="AWSSDK.Core" version="4.0.0.26" />
         <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
@@ -342,6 +342,10 @@ namespace Amazon.Extensions.NETCore.Setup
             {
                 config.ConnectTimeout = defaultConfig.ConnectTimeout.Value;
             }
+            if (defaultConfig.MaxConnectionsPerServer.HasValue)
+            {
+                config.MaxConnectionsPerServer = defaultConfig.MaxConnectionsPerServer.Value;
+            }
 #endif
             if (defaultConfig.UseAlternateUserAgentHeader.HasValue)
             {

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ConfigurationExtensions.cs
@@ -323,6 +323,15 @@ namespace Microsoft.Extensions.Configuration
 
                     options.DefaultClientConfig.ConnectTimeout = TimeSpan.FromMilliseconds(connectTimeout);
                 }
+                else if (string.Equals(element.Key, nameof(DefaultClientConfig.MaxConnectionsPerServer), StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!int.TryParse(element.Value, out var maxConnectionsPerServer))
+                    {
+                        throw new ArgumentException($"Invalid integer value for {nameof(DefaultClientConfig.MaxConnectionsPerServer)}.");
+                    }
+
+                    options.DefaultClientConfig.MaxConnectionsPerServer = maxConnectionsPerServer;
+                }
 #endif
                 else if (string.Equals(element.Key, nameof(DefaultClientConfig.UseAlternateUserAgentHeader), StringComparison.OrdinalIgnoreCase))
                 {

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/DefaultClientConfig.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/DefaultClientConfig.cs
@@ -221,6 +221,11 @@ namespace Amazon.Extensions.NETCore.Setup
         /// connection timeout for the HttpClient infinite waiting period.
         /// </summary>
         public TimeSpan? ConnectTimeout { get; set; }
+
+        /// <summary>
+        /// This property is used to set the MaxConnectionsPerServer on the matching property on the underlying HttpClient to make service calls.
+        /// </summary>
+        public int? MaxConnectionsPerServer { get; set; }
 #endif
 
         /// <summary>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/Schema/ConfigurationSchema.json
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/Schema/ConfigurationSchema.json
@@ -23,6 +23,10 @@
           "type": "string",
           "description": "ClientAppId is an optional application specific identifier that can be set. When set it will be appended to the User-Agent header of every request in the form of app/{ClientAppId}."
         },
+        "ConnectTimeout": {
+          "type": "integer",
+          "description": "The ConnectTimeout property controls the timeout when establishing a connection. The units for the property is milliseconds"
+        },
         "DefaultsMode": {
           "enum": [
             "Standard",
@@ -72,6 +76,10 @@
         "LogResponse": {
           "type": "boolean",
           "description": "If this property is set to true, the service response is logged."
+        },
+        "MaxConnectionsPerServer": {
+          "type": "integer",
+          "description": "This property is used to set the MaxConnectionsPerServer on the matching property on the underlying HttpClient to make service calls."
         },
         "MaxErrorRetry": {
           "type": "integer",

--- a/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
+++ b/extensions/test/NETCore.SetupTests/ConfigurationTests.cs
@@ -131,6 +131,9 @@ namespace NETCore.SetupTests
 #if NET8_0_OR_GREATER
             Assert.Equal(TimeSpan.FromMilliseconds(500), options.DefaultClientConfig.ConnectTimeout);
             Assert.Equal(TimeSpan.FromMilliseconds(500), clientConfig.ConnectTimeout);
+
+            Assert.Equal(5, options.DefaultClientConfig.MaxConnectionsPerServer);
+            Assert.Equal(5, clientConfig.MaxConnectionsPerServer);
 #endif
         }
 

--- a/extensions/test/NETCore.SetupTests/TestFiles/GetClientConfigSettingsTest.json
+++ b/extensions/test/NETCore.SetupTests/TestFiles/GetClientConfigSettingsTest.json
@@ -4,6 +4,7 @@
     "MaxErrorRetry": 6,
     "Timeout": 1000,
     "ConnectTimeout": 500,
+    "MaxConnectionsPerServer": 5,
     "AuthenticationRegion": "us-east-1",
     "Region": "us-west-2",
     "DefaultsMode": "Standard",

--- a/generator/.DevConfigs/95b168bb-4b94-4b29-8ce8-e8eff92f6748.json
+++ b/generator/.DevConfigs/95b168bb-4b94-4b29-8ce8-e8eff92f6748.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "Added support in AWSSDK.Extensions.NETCore.Setup package to set the MaxConnectionsPerServer property on service client config objects."
+    ]
+  }
+}


### PR DESCRIPTION
## Description
Service clients config already had a property for setting the `MaxConnectionsPerServer` but it wasn't exposed via `AWSSDK.Extensions.NETCore.Setup`.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/4005

## Testing
Updated unit tests to confirm the MaxConnectionsPerServer is being set from settings file to service client config.

