### PR TITLE
fix silently failing test

### DIFF
--- a/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
@@ -909,7 +909,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                     Assert.IsNotNull(args.Request);
                     Assert.IsNotNull(args.Response);
                     Assert.AreEqual(-1, args.TotalBytes); // Unseekable streams have unknown length
-                    Assert.AreEqual(20 * MEG_SIZE, args.TransferredBytes); // since we know the actual length via testing it, we can check the transferredbytes size
+                    Assert.AreEqual(0, args.TransferredBytes); // unseekable streams we dont attach and progress listeners so we wont have transferredbytes.
                 }
             };
             UploadUnseekableStreamWithLifecycleEvents(20 * MEG_SIZE, null, eventValidator, null);
@@ -964,7 +964,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                     Assert.IsNotNull(args.Request);
                     Assert.IsNotNull(args.Response);
                     Assert.AreEqual(-1, args.TotalBytes); // Unseekable streams have unknown length
-                    Assert.AreEqual(18 * MEG_SIZE, args.TransferredBytes); // Should have transferred all bytes
+                    Assert.AreEqual(0, args.TransferredBytes); // unseekable streams we dont attach and progress listeners so we wont have transferredbytes.
                 }
             };
 
@@ -1758,15 +1758,16 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             {
                 try
                 {
-                    EventFired = true;
                     Console.WriteLine("Lifecycle Event Fired: {0}", typeof(T).Name);
                     Validate?.Invoke(eventArgs);
+                    EventFired = true;  // Only set if validation passes
                 }
                 catch (Exception ex)
                 {
                     EventException = ex;
+                    EventFired = false;  // Ensure we don't mark as fired on failure
                     Console.WriteLine("Exception caught in lifecycle event: {0}", ex.Message);
-                    throw;
+                    // Don't re-throw, let AssertEventFired() handle it
                 }
             }
 


### PR DESCRIPTION
Fix silently failing test. the logic in OnEventFired was wrong. it was throwing exception but not failing the test. there was 2 test cases not working related to unseekable streams. the issue was i was expecting transferred bytes to set for unseekable streams but in reality we dont set it (https://github.com/aws/aws-sdk-net/blob/3179a71b8f242c7a6177387c9f93752f71821a93/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs#L283). so this updates the test case to expect 0 bytes for these cases for transferredbytes.

Probably we can come back to this logic in multipartupload in the future, im not sure why transferredbytes wouldnt be able to be calculated?


## Motivation and Context
fix integ test

## Testing
ran test locally


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement