### PR TITLE
Add Progress listeners for initiated, complete, and failed for simple upload

### DIFF
--- a/generator/.DevConfigs/433a9a6d-b8ea-4676-b763-70711e8288e2.json
+++ b/generator/.DevConfigs/433a9a6d-b8ea-4676-b763-70711e8288e2.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "minor",
+      "changeLogMessages": [
+        "Added UploadInitiatedEvent, UploadCompletedEvent, and UploadFailedEvent for non multipart uploads."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/SimpleUploadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/SimpleUploadCommand.cs
@@ -41,12 +41,18 @@ namespace Amazon.S3.Transfer.Internal
         IAmazonS3 _s3Client;
         TransferUtilityConfig _config;
         TransferUtilityUploadRequest _fileTransporterRequest;
+        long _totalTransferredBytes;
+        private readonly long _contentLength;
 
         internal SimpleUploadCommand(IAmazonS3 s3Client, TransferUtilityConfig config, TransferUtilityUploadRequest fileTransporterRequest)
         {
             this._s3Client = s3Client;
             this._config = config;
             this._fileTransporterRequest = fileTransporterRequest;
+            
+            // Cache content length immediately while stream is accessible to avoid ObjectDisposedException in failure scenarios
+            this._contentLength = this._fileTransporterRequest.ContentLength;
+            
             var fileName = fileTransporterRequest.FilePath;
         }
 
@@ -108,9 +114,48 @@ namespace Amazon.S3.Transfer.Internal
 
         private void PutObjectProgressEventCallback(object sender, UploadProgressArgs e)
         {
-            var progressArgs = new UploadProgressArgs(e.IncrementTransferred, e.TransferredBytes, e.TotalBytes, 
-                e.CompensationForRetry, _fileTransporterRequest.FilePath);
+            // Keep track of the total transferred bytes so that we can also return this value in case of failure
+            long transferredBytes = Interlocked.Add(ref _totalTransferredBytes, e.IncrementTransferred - e.CompensationForRetry);
+            
+            var progressArgs = new UploadProgressArgs(e.IncrementTransferred, transferredBytes, _contentLength, 
+                e.CompensationForRetry, _fileTransporterRequest.FilePath, _fileTransporterRequest);
             this._fileTransporterRequest.OnRaiseProgressEvent(progressArgs);
+        }
+
+        private void FireTransferInitiatedEvent()
+        {
+            var initiatedArgs = new UploadInitiatedEventArgs(
+                request: _fileTransporterRequest,
+                filePath: _fileTransporterRequest.FilePath,
+                totalBytes: _contentLength
+            );
+            
+            _fileTransporterRequest.OnRaiseTransferInitiatedEvent(initiatedArgs);
+        }
+
+        private void FireTransferCompletedEvent(TransferUtilityUploadResponse response)
+        {
+            var completedArgs = new UploadCompletedEventArgs(
+                request: _fileTransporterRequest,
+                response: response,
+                filePath: _fileTransporterRequest.FilePath,
+                transferredBytes: Interlocked.Read(ref _totalTransferredBytes),
+                totalBytes: _contentLength
+            );
+            
+            _fileTransporterRequest.OnRaiseTransferCompletedEvent(completedArgs);
+        }
+
+        private void FireTransferFailedEvent()
+        {
+            var failedArgs = new UploadFailedEventArgs(
+                request: _fileTransporterRequest,
+                filePath: _fileTransporterRequest.FilePath,
+                transferredBytes: Interlocked.Read(ref _totalTransferredBytes),
+                totalBytes: _contentLength
+            );
+            
+            _fileTransporterRequest.OnRaiseTransferFailedEvent(failedArgs);
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/SimpleUploadCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/SimpleUploadCommand.async.cs
@@ -38,9 +38,20 @@ namespace Amazon.S3.Transfer.Internal
                         .ConfigureAwait(continueOnCapturedContext: false);
                 }
 
+                FireTransferInitiatedEvent();
+
                 var putRequest = ConstructRequest();
-                await _s3Client.PutObjectAsync(putRequest, cancellationToken)
+                var response = await _s3Client.PutObjectAsync(putRequest, cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);
+
+                var mappedResponse = ResponseMapper.MapPutObjectResponse(response);
+
+                FireTransferCompletedEvent(mappedResponse);
+            }
+            catch (Exception)
+            {
+                FireTransferFailedEvent();
+                throw;
             }
             finally
             {

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityUploadRequest.cs
@@ -25,6 +25,7 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Text;
 
+using Amazon.Runtime;
 using Amazon.Runtime.Internal;
 using Amazon.S3.Model;
 using Amazon.Util;
@@ -169,6 +170,132 @@ namespace Amazon.S3.Transfer
         /// </code>
         /// </remarks>
         public event EventHandler<UploadProgressArgs> UploadProgressEvent;
+
+        /// <summary>
+        /// The event for UploadInitiatedEvent notifications. All
+        /// subscribers will be notified when a transfer operation
+        /// starts.
+        /// <para>
+        /// The UploadInitiatedEvent is fired exactly once when 
+        /// a transfer operation begins. The delegates attached to the event 
+        /// will be passed information about the upload request and 
+        /// total file size, but no progress information.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Subscribe to this event if you want to receive
+        /// UploadInitiatedEvent notifications. Here is how:<br />
+        /// 1. Define a method with a signature similar to this one:
+        /// <code>
+        /// private void uploadStarted(object sender, UploadInitiatedEventArgs args)
+        /// {
+        ///     Console.WriteLine($"Upload started: {args.FilePath}");
+        ///     Console.WriteLine($"Total size: {args.TotalBytes} bytes");
+        ///     Console.WriteLine($"Bucket: {args.Request.BucketName}");
+        ///     Console.WriteLine($"Key: {args.Request.Key}");
+        /// }
+        /// </code>
+        /// 2. Add this method to the UploadInitiatedEvent delegate's invocation list
+        /// <code>
+        /// TransferUtilityUploadRequest request = new TransferUtilityUploadRequest();
+        /// request.UploadInitiatedEvent += uploadStarted;
+        /// </code>
+        /// </remarks>
+        public event EventHandler<UploadInitiatedEventArgs> UploadInitiatedEvent;
+
+        /// <summary>
+        /// The event for UploadCompletedEvent notifications. All
+        /// subscribers will be notified when a transfer operation
+        /// completes successfully.
+        /// <para>
+        /// The UploadCompletedEvent is fired exactly once when 
+        /// a transfer operation completes successfully. The delegates attached to the event 
+        /// will be passed information about the completed upload including
+        /// the final response from S3 with ETag, VersionId, and other metadata.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Subscribe to this event if you want to receive
+        /// UploadCompletedEvent notifications. Here is how:<br />
+        /// 1. Define a method with a signature similar to this one:
+        /// <code>
+        /// private void uploadCompleted(object sender, UploadCompletedEventArgs args)
+        /// {
+        ///     Console.WriteLine($"Upload completed: {args.FilePath}");
+        ///     Console.WriteLine($"Transferred: {args.TransferredBytes} bytes");
+        ///     Console.WriteLine($"ETag: {args.Response.ETag}");
+        ///     Console.WriteLine($"S3 Key: {args.Response.Key}");
+        ///     Console.WriteLine($"Version ID: {args.Response.VersionId}");
+        /// }
+        /// </code>
+        /// 2. Add this method to the UploadCompletedEvent delegate's invocation list
+        /// <code>
+        /// TransferUtilityUploadRequest request = new TransferUtilityUploadRequest();
+        /// request.UploadCompletedEvent += uploadCompleted;
+        /// </code>
+        /// </remarks>
+        public event EventHandler<UploadCompletedEventArgs> UploadCompletedEvent;
+
+        /// <summary>
+        /// The event for UploadFailedEvent notifications. All
+        /// subscribers will be notified when a transfer operation
+        /// fails.
+        /// <para>
+        /// The UploadFailedEvent is fired exactly once when 
+        /// a transfer operation fails. The delegates attached to the event 
+        /// will be passed information about the failed upload including
+        /// partial progress information, but no response data since the upload failed.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Subscribe to this event if you want to receive
+        /// UploadFailedEvent notifications. Here is how:<br />
+        /// 1. Define a method with a signature similar to this one:
+        /// <code>
+        /// private void uploadFailed(object sender, UploadFailedEventArgs args)
+        /// {
+        ///     Console.WriteLine($"Upload failed: {args.FilePath}");
+        ///     Console.WriteLine($"Partial progress: {args.TransferredBytes} / {args.TotalBytes} bytes");
+        ///     var percent = (double)args.TransferredBytes / args.TotalBytes * 100;
+        ///     Console.WriteLine($"Completion: {percent:F1}%");
+        ///     Console.WriteLine($"Bucket: {args.Request.BucketName}");
+        ///     Console.WriteLine($"Key: {args.Request.Key}");
+        /// }
+        /// </code>
+        /// 2. Add this method to the UploadFailedEvent delegate's invocation list
+        /// <code>
+        /// TransferUtilityUploadRequest request = new TransferUtilityUploadRequest();
+        /// request.UploadFailedEvent += uploadFailed;
+        /// </code>
+        /// </remarks>
+        public event EventHandler<UploadFailedEventArgs> UploadFailedEvent;
+
+        /// <summary>
+        /// Causes the UploadInitiatedEvent event to be fired.
+        /// </summary>
+        /// <param name="args">UploadInitiatedEventArgs args</param>
+        internal void OnRaiseTransferInitiatedEvent(UploadInitiatedEventArgs args)
+        {
+            AWSSDKUtils.InvokeInBackground(UploadInitiatedEvent, args, this);
+        }
+
+        /// <summary>
+        /// Causes the UploadCompletedEvent event to be fired.
+        /// </summary>
+        /// <param name="args">UploadCompletedEventArgs args</param>
+        internal void OnRaiseTransferCompletedEvent(UploadCompletedEventArgs args)
+        {
+            AWSSDKUtils.InvokeInBackground(UploadCompletedEvent, args, this);
+        }
+
+        /// <summary>
+        /// Causes the UploadFailedEvent event to be fired.
+        /// </summary>
+        /// <param name="args">UploadFailedEventArgs args</param>
+        internal void OnRaiseTransferFailedEvent(UploadFailedEventArgs args)
+        {
+            AWSSDKUtils.InvokeInBackground(UploadFailedEvent, args, this);
+        }
 
 
         /// <summary>
@@ -460,7 +587,7 @@ namespace Amazon.S3.Transfer
         /// currently transferred bytes and the
         /// total number of bytes to be transferred
         /// </summary>
-        /// <param name="incrementTransferred">The how many bytes were transferred since last event.</param>
+        /// <param name="incrementTransferred">How many bytes were transferred since last event.</param>
         /// <param name="transferred">The number of bytes transferred</param>
         /// <param name="total">The total number of bytes to be transferred</param>
         public UploadProgressArgs(long incrementTransferred, long transferred, long total)
@@ -473,7 +600,7 @@ namespace Amazon.S3.Transfer
         /// currently transferred bytes and the
         /// total number of bytes to be transferred
         /// </summary>
-        /// <param name="incrementTransferred">The how many bytes were transferred since last event.</param>
+        /// <param name="incrementTransferred">How many bytes were transferred since last event.</param>
         /// <param name="transferred">The number of bytes transferred</param>
         /// <param name="total">The total number of bytes to be transferred</param>        
         /// <param name="filePath">The file being uploaded</param>
@@ -487,7 +614,7 @@ namespace Amazon.S3.Transfer
         /// currently transferred bytes and the
         /// total number of bytes to be transferred
         /// </summary>
-        /// <param name="incrementTransferred">The how many bytes were transferred since last event.</param>
+        /// <param name="incrementTransferred">How many bytes were transferred since last event.</param>
         /// <param name="transferred">The number of bytes transferred</param>
         /// <param name="total">The total number of bytes to be transferred</param>
         /// <param name="compensationForRetry">A compensation for any upstream aggregators if this event to correct theit totalTransferred count,
@@ -501,10 +628,163 @@ namespace Amazon.S3.Transfer
         }
 
         /// <summary>
+        /// Constructor for upload progress with request
+        /// </summary>
+        /// <param name="incrementTransferred">How many bytes were transferred since last event.</param>
+        /// <param name="transferred">The number of bytes transferred</param>
+        /// <param name="total">The total number of bytes to be transferred</param>
+        /// <param name="compensationForRetry">A compensation for any upstream aggregators if this event to correct their totalTransferred count,
+        /// in case the underlying request is retried.</param>
+        /// <param name="filePath">The file being uploaded</param>
+        /// <param name="request">The original TransferUtilityUploadRequest created by the user</param>
+        internal UploadProgressArgs(long incrementTransferred, long transferred, long total, long compensationForRetry, string filePath, TransferUtilityUploadRequest request)
+            : base(incrementTransferred, transferred, total)
+        {
+            this.FilePath = filePath;
+            this.CompensationForRetry = compensationForRetry;
+            this.Request = request;
+        }
+
+        /// <summary>
         /// Gets the FilePath.
         /// </summary>
         public string FilePath { get; private set; }
 
         internal long CompensationForRetry { get; set; }
+
+        /// <summary>
+        /// The original TransferUtilityUploadRequest created by the user.
+        /// </summary>
+        public TransferUtilityUploadRequest Request { get; internal set; }
+    }
+
+    /// <summary>
+    /// Encapsulates the information needed when a transfer operation is initiated.
+    /// Provides access to the original request and total file size without any progress information.
+    /// </summary>
+    public class UploadInitiatedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the UploadInitiatedEventArgs class.
+        /// </summary>
+        /// <param name="request">The original TransferUtilityUploadRequest created by the user</param>
+        /// <param name="filePath">The file being uploaded</param>
+        /// <param name="totalBytes">The total number of bytes to be transferred</param>
+        internal UploadInitiatedEventArgs(TransferUtilityUploadRequest request, string filePath, long totalBytes)
+        {
+            Request = request;
+            FilePath = filePath;
+            TotalBytes = totalBytes;
+        }
+
+        /// <summary>
+        /// The original TransferUtilityUploadRequest created by the user.
+        /// Contains all the upload parameters and configuration.
+        /// </summary>
+        public TransferUtilityUploadRequest Request { get; private set; }
+
+        /// <summary>
+        /// Gets the file being uploaded.
+        /// </summary>
+        public string FilePath { get; private set; }
+
+        /// <summary>
+        /// Gets the total number of bytes to be transferred.
+        /// </summary>
+        public long TotalBytes { get; private set; }
+    }
+
+    /// <summary>
+    /// Encapsulates the information needed when a transfer operation completes successfully.
+    /// Provides access to the original request, final response, and completion details.
+    /// </summary>
+    public class UploadCompletedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the UploadCompletedEventArgs class.
+        /// </summary>
+        /// <param name="request">The original TransferUtilityUploadRequest created by the user</param>
+        /// <param name="response">The unified response from Transfer Utility</param>
+        /// <param name="filePath">The file being uploaded</param>
+        /// <param name="transferredBytes">The total number of bytes transferred</param>
+        /// <param name="totalBytes">The total number of bytes that were transferred (should equal transferredBytes for successful uploads).</param>
+        internal UploadCompletedEventArgs(TransferUtilityUploadRequest request, TransferUtilityUploadResponse response, string filePath, long transferredBytes, long totalBytes)
+        {
+            Request = request;
+            Response = response; 
+            FilePath = filePath;
+            TransferredBytes = transferredBytes;
+            TotalBytes = totalBytes;
+        }
+
+        /// <summary>
+        /// The original TransferUtilityUploadRequest created by the user.
+        /// Contains all the upload parameters and configuration.
+        /// </summary>
+        public TransferUtilityUploadRequest Request { get; private set; }
+
+        /// <summary>
+        /// The unified response from Transfer Utility after successful upload completion.
+        /// Contains mapped fields from either PutObjectResponse (simple uploads) or CompleteMultipartUploadResponse (multipart uploads).
+        /// </summary>
+        public TransferUtilityUploadResponse Response { get; private set; }
+
+        /// <summary>
+        /// Gets the file being uploaded.
+        /// </summary>
+        public string FilePath { get; private set; }
+
+        /// <summary>
+        /// Gets the total number of bytes that were successfully transferred.
+        /// </summary>
+        public long TransferredBytes { get; private set; }
+
+        /// <summary>
+        /// Gets the total number of bytes that were transferred (should equal TransferredBytes for successful uploads).
+        /// </summary>
+        public long TotalBytes { get; private set; }
+    }
+
+    /// <summary>
+    /// Encapsulates the information needed when a transfer operation fails.
+    /// Provides access to the original request and partial progress information.
+    /// </summary>
+    public class UploadFailedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the UploadFailedEventArgs class.
+        /// </summary>
+        /// <param name="request">The original TransferUtilityUploadRequest created by the user</param>
+        /// <param name="filePath">The file being uploaded</param>
+        /// <param name="transferredBytes">The number of bytes transferred before failure</param>
+        /// <param name="totalBytes">The total number of bytes that should have been transferred</param>
+        internal UploadFailedEventArgs(TransferUtilityUploadRequest request, string filePath, long transferredBytes, long totalBytes)
+        {
+            Request = request;
+            FilePath = filePath;
+            TransferredBytes = transferredBytes;
+            TotalBytes = totalBytes;
+        }
+
+        /// <summary>
+        /// The original TransferUtilityUploadRequest created by the user.
+        /// Contains all the upload parameters and configuration.
+        /// </summary>
+        public TransferUtilityUploadRequest Request { get; private set; }
+
+        /// <summary>
+        /// Gets the file being uploaded.
+        /// </summary>
+        public string FilePath { get; private set; }
+
+        /// <summary>
+        /// Gets the number of bytes that were transferred before the failure occurred.
+        /// </summary>
+        public long TransferredBytes { get; private set; }
+
+        /// <summary>
+        /// Gets the total number of bytes that should have been transferred.
+        /// </summary>
+        public long TotalBytes { get; private set; }
     }
 }

--- a/sdk/test/Services/S3/UnitTests/Custom/ResponseMapperTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/ResponseMapperTests.cs
@@ -165,7 +165,11 @@ namespace AWSSDK.UnitTests
                     var simpleUploadCommand = new SimpleUploadCommand(null, null, sourceRequest);
                     return simpleUploadCommand.ConstructRequest();
                 },
-                usesHeadersCollection: false);
+                usesHeadersCollection: false,
+                (sourceRequest) =>
+                {
+                    sourceRequest.InputStream = new MemoryStream(1024);
+                });
         }
 
         [TestMethod]


### PR DESCRIPTION
Stacked PRs:
 * #4064
 * #4063
 * #4062
 * #4061
 * #4060
 * __->__#4059


--- --- ---

## Description

This change adds progress listeners for "initiated", "complete", and "failed" lifecycle events for the SimpleUploadCommand (non multipart). Consumers can subscribe to these callbacks to receive notifications when a simple upload starts, finishes successfully, or fails. We will also make this change for multi part upload command here https://github.com/aws/aws-sdk-net/pull/4061

## Example usage
```
// Create a TransferUtilityUploadRequest
TransferUtilityUploadRequest request = new TransferUtilityUploadRequest();

// Subscribe to the progress events
request.UploadInitiatedEvent += Request_UploadInitiatedEvent;
request.UploadCompletedEvent += Request_UploadCompletedEvent;
request.UploadFailedEvent += Request_UploadFailedEvent;

// Use the Transfer Utility to upload the file
using (var transferUtility = new TransferUtility(s3Client))
{
    transferUtility.UploadAsync(request);
}

private void Request_UploadInitiatedEvent(object sender, UploadInitiatedEventArgs e)
{
    Console.WriteLine($"Upload initiated for file: {e.FilePath}");
    Console.WriteLine($"Total bytes to transfer: {e.TotalBytes}");
}

private void Request_UploadCompletedEvent(object sender, UploadCompletedEventArgs e)
{
    Console.WriteLine($"Upload completed for file: {e.FilePath}");
    Console.WriteLine($"Transferred bytes: {e.TransferredBytes}");
    Console.WriteLine($"ETag: {e.Response.ETag}");
    Console.WriteLine($"Version ID: {e.Response.VersionId}");
}

private void Request_UploadFailedEvent(object sender, UploadFailedEventArgs e)
{
    Console.WriteLine($"Upload failed for file: {e.FilePath}");
    Console.WriteLine($"Transferred bytes: {e.TransferredBytes} / {e.TotalBytes}");
}


```

## Motivation and Context
1. To adhere to the SEP

## Testing
1. 46a4bf17-39fd-41e9-b625-1fba1b49f5a4 - pass
2. Integration tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement