### PR TITLE
Moving copying UserAgentDetails from the OriginalRequest to HttpHandler

### DIFF
--- a/generator/.DevConfigs/6861e08c-84a4-4e33-b3f8-932c13670916.json
+++ b/generator/.DevConfigs/6861e08c-84a4-4e33-b3f8-932c13670916.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Moving copying UserAgentDetails from the OriginalRequest to HttpHandler"
+    ],
+    "type": "patch",
+    "updateMinimum": false
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
@@ -115,13 +115,6 @@ namespace Amazon.Runtime.Internal
                     return _userAgentDetails;
 
                 _userAgentDetails = new UserAgentDetails();
-
-                _userAgentDetails.AddUserAgentComponent(((IAmazonWebServiceRequest)OriginalRequest).UserAgentDetails.GetCustomUserAgentComponents());
-                foreach (var featureId in ((IAmazonWebServiceRequest)OriginalRequest).UserAgentDetails.TrackedFeatureIds)
-                {
-                    _userAgentDetails.AddFeature(featureId);
-                }
-
                 return _userAgentDetails;
             }
         }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/HttpHandler.cs
@@ -525,6 +525,14 @@ namespace Amazon.Runtime.Internal
             if (requestContext.Request.SignatureVersion == SignatureVersion.SigV4a)
                 requestContext.UserAgentDetails.AddFeature(UserAgentFeatureId.SIGV4A_SIGNING);
 
+            var originalRequest = (IAmazonWebServiceRequest)requestContext.OriginalRequest;
+
+            requestContext.UserAgentDetails.AddUserAgentComponent(originalRequest.UserAgentDetails.GetCustomUserAgentComponents());
+            foreach (var featureId in originalRequest.UserAgentDetails.TrackedFeatureIds)
+            {
+                requestContext.UserAgentDetails.AddFeature(featureId);
+            }
+
             var metricsUserAgent = requestContext.UserAgentDetails.GenerateUserAgentWithMetrics();
             Logger.DebugFormat("User-Agent Header: {0}", metricsUserAgent);
 

--- a/sdk/test/UnitTests/Custom/Runtime/UserAgentTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/UserAgentTests.cs
@@ -101,6 +101,30 @@ namespace AWSSDK.UnitTests
         }
 
         [TestMethod]
+        public void TestUserAgentRequestAddition()
+        {
+            var listObjectsV2Request = new ListObjectsV2Request
+            {
+                BucketName = "test"
+            };
+
+            var uaComponent = "testing-component";
+
+            ((IAmazonWebServiceRequest)listObjectsV2Request).UserAgentDetails.AddUserAgentComponent(uaComponent);
+            ((IAmazonWebServiceRequest)listObjectsV2Request).UserAgentDetails.AddFeature(UserAgentFeatureId.ACCOUNT_ID_MODE_DISABLED);
+            var request = RunMockRequest(listObjectsV2Request, new AmazonS3Config(), ListObjectsV2RequestMarshaller.Instance, ListObjectsV2ResponseUnmarshaller.Instance);
+
+            request.Headers.TryGetValue(HeaderKeys.UserAgentHeader, out string userAgentHeader);
+            Assert.IsNotNull(userAgentHeader);
+
+            Assert.IsTrue(userAgentHeader.Contains(uaComponent));
+
+            var metricsSection = userAgentHeader.Split(' ').First(part => part.StartsWith("m/")).Remove(0, 2);
+            Assert.IsTrue(metricsSection.Contains(UserAgentFeatureId.ACCOUNT_ID_MODE_DISABLED));
+
+        }
+
+        [TestMethod]
         public void TestUserAgentAdditionForPaginators()
         {
             var listObjectsV2Request = new ListObjectsV2Request


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`RequestContext.UserAgentDetails` was created, and `OriginalRequest.UserAgentDetails` was copied to it as part of the getter. In some cases, this property is not accessed until the marshaller pipeline hanlder, which happens before the `BeforeRequestEvent` callback. This causes `RequestContext.UserAgentDetails` to miss the changes made to the original request in `BeforeRequestEvent`. 

This PR moves the copying of `UserAgentDetails` from the OriginalRequest to `HttpHandler`, which is the final step before sending the request.

## Testing
* `DRY_RUN-369ec115-0587-4ec8-ad09-a550c84d8cf6`
* Add unit test to make sure `UserAgentDetails` is copied correctly from the original request.
* Tested a request with UA changes in `BeforeRequestEvent` callback and made sure it applies correctly.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement