### PR TITLE
Add mapping of CompletemultipartUploadResponse to TransferUtilityUploadResponse

### DIFF
--- a/generator/.DevConfigs/433a9a6d-b8ea-4676-b763-70711e8288e6.json
+++ b/generator/.DevConfigs/433a9a6d-b8ea-4676-b763-70711e8288e6.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Added CompleteMultipartUploadResponse to TransferUtilityUploadResponse mapping"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/ResponseMapper.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/ResponseMapper.cs
@@ -99,6 +99,67 @@ namespace Amazon.S3.Transfer.Internal
 
             return response;
         }
+
+        /// <summary>
+        /// Maps a CompleteMultipartUploadResponse to TransferUtilityUploadResponse.
+        /// Uses the field mappings defined in mapping.json "Conversion" -> "CompleteMultipartResponse" -> "UploadResponse".
+        /// </summary>
+        /// <param name="source">The CompleteMultipartUploadResponse to map from</param>
+        /// <returns>A new TransferUtilityUploadResponse with mapped fields</returns>
+        internal static TransferUtilityUploadResponse MapCompleteMultipartUploadResponse(CompleteMultipartUploadResponse source)
+        {
+            if (source == null)
+                return null;
+
+            var response = new TransferUtilityUploadResponse();
+
+            // Map all fields as defined in mapping.json "Conversion" -> "CompleteMultipartResponse" -> "UploadResponse"
+            if (source.IsSetBucketKeyEnabled())
+                response.BucketKeyEnabled = source.BucketKeyEnabled.GetValueOrDefault();
+
+            if (source.IsSetChecksumCRC32())
+                response.ChecksumCRC32 = source.ChecksumCRC32;
+
+            if (source.IsSetChecksumCRC32C())
+                response.ChecksumCRC32C = source.ChecksumCRC32C;
+
+            if (source.IsSetChecksumCRC64NVME())
+                response.ChecksumCRC64NVME = source.ChecksumCRC64NVME;
+
+            if (source.IsSetChecksumSHA1())
+                response.ChecksumSHA1 = source.ChecksumSHA1;
+
+            if (source.IsSetChecksumSHA256())
+                response.ChecksumSHA256 = source.ChecksumSHA256;
+
+            if (source.ChecksumType != null)
+                response.ChecksumType = source.ChecksumType;
+
+            if (source.IsSetETag())
+                response.ETag = source.ETag;
+
+            if (source.Expiration != null)
+                response.Expiration = source.Expiration;
+
+            if (source.IsSetRequestCharged())
+                response.RequestCharged = source.RequestCharged;
+
+            if (source.ServerSideEncryptionMethod != null)
+                response.ServerSideEncryptionMethod = source.ServerSideEncryptionMethod;
+
+            if (source.IsSetServerSideEncryptionKeyManagementServiceKeyId())
+                response.ServerSideEncryptionKeyManagementServiceKeyId = source.ServerSideEncryptionKeyManagementServiceKeyId;
+
+            if (source.IsSetVersionId())
+                response.VersionId = source.VersionId;
+
+            // Copy response metadata
+            response.ResponseMetadata = source.ResponseMetadata;
+            response.ContentLength = source.ContentLength;
+            response.HttpStatusCode = source.HttpStatusCode;
+
+            return response;
+        }
         
     }
 }

--- a/sdk/test/Services/S3/UnitTests/Custom/EmbeddedResource/property-aliases.json
+++ b/sdk/test/Services/S3/UnitTests/Custom/EmbeddedResource/property-aliases.json
@@ -112,6 +112,10 @@
     },
     "AbortMultipartUploadRequest": {
       "Bucket": "BucketName"
+    },
+    "CompleteMultipartUploadResponse": {
+      "ServerSideEncryption": "ServerSideEncryptionMethod",
+      "SSEKMSKeyId": "ServerSideEncryptionKeyManagementServiceKeyId"
     }
   }
 }

--- a/sdk/test/Services/S3/UnitTests/Custom/ResponseMapperTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/ResponseMapperTests.cs
@@ -489,6 +489,56 @@ namespace AWSSDK.UnitTests
 
         [TestMethod]
         [TestCategory("S3")]
+        public void MapCompleteMultipartUploadResponse_AllMappedProperties_WorkCorrectly()
+        {
+            ValidateMappingTransferUtilityAndSdkRequests<CompleteMultipartUploadResponse, TransferUtilityUploadResponse>(
+                new[] { "Conversion", "CompleteMultipartResponse", "UploadResponse" },
+                (sourceResponse) =>
+                {
+                    return ResponseMapper.MapCompleteMultipartUploadResponse(sourceResponse);
+                },
+                usesHeadersCollection: false,
+                (sourceResponse) =>
+                {
+                    sourceResponse.HttpStatusCode = HttpStatusCode.OK;
+                    sourceResponse.ContentLength = 2048;
+                },
+                (sourceResponse, targetResponse) =>
+                {
+                    Assert.AreEqual(sourceResponse.HttpStatusCode, targetResponse.HttpStatusCode, "HttpStatusCode should match");
+                    Assert.AreEqual(sourceResponse.ContentLength, targetResponse.ContentLength, "ContentLength should match");
+                });
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void MapCompleteMultipartUploadResponse_NullValues_HandledCorrectly()
+        {
+            // Test null handling scenarios
+            var testCases = new[]
+            {
+                // Test null Expiration
+                new CompleteMultipartUploadResponse { Expiration = null },
+                
+                // Test null enum conversions
+                new CompleteMultipartUploadResponse { ChecksumType = null, RequestCharged = null, ServerSideEncryptionMethod = null }
+            };
+
+            foreach (var testCase in testCases)
+            {
+                var mapped = ResponseMapper.MapCompleteMultipartUploadResponse(testCase);
+                Assert.IsNotNull(mapped, "Response should always be mappable");
+
+                // Test null handling
+                if (testCase.Expiration == null)
+                {
+                    Assert.IsNull(mapped.Expiration, "Null Expiration should map to null");
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
         public void ValidateCompleteMultipartUploadResponseConversionCompleteness()
         {
             ValidateResponseDefinitionCompleteness<TransferUtilityUploadResponse>(


### PR DESCRIPTION
Stacked PRs:
 * #4064
 * #4063
 * #4062
 * #4061
 * __->__#4060


--- --- ---

## Description
This change adds a function to map the CompletemultipartUploadResponse to TransferUtilityUploadResponse. This is needed because we eventually need to return `TransferUtilityUploadResponse` as part of the progress listener for multi part upload here https://github.com/aws/aws-sdk-net/pull/4061


## Motivation and Context
1. DOTNET-8276

## Testing
1. Unit tests
2. 8338c01e-36d5-4617-b5af-b4a255e7c141 - pass


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement