### PR TITLE
Fixed issue calling UploadPart with an unseekable stream and disablin…

### DIFF
--- a/generator/.DevConfigs/32a12d7c-afc6-4bcf-a2d8-9c49b335b935.json
+++ b/generator/.DevConfigs/32a12d7c-afc6-4bcf-a2d8-9c49b335b935.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fixed issue calling UploadPart with an unseekable stream and disabling checksum failing."
+      ]
+    }
+  ]
+}

--- a/sdk/test/Services/S3/IntegrationTests/PutUnseekableStreamTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/PutUnseekableStreamTests.cs
@@ -1,0 +1,130 @@
+﻿using System.IO;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Util;
+using System.Threading.Tasks;
+
+namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
+{
+    [TestClass]
+    public class PutUnseekableStreamTests : TestBase<AmazonS3Client>
+    {
+        private static string bucketName;
+
+        [ClassInitialize()]
+        public static void Initialize(TestContext a)
+        {
+            StreamWriter writer = File.CreateText("PutObjectFile.txt");
+            writer.Write("This is some sample text.!!");
+            writer.Close();
+
+            bucketName = S3TestUtils.CreateBucketWithWait(Client, true);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            AmazonS3Util.DeleteS3BucketWithObjects(Client, bucketName);
+            BaseClean();
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public async Task TestPutObject()
+        {
+            var stream = new CustomStream(Encoding.UTF8.GetBytes("Hello, S3!"));
+            var putRequest = new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = "put-object-unseekable-test.txt",
+                InputStream = stream,
+                DisablePayloadSigning = true
+            };
+
+            await Client.PutObjectAsync(putRequest);
+
+            var getRequest = new GetObjectRequest
+            {
+                BucketName = bucketName,
+                Key = "put-object-unseekable-test.txt"
+            };
+            using (var getResponse = await Client.GetObjectAsync(getRequest))
+            {
+                using (var reader = new StreamReader(getResponse.ResponseStream))
+                {
+                    var content = reader.ReadToEnd();
+                    Assert.AreEqual("Hello, S3!", content);
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public async Task TestUploadPart()
+        {
+            var stream = new CustomStream(Encoding.UTF8.GetBytes("Hello, S3!"));
+
+            var initiateMultipartUploadRequest = new InitiateMultipartUploadRequest
+            {
+                BucketName = bucketName,
+                Key = "upload-part-unseekable-test.txt"
+            };
+
+            var initiateMultipartUploadResponse = await Client.InitiateMultipartUploadAsync(initiateMultipartUploadRequest);
+
+            var uploadPartRequest = new UploadPartRequest
+            {
+                BucketName = bucketName,
+                Key = "upload-part-unseekable-test.txt",
+                UploadId = initiateMultipartUploadResponse.UploadId,
+                PartNumber = 1,
+                PartSize = stream.Length,
+                InputStream = stream,
+                DisablePayloadSigning = true,
+                IsLastPart = true,
+            };
+
+
+            var uploadPartResponse = await Client.UploadPartAsync(uploadPartRequest);
+
+            var completeMultipartUploadRequest = new CompleteMultipartUploadRequest
+            {
+                BucketName = bucketName,
+                Key = "upload-part-unseekable-test.txt",
+                UploadId = initiateMultipartUploadResponse.UploadId
+            };
+
+            completeMultipartUploadRequest.AddPartETags(uploadPartResponse);
+
+            await Client.CompleteMultipartUploadAsync(completeMultipartUploadRequest);
+
+            var getRequest = new GetObjectRequest
+            {
+                BucketName = bucketName,
+                Key = "upload-part-unseekable-test.txt"
+            };
+            using (var getResponse = await Client.GetObjectAsync(getRequest))
+            {
+                using (var reader = new StreamReader(getResponse.ResponseStream))
+                {
+                    var content = reader.ReadToEnd();
+                    Assert.AreEqual("Hello, S3!", content);
+                }
+            }
+        }
+
+
+        public class CustomStream : MemoryStream
+        {
+            public CustomStream(byte[] buffer) : base(buffer)
+            {
+            }
+
+            public override bool CanSeek => false;
+
+        }
+    }
+}


### PR DESCRIPTION
PR in draft mode till full dry run is successul

## Description
The PutObject operation does work with an unseekable stream if you set both `DisablePayloadSigning` is set to `true` but the UploadPart which also fail. That is because it is always wrapping the input stream in a `PartialWrapperStream` which requires the stream to be seekable. The PR switches the code to use the `GetStreamWithLength` method like PutObject which returns back a `PartialReadOnlyWrapperStream` instance which does not require the wrapped stream to be seekable.

The content-length will be determine by either the stream's length if available and then fallback to `PartSize property of the `UploadPartRequest`.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/4010

## Testing
Added new integ tests
Dry run: pending
