### PR TITLE
Fix: Skip adding extra empty chunk for empty streams in TrailingHeadersWrapperStream

### DIFF
--- a/generator/.DevConfigs/99b6cdf3-717c-4830-9237-eb00d414a964.json
+++ b/generator/.DevConfigs/99b6cdf3-717c-4830-9237-eb00d414a964.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Skip adding extra empty chunk for empty streams in TrailingHeadersWrapperStream."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Requesting a release of https://github.com/aws/aws-sdk-net/pull/4013 since the proper devConfig was missing.

## Motivation and Context
https://github.com/aws/aws-sdk-net/pull/4013
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
`DRY_RUN-2cca33f8-61ed-428f-9c9f-9127a43f024f`
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement