### PR TITLE
Remove AmazonWebServiceResponse as base class for transfer utility repsonse objects.

### DIFF
--- a/generator/.DevConfigs/c49077d9-90b3-437f-b316-6d8d8833ae75.json
+++ b/generator/.DevConfigs/c49077d9-90b3-437f-b316-6d8d8833ae75.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Remove AmazonWebServiceResponse as base class for transfer utility repsonse objects."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/ResponseMapper.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/ResponseMapper.cs
@@ -63,11 +63,6 @@ namespace Amazon.S3.Transfer.Internal
             response.VersionId = source.VersionId;
             response.Size = source.Size;
 
-            // Copy response metadata
-            response.ResponseMetadata = source.ResponseMetadata;
-            response.ContentLength = source.ContentLength;
-            response.HttpStatusCode = source.HttpStatusCode;
-
             return response;
         }
 
@@ -101,11 +96,6 @@ namespace Amazon.S3.Transfer.Internal
             response.BucketName = source.BucketName;
             response.Key = source.Key;
             response.Location = source.Location;
-
-            // Copy response metadata
-            response.ResponseMetadata = source.ResponseMetadata;
-            response.ContentLength = source.ContentLength;
-            response.HttpStatusCode = source.HttpStatusCode;
 
             return response;
         }
@@ -157,12 +147,6 @@ namespace Amazon.S3.Transfer.Internal
             response.TagCount = source.TagCount;
             response.VersionId = source.VersionId;
             response.WebsiteRedirectLocation = source.WebsiteRedirectLocation;
-
-            // Copy response metadata
-            response.ResponseMetadata = source.ResponseMetadata;
-            response.ContentLength = source.ContentLength;
-            response.HttpStatusCode = source.HttpStatusCode;
-
             return response;
         }
         

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadResponse.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadResponse.cs
@@ -31,7 +31,7 @@ namespace Amazon.S3.Transfer
     /// Response object for Transfer Utility download operations.
     /// Contains response metadata from download operations.
     /// </summary>
-    public class TransferUtilityDownloadResponse : AmazonWebServiceResponse
+    public class TransferUtilityDownloadResponse
     {
         /// <summary>
         /// Gets and sets the AcceptRanges property.

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityUploadResponse.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityUploadResponse.cs
@@ -32,7 +32,7 @@ namespace Amazon.S3.Transfer
     /// Contains unified response fields from both simple uploads (PutObjectResponse) 
     /// and multipart uploads (CompleteMultipartUploadResponse).
     /// </summary>
-    public class TransferUtilityUploadResponse : AmazonWebServiceResponse
+    public class TransferUtilityUploadResponse
     {
         private bool? _bucketKeyEnabled;
         private string _bucketName;

--- a/sdk/test/Services/S3/UnitTests/Custom/ResponseMapperTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/ResponseMapperTests.cs
@@ -149,8 +149,7 @@ namespace AWSSDK.UnitTests
                 },
                 (sourceResponse, targetResponse) =>
                 {
-                    Assert.AreEqual(sourceResponse.HttpStatusCode, targetResponse.HttpStatusCode, "HttpStatusCode should match");
-                    Assert.AreEqual(sourceResponse.ContentLength, targetResponse.ContentLength, "ContentLength should match");
+                  
                 });
         }
 
@@ -644,12 +643,11 @@ namespace AWSSDK.UnitTests
                 (sourceResponse) =>
                 {
                     sourceResponse.HttpStatusCode = HttpStatusCode.OK;
-                    sourceResponse.ContentLength = 2048;
+                    sourceResponse.ContentLength = 1024;
                 },
                 (sourceResponse, targetResponse) =>
                 {
-                    Assert.AreEqual(sourceResponse.HttpStatusCode, targetResponse.HttpStatusCode, "HttpStatusCode should match");
-                    Assert.AreEqual(sourceResponse.ContentLength, targetResponse.ContentLength, "ContentLength should match");
+                    
                 });
         }
 
@@ -720,12 +718,11 @@ namespace AWSSDK.UnitTests
                 (sourceResponse) =>
                 {
                     sourceResponse.HttpStatusCode = HttpStatusCode.OK;
-                    sourceResponse.ContentLength = 2048;
+                    sourceResponse.ContentLength = 1024;
                 },
                 (sourceResponse, targetResponse) =>
                 {
-                    Assert.AreEqual(sourceResponse.HttpStatusCode, targetResponse.HttpStatusCode, "HttpStatusCode should match");
-                    Assert.AreEqual(sourceResponse.ContentLength, targetResponse.ContentLength, "ContentLength should match");
+                    
                 });
         }
 


### PR DESCRIPTION

--- --- ---
Remove AmazonWebServiceResponse as base class for transfer utility response objects. These shouldnt extend this class since its not the raw response from amazon web service.

Ran response mapper and transfer utility tests locally. 

Dry run - c4907d4e-948c-49c2-9b57-57f93dbde562 - in progress