### PR TITLE
Prevent duplicate entries in User Agent custom components

### DIFF
--- a/generator/.DevConfigs/e890aefd-0815-4204-a9bb-e1b5754184a3.json
+++ b/generator/.DevConfigs/e890aefd-0815-4204-a9bb-e1b5754184a3.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Prevent duplicate entries in User Agent custom components"
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentDetails.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/UserAgent/UserAgentDetails.cs
@@ -27,7 +27,7 @@ namespace Amazon.Runtime.Internal.UserAgent
     {
         private const int MaxSizeBytes = 1024; // 1 KB size limit
         private readonly HashSet<string> _trackedFeatureIds = new HashSet<string>();
-        private readonly StringBuilder _userAgentBuilder = new StringBuilder();
+        private readonly HashSet<string> _userAgentCustomComponents = new HashSet<string>();
 
         /// <summary>
         /// Gets the list of tracked feature IDs.
@@ -40,9 +40,9 @@ namespace Amazon.Runtime.Internal.UserAgent
         /// <param name="component">The user-agent component to append.</param>
         public void AddUserAgentComponent(string component)
         {
-            if (!string.IsNullOrEmpty(component))
+            if (!string.IsNullOrWhiteSpace(component))
             {
-                _userAgentBuilder.Append(' ').Append(component);
+                _userAgentCustomComponents.Add(component.Trim());
             }
         }
 
@@ -62,7 +62,7 @@ namespace Amazon.Runtime.Internal.UserAgent
         /// </summary>
         public string GetCustomUserAgentComponents()
         {
-            return _userAgentBuilder.ToString().Trim();
+            return string.Join(" ", _userAgentCustomComponents);
         }
 
         /// <summary>
@@ -74,9 +74,9 @@ namespace Amazon.Runtime.Internal.UserAgent
             var metricsUserAgent = GenerateMetricsUserAgent();
             if (!string.IsNullOrEmpty(metricsUserAgent))
             {
-                return $"{_userAgentBuilder.ToString().Trim()} {metricsUserAgent}";
+                return $"{string.Join(" ", _userAgentCustomComponents)} {metricsUserAgent}";
             }
-            return _userAgentBuilder.ToString().Trim();
+            return string.Join(" ", _userAgentCustomComponents);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modified `UserAgentDetails.cs` to prevent duplicate entries in custom user agent components by replacing the StringBuilder-based implementation with a `HashSet<string>`. This change ensures that identical components aren't added multiple times to the user agent string.
<!--- Describe your changes in detail -->

## Motivation and Context
https://github.com/aws/aws-logging-dotnet/issues/340
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
- `DRY_RUN-cc8698dd-7c4a-4e1b-a7f5-ca84d8785ff6`.
- Verified that duplicate custom components are only included once in the final user agent string manually.
- Added `Test_AddsCustomUserAgentAddition_SkipDuplicates` unit test.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement