### PR TITLE
Preemptively expand CBOR buffer to fit large strings

### DIFF
--- a/generator/.DevConfigs/2125291c-5bf5-4612-b8ff-dc3cfdbacd2b.json
+++ b/generator/.DevConfigs/2125291c-5bf5-4612-b8ff-dc3cfdbacd2b.json
@@ -1,0 +1,11 @@
+{
+    "extensions": [
+        {
+            "extensionName": "Extensions.CborProtocol",
+            "type": "patch",
+            "changeLogMessages": [
+                "Improve performance of CBOR deserialization for large strings by preemptively expanding the buffer to fit the string."
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces a new method, `ExpandBufferSizeForLargeStrings()`, which improves the efficiency of reading large CBOR text and byte strings by reducing repeated refills and buffer copies during streaming.
The method is invoked within `ReadTextString()` and `ReadByteString()` before reading their respective values.

Previously, large CBOR strings when their declared length exceeded the current buffer capacity, triggered multiple incremental buffer refills. While functionally correct, this caused unnecessary overhead from multiple read operations and redundant data copies particularly noticeable for long text or byte strings spanning multiple chunks. 
Here is an example of CBOR unmarshalling performance before this PR

| Namespace                                                | Job               | Service        | Test Case               | Benchmark            | DimensionValue | P50           | P90           | Ratio | Allocated | Alloc Ratio |
|--------------------------------------------------------- |------------------ |--------------- |------------------------ |--------------------- |--------------- |--------------:|--------------:|------:|----------:|------------:|
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 64             |     25.035 μs |     30.485 μs |  1.31 |    6632 B |        1.16 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 64             |     24.139 μs |     26.530 μs |  1.19 |    3480 B |        0.61 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 64             |     24.601 μs |     29.801 μs |  1.29 |    6320 B |        1.12 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 64             |     22.485 μs |     24.451 μs |  1.13 |    3448 B |        0.61 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 512            |     27.126 μs |     31.848 μs |  1.42 |    9456 B |        1.66 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 512            |     27.621 μs |     28.653 μs |  1.35 |    3928 B |        0.69 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 512            |     27.456 μs |     33.286 μs |  1.48 |    8144 B |        1.44 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 512            |     24.260 μs |     28.052 μs |  1.22 |    4344 B |        0.77 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 4096           |     46.017 μs |     50.926 μs |  2.16 |   26888 B |        4.71 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 4096           |    116.927 μs |    121.678 μs |  5.34 |   19240 B |        3.37 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 4096           |     75.231 μs |    149.543 μs |  4.99 |   19936 B |        3.52 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 4096           |    118.037 μs |    124.258 μs |  6.13 |   22808 B |        4.03 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 8192           |     63.642 μs |     70.786 μs |  3.21 |   50184 B |        8.79 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 8192           |    130.023 μs |    137.496 μs |  6.52 |   32232 B |        5.64 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 8192           |    101.922 μs |    270.968 μs |  7.29 |   36408 B |        6.43 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 8192           |    133.858 μs |    137.327 μs |  6.67 |   40760 B |        7.20 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 45056          |    189.865 μs |    206.197 μs |  9.38 |  234680 B |       41.09 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 45056          |    232.696 μs |    241.316 μs | 11.25 |  119656 B |       20.95 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 45056          |    186.715 μs |    339.978 μs | 10.82 |  159464 B |       28.15 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 45056          |    174.565 μs |    178.378 μs |  7.98 |  165048 B |       29.14 |

The solution was to add `ExpandBufferSizeForLargeStrings()`, it parses the CBOR header to determine the declared length of the upcoming value (if definite-length). If the declared length exceeds the current buffer capacity, it proactively allocates a larger buffer that can fit the entire value instead of waiting for `CborReader` to throw an exception and do a regular refill which can happen multiple times based on the string size. 

## Testing
- `DRY_RUN-5c367f56-e493-406e-b9f5-94881cf2c4bc`
- Cbor reader Unit tests already has tests that unmarshall large text strings and byte strings.
   -  https://github.com/aws/aws-sdk-net/blob/bba83b2cedfbe4e8c707857a539d5c500f5a6522/extensions/test/CborProtocol.Tests/CborStreamReaderTests.cs#L332
   - https://github.com/aws/aws-sdk-net/blob/bba83b2cedfbe4e8c707857a539d5c500f5a6522/extensions/test/CborProtocol.Tests/CborStreamReaderTests.cs#L350
- Ran the same performance tests and showed a noticeable improvement in comparison to the above results

| Namespace                                                | Job               | Service        | Test Case               | Benchmark            | DimensionValue | P50           | P90           | Ratio | Allocated | Alloc Ratio |
|--------------------------------------------------------- |------------------ |--------------- |------------------------ |--------------------- |--------------- |--------------:|--------------:|------:|----------:|------------:|
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 64             |     24.861 μs |     37.050 μs |  1.43 |    6632 B |        1.16 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 64             |     23.795 μs |     27.822 μs |  1.25 |    4184 B |        0.73 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 64             |     30.715 μs |     32.179 μs |  1.42 |    6320 B |        1.12 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 64             |     24.516 μs |     27.091 μs |  1.19 |    4152 B |        0.73 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 512            |     35.566 μs |     42.156 μs |  1.76 |    9456 B |        1.66 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 512            |     24.160 μs |     25.730 μs |  1.19 |    4632 B |        0.81 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 512            |     26.930 μs |     33.319 μs |  1.41 |    8128 B |        1.44 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 512            |     23.870 μs |     25.358 μs |  1.17 |    5048 B |        0.89 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 4096           |     47.546 μs |     52.056 μs |  2.44 |   26888 B |        4.71 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 4096           |     89.392 μs |     93.678 μs |  4.58 |   19056 B |        3.34 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 4096           |     70.572 μs |    151.771 μs |  4.28 |   19936 B |        3.52 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 4096           |     91.992 μs |     97.776 μs |  4.31 |   23056 B |        4.07 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 8192           |     64.701 μs |     72.280 μs |  3.40 |   50184 B |        8.79 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 8192           |     88.892 μs |     92.942 μs |  4.62 |   31344 B |        5.49 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 8192           |    114.353 μs |    269.964 μs |  8.11 |   36408 B |        6.43 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 8192           |     92.963 μs |     98.318 μs |  4.67 |   39440 B |        6.96 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get binary secret       | Deserialization time | 45056          |    187.289 μs |    196.712 μs |  9.47 |  234680 B |       41.09 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get binary secret       | Deserialization time | 45056          |     96.652 μs |    101.450 μs |  4.91 |  117360 B |       20.55 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | OldProtocol       | SecretsManager | Get string secret       | Deserialization time | 45056          |    281.737 μs |    330.248 μs | 13.03 |  159464 B |       28.15 |
| CborPerformanceBenchmarksRunner.SecretsManagerBenchmarks | RPCv2CborProtocol | SecretsManager | Get string secret       | Deserialization time | 45056          |    104.913 μs |    114.708 μs |  5.16 |  162320 B |       28.66 |

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement