### PR TITLE
Remove trailing slash in x-amz-credential for s3 presigned post

### DIFF
--- a/generator/.DevConfigs/83a796ab-97eb-4d84-9814-93186db001fe.json
+++ b/generator/.DevConfigs/83a796ab-97eb-4d84-9814-93186db001fe.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Remove trailing slash in x-amz-credential for presigned post"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Util/S3PostUploadSignedPolicy.cs
+++ b/sdk/src/Services/S3/Custom/Util/S3PostUploadSignedPolicy.cs
@@ -120,7 +120,7 @@ namespace Amazon.S3.Util
             var algorithm = "AWS4-HMAC-SHA256";
             var dateStamp = Runtime.Internal.Auth.AWS4Signer.FormatDateTime(signedAt, AWSSDKUtils.ISO8601BasicDateFormat);
             var dateTimeStamp = Runtime.Internal.Auth.AWS4Signer.FormatDateTime(signedAt, AWSSDKUtils.ISO8601BasicDateTimeFormat);
-            var credentialString = string.Format(CultureInfo.InvariantCulture, "{0}/{1}/{2}/{3}/{4}/", iCreds.AccessKey, dateStamp, region, "s3", Runtime.Internal.Auth.AWS4Signer.Terminator);
+            var credentialString = string.Format(CultureInfo.InvariantCulture, "{0}/{1}/{2}/{3}/{4}", iCreds.AccessKey, dateStamp, region, "s3", Runtime.Internal.Auth.AWS4Signer.Terminator);
 
             Dictionary<string, string> extraConditions = new Dictionary<string, string> {
                 { S3Constants.PostFormDataXAmzCredential, credentialString },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes issue #4069 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

Removes trailing slash from `x-amz-credential`. We do this for normal SigV4 signing, looks like we just added a trailing slash unintentionally when implementing signing for presigned post.
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Dry-run 66bf4a77-4329-4dc2-8282-947345459739  in progress.
I didn't add additional tests because we already have so many for presigned post. I'm making the assumption that if those pass then we are covered.
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement