### PR TITLE
Tweak BedrockChatClient to compensate for missing content

### DIFF
--- a/generator/.DevConfigs/4e3b0381-12b4-43df-a1fd-3e9ace823ff1.json
+++ b/generator/.DevConfigs/4e3b0381-12b4-43df-a1fd-3e9ace823ff1.json
@@ -1,0 +1,11 @@
+{
+    "extensions": [
+        {
+            "extensionName": "Extensions.Bedrock.MEAI",
+            "type": "patch",
+            "changeLogMessages": [
+                "Tweak BedrockChatClient to compensate for missing content"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Description

The service sends back failure if there's no content in the request or if there's any content with empty or blank text.

## Motivation and Context

If a request gets created that lacks any messages, or if any of the messages contain empty text, the service fails.

## Testing

Manual testing.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement