### PR TITLE
Add DownloadResponse mapping

### DIFF
--- a/generator/.DevConfigs/7f23582e-3225-487b-83e7-167cf17cb231.json
+++ b/generator/.DevConfigs/7f23582e-3225-487b-83e7-167cf17cb231.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Add GetObjectResponse to TransferUtilityDownloadResponse mapping."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectResponseUnmarshaller.cs
@@ -89,6 +89,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                 response.ContentLanguage = S3Transforms.ToString(responseData.GetHeaderValue("Content-Language"));
             if (responseData.IsHeaderPresent("Content-Length"))
                 response.Headers.ContentLength = long.Parse(responseData.GetHeaderValue("Content-Length"), CultureInfo.InvariantCulture);
+                response.Headers.ContentLanguage = S3Transforms.ToString(responseData.GetHeaderValue("Content-Language"));
             if (responseData.IsHeaderPresent("x-amz-object-lock-legal-hold"))
                 response.ObjectLockLegalHoldStatus = S3Transforms.ToString(responseData.GetHeaderValue("x-amz-object-lock-legal-hold"));
             if (responseData.IsHeaderPresent("x-amz-object-lock-mode"))

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/ResponseMapper.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/ResponseMapper.cs
@@ -20,6 +20,7 @@
  *
  */
 
+using System.Collections.Generic;
 using Amazon.S3.Model;
 
 namespace Amazon.S3.Transfer.Internal
@@ -152,6 +153,127 @@ namespace Amazon.S3.Transfer.Internal
 
             if (source.IsSetVersionId())
                 response.VersionId = source.VersionId;
+
+            // Copy response metadata
+            response.ResponseMetadata = source.ResponseMetadata;
+            response.ContentLength = source.ContentLength;
+            response.HttpStatusCode = source.HttpStatusCode;
+
+            return response;
+        }
+
+        /// <summary>
+        /// Maps a GetObjectResponse to TransferUtilityDownloadResponse.
+        /// Uses the field mappings defined in mapping.json "Conversion" -> "GetObjectResponse" -> "DownloadResponse".
+        /// </summary>
+        /// <param name="source">The GetObjectResponse to map from</param>
+        /// <returns>A new TransferUtilityDownloadResponse with mapped fields</returns>
+        internal static TransferUtilityDownloadResponse MapGetObjectResponse(GetObjectResponse source)
+        {
+            if (source == null)
+                return null;
+
+            var response = new TransferUtilityDownloadResponse();
+
+            // Map all fields as defined in mapping.json "Conversion" -> "GetObjectResponse" -> "DownloadResponse"
+            if (source.IsSetAcceptRanges())
+                response.AcceptRanges = source.AcceptRanges;
+
+            if (source.IsSetBucketKeyEnabled())
+                response.BucketKeyEnabled = source.BucketKeyEnabled.GetValueOrDefault();
+
+            if (source.IsSetChecksumCRC32())
+                response.ChecksumCRC32 = source.ChecksumCRC32;
+
+            if (source.IsSetChecksumCRC32C())
+                response.ChecksumCRC32C = source.ChecksumCRC32C;
+
+            if (source.IsSetChecksumCRC64NVME())
+                response.ChecksumCRC64NVME = source.ChecksumCRC64NVME;
+
+            if (source.IsSetChecksumSHA1())
+                response.ChecksumSHA1 = source.ChecksumSHA1;
+
+            if (source.IsSetChecksumSHA256())
+                response.ChecksumSHA256 = source.ChecksumSHA256;
+
+            if (source.IsSetChecksumType())
+                response.ChecksumType = source.ChecksumType;
+
+            response.ContentLength = source.ContentLength;
+
+            if (source.IsSetContentRange())
+                response.ContentRange = source.ContentRange;
+
+            response.Headers = source.Headers;
+
+            if (source.IsSetDeleteMarker())
+                response.DeleteMarker = source.DeleteMarker;
+
+            if (source.IsSetETag())
+                response.ETag = source.ETag;
+
+            if (source.Expiration != null)
+                response.Expiration = source.Expiration;
+
+            if (source.ExpiresString != null)
+                response.ExpiresString = source.ExpiresString;
+
+            if (source.IsSetLastModified())
+                response.LastModified = source.LastModified;
+
+            if (source.Metadata != null)
+                response.Metadata = source.Metadata;
+
+            if (source.IsSetMissingMeta())
+                response.MissingMeta = source.MissingMeta;
+
+            if (source.IsSetObjectLockLegalHoldStatus())
+                response.ObjectLockLegalHoldStatus = source.ObjectLockLegalHoldStatus;
+
+            if (source.IsSetObjectLockMode())
+                response.ObjectLockMode = source.ObjectLockMode;
+
+            if (source.IsSetObjectLockRetainUntilDate())
+                response.ObjectLockRetainUntilDate = source.ObjectLockRetainUntilDate;
+
+            if (source.IsSetPartsCount())
+                response.PartsCount = source.PartsCount;
+
+            if (source.IsSetReplicationStatus())
+                response.ReplicationStatus = source.ReplicationStatus;
+
+            if (source.IsSetRequestCharged())
+                response.RequestCharged = source.RequestCharged;
+
+            if (source.RestoreExpiration.HasValue)
+                response.RestoreExpiration = source.RestoreExpiration;
+
+            if (source.RestoreInProgress.HasValue)
+                response.RestoreInProgress = source.RestoreInProgress;
+
+            if (source.ServerSideEncryptionCustomerMethod != null)
+                response.ServerSideEncryptionCustomerMethod = source.ServerSideEncryptionCustomerMethod;
+
+            if (source.ServerSideEncryptionCustomerProvidedKeyMD5 != null)
+                response.ServerSideEncryptionCustomerProvidedKeyMD5 = source.ServerSideEncryptionCustomerProvidedKeyMD5;
+
+            if (source.IsSetServerSideEncryptionKeyManagementServiceKeyId())
+                response.ServerSideEncryptionKeyManagementServiceKeyId = source.ServerSideEncryptionKeyManagementServiceKeyId;
+
+            if (source.IsSetServerSideEncryptionMethod())
+                response.ServerSideEncryptionMethod = source.ServerSideEncryptionMethod;
+
+            if (source.IsSetStorageClass())
+                response.StorageClass = source.StorageClass;
+
+            response.TagCount = source.TagCount;
+
+            if (source.IsSetVersionId())
+                response.VersionId = source.VersionId;
+
+            if (source.IsSetWebsiteRedirectLocation())
+                response.WebsiteRedirectLocation = source.WebsiteRedirectLocation;
 
             // Copy response metadata
             response.ResponseMetadata = source.ResponseMetadata;

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadResponse.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadResponse.cs
@@ -1,0 +1,293 @@
+/*******************************************************************************
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License. A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file.
+ *  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ * *****************************************************************************
+ *    __  _    _  ___
+ *   (  )( \/\/ )/ __)
+ *   /__\ \    / \__ \
+ *  (_)(_) \/\/  (___/
+ *
+ *  AWS SDK for .NET
+ *  API Version: 2006-03-01
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using Amazon.Runtime;
+using Amazon.S3.Model;
+
+namespace Amazon.S3.Transfer
+{
+    /// <summary>
+    /// Response object for Transfer Utility download operations.
+    /// Contains response metadata from download operations.
+    /// </summary>
+    public class TransferUtilityDownloadResponse : AmazonWebServiceResponse
+    {
+        /// <summary>
+        /// Gets and sets the AcceptRanges property.
+        /// </summary>
+        public string AcceptRanges { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property BucketKeyEnabled. 
+        /// <para>
+        /// Indicates whether the object uses an S3 Bucket Key for server-side encryption with
+        /// Amazon Web Services KMS (SSE-KMS).
+        /// </para>
+        /// </summary>
+        public bool? BucketKeyEnabled { get; set; }
+
+        /// <summary>
+        /// The collection of headers for the response.
+        /// </summary>
+        public HeadersCollection Headers { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ChecksumCRC32. 
+        /// <para>
+        /// The Base64 encoded, 32-bit CRC-32 checksum of the object.
+        /// </para>
+        /// </summary>
+        public string ChecksumCRC32 { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ChecksumCRC32C. 
+        /// <para>
+        /// The Base64 encoded, 32-bit CRC-32C checksum of the object.
+        /// </para>
+        /// </summary>
+        public string ChecksumCRC32C { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ChecksumCRC64NVME. 
+        /// <para>
+        /// The Base64 encoded, 64-bit CRC-64NVME checksum of the object.
+        /// </para>
+        /// </summary>
+        public string ChecksumCRC64NVME { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ChecksumSHA1. 
+        /// <para>
+        /// The Base64 encoded, 160-bit SHA-1 digest of the object.
+        /// </para>
+        /// </summary>
+        public string ChecksumSHA1 { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ChecksumSHA256. 
+        /// <para>
+        /// The Base64 encoded, 256-bit SHA-256 checksum of the object.
+        /// </para>
+        /// </summary>
+        public string ChecksumSHA256 { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ChecksumType. 
+        /// <para>
+        /// The checksum type used to calculate the object-level checksum.
+        /// </para>
+        /// </summary>
+        public ChecksumType ChecksumType { get; set; }
+
+        /// <summary>
+        /// Gets and sets the ContentRange property.
+        /// </summary>
+        public string ContentRange { get; set; }
+
+        /// <summary>
+        /// Gets and sets the DeleteMarker property.
+        /// <para>
+        /// Specifies whether the object retrieved was (true) or was not (false) a Delete Marker.
+        /// </para>
+        /// </summary>
+        public string DeleteMarker { get; set; }
+
+        /// <summary>
+        /// Gets and sets the ETag property.
+        /// <para>
+        /// An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL.
+        /// </para>
+        /// </summary>
+        public string ETag { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property Expiration. 
+        /// <para>
+        /// If the object expiration is configured, this will contain the expiration date and rule ID.
+        /// </para>
+        /// </summary>
+        public Expiration Expiration { get; set; }
+
+        /// <summary>
+        /// Gets and sets the ExpiresString property.
+        /// <para>
+        /// The date and time at which the object is no longer cacheable (string format).
+        /// </para>
+        /// </summary>
+        public string ExpiresString { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property LastModified. 
+        /// <para>
+        /// Date and time when the object was last modified.
+        /// </para>
+        /// </summary>
+        public DateTime? LastModified { get; set; }
+
+        /// <summary>
+        /// Gets and sets the Metadata property.
+        /// <para>
+        /// The collection of metadata for the object.
+        /// </para>
+        /// </summary>
+        public MetadataCollection Metadata { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property MissingMeta. 
+        /// <para>
+        /// This is set to the number of metadata entries not returned in the headers that are
+        /// prefixed with x-amz-meta-.
+        /// </para>
+        /// </summary>
+        public int? MissingMeta { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ObjectLockLegalHoldStatus. 
+        /// <para>
+        /// Indicates whether this object has an active legal hold.
+        /// </para>
+        /// </summary>
+        public ObjectLockLegalHoldStatus ObjectLockLegalHoldStatus { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ObjectLockMode. 
+        /// <para>
+        /// The Object Lock mode that's currently in place for this object.
+        /// </para>
+        /// </summary>
+        public ObjectLockMode ObjectLockMode { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ObjectLockRetainUntilDate. 
+        /// <para>
+        /// The date and time when this object's Object Lock will expire.
+        /// </para>
+        /// </summary>
+        public DateTime? ObjectLockRetainUntilDate { get; set; }
+
+        /// <summary>
+        /// Gets and sets the PartsCount property.
+        /// <para>
+        /// The number of parts this object has.
+        /// </para>
+        /// </summary>
+        public int? PartsCount { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property ReplicationStatus. 
+        /// <para>
+        /// Amazon S3 can return this if your request involves a bucket that is either a source
+        /// or destination in a replication rule.
+        /// </para>
+        /// </summary>
+        public ReplicationStatus ReplicationStatus { get; set; }
+
+        /// <summary>
+        /// Gets and sets the RequestCharged property.
+        /// <para>
+        /// If present, indicates that the requester was successfully charged for the request.
+        /// </para>
+        /// </summary>
+        public RequestCharged RequestCharged { get; set; }
+
+        /// <summary>
+        /// Gets and sets the RestoreExpiration property.
+        /// <para>
+        /// RestoreExpiration will be set for objects that have been restored from Amazon Glacier.
+        /// It indicates for those objects how long the restored object will exist.
+        /// </para>
+        /// </summary>
+        public DateTime? RestoreExpiration { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool? RestoreInProgress { get; set; }
+
+        /// <summary>
+        /// Gets and sets the ServerSideEncryptionCustomerMethod property.
+        /// <para>
+        /// The server-side encryption algorithm to be used with the customer provided key.
+        /// </para>
+        /// </summary>
+        public ServerSideEncryptionCustomerMethod ServerSideEncryptionCustomerMethod { get; set; }
+
+        /// <summary>
+        /// Gets and sets the ServerSideEncryptionCustomerProvidedKeyMD5 property.
+        /// <para>
+        /// The MD5 server-side encryption of the customer-provided encryption key.
+        /// </para>
+        /// </summary>
+        public string ServerSideEncryptionCustomerProvidedKeyMD5 { get; set; }
+
+        /// <summary>
+        /// Gets and sets the ServerSideEncryptionKeyManagementServiceKeyId property.
+        /// <para>
+        /// If present, indicates the ID of the KMS key that was used for object encryption.
+        /// </para>
+        /// </summary>
+        public string ServerSideEncryptionKeyManagementServiceKeyId { get; set; }
+
+        /// <summary>
+        /// Gets and sets the ServerSideEncryptionMethod property.
+        /// <para>
+        /// The server-side encryption algorithm used when you store this object in Amazon S3.
+        /// </para>
+        /// </summary>
+        public ServerSideEncryptionMethod ServerSideEncryptionMethod { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property StorageClass. 
+        /// <para>
+        /// Provides storage class information of the object.
+        /// </para>
+        /// </summary>
+        public S3StorageClass StorageClass { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property TagCount. 
+        /// <para>
+        /// The number of tags, if any, on the object.
+        /// </para>
+        /// </summary>
+        public int TagCount { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property VersionId. 
+        /// <para>
+        /// Version ID of the object.
+        /// </para>
+        /// </summary>
+        public string VersionId { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property WebsiteRedirectLocation. 
+        /// <para>
+        /// If the bucket is configured as a website, redirects requests for this object to another
+        /// object in the same bucket or to an external URL.
+        /// </para>
+        /// </summary>
+        public string WebsiteRedirectLocation { get; set; }
+    }
+}

--- a/sdk/test/Services/S3/UnitTests/Custom/EmbeddedResource/property-aliases.json
+++ b/sdk/test/Services/S3/UnitTests/Custom/EmbeddedResource/property-aliases.json
@@ -116,6 +116,20 @@
     "CompleteMultipartUploadResponse": {
       "ServerSideEncryption": "ServerSideEncryptionMethod",
       "SSEKMSKeyId": "ServerSideEncryptionKeyManagementServiceKeyId"
+    },
+    "GetObjectResponse": {
+      "SSECustomerAlgorithm": "ServerSideEncryptionCustomerMethod",
+      "SSECustomerKeyMD5": "ServerSideEncryptionCustomerProvidedKeyMD5", 
+      "SSEKMSKeyId": "ServerSideEncryptionKeyManagementServiceKeyId",
+      "ServerSideEncryption": "ServerSideEncryptionMethod",
+      "Restore": "RestoreExpiration"
+    },
+    "TransferUtilityDownloadResponse": {
+      "SSECustomerAlgorithm": "ServerSideEncryptionCustomerMethod",
+      "SSECustomerKeyMD5": "ServerSideEncryptionCustomerProvidedKeyMD5",
+      "SSEKMSKeyId": "ServerSideEncryptionKeyManagementServiceKeyId", 
+      "ServerSideEncryption": "ServerSideEncryptionMethod",
+      "Restore": "RestoreExpiration"
     }
   }
 }


### PR DESCRIPTION
Stacked PRs:
 * #4062
 * #4064
 * __->__#4063


--- --- ---
## Description
This change adds a function to map the GetObjectResponse to TransferUtilityDownloadResponse. 


## Motivation and Context
1. DOTNET-8280

## Testing
1. Unit tests
2.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement