### PR TITLE
[V4] Update credentials resolver to handle empty profile names in config

### DIFF
--- a/generator/.DevConfigs/fe2b0bd7-f45d-4cc5-ba88-0be51c08e324.json
+++ b/generator/.DevConfigs/fe2b0bd7-f45d-4cc5-ba88-0be51c08e324.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Fix regression in V4 where the credentials resolver would attempt to fetch a profile even when its name was empty or null (https://github.com/aws/aws-sdk-net/issues/4028)"
+        ],
+        "type": "patch",
+        "updateMinimum": true
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -101,7 +101,7 @@ namespace Amazon.Runtime.Credentials
         public AWSCredentials ResolveIdentity(IClientConfig clientConfig)
         {
             var profile = clientConfig?.Profile;
-            if (profile != null)
+            if (!string.IsNullOrEmpty(profile?.Name))
             {
                 var source = new CredentialProfileStoreChain(profile.Location);
                 if (source.TryGetProfile(profile.Name, out CredentialProfile storedProfile))


### PR DESCRIPTION
Fixes #4028 

## Motivation and Context
Fixes a regression in V4 where the credentials resolver was not handling the scenario where: The `Profile` property in the `ClientConfig` object was set, but without a value in non-local environments (causing an `AmazonClientException` to be thrown when running on an EC2 instance).

## Testing
Dry-run: `DRY_RUN-8d688ddb-21af-49aa-b2d4-5c3888e18cc4` (in progress)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
