### PR TITLE
Add DownloadInitiated, Failed and Completed events

### DIFF
--- a/generator/.DevConfigs/9d07dc1e-d82d-4f94-8700-c7b57f872123.json
+++ b/generator/.DevConfigs/9d07dc1e-d82d-4f94-8700-c7b57f872123.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "minor",
+      "changeLogMessages": [
+      "Added DownloadInitiatedEvent, DownloadCompletedEvent, and DownloadFailedEvent for TransferUtility Download."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/GetObjectResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectResponse.cs
@@ -25,6 +25,7 @@ using System.Globalization;
 using Amazon.S3.Model.Internal.MarshallTransformations;
 using Amazon.S3;
 using Amazon.Runtime.Internal;
+using Amazon.S3.Transfer;
 
 namespace Amazon.S3.Model
 {
@@ -1042,5 +1043,10 @@ namespace Amazon.S3.Model
         /// True if writing is complete
         /// </summary>
         public bool IsCompleted { get; private set; }
+
+        /// <summary>
+        /// The original TransferUtilityDownloadRequest created by the user.
+        /// </summary>
+        public TransferUtilityDownloadRequest Request { get; internal set; }
     }  
 }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadCommand.cs
@@ -62,6 +62,34 @@ namespace Amazon.S3.Transfer.Internal
 
         IAmazonS3 _s3Client;
         TransferUtilityDownloadRequest _request;
+        long _totalTransferredBytes;
+
+        #region Event Firing Methods
+
+        private void FireTransferInitiatedEvent()
+        {
+            var transferInitiatedEventArgs = new DownloadInitiatedEventArgs(_request, _request.FilePath);
+            _request.OnRaiseTransferInitiatedEvent(transferInitiatedEventArgs);
+        }
+
+        private void FireTransferCompletedEvent(TransferUtilityDownloadResponse response, string filePath, long transferredBytes, long totalBytes)
+        {
+            var transferCompletedEventArgs = new DownloadCompletedEventArgs(
+                _request, 
+                response, 
+                filePath, 
+                transferredBytes, 
+                totalBytes);
+            _request.OnRaiseTransferCompletedEvent(transferCompletedEventArgs);
+        }
+
+        private void FireTransferFailedEvent(string filePath, long transferredBytes, long totalBytes = -1)
+        {
+            var eventArgs = new DownloadFailedEventArgs(this._request, filePath, transferredBytes, totalBytes);
+            this._request.OnRaiseTransferFailedEvent(eventArgs);
+        }
+
+        #endregion
 
         internal DownloadCommand(IAmazonS3 s3Client, TransferUtilityDownloadRequest request)
         {
@@ -89,6 +117,12 @@ namespace Amazon.S3.Transfer.Internal
 
         void OnWriteObjectProgressEvent(object sender, WriteObjectProgressArgs e)
         {
+            // Keep track of the total transferred bytes so that we can also return this value in case of failure
+            Interlocked.Add(ref _totalTransferredBytes, e.IncrementTransferred);
+            
+            // Set the Request property to enable access to the original download request
+            e.Request = this._request;
+            
             this._request.OnRaiseProgressEvent(e);
         }
 

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/DownloadCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/DownloadCommand.async.cs
@@ -33,12 +33,17 @@ namespace Amazon.S3.Transfer.Internal
         public override async Task<TransferUtilityDownloadResponse> ExecuteAsync(CancellationToken cancellationToken)
         {
             ValidateRequest();
+            
+            FireTransferInitiatedEvent();
+            
             GetObjectRequest getRequest = ConvertToGetObjectRequest(this._request);
 
             var maxRetries = _s3Client.Config.MaxErrorRetry;
             var retries = 0;
             bool shouldRetry = false;
             string mostRecentETag = null;
+            TransferUtilityDownloadResponse lastSuccessfulMappedResponse = null;
+            long? totalBytesFromResponse = null; // Track total bytes once we have response headers
             do
             {
                 shouldRetry = false;
@@ -54,12 +59,16 @@ namespace Amazon.S3.Transfer.Internal
                     using (var response = await this._s3Client.GetObjectAsync(getRequest, cancellationToken)
                         .ConfigureAwait(continueOnCapturedContext: false))
                     {
+                        // Capture total bytes from response headers as soon as we get them
+                        totalBytesFromResponse = response.ContentLength;
+
                         if (!string.IsNullOrEmpty(mostRecentETag) && !string.Equals(mostRecentETag, response.ETag))
                         {
                             //if the eTag changed, we need to retry from the start of the file
                             mostRecentETag = response.ETag;
                             getRequest.ByteRange = null;
                             retries = 0;
+                            Interlocked.Exchange(ref _totalTransferredBytes, 0);
                             shouldRetry = true;
                             WaitBeforeRetry(retries);
                             continue;
@@ -101,6 +110,8 @@ namespace Amazon.S3.Transfer.Internal
                             await response.WriteResponseStreamToFileAsync(this._request.FilePath, true, cancellationToken)
                                 .ConfigureAwait(continueOnCapturedContext: false);
                         }
+
+                        lastSuccessfulMappedResponse = ResponseMapper.MapGetObjectResponse(response);
                     }
                 }
                 catch (Exception exception)
@@ -109,6 +120,9 @@ namespace Amazon.S3.Transfer.Internal
                     shouldRetry = HandleExceptionForHttpClient(exception, retries, maxRetries);
                     if (!shouldRetry)
                     {
+                        // Pass total bytes if we have them from response headers, otherwise -1 for unknown
+                        FireTransferFailedEvent(this._request.FilePath, Interlocked.Read(ref _totalTransferredBytes), totalBytesFromResponse ?? -1);
+
                         if (exception is IOException)
                         {
                             throw;
@@ -130,9 +144,16 @@ namespace Amazon.S3.Transfer.Internal
                 }
                 WaitBeforeRetry(retries);
             } while (shouldRetry);
+            
+            // This should never happen under normal logic flow since we always throw exception on error.
+            if (lastSuccessfulMappedResponse == null)
+            {
+                throw new InvalidOperationException("Download completed without any successful response. This indicates a logical error in the retry handling.");
+            }
 
-            // TODO map and return response
-            return new TransferUtilityDownloadResponse();
+            FireTransferCompletedEvent(lastSuccessfulMappedResponse, this._request.FilePath, Interlocked.Read(ref _totalTransferredBytes), totalBytesFromResponse ?? -1);
+
+            return lastSuccessfulMappedResponse;
         }
 
         private static bool HandleExceptionForHttpClient(Exception exception, int retries, int maxRetries)

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadRequest.cs
@@ -90,5 +90,254 @@ namespace Amazon.S3.Transfer
         {
             AWSSDKUtils.InvokeInBackground(WriteObjectProgressEvent, progressArgs, this);
         }
+
+        /// <summary>
+        /// The event for DownloadInitiatedEvent notifications. All
+        /// subscribers will be notified when a download transfer operation
+        /// starts.
+        /// <para>
+        /// The DownloadInitiatedEvent is fired exactly once when 
+        /// a download transfer operation begins. The delegates attached to the event 
+        /// will be passed information about the download request and 
+        /// file path, but no progress information.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Subscribe to this event if you want to receive
+        /// DownloadInitiatedEvent notifications. Here is how:<br />
+        /// 1. Define a method with a signature similar to this one:
+        /// <code>
+        /// private void downloadStarted(object sender, DownloadInitiatedEventArgs args)
+        /// {
+        ///     Console.WriteLine($"Download started: {args.FilePath}");
+        ///     Console.WriteLine($"Bucket: {args.Request.BucketName}");
+        ///     Console.WriteLine($"Key: {args.Request.Key}");
+        /// }
+        /// </code>
+        /// 2. Add this method to the DownloadInitiatedEvent delegate's invocation list
+        /// <code>
+        /// TransferUtilityDownloadRequest request = new TransferUtilityDownloadRequest();
+        /// request.DownloadInitiatedEvent += downloadStarted;
+        /// </code>
+        /// </remarks>
+        public event EventHandler<DownloadInitiatedEventArgs> DownloadInitiatedEvent;
+
+        /// <summary>
+        /// The event for DownloadCompletedEvent notifications. All
+        /// subscribers will be notified when a download transfer operation
+        /// completes successfully.
+        /// <para>
+        /// The DownloadCompletedEvent is fired exactly once when 
+        /// a download transfer operation completes successfully. The delegates attached to the event 
+        /// will be passed information about the completed download including
+        /// the final response from S3 with ETag, VersionId, and other metadata.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Subscribe to this event if you want to receive
+        /// DownloadCompletedEvent notifications. Here is how:<br />
+        /// 1. Define a method with a signature similar to this one:
+        /// <code>
+        /// private void downloadCompleted(object sender, DownloadCompletedEventArgs args)
+        /// {
+        ///     Console.WriteLine($"Download completed: {args.FilePath}");
+        ///     Console.WriteLine($"Transferred: {args.TransferredBytes} bytes");
+        ///     Console.WriteLine($"ETag: {args.Response.ETag}");
+        ///     Console.WriteLine($"S3 Key: {args.Response.Key}");
+        ///     Console.WriteLine($"Version ID: {args.Response.VersionId}");
+        /// }
+        /// </code>
+        /// 2. Add this method to the DownloadCompletedEvent delegate's invocation list
+        /// <code>
+        /// TransferUtilityDownloadRequest request = new TransferUtilityDownloadRequest();
+        /// request.DownloadCompletedEvent += downloadCompleted;
+        /// </code>
+        /// </remarks>
+        public event EventHandler<DownloadCompletedEventArgs> DownloadCompletedEvent;
+
+        /// <summary>
+        /// The event for DownloadFailedEvent notifications. All
+        /// subscribers will be notified when a download transfer operation
+        /// fails.
+        /// <para>
+        /// The DownloadFailedEvent is fired exactly once when 
+        /// a download transfer operation fails. The delegates attached to the event 
+        /// will be passed information about the failed download including
+        /// partial progress information, but no response data since the download failed.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Subscribe to this event if you want to receive
+        /// DownloadFailedEvent notifications. Here is how:<br />
+        /// 1. Define a method with a signature similar to this one:
+        /// <code>
+        /// private void downloadFailed(object sender, DownloadFailedEventArgs args)
+        /// {
+        ///     Console.WriteLine($"Download failed: {args.FilePath}");
+        ///     Console.WriteLine($"Partial progress: {args.TransferredBytes} bytes");
+        ///     Console.WriteLine($"Bucket: {args.Request.BucketName}");
+        ///     Console.WriteLine($"Key: {args.Request.Key}");
+        /// }
+        /// </code>
+        /// 2. Add this method to the DownloadFailedEvent delegate's invocation list
+        /// <code>
+        /// TransferUtilityDownloadRequest request = new TransferUtilityDownloadRequest();
+        /// request.DownloadFailedEvent += downloadFailed;
+        /// </code>
+        /// </remarks>
+        public event EventHandler<DownloadFailedEventArgs> DownloadFailedEvent;
+
+        /// <summary>
+        /// Causes the DownloadInitiatedEvent event to be fired.
+        /// </summary>
+        /// <param name="args">DownloadInitiatedEventArgs args</param>
+        internal void OnRaiseTransferInitiatedEvent(DownloadInitiatedEventArgs args)
+        {
+            AWSSDKUtils.InvokeInBackground(DownloadInitiatedEvent, args, this);
+        }
+
+        /// <summary>
+        /// Causes the DownloadCompletedEvent event to be fired.
+        /// </summary>
+        /// <param name="args">DownloadCompletedEventArgs args</param>
+        internal void OnRaiseTransferCompletedEvent(DownloadCompletedEventArgs args)
+        {
+            AWSSDKUtils.InvokeInBackground(DownloadCompletedEvent, args, this);
+        }
+
+        /// <summary>
+        /// Causes the DownloadFailedEvent event to be fired.
+        /// </summary>
+        /// <param name="args">DownloadFailedEventArgs args</param>
+        internal void OnRaiseTransferFailedEvent(DownloadFailedEventArgs args)
+        {
+            AWSSDKUtils.InvokeInBackground(DownloadFailedEvent, args, this);
+        }
+    }
+
+    /// <summary>
+    /// Encapsulates the information needed when a download transfer operation is initiated.
+    /// Provides access to the original request without progress or total byte information.
+    /// </summary>
+    public class DownloadInitiatedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the DownloadInitiatedEventArgs class.
+        /// </summary>
+        /// <param name="request">The original TransferUtilityDownloadRequest created by the user</param>
+        /// <param name="filePath">The file being downloaded</param>
+        internal DownloadInitiatedEventArgs(TransferUtilityDownloadRequest request, string filePath)
+        {
+            Request = request;
+            FilePath = filePath;
+        }
+
+        /// <summary>
+        /// The original TransferUtilityDownloadRequest created by the user.
+        /// Contains all the download parameters and configuration.
+        /// </summary>
+        public TransferUtilityDownloadRequest Request { get; private set; }
+
+        /// <summary>
+        /// Gets the file being downloaded.
+        /// </summary>
+        public string FilePath { get; private set; }
+    }
+
+    /// <summary>
+    /// Encapsulates the information needed when a download transfer operation completes successfully.
+    /// Provides access to the original request, final response, and completion details.
+    /// </summary>
+    public class DownloadCompletedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the DownloadCompletedEventArgs class.
+        /// </summary>
+        /// <param name="request">The original TransferUtilityDownloadRequest created by the user</param>
+        /// <param name="response">The unified response from Transfer Utility</param>
+        /// <param name="filePath">The file being downloaded</param>
+        /// <param name="transferredBytes">The total number of bytes transferred</param>
+        /// <param name="totalBytes">The total number of bytes for the complete file</param>
+        internal DownloadCompletedEventArgs(TransferUtilityDownloadRequest request, TransferUtilityDownloadResponse response, string filePath, long transferredBytes, long totalBytes)
+        {
+            Request = request;
+            Response = response; 
+            FilePath = filePath;
+            TransferredBytes = transferredBytes;
+            TotalBytes = totalBytes;
+        }
+
+        /// <summary>
+        /// The original TransferUtilityDownloadRequest created by the user.
+        /// Contains all the download parameters and configuration.
+        /// </summary>
+        public TransferUtilityDownloadRequest Request { get; private set; }
+
+        /// <summary>
+        /// The unified response from Transfer Utility after successful download completion.
+        /// Contains mapped fields from GetObjectResponse.
+        /// </summary>
+        public TransferUtilityDownloadResponse Response { get; private set; }
+
+        /// <summary>
+        /// Gets the file being downloaded.
+        /// </summary>
+        public string FilePath { get; private set; }
+
+        /// <summary>
+        /// Gets the total number of bytes that were successfully transferred.
+        /// </summary>
+        public long TransferredBytes { get; private set; }
+
+        /// <summary>
+        /// Gets the total number of bytes for the complete file.
+        /// </summary>
+        public long TotalBytes { get; private set; }
+    }
+
+    /// <summary>
+    /// Encapsulates the information needed when a download transfer operation fails.
+    /// Provides access to the original request and partial progress information.
+    /// </summary>
+    public class DownloadFailedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the DownloadFailedEventArgs class.
+        /// </summary>
+        /// <param name="request">The original TransferUtilityDownloadRequest created by the user</param>
+        /// <param name="filePath">The file being downloaded</param>
+        /// <param name="transferredBytes">The number of bytes transferred before failure</param>
+        /// <param name="totalBytes">The total number of bytes for the complete file, or -1 if unknown</param>
+        internal DownloadFailedEventArgs(TransferUtilityDownloadRequest request, string filePath, long transferredBytes, long totalBytes)
+        {
+            Request = request;
+            FilePath = filePath;
+            TransferredBytes = transferredBytes;
+            TotalBytes = totalBytes;
+        }
+
+        /// <summary>
+        /// The original TransferUtilityDownloadRequest created by the user.
+        /// Contains all the download parameters and configuration.
+        /// </summary>
+        public TransferUtilityDownloadRequest Request { get; private set; }
+
+        /// <summary>
+        /// Gets the file being downloaded.
+        /// </summary>
+        public string FilePath { get; private set; }
+
+        /// <summary>
+        /// Gets the number of bytes that were transferred before the failure occurred.
+        /// </summary>
+        public long TransferredBytes { get; private set; }
+
+        /// <summary>
+        /// Gets the total number of bytes for the complete file, or -1 if unknown.
+        /// This will be -1 for failures that occur before receiving the GetObjectResponse 
+        /// (e.g., authentication errors, non-existent objects), and will contain the actual 
+        /// file size for failures that occur after receiving response headers (e.g., disk full).
+        /// </summary>
+        public long TotalBytes { get; private set; }
     }
 }


### PR DESCRIPTION
Stacked PRs:
 * #4109
 * __->__#4079


--- --- ---

## Description

This change adds progress listeners for "initiated", "complete", and "failed" lifecycle events for the DownloadCommand Consumers can subscribe to these callbacks to receive notifications when a simple upload starts, finishes successfully, or fails. Its similar to https://github.com/aws/aws-sdk-net/pull/4059 but for downloads


## Motivation and Context
1. To adhere to the SEP

## Testing
1. `f0cb4050-fb2c-4fb0-b489-280eb3313ca9` - pass
2. Integration tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement