### PR TITLE
Skip adding extra empty chunk for empty streams in TrailingHeadersWrapperStream v3

### DIFF
--- a/generator/.DevConfigs/e1581368-00fb-4a1a-b674-d98b961314f3.json
+++ b/generator/.DevConfigs/e1581368-00fb-4a1a-b674-d98b961314f3.json
@@ -1,0 +1,12 @@
+
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fixed a bug where PutObject was failing when sending zero-byte InputStream with DisablePayloadSigning set to true."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/TrailingHeadersWrapperStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/TrailingHeadersWrapperStream.cs
@@ -232,11 +232,16 @@ namespace Amazon.Runtime.Internal.Util
         {
             var trailer = new StringBuilder();
 
-            // End the data chunk
-            trailer.Append(STREAM_NEWLINE);
+            // Avoid adding an empty chunk for an empty stream. Adding the empty chunk for an empty stream will trigger
+            // service error for malformed trailing headers.
+            if (_baseStream.Length > 0)
+            {
+                // End the data chunk
+                trailer.Append(STREAM_NEWLINE);
 
-            // Append a chunk of size 0
-            trailer.Append(EMPTY_CHUNK);
+                // Append a chunk of size 0
+                trailer.Append(EMPTY_CHUNK);
+            }
 
             // Append trailing headers, including special handling for the checksum.
             // The order here must match the order of keys sent already in the X-Amz-Trailer header.
@@ -319,11 +324,16 @@ namespace Amazon.Runtime.Internal.Util
                 }
             }
 
+            var emptyChunkTotalLength = NEWLINE_LENGTH + EMPTY_CHUNK_LENGTH;
+            if (baseStreamLength == 0) // Empty chunk is only added when the baseStream isn't empty
+            {
+                emptyChunkTotalLength = 0;
+            }
+
             return prefixLength +
                    NEWLINE_LENGTH +
                    baseStreamLength +
-                   NEWLINE_LENGTH +
-                   EMPTY_CHUNK_LENGTH +
+                   emptyChunkTotalLength +
                    trailingHeaderLength +
                    NEWLINE_LENGTH;
         }

--- a/sdk/test/Services/S3/IntegrationTests/PutObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/PutObjectTests.cs
@@ -419,6 +419,27 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             VerifyPut(testContent, request);
         }
 
+        [DataTestMethod]
+        [TestCategory("S3")]
+        [DataRow(false, false)]
+        [DataRow(true, false)]
+        [DataRow(false, true)]
+        [DataRow(true, true)]
+        public void PutObjectWithEmptyInputStream(bool disablePayloadSigning, bool disableDefaultChecksumValidation)
+        {
+            PutObjectRequest request = new PutObjectRequest()
+            {
+                BucketName = bucketName,
+                Key = "inputStreamPut" + random.Next(),
+                InputStream = new MemoryStream(),
+                DisableDefaultChecksumValidation = disableDefaultChecksumValidation,
+                DisablePayloadSigning = disablePayloadSigning,
+            };
+            PutObjectResponse response = Client.PutObject(request);
+
+            Assert.IsTrue(response.ETag.Length > 0);
+        }
+
         [TestMethod]
         [TestCategory("S3")]
         public void PutObject_SigV4()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Copy of https://github.com/aws/aws-sdk-net/pull/4013 for V3

## Description
Fixes an issue where sending a `PutObjectRequest` with a zero-byte InputStream and `DisablePayloadSigning = true` throws:
```
The request contained trailing data that was not well-formed or did not conform to our published schema.
```

This happens because we are adding add an extra empty chunk (`0`) at the end to mark the end of the stream before the trailing headers
```
4
x  
0
x-amz-checksum-crc32:iQSVhA==
```

This is correct for requests with some data like the above one, but for zero byte stream we send the following 
```
0

0
x-amz-checksum-crc32:AAAAAA==
```
And sending 2x `0` isn't acceptable by S3 and causing `The request contained trailing data that was not well-formed or did not conform to our published schema.` exception.

This PR fixes this issue by only adding the additional empty chunk when there the stream isn't empty.




<!--- Describe your changes in detail -->

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/4012
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
* Tested the reproduction steps in https://github.com/aws/aws-sdk-net/issues/4012.
* Added unit tests that uploads empty stream with `DisablePayloadSigning`  and without it.
* `DRY_RUN-96a52ee2-7e98-4a2b-9b23-18c4a8b9bc21`
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement