### PR TITLE
Add multipartupload lifecycle tracking

### DIFF
--- a/generator/.DevConfigs/433a9a6d-b8ea-4676-b763-70711e8288e3.json
+++ b/generator/.DevConfigs/433a9a6d-b8ea-4676-b763-70711e8288e3.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "minor",
+      "changeLogMessages": [
+        "Added UploadInitiatedEvent, UploadCompletedEvent, and UploadFailedEvent for multipart uploads."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
@@ -375,8 +375,44 @@ namespace Amazon.S3.Transfer.Internal
             long transferredBytes = Interlocked.Add(ref _totalTransferredBytes, e.IncrementTransferred - e.CompensationForRetry);
 
             var progressArgs = new UploadProgressArgs(e.IncrementTransferred, transferredBytes, this._contentLength,
-                e.CompensationForRetry, this._fileTransporterRequest.FilePath);
+                e.CompensationForRetry, this._fileTransporterRequest.FilePath, this._fileTransporterRequest);
             this._fileTransporterRequest.OnRaiseProgressEvent(progressArgs);
+        }
+
+        private void FireTransferInitiatedEvent()
+        {
+            var initiatedArgs = new UploadInitiatedEventArgs(
+                request: _fileTransporterRequest,
+                totalBytes: _contentLength,
+                filePath: _fileTransporterRequest.FilePath
+            );
+            
+            _fileTransporterRequest.OnRaiseTransferInitiatedEvent(initiatedArgs);
+        }
+
+        private void FireTransferCompletedEvent(TransferUtilityUploadResponse response)
+        {
+            var completedArgs = new UploadCompletedEventArgs(
+                request: _fileTransporterRequest,
+                filePath: _fileTransporterRequest.FilePath,
+                response: response,
+                transferredBytes: Interlocked.Read(ref _totalTransferredBytes),
+                totalBytes: _contentLength
+            );
+            
+            _fileTransporterRequest.OnRaiseTransferCompletedEvent(completedArgs);
+        }
+
+        private void FireTransferFailedEvent()
+        {
+            var failedArgs = new UploadFailedEventArgs(
+                request: _fileTransporterRequest,
+                filePath: _fileTransporterRequest.FilePath,
+                transferredBytes: Interlocked.Read(ref _totalTransferredBytes),
+                totalBytes: _contentLength
+            );
+            
+            _fileTransporterRequest.OnRaiseTransferFailedEvent(failedArgs);
         }
 
         /// <summary>


### PR DESCRIPTION
Stacked PRs:
 * #4064
 * #4063
 * #4062
 * __->__#4061


--- --- ---

## Description

This change adds progress listeners for "initiated", "complete", and "failed" lifecycle events for the MultiUploadCommand. Consumers can subscribe to these callbacks to receive notifications when a simple upload starts, finishes successfully, or fails. this is similar to https://github.com/aws/aws-sdk-net/pull/4059 but for multi part upload command.

## Example usage
```
// Create a TransferUtilityUploadRequest
TransferUtilityUploadRequest request = new TransferUtilityUploadRequest();

// Subscribe to the progress events
request.UploadInitiatedEvent += Request_UploadInitiatedEvent;
request.UploadCompletedEvent += Request_UploadCompletedEvent;
request.UploadFailedEvent += Request_UploadFailedEvent;

// Use the Transfer Utility to upload the file
using (var transferUtility = new TransferUtility(s3Client))
{
    transferUtility.UploadAsync(request);
}

private void Request_UploadInitiatedEvent(object sender, UploadInitiatedEventArgs e)
{
    Console.WriteLine($"Upload initiated for file: {e.FilePath}");
    Console.WriteLine($"Total bytes to transfer: {e.TotalBytes}");
}

private void Request_UploadCompletedEvent(object sender, UploadCompletedEventArgs e)
{
    Console.WriteLine($"Upload completed for file: {e.FilePath}");
    Console.WriteLine($"Transferred bytes: {e.TransferredBytes}");
    Console.WriteLine($"ETag: {e.Response.ETag}");
    Console.WriteLine($"Version ID: {e.Response.VersionId}");
}

private void Request_UploadFailedEvent(object sender, UploadFailedEventArgs e)
{
    Console.WriteLine($"Upload failed for file: {e.FilePath}");
    Console.WriteLine($"Transferred bytes: {e.TransferredBytes} / {e.TotalBytes}");
}


```

## Motivation and Context
1. To adhere to the SEP

## Testing
1 .84f23e9a-f014-44a6-b129-5d10e7aea8d6 - pass
2. Integration tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement