### PR TITLE
Remove isset/null checks from response mapper

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/ResponseMapper.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/ResponseMapper.cs
@@ -44,53 +44,22 @@ namespace Amazon.S3.Transfer.Internal
             var response = new TransferUtilityUploadResponse();
 
             // Map all fields as defined in mapping.json "Conversion" -> "PutObjectResponse" -> "UploadResponse"
-            if (source.IsSetBucketKeyEnabled())
-                response.BucketKeyEnabled = source.BucketKeyEnabled.GetValueOrDefault();
-
-            if (source.IsSetChecksumCRC32())
-                response.ChecksumCRC32 = source.ChecksumCRC32;
-
-            if (source.IsSetChecksumCRC32C())
-                response.ChecksumCRC32C = source.ChecksumCRC32C;
-
-            if (source.IsSetChecksumCRC64NVME())
-                response.ChecksumCRC64NVME = source.ChecksumCRC64NVME;
-
-            if (source.IsSetChecksumSHA1())
-                response.ChecksumSHA1 = source.ChecksumSHA1;
-
-            if (source.IsSetChecksumSHA256())
-                response.ChecksumSHA256 = source.ChecksumSHA256;
-
-            if (source.IsSetChecksumType())
-                response.ChecksumType = source.ChecksumType;
-
-            if (source.IsSetETag())
-                response.ETag = source.ETag;
-
-            if (source.Expiration != null)
-                response.Expiration = source.Expiration;
-
-            if (source.IsSetRequestCharged())
-                response.RequestCharged = source.RequestCharged;
-
-            if (source.ServerSideEncryptionCustomerMethod != null)
-                response.ServerSideEncryptionCustomerMethod = source.ServerSideEncryptionCustomerMethod;
-
-            if (source.ServerSideEncryptionCustomerProvidedKeyMD5 != null)
-                response.ServerSideEncryptionCustomerProvidedKeyMD5 = source.ServerSideEncryptionCustomerProvidedKeyMD5;
-
-            if (source.ServerSideEncryptionKeyManagementServiceEncryptionContext != null)
-                response.ServerSideEncryptionKeyManagementServiceEncryptionContext = source.ServerSideEncryptionKeyManagementServiceEncryptionContext;
-
-            if (source.IsSetServerSideEncryptionKeyManagementServiceKeyId())
-                response.ServerSideEncryptionKeyManagementServiceKeyId = source.ServerSideEncryptionKeyManagementServiceKeyId;
-
-            if (source.ServerSideEncryptionMethod != null)
-                response.ServerSideEncryptionMethod = source.ServerSideEncryptionMethod;
-
-            if (source.IsSetVersionId())
-                response.VersionId = source.VersionId;
+            response.BucketKeyEnabled = source.BucketKeyEnabled.GetValueOrDefault();
+            response.ChecksumCRC32 = source.ChecksumCRC32;
+            response.ChecksumCRC32C = source.ChecksumCRC32C;
+            response.ChecksumCRC64NVME = source.ChecksumCRC64NVME;
+            response.ChecksumSHA1 = source.ChecksumSHA1;
+            response.ChecksumSHA256 = source.ChecksumSHA256;
+            response.ChecksumType = source.ChecksumType;
+            response.ETag = source.ETag;
+            response.Expiration = source.Expiration;
+            response.RequestCharged = source.RequestCharged;
+            response.ServerSideEncryptionCustomerMethod = source.ServerSideEncryptionCustomerMethod;
+            response.ServerSideEncryptionCustomerProvidedKeyMD5 = source.ServerSideEncryptionCustomerProvidedKeyMD5;
+            response.ServerSideEncryptionKeyManagementServiceEncryptionContext = source.ServerSideEncryptionKeyManagementServiceEncryptionContext;
+            response.ServerSideEncryptionKeyManagementServiceKeyId = source.ServerSideEncryptionKeyManagementServiceKeyId;
+            response.ServerSideEncryptionMethod = source.ServerSideEncryptionMethod;
+            response.VersionId = source.VersionId;
 
             // Copy response metadata
             response.ResponseMetadata = source.ResponseMetadata;
@@ -114,44 +83,19 @@ namespace Amazon.S3.Transfer.Internal
             var response = new TransferUtilityUploadResponse();
 
             // Map all fields as defined in mapping.json "Conversion" -> "CompleteMultipartResponse" -> "UploadResponse"
-            if (source.IsSetBucketKeyEnabled())
-                response.BucketKeyEnabled = source.BucketKeyEnabled.GetValueOrDefault();
-
-            if (source.IsSetChecksumCRC32())
-                response.ChecksumCRC32 = source.ChecksumCRC32;
-
-            if (source.IsSetChecksumCRC32C())
-                response.ChecksumCRC32C = source.ChecksumCRC32C;
-
-            if (source.IsSetChecksumCRC64NVME())
-                response.ChecksumCRC64NVME = source.ChecksumCRC64NVME;
-
-            if (source.IsSetChecksumSHA1())
-                response.ChecksumSHA1 = source.ChecksumSHA1;
-
-            if (source.IsSetChecksumSHA256())
-                response.ChecksumSHA256 = source.ChecksumSHA256;
-
-            if (source.ChecksumType != null)
-                response.ChecksumType = source.ChecksumType;
-
-            if (source.IsSetETag())
-                response.ETag = source.ETag;
-
-            if (source.Expiration != null)
-                response.Expiration = source.Expiration;
-
-            if (source.IsSetRequestCharged())
-                response.RequestCharged = source.RequestCharged;
-
-            if (source.ServerSideEncryptionMethod != null)
-                response.ServerSideEncryptionMethod = source.ServerSideEncryptionMethod;
-
-            if (source.IsSetServerSideEncryptionKeyManagementServiceKeyId())
-                response.ServerSideEncryptionKeyManagementServiceKeyId = source.ServerSideEncryptionKeyManagementServiceKeyId;
-
-            if (source.IsSetVersionId())
-                response.VersionId = source.VersionId;
+            response.BucketKeyEnabled = source.BucketKeyEnabled.GetValueOrDefault();
+            response.ChecksumCRC32 = source.ChecksumCRC32;
+            response.ChecksumCRC32C = source.ChecksumCRC32C;
+            response.ChecksumCRC64NVME = source.ChecksumCRC64NVME;
+            response.ChecksumSHA1 = source.ChecksumSHA1;
+            response.ChecksumSHA256 = source.ChecksumSHA256;
+            response.ChecksumType = source.ChecksumType;
+            response.ETag = source.ETag;
+            response.Expiration = source.Expiration;
+            response.RequestCharged = source.RequestCharged;
+            response.ServerSideEncryptionMethod = source.ServerSideEncryptionMethod;
+            response.ServerSideEncryptionKeyManagementServiceKeyId = source.ServerSideEncryptionKeyManagementServiceKeyId;
+            response.VersionId = source.VersionId;
 
             // Copy response metadata
             response.ResponseMetadata = source.ResponseMetadata;


### PR DESCRIPTION
since we want this to be a pass through, the isSet and null checks dont add any value. for example, the default value is null for things and copying a null value into a null value is the same. 

## Testing
- reran unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement