### PR TITLE
Migrate the self service model option of generator to V4

### DIFF
--- a/generator/.DevConfigs/57988500-f010-4dca-80ba-ddc4ab2b2271.json
+++ b/generator/.DevConfigs/57988500-f010-4dca-80ba-ddc4ab2b2271.json
@@ -1,9 +1,0 @@
-{
-  "core": {
-    "updateMinimum": true,
-    "type": "minor",
-    "changeLogMessages": [
-      "Migrates the self service model option of the generator to use V4"
-    ]
-  }
-}

--- a/generator/.DevConfigs/57988500-f010-4dca-80ba-ddc4ab2b2271.json
+++ b/generator/.DevConfigs/57988500-f010-4dca-80ba-ddc4ab2b2271.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "minor",
+    "changeLogMessages": [
+      "Migrates the self service model option of the generator to use V4"
+    ]
+  }
+}

--- a/generator/ServiceClientGenerator/Program.cs
+++ b/generator/ServiceClientGenerator/Program.cs
@@ -92,10 +92,10 @@ namespace ServiceClientGenerator
                     var serviceConfig = new ServiceConfiguration
                     {
                         ModelPath = options.SelfServiceModel,
-                        ServiceFileVersion = "3.1.0.0"
+                        ServiceFileVersion = "4.0.0.0"
                     };
                     serviceConfig.ModelName = Path.GetFileName(serviceConfig.ModelPath);
-                    serviceConfig.ServiceDependencies = new Dictionary<string, string> { {"Core", "3.1.0.0"} };
+                    serviceConfig.ServiceDependencies = new Dictionary<string, string> { {"Core", "4.0.0.18"} };
                     serviceConfig.GenerateConstructors = true;
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The [VS IDE extensions telemetry generator ](https://github.com/aws/aws-toolkit-common/blob/8c88537fae2ac7e6524fb2b29ae336c606850eeb/telemetry/csharp/TelemetryClient.proj#L72)uses the AWS SDK generator to produce its own service client. It is now being migrated to use sdk v4. However the self service option of the generator still points to v3.x of dependencies such as Core. This change updates it to v4.


## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement