### PR TITLE
Update AbortMultipartUploadcommand to use all fields

### DIFF
--- a/generator/.DevConfigs/9d07dc1e-d82d-4f94-8700-c7b57f872041.json
+++ b/generator/.DevConfigs/9d07dc1e-d82d-4f94-8700-c7b57f872041.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Create AbortMultipartUploads api that takes in TransferUtilityAbortMultipartUploadRequest."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/AbortMultipartUploadsCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/AbortMultipartUploadsCommand.cs
@@ -31,24 +31,30 @@ namespace Amazon.S3.Transfer.Internal
     internal partial class AbortMultipartUploadsCommand : BaseCommand
     {
         IAmazonS3 _s3Client;
-        string _bucketName; 
-        DateTime _initiatedDate;
+        TransferUtilityAbortMultipartUploadRequest _request;
+        TransferUtilityConfig _config;
 
-        internal AbortMultipartUploadsCommand(IAmazonS3 s3Client, string bucketName, DateTime initiateDate)
+        internal AbortMultipartUploadsCommand(IAmazonS3 s3Client, TransferUtilityAbortMultipartUploadRequest request, TransferUtilityConfig config)
         {
             this._s3Client = s3Client;
-            this._bucketName = bucketName;
-            this._initiatedDate = initiateDate;
+            this._request = request;
+            this._config = config;
         }
 
         internal ListMultipartUploadsRequest ConstructListMultipartUploadsRequest(ListMultipartUploadsResponse listResponse)
             {
                 ListMultipartUploadsRequest listRequest = new ListMultipartUploadsRequest()
                 {
-                    BucketName = this._bucketName,
+                    BucketName = this._request.BucketName,
                     KeyMarker = listResponse.KeyMarker,
                     UploadIdMarker = listResponse.NextUploadIdMarker,
+                    ExpectedBucketOwner = this._request.ExpectedBucketOwner,
+                    RequestPayer = this._request.RequestPayer
                 };
+
+               
+                    
+
                 ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)listRequest).AddBeforeRequestHandler(this.RequestEventHandler);
             return listRequest;
         }
@@ -57,10 +63,13 @@ namespace Amazon.S3.Transfer.Internal
                     {
                         var abortRequest = new AbortMultipartUploadRequest()
                         {
-                            BucketName = this._bucketName,
+                            BucketName = this._request.BucketName,
                             Key = upload.Key,
                             UploadId = upload.UploadId,
+                            ExpectedBucketOwner = this._request.ExpectedBucketOwner,
+                            RequestPayer = this._request.RequestPayer
                         };
+
                         ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)abortRequest).AddBeforeRequestHandler(this.RequestEventHandler);
             return abortRequest;
         }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/AbortMultipartUploadsCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/AbortMultipartUploadsCommand.async.cs
@@ -26,21 +26,17 @@ namespace Amazon.S3.Transfer.Internal
 {
     internal partial class AbortMultipartUploadsCommand : BaseCommand
     {
-        TransferUtilityConfig _config;
-
-        internal AbortMultipartUploadsCommand(IAmazonS3 s3Client, string bucketName, DateTime initiateDate, TransferUtilityConfig config)
-        {
-            this._s3Client = s3Client;
-            this._bucketName = bucketName;
-            this._initiatedDate = initiateDate;
-            this._config = config;
-        }
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(this._bucketName))
+            if (string.IsNullOrEmpty(this._request.BucketName))
             {
                 throw new InvalidOperationException("The bucketName specified is null or empty!");
+            }
+
+            if (!this._request.IsSetInitiatedDate())
+            {
+                throw new InvalidOperationException("InitiatedDate must be specified!");
             }
 
             SemaphoreSlim asyncThrottler = null;
@@ -72,7 +68,7 @@ namespace Amazon.S3.Transfer.Internal
                                 // responses and throw the original exception.
                                 break;
                             }
-                            if (upload.Initiated < this._initiatedDate)
+                            if (upload.Initiated < this._request.InitiatedDate.Value)
                             {
                                 await asyncThrottler.WaitAsync(cancellationToken)
                                     .ConfigureAwait(continueOnCapturedContext: false);

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityAbortMultipartUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityAbortMultipartUploadRequest.cs
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License. A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file.
+ *  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ * *****************************************************************************
+ *    __  _    _  ___
+ *   (  )( \/\/ )/ __)
+ *   /__\ \    / \__ \
+ *  (_)(_) \/\/  (___/
+ *
+ *  AWS SDK for .NET
+ *  API Version: 2006-03-01
+ *
+ */
+using System;
+using Amazon.S3.Model;
+
+namespace Amazon.S3.Transfer
+{
+    /// <summary>
+    /// Contains all the parameters that can be set when making a request to abort multipart uploads
+    /// with the <c>TransferUtility</c> method.
+    /// </summary>
+    public class TransferUtilityAbortMultipartUploadRequest
+    {
+        private string _bucketName;
+        private DateTime? _initiatedDate;
+        private string _expectedBucketOwner;
+        private RequestPayer _requestPayer;
+
+        /// <summary>
+        /// Gets or sets the name of the bucket containing multipart uploads.
+        /// </summary>
+        /// <value>
+        /// The name of the bucket containing multipart uploads.
+        /// </value>
+        public string BucketName
+        {
+            get { return this._bucketName; }
+            set { this._bucketName = value; }
+        }
+
+        /// <summary>
+        /// Checks if BucketName property is set.
+        /// </summary>
+        /// <returns>true if BucketName property is set.</returns>
+        internal bool IsSetBucketName()
+        {
+            return !string.IsNullOrEmpty(this._bucketName);
+        }
+
+        /// <summary>
+        /// Gets or sets the date before which the multipart uploads were initiated.
+        /// </summary>
+        /// <value>
+        /// The date before which the multipart uploads were initiated.
+        /// </value>
+        public DateTime? InitiatedDate
+        {
+            get { return this._initiatedDate; }
+            set { this._initiatedDate = value; }
+        }
+
+        /// <summary>
+        /// Checks if InitiatedDate property is set.
+        /// </summary>
+        /// <returns>true if InitiatedDate property is set.</returns>
+        internal bool IsSetInitiatedDate()
+        {
+            return this._initiatedDate.HasValue;
+        }
+
+        /// <summary>
+        /// Gets or sets the account ID of the expected bucket owner.
+        /// If the account ID that you provide does not match the actual owner of the bucket,
+        /// the request fails with the HTTP status code 403 Forbidden (access denied).
+        /// </summary>
+        /// <value>
+        /// The account ID of the expected bucket owner.
+        /// </value>
+        public string ExpectedBucketOwner
+        {
+            get { return this._expectedBucketOwner; }
+            set { this._expectedBucketOwner = value; }
+        }
+
+        /// <summary>
+        /// Checks if ExpectedBucketOwner property is set.
+        /// </summary>
+        /// <returns>true if ExpectedBucketOwner property is set.</returns>
+        internal bool IsSetExpectedBucketOwner()
+        {
+            return !string.IsNullOrEmpty(this._expectedBucketOwner);
+        }
+
+        /// <summary>
+        /// Gets or sets the request payer setting for the abort multipart upload operations.
+        /// Confirms that the requester knows that they will be charged for the request.
+        /// Bucket owners need not specify this parameter in their requests.
+        /// </summary>
+        /// <value>
+        /// The request payer setting for the abort multipart upload operations.
+        /// </value>
+        public RequestPayer RequestPayer
+        {
+            get { return this._requestPayer; }
+            set { this._requestPayer = value; }
+        }
+
+        /// <summary>
+        /// Checks if RequestPayer property is set.
+        /// </summary>
+        /// <returns>true if RequestPayer property is set.</returns>
+        internal bool IsSetRequestPayer()
+        {
+            return this._requestPayer != null;
+        }
+    }
+}

--- a/sdk/src/Services/S3/Custom/Transfer/_async/TransferUtility.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_async/TransferUtility.async.cs
@@ -238,7 +238,32 @@ namespace Amazon.S3.Transfer
             using(CreateSpan(nameof(AbortMultipartUploadsAsync), null, Amazon.Runtime.Telemetry.Tracing.SpanKind.CLIENT))
             {
                 CheckForBlockedArn(bucketName, "AbortMultipartUploads");
-                var command = new AbortMultipartUploadsCommand(this._s3Client, bucketName, initiatedDate, this._config);
+                var request = new TransferUtilityAbortMultipartUploadRequest
+                {
+                    BucketName = bucketName,
+                    InitiatedDate = initiatedDate
+                };
+                var command = new AbortMultipartUploadsCommand(this._s3Client, request, this._config);
+                await command.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// 	Aborts the multipart uploads based on the specified request parameters.
+        /// </summary>
+        /// <param name="request">
+        /// 	Contains all the parameters required to abort multipart uploads.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        public async Task AbortMultipartUploadsAsync(TransferUtilityAbortMultipartUploadRequest request, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using(CreateSpan(nameof(AbortMultipartUploadsAsync), null, Amazon.Runtime.Telemetry.Tracing.SpanKind.CLIENT))
+            {
+                CheckForBlockedArn(request.BucketName, "AbortMultipartUploads");
+                var command = new AbortMultipartUploadsCommand(this._s3Client, request, this._config);
                 await command.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             }
         }

--- a/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/TransferUtility.sync.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/TransferUtility.sync.cs
@@ -459,6 +459,24 @@ namespace Amazon.S3.Transfer
             }
         }
 
+        /// <summary>
+        /// 	Aborts the multipart uploads based on the specified request parameters.
+        /// </summary>
+        /// <param name="request">
+        /// 	Contains all the parameters required to abort multipart uploads.
+        /// </param>
+        public void AbortMultipartUploads(TransferUtilityAbortMultipartUploadRequest request)
+        {
+            try
+            {
+                AbortMultipartUploadsAsync(request).Wait();
+            }
+            catch (AggregateException e)
+            {
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+            }
+        }
+
         #endregion
     }
 }

--- a/sdk/test/Services/S3/UnitTests/Custom/ResponseMapperTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/ResponseMapperTests.cs
@@ -262,6 +262,126 @@ namespace AWSSDK.UnitTests
 
         [TestMethod]
         [TestCategory("S3")]
+        public void MapAbortMultipartUploadsCommand_ConstructAbortMultipartUploadRequest_AllMappedProperties_WorkCorrectly()
+        {
+            // Create a TransferUtilityAbortMultipartUploadRequest with all fields set
+            var abortRequest = new TransferUtilityAbortMultipartUploadRequest
+            {
+                BucketName = "test-bucket",
+                InitiatedDate = DateTime.UtcNow.AddDays(-1),
+                ExpectedBucketOwner = "test-bucket-owner",
+                RequestPayer = RequestPayer.Requester
+            };
+
+            // Create the command with the new constructor
+            var abortCommand = new AbortMultipartUploadsCommand(null, abortRequest, null);
+
+            // Create a test MultipartUpload
+            var multipartUpload = new MultipartUpload
+            {
+                Key = "test-key",
+                UploadId = "test-upload-id"
+            };
+
+            // Call the method we want to test
+            var result = abortCommand.ConstructAbortMultipartUploadRequest(multipartUpload);
+
+            // Validate all fields are properly mapped
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.AreEqual("test-bucket", result.BucketName, "BucketName should match");
+            Assert.AreEqual("test-key", result.Key, "Key should match from MultipartUpload");
+            Assert.AreEqual("test-upload-id", result.UploadId, "UploadId should match from MultipartUpload");
+            Assert.AreEqual("test-bucket-owner", result.ExpectedBucketOwner, "ExpectedBucketOwner should be set");
+            Assert.AreEqual(RequestPayer.Requester, result.RequestPayer, "RequestPayer should be set");
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void MapAbortMultipartUploadsCommand_ConstructListMultipartUploadsRequest_AllMappedProperties_WorkCorrectly()
+        {
+            // Create a TransferUtilityAbortMultipartUploadRequest with all fields set
+            var abortRequest = new TransferUtilityAbortMultipartUploadRequest
+            {
+                BucketName = "test-bucket",
+                InitiatedDate = DateTime.UtcNow.AddDays(-1),
+                ExpectedBucketOwner = "test-bucket-owner",
+                RequestPayer = RequestPayer.Requester
+            };
+
+            // Create the command with the new constructor
+            var abortCommand = new AbortMultipartUploadsCommand(null, abortRequest, null);
+
+            // Create a test ListMultipartUploadsResponse
+            var listResponse = new ListMultipartUploadsResponse
+            {
+                KeyMarker = "test-key-marker",
+                NextUploadIdMarker = "test-upload-id-marker"
+            };
+
+            // Call the method we want to test
+            var result = abortCommand.ConstructListMultipartUploadsRequest(listResponse);
+
+            // Validate all fields are properly mapped
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.AreEqual("test-bucket", result.BucketName, "BucketName should match");
+            Assert.AreEqual("test-key-marker", result.KeyMarker, "KeyMarker should match from response");
+            Assert.AreEqual("test-upload-id-marker", result.UploadIdMarker, "UploadIdMarker should match from response");
+            Assert.AreEqual("test-bucket-owner", result.ExpectedBucketOwner, "ExpectedBucketOwner should be set");
+            Assert.AreEqual(RequestPayer.Requester, result.RequestPayer, "RequestPayer should be set");
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public void MapAbortMultipartUploadsCommand_MinimalRequest_DoesNotSetOptionalFields()
+        {
+            // Create a minimal request with only required fields (BucketName and InitiatedDate)
+            var abortRequest = new TransferUtilityAbortMultipartUploadRequest
+            {
+                BucketName = "test-bucket",
+                InitiatedDate = DateTime.UtcNow.AddDays(-1)
+                // ExpectedBucketOwner and RequestPayer are not set (null)
+            };
+
+            // Create the command with the minimal request
+            var abortCommand = new AbortMultipartUploadsCommand(null, abortRequest, null);
+
+            // Test ConstructAbortMultipartUploadRequest
+            var multipartUpload = new MultipartUpload
+            {
+                Key = "test-key",
+                UploadId = "test-upload-id"
+            };
+
+            var abortResult = abortCommand.ConstructAbortMultipartUploadRequest(multipartUpload);
+
+            // Validate core fields are set but optional fields are not
+            Assert.IsNotNull(abortResult, "AbortMultipartUploadRequest should not be null");
+            Assert.AreEqual("test-bucket", abortResult.BucketName, "BucketName should match");
+            Assert.AreEqual("test-key", abortResult.Key, "Key should match");
+            Assert.AreEqual("test-upload-id", abortResult.UploadId, "UploadId should match");
+            Assert.IsNull(abortResult.ExpectedBucketOwner, "ExpectedBucketOwner should be null with minimal request");
+            Assert.IsNull(abortResult.RequestPayer, "RequestPayer should be null with minimal request");
+
+            // Test ConstructListMultipartUploadsRequest
+            var listResponse = new ListMultipartUploadsResponse
+            {
+                KeyMarker = "test-key-marker",
+                NextUploadIdMarker = "test-upload-id-marker"
+            };
+
+            var listResult = abortCommand.ConstructListMultipartUploadsRequest(listResponse);
+
+            // Validate core fields are set but optional fields are not
+            Assert.IsNotNull(listResult, "ListMultipartUploadsRequest should not be null");
+            Assert.AreEqual("test-bucket", listResult.BucketName, "BucketName should match");
+            Assert.AreEqual("test-key-marker", listResult.KeyMarker, "KeyMarker should match");
+            Assert.AreEqual("test-upload-id-marker", listResult.UploadIdMarker, "UploadIdMarker should match");
+            Assert.IsNull(listResult.ExpectedBucketOwner, "ExpectedBucketOwner should be null with minimal request");
+            Assert.IsNull(listResult.RequestPayer, "RequestPayer should be null with minimal request");
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
         public void MapPutObjectResponse_NullValues_HandledCorrectly()
         {
             // Test null handling scenarios


### PR DESCRIPTION
## Description
1. Create TransferUtilityAbortMultipartUploadRequest and new api that uses this request object so that all fields (Request player, expected bucket owner) are used when aborting a request.

## Motivation and Context
To adhere to the SEP

## Testing
1. Unit tests
2. Dry Run 6b6ec5e3-51da-4b4a-aad4-3ff0c894e70b PASS


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement