### PR TITLE
Add additional CborPerformanceBenchmarks that requires an order of execution

### DIFF
--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/BaseDoubleBenchmarks.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/BaseDoubleBenchmarks.cs
@@ -1,0 +1,133 @@
+﻿using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Transform;
+using BenchmarkDotNet.Attributes;
+using System.Net;
+using System.Text;
+
+
+// Allowing us to run two benchmarks in the same class, as some benchmarks depends on another one
+public abstract class BaseDoubleBenchmarks : BaseBenchmarks
+{
+    public abstract string TestCase2 { get; }
+    public long RequestSizeBytes2 { get; set; }
+    public long ResponseSizeBytes2 { get; set; }
+    public Stream ResponseStream2 { get; set; }
+    public IRequest MarshalledRequest2 { get; set; }
+
+
+    [IterationSetup(Target = nameof(Marshall2))]
+    public virtual void BeforeMarshallIteration2()
+    {
+        IterationCount++;
+        GenerateRequest2();
+    }
+
+    public abstract byte[] Marshall2();
+
+
+    [GlobalCleanup(Target = nameof(Marshall2))]
+    public virtual void AfterMarshall2()
+    {
+#if USE_CBOR
+        RequestSizeBytes2 = Math.Max(RequestSizeBytes2, MarshalledRequest2.Content.Length);
+#else
+        if (Protocol == "Query")
+        {
+            string queryString = Utils.GetParametersAsString(MarshalledRequest2.ParameterCollection);
+            var content = Encoding.UTF8.GetBytes(queryString);
+
+            RequestSizeBytes2 = Math.Max(RequestSizeBytes2, content.Length);
+        }
+        else if (Protocol == "JSON")
+        {
+            RequestSizeBytes2 = Math.Max(RequestSizeBytes2, MarshalledRequest2.Content.Length);
+        }
+        else
+        {
+            throw new NotImplementedException();
+        }
+#endif
+        var record = new BenchmarkRecord(Service, TestCase2, Protocol, DimensionValue, "Request payload size (bytes)", RequestSizeBytes2, RequestSizeBytes2, RequestSizeBytes2);
+        Utils.StoreBenchmarkRecords(new List<BenchmarkRecord> { record });
+        RequestSizeBytes2 = 0;
+    }
+
+
+    [GlobalSetup(Target = nameof(TotalRequest2))]
+    public virtual void BeforeTotalRequest2()
+    {
+        IterationCount = 0;
+        CreateServiceClient();
+    }
+
+    [IterationSetup(Target = nameof(TotalRequest2))]
+    public virtual void TotalRequestBeforeIteration2()
+    {
+        IterationCount++;
+        GenerateRequest2();
+    }
+
+    public abstract Task<AmazonWebServiceResponse> TotalRequest2();
+
+    [GlobalCleanup(Target = nameof(TotalRequest2))]
+    public virtual void AfterTotalRequest2()
+    {
+        var record = new BenchmarkRecord(Service, TestCase2, Protocol, DimensionValue, "Response payload size (bytes)", ResponseSizeBytes2, ResponseSizeBytes2, ResponseSizeBytes2);
+        Utils.StoreBenchmarkRecords(new List<BenchmarkRecord> { record });
+        ResponseSizeBytes2 = 0;
+    }
+
+    public abstract void GenerateRequest2();
+
+
+
+    [GlobalSetup(Target = nameof(Unmarshall2))]
+    public virtual async Task BeforeUnmarshall2()
+    {
+        IterationCount = 0;
+        IterationCount++;
+
+        ResponseStream2 = new MemoryStream();
+        RuntimePipelineCustomizerRegistry.Instance.Register(new PipelineCustomizer(ResponseStream2));
+
+        // Recreate the service client to pick up the new pipeline handler.
+        CreateServiceClient();
+        GenerateRequest2();
+        try
+        {
+            // Make a request and copy the response to the ResponseStream
+            await TotalRequest2();
+        }
+        catch (ApplicationException)
+        {
+            // We expected this exception as we have already read and stored the stream.
+        }
+    }
+
+    [IterationSetup(Target = nameof(Unmarshall2))]
+    public virtual void BeforeUnmarshallIteration2()
+    {
+        var webResponseData = new FakeWebResponseData();
+        webResponseData.StatusCode = (HttpStatusCode)Enum.ToObject(typeof(HttpStatusCode), 200);
+        ResponseStream2.Position = 0;
+#if USE_CBOR
+        UnmarshallerContext = new Amazon.Extensions.CborProtocol.Internal.Transform.CborUnmarshallerContext(ResponseStream2, true, webResponseData);
+#else
+        if (Service == "CloudWatch")
+            UnmarshallerContext = new XmlUnmarshallerContext(ResponseStream2, true, webResponseData);
+        else
+            UnmarshallerContext = new JsonUnmarshallerContext(ResponseStream2, true, webResponseData);
+#endif
+    }
+
+    public abstract AmazonWebServiceResponse Unmarshall2();
+
+
+    [GlobalCleanup(Target = nameof(Unmarshall2))]
+    public virtual void AfterUnmarshall2()
+    {
+        RuntimePipelineCustomizerRegistry.Instance.Deregister(PipelineCustomizer.UniqueName);
+    }
+}

--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/CloudWatchBenchmarks/PutAndGetMetricDataBenchmarks.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/CloudWatchBenchmarks/PutAndGetMetricDataBenchmarks.cs
@@ -1,0 +1,174 @@
+﻿using Amazon;
+using Amazon.CloudWatch;
+using Amazon.CloudWatch.Model;
+using Amazon.CloudWatch.Model.Internal.MarshallTransformations;
+using Amazon.Runtime;
+using BenchmarkDotNet.Attributes;
+
+namespace CborPerformanceBenchmarksRunner.CloudWatchBenchmarks;
+
+public class PutAndGetMetricDataBenchmarks : BaseDoubleBenchmarks
+{
+    [Params(16, 64, 256, 1000)]
+    public override int DimensionValue { get; set; }
+    public override string Protocol { get; } =
+#if USE_CBOR
+        "CBOR";
+#else
+        "Query";
+#endif
+
+    public static string SuiteId { get; set; } = Guid.NewGuid().ToString();
+    public static DateTime BaseTime { get; set; } = DateTime.Now.AddHours(-2);
+
+    public override string Service { get; } = "CloudWatch";
+    public override string TestCase { get; } = "Put metric data";
+    public override string TestCase2 { get; } = "Get metric data";
+
+    protected IAmazonCloudWatch _client;
+    public override void CreateServiceClient()
+    {
+        _client = new AmazonCloudWatchClient(new AmazonCloudWatchConfig
+        {
+            DisableRequestCompression = true,
+            MaxErrorRetry = 0,
+            RegionEndpoint = RegionEndpoint.USWest2,
+        });
+    }
+
+    private PutMetricDataRequest request;
+
+    [Benchmark(Description = "Serialization time (ms)")]
+    public override byte[] Marshall()
+    {
+        var iRequest = PutMetricDataRequestMarshaller.Instance.Marshall(request);
+        MarshalledRequest = iRequest;
+
+        return iRequest.Content;
+    }
+
+    [Benchmark(Description = "Total request time (ms)")]
+    public async override Task<AmazonWebServiceResponse> TotalRequest()
+    {
+        var response = await _client.PutMetricDataAsync(request);
+        ResponseSizeBytes = Math.Max(ResponseSizeBytes, response.ContentLength);
+
+        return response;
+    }
+
+    public override void GenerateRequest()
+    {
+        var rng = Random.Shared;
+
+        request = new PutMetricDataRequest()
+        {
+            Namespace = "TestNamespace",
+            MetricData =
+            Enumerable.Range(1, DimensionValue).Select(i =>
+            new MetricDatum
+            {
+                MetricName = "TestMetric",
+                Dimensions = new List<Dimension>
+                {
+                    new Dimension
+                    {
+                        Name = "TestDimension",
+                        Value = $"{SuiteId}-{DimensionValue}"
+                    }
+                },
+                Unit = "None",
+                Timestamp = BaseTime.AddSeconds(2 * (i + 1)),
+                Value = rng.NextDouble(),
+            }).ToList()
+        };
+    }
+
+    [Benchmark(Description = "Deserialization time (ms)")]
+    public override AmazonWebServiceResponse Unmarshall()
+    {
+        var response = PutMetricDataResponseUnmarshaller.Instance.Unmarshall(UnmarshallerContext);
+        return response;
+    }
+
+    private GetMetricDataRequest request2;
+
+    [Benchmark(Description = "Serialization time (ms)")]
+    public override byte[] Marshall2()
+    {
+        var iRequest = GetMetricDataRequestMarshaller.Instance.Marshall(request2);
+        MarshalledRequest2 = iRequest;
+
+        return iRequest.Content;
+    }
+
+    [Benchmark(Description = "Total request time (ms)")]
+    public async override Task<AmazonWebServiceResponse> TotalRequest2()
+    {
+        var response = await _client.GetMetricDataAsync(request2);
+        ResponseSizeBytes2 = Math.Max(ResponseSizeBytes2, response.ContentLength);
+
+        return response;
+    }
+
+    public override void GenerateRequest2()
+    {
+        request2 = new GetMetricDataRequest
+        {
+            StartTime = BaseTime,
+            EndTime = BaseTime.AddHours(1),
+            MetricDataQueries = new List<MetricDataQuery>
+            {
+                new MetricDataQuery
+                {
+                    Id = "m0",
+                    ReturnData = true,
+                    MetricStat = new MetricStat
+                    {
+                        Unit = "None",
+                        Stat = "Sum",
+                        Period = 60,
+                        Metric = new Amazon.CloudWatch.Model.Metric
+                        {
+                            Namespace = "TestNamespace",
+                            MetricName = "TestMetric",
+                            Dimensions = new List<Dimension>
+                            {
+                                new Dimension
+                                {
+                                    Name = "TestDimension",
+                                    Value = $"{SuiteId}-{DimensionValue}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    [Benchmark(Description = "Deserialization time (ms)")]
+    public override AmazonWebServiceResponse Unmarshall2()
+    {
+        var response = GetMetricDataResponseUnmarshaller.Instance.Unmarshall(UnmarshallerContext);
+        return response;
+    }
+
+
+    public override void TotalRequestBeforeIteration()
+    {
+        if (IterationCount % 50 == 0)
+        {
+            Thread.Sleep(2000); // Sleep 2 seconds every 50 iterations to avoid throttling
+        }
+        base.TotalRequestBeforeIteration();
+    }
+
+    public override void TotalRequestBeforeIteration2()
+    {
+        if (IterationCount % 50 == 0)
+        {
+            Thread.Sleep(2000); // Sleep 2 seconds every 50 iterations to avoid throttling
+        }
+        base.TotalRequestBeforeIteration2();
+    }
+}

--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/Program.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/Program.cs
@@ -13,7 +13,10 @@ var benchmarkTypes = new Type[]
             typeof(LongListOfStringsBenchmarks),
             typeof(ListOfComplexObjectBenchmarks),
             typeof(VeryLargeBlobBenchmarks),
+            typeof(PutAndGetMetricDataBenchmarks),
             typeof(ListMetricsBenchmarks),
+            typeof(PutAndGetStringBenchmarks),
+            typeof(PutAndGetBinaryBenchmarks),
             typeof(DescribeSecretBenchmarks),
             typeof(ListSecretsBenchmarks),
         };

--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/SecretsManagerBenchmarks/PutAndGetBinaryBenchmarks.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/SecretsManagerBenchmarks/PutAndGetBinaryBenchmarks.cs
@@ -1,0 +1,32 @@
+﻿using Amazon.SecretsManager.Model;
+using System.Security.Cryptography;
+
+namespace CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks;
+
+public class PutAndGetBinaryBenchmarks: PutAndGetStringBenchmarks
+{
+    public override string TestCase { get; } = "Put binary secret";
+    public override string TestCase2 { get; } = "Get binary secret";
+
+    public override void GenerateRequest()
+    {
+        request = new PutSecretValueRequest()
+        {
+            SecretId = $"TestBinarySecret_{Utils.RunStartTimestamp}_{IterationCount.ToString("D3")}"
+        };
+
+        var rng = RandomNumberGenerator.Create();
+        byte[] buffer = new byte[DimensionValue];
+        rng.GetBytes(buffer);
+
+        request.SecretBinary = new MemoryStream(buffer);
+    }
+
+    public override void GenerateRequest2()
+    {
+        request2 = new GetSecretValueRequest()
+        {
+            SecretId = $"TestBinarySecret_{Utils.RunStartTimestamp}_{IterationCount.ToString("D3")}"
+        };
+    }
+}

--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/SecretsManagerBenchmarks/PutAndGetStringBenchmarks.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/SecretsManagerBenchmarks/PutAndGetStringBenchmarks.cs
@@ -1,0 +1,125 @@
+﻿using Amazon;
+using Amazon.Runtime;
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+using Amazon.SecretsManager.Model.Internal.MarshallTransformations;
+using BenchmarkDotNet.Attributes;
+using System.Text;
+
+namespace CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks;
+
+public class PutAndGetStringBenchmarks : BaseDoubleBenchmarks
+{
+    [Params(64, 512, 4096, 8192, 45056)]
+    public override int DimensionValue { get; set; }
+
+    public override string Service { get; } = "SecretsManager";
+
+    protected IAmazonSecretsManager _client;
+
+
+    public override void CreateServiceClient()
+    {
+        _client = new AmazonSecretsManagerClient(new AmazonSecretsManagerConfig
+        {
+            DisableRequestCompression = true,
+            MaxErrorRetry = 0,
+            RegionEndpoint = RegionEndpoint.USWest2,
+        });
+    }
+
+    public override string TestCase { get; } = "Put string secret";
+    public override string TestCase2 { get; } = "Get string secret";
+
+    protected PutSecretValueRequest request;
+    protected GetSecretValueRequest request2;
+
+    [Benchmark(Description = "Serialization time (ms)")]
+    public override byte[] Marshall()
+    {
+        var iRequest = PutSecretValueRequestMarshaller.Instance.Marshall(request);
+        MarshalledRequest = iRequest;
+
+        return iRequest.Content;
+    }
+
+    [Benchmark(Description = "Total request time (ms)")]
+    public async override Task<AmazonWebServiceResponse> TotalRequest()
+    {
+        var response = await _client.PutSecretValueAsync(request);
+        ResponseSizeBytes = Math.Max(ResponseSizeBytes, response.ContentLength);
+
+        return response;
+    }
+
+    [Benchmark(Description = "Deserialization time (ms)")]
+    public override AmazonWebServiceResponse Unmarshall()
+    {
+        var response = PutSecretValueResponseUnmarshaller.Instance.Unmarshall(UnmarshallerContext);
+        return response;
+    }
+
+    public override void GenerateRequest()
+    {
+        request = new PutSecretValueRequest()
+        {
+            SecretId = $"TestSecret_{Utils.RunStartTimestamp}_{IterationCount.ToString("D3")}"
+        };
+
+        var rng = Random.Shared;
+        var sb = new StringBuilder(DimensionValue);
+        int currentByteCount = 0;
+
+        while (true)
+        {
+            char c = (char)rng.Next(32, 127);
+
+            sb.Append(c);
+            currentByteCount = Encoding.UTF8.GetByteCount(sb.ToString());
+
+            if (currentByteCount > DimensionValue)
+            {
+                sb.Length--;
+                break;
+            }
+            if (currentByteCount == DimensionValue)
+            {
+                break;
+            }
+        }
+
+        request.SecretString = sb.ToString();
+    }
+
+    [Benchmark(Description = "Serialization time (ms)")]
+    public override byte[] Marshall2()
+    {
+        var iRequest = GetSecretValueRequestMarshaller.Instance.Marshall(request2);
+        MarshalledRequest2 = iRequest;
+
+        return iRequest.Content;
+    }
+    [Benchmark(Description = "Total request time (ms)")]
+    public async override Task<AmazonWebServiceResponse> TotalRequest2()
+    {
+        var response = await _client.GetSecretValueAsync(request2);
+        ResponseSizeBytes2 = Math.Max(ResponseSizeBytes2, response.ContentLength);
+
+        return response;
+    }
+
+    [Benchmark(Description = "Deserialization time (ms)")]
+    public override AmazonWebServiceResponse Unmarshall2()
+    {
+        var response = GetSecretValueResponseUnmarshaller.Instance.Unmarshall(UnmarshallerContext);
+        return response;
+    }
+
+    public override void GenerateRequest2()
+    {
+        request2 = new GetSecretValueRequest()
+        {
+            SecretId = $"TestSecret_{Utils.RunStartTimestamp}_{IterationCount.ToString("D3")}"
+        };
+    }
+}

--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/Utils.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/Utils.cs
@@ -146,11 +146,18 @@ public static class Utils
         {
             // All cases share the same DimensionValue in this sample; read from parameters
             int dimensionValue = int.Parse(jobGroup.First().BenchmarkCase.Parameters["DimensionValue"].ToString());
-            var benchmarkObject = (BaseBenchmarks)Activator.CreateInstance(jobGroup.First().BenchmarkCase.Descriptor.WorkloadMethod.DeclaringType)!;
+            var benchmarkObject = (BaseBenchmarks)Activator.CreateInstance(jobGroup.First().BenchmarkCase.Descriptor.Type)!;
 
             AddMetric("TotalRequest");
             AddMetric("Marshall");
             AddMetric("Unmarshall");
+
+            if (benchmarkObject is BaseDoubleBenchmarks benchmark2)
+            {
+                AddMetric("TotalRequest2");
+                AddMetric("Marshall2");
+                AddMetric("Unmarshall2");
+            }
 
             void AddMetric(string metricName)
             {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR follows up on [#4000](https://github.com/aws/aws-sdk-net/pull/4000)
It supports running certain CBOR performance benchmarks in sequence. Some scenarios, such as “Put an item → Retrieve it”, require multiple operations to be executed in a defined order to produce meaningful results.

To support this, I’ve added a `BaseDoubleBenchmarks` class that enables chaining two benchmarks together. The current implementation is intentionally minimal since we only need ordering for two benchmarks at the moment. This allowed us to get the performance data as quick as possible since we needed to make some decision based on them.

If future benchmarks require running more than two operations in sequence, the current approach will need to be generalized and restructured into a more extensible solution.

## Motivation and Context

`DOTNET-7728`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
Ran the benchmarks and generated the benchmark artifacts.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement