### PR TITLE
Add UploadWithResponseAsync api

### DIFF
--- a/generator/.DevConfigs/77d980ad-8f58-4f2e-97f8-d2c8c5ba3732.json
+++ b/generator/.DevConfigs/77d980ad-8f58-4f2e-97f8-d2c8c5ba3732.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "minor",
+      "changeLogMessages": [
+        "Create new UploadWithResponse API that returns response metadata information for transfer utility."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/AbortMultipartUploadsCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/AbortMultipartUploadsCommand.cs
@@ -28,7 +28,7 @@ using Amazon.S3.Model;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class AbortMultipartUploadsCommand : BaseCommand
+    internal partial class AbortMultipartUploadsCommand : BaseCommand<TransferUtilityAbortMultipartUploadsResponse>
     {
         IAmazonS3 _s3Client;
         TransferUtilityAbortMultipartUploadRequest _request;

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/BaseCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/BaseCommand.cs
@@ -30,13 +30,12 @@ using Amazon.Runtime.Internal.UserAgent;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal abstract partial class BaseCommand
+    /// <summary>
+    /// Generic base command that returns a typed response
+    /// </summary>
+    /// <typeparam name="TResponse">Type of response returned by the command</typeparam>
+    internal abstract partial class BaseCommand<TResponse> where TResponse : class
     {
-        public virtual object Return
-        {
-            get { return null; }
-        }
-
         internal GetObjectRequest ConvertToGetObjectRequest(BaseDownloadRequest request)
         {
             GetObjectRequest getRequest = new GetObjectRequest()

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadCommand.cs
@@ -33,7 +33,7 @@ using System.IO;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class DownloadCommand : BaseCommand
+    internal partial class DownloadCommand : BaseCommand<TransferUtilityDownloadResponse>
     {
         static int MAX_BACKOFF_IN_MILLISECONDS = (int)TimeSpan.FromSeconds(30).TotalMilliseconds;
 
@@ -176,4 +176,3 @@ namespace Amazon.S3.Transfer.Internal
         }
     }
 }
-

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
@@ -33,7 +33,7 @@ using Amazon.Runtime;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class DownloadDirectoryCommand : BaseCommand
+    internal partial class DownloadDirectoryCommand : BaseCommand<TransferUtilityDownloadDirectoryResponse>
     {
         private readonly IAmazonS3 _s3Client;
         private readonly TransferUtilityDownloadDirectoryRequest _request;

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
@@ -37,7 +37,7 @@ namespace Amazon.S3.Transfer.Internal
     /// <summary>
     /// The command to manage an upload using the S3 multipart API.
     /// </summary>
-    internal partial class MultipartUploadCommand : BaseCommand
+    internal partial class MultipartUploadCommand : BaseCommand<TransferUtilityUploadResponse>
     {
         IAmazonS3 _s3Client;
         long _partSize;

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/OpenStreamCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/OpenStreamCommand.cs
@@ -29,7 +29,7 @@ using Amazon.S3.Model;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class OpenStreamCommand : BaseCommand
+    internal partial class OpenStreamCommand : BaseCommand<TransferUtilityOpenStreamResponse>
     {
         IAmazonS3 _s3Client;
         TransferUtilityOpenStreamRequest _request;
@@ -58,11 +58,6 @@ namespace Amazon.S3.Transfer.Internal
         internal Stream ResponseStream
         {
             get { return this._responseStream; }
-        }
-
-        public override object  Return
-        {
-            get { return this.ResponseStream; }
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/SimpleUploadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/SimpleUploadCommand.cs
@@ -36,7 +36,7 @@ namespace Amazon.S3.Transfer.Internal
     /// <summary>
     /// This command is for doing regular PutObject requests.
     /// </summary>
-    internal partial class SimpleUploadCommand : BaseCommand
+    internal partial class SimpleUploadCommand : BaseCommand<TransferUtilityUploadResponse>
     {
         IAmazonS3 _s3Client;
         TransferUtilityConfig _config;

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/UploadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/UploadDirectoryCommand.cs
@@ -32,7 +32,7 @@ namespace Amazon.S3.Transfer.Internal
     /// This command files all the files that meets the criteria specified in the TransferUtilityUploadDirectoryRequest request
     /// and uploads them.
     /// </summary>
-    internal partial class UploadDirectoryCommand : BaseCommand
+    internal partial class UploadDirectoryCommand : BaseCommand<TransferUtilityUploadDirectoryResponse>
     {
         TransferUtilityUploadDirectoryRequest _request;
         TransferUtility _utility;

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/AbortMultipartUploadsCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/AbortMultipartUploadsCommand.async.cs
@@ -24,10 +24,10 @@ using System.Threading.Tasks;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class AbortMultipartUploadsCommand : BaseCommand
+    internal partial class AbortMultipartUploadsCommand : BaseCommand<TransferUtilityAbortMultipartUploadsResponse>
     {
 
-        public override async Task ExecuteAsync(CancellationToken cancellationToken)
+        public override async Task<TransferUtilityAbortMultipartUploadsResponse> ExecuteAsync(CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(this._request.BucketName))
             {
@@ -84,6 +84,8 @@ namespace Amazon.S3.Transfer.Internal
 
                 await WhenAllOrFirstExceptionAsync(pendingTasks,cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);
+
+                return new TransferUtilityAbortMultipartUploadsResponse();
             }
             finally
             {

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/BaseCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/BaseCommand.async.cs
@@ -24,9 +24,12 @@ using System.Threading.Tasks;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal abstract partial class BaseCommand
+    internal abstract partial class BaseCommand<TResponse> where TResponse : class
     {
-        public abstract Task ExecuteAsync(CancellationToken cancellationToken);
+        /// <summary>
+        /// Executes the command and returns a typed response
+        /// </summary>
+        public abstract Task<TResponse> ExecuteAsync(CancellationToken cancellationToken);
 
         /// <summary>
         ///  Waits for all of the tasks to complete or till any task fails or is canceled.
@@ -80,7 +83,7 @@ namespace Amazon.S3.Transfer.Internal
             }
         }
 
-        protected static async Task ExecuteCommandAsync(BaseCommand command, CancellationTokenSource internalCts, SemaphoreSlim throttler)
+        protected static async Task ExecuteCommandAsync<T>(BaseCommand<T> command, CancellationTokenSource internalCts, SemaphoreSlim throttler) where T : class
         {
             try
             {

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/DownloadCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/DownloadCommand.async.cs
@@ -28,9 +28,9 @@ using System.Threading.Tasks;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class DownloadCommand : BaseCommand
+    internal partial class DownloadCommand : BaseCommand<TransferUtilityDownloadResponse>
     {
-        public override async Task ExecuteAsync(CancellationToken cancellationToken)
+        public override async Task<TransferUtilityDownloadResponse> ExecuteAsync(CancellationToken cancellationToken)
         {
             ValidateRequest();
             GetObjectRequest getRequest = ConvertToGetObjectRequest(this._request);
@@ -130,6 +130,9 @@ namespace Amazon.S3.Transfer.Internal
                 }
                 WaitBeforeRetry(retries);
             } while (shouldRetry);
+
+            // TODO map and return response
+            return new TransferUtilityDownloadResponse();
         }
 
         private static bool HandleExceptionForHttpClient(Exception exception, int retries, int maxRetries)

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/OpenStreamCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/OpenStreamCommand.async.cs
@@ -24,14 +24,16 @@ using System.Threading.Tasks;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class OpenStreamCommand : BaseCommand
+    internal partial class OpenStreamCommand : BaseCommand<TransferUtilityOpenStreamResponse>
     {
-        public override async Task ExecuteAsync(CancellationToken cancellationToken)
+        public override async Task<TransferUtilityOpenStreamResponse> ExecuteAsync(CancellationToken cancellationToken)
         {
             var getRequest = ConstructRequest();
             var response = await _s3Client.GetObjectAsync(getRequest, cancellationToken)
                 .ConfigureAwait(continueOnCapturedContext: false);
             _responseStream = response.ResponseStream;
+            // TODO map and return response
+            return new TransferUtilityOpenStreamResponse();
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/SimpleUploadCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/SimpleUploadCommand.async.cs
@@ -24,11 +24,11 @@ using System.Threading.Tasks;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class SimpleUploadCommand : BaseCommand
+    internal partial class SimpleUploadCommand : BaseCommand<TransferUtilityUploadResponse>
     {
         public SemaphoreSlim AsyncThrottler { get; set; }
 
-        public override async Task ExecuteAsync(CancellationToken cancellationToken)
+        public override async Task<TransferUtilityUploadResponse> ExecuteAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -47,6 +47,8 @@ namespace Amazon.S3.Transfer.Internal
                 var mappedResponse = ResponseMapper.MapPutObjectResponse(response);
 
                 FireTransferCompletedEvent(mappedResponse);
+                
+                return mappedResponse;
             }
             catch (Exception)
             {

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class DownloadDirectoryCommand : BaseCommand
+    internal partial class DownloadDirectoryCommand : BaseCommand<TransferUtilityDownloadDirectoryResponse>
     {
 
         TransferUtilityConfig _config;
@@ -38,7 +38,7 @@ namespace Amazon.S3.Transfer.Internal
             this._config = config;
         }
 
-        public override async Task ExecuteAsync(CancellationToken cancellationToken)
+        public override async Task<TransferUtilityDownloadDirectoryResponse> ExecuteAsync(CancellationToken cancellationToken)
         {
             ValidateRequest();
             EnsureDirectoryExists(new DirectoryInfo(this._request.LocalDirectory));
@@ -112,6 +112,8 @@ namespace Amazon.S3.Transfer.Internal
                 }
                 await WhenAllOrFirstExceptionAsync(pendingTasks, cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);
+
+                return new TransferUtilityDownloadDirectoryResponse();
             }
             finally
             {

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/UploadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/UploadDirectoryCommand.cs
@@ -23,11 +23,11 @@ using System.Threading.Tasks;
 
 namespace Amazon.S3.Transfer.Internal
 {
-    internal partial class UploadDirectoryCommand : BaseCommand
+    internal partial class UploadDirectoryCommand : BaseCommand<TransferUtilityUploadDirectoryResponse>
     {
         public bool UploadFilesConcurrently { get; set; }
 
-        public override async Task ExecuteAsync(CancellationToken cancellationToken)
+        public override async Task<TransferUtilityUploadDirectoryResponse> ExecuteAsync(CancellationToken cancellationToken)
         {
             string prefix = GetKeyPrefix();
 
@@ -87,6 +87,8 @@ namespace Amazon.S3.Transfer.Internal
                 if (asyncThrottler != null)
                     asyncThrottler.Dispose();
             }
+
+            return new TransferUtilityUploadDirectoryResponse();
         }
 
         private Task<string[]> GetFiles(string path, string searchPattern, SearchOption searchOption, CancellationToken cancellationToken)

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtility.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtility.cs
@@ -386,7 +386,7 @@ namespace Amazon.S3.Transfer
             };
         }
 
-        internal BaseCommand GetUploadCommand(TransferUtilityUploadRequest request)
+        internal BaseCommand<TransferUtilityUploadResponse> GetUploadCommand(TransferUtilityUploadRequest request)
         {
             validate(request);
 

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityAbortMultipartUploadsResponse.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityAbortMultipartUploadsResponse.cs
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License. A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file.
+ *  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ * *****************************************************************************
+ *    __  _    _  ___
+ *   (  )( \/\/ )/ __)
+ *   /__\ \    / \__ \
+ *  (_)(_) \/\/  (___/
+ *
+ *  AWS SDK for .NET
+ *  API Version: 2006-03-01
+ *
+ */
+
+using Amazon.Runtime;
+
+namespace Amazon.S3.Transfer
+{
+    /// <summary>
+    /// Response object for Transfer Utility abort multipart uploads operations.
+    /// Contains response metadata from abort multipart uploads operations.
+    /// </summary>
+    public class TransferUtilityAbortMultipartUploadsResponse
+    {
+        // Empty placeholder class - properties will be added in future iterations
+    }
+}

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryResponse.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryResponse.cs
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.Runtime;
+
+namespace Amazon.S3.Transfer
+{
+    /// <summary>
+    /// Contains the details returned from a Transfer Utility download directory operation.
+    /// </summary>
+    public class TransferUtilityDownloadDirectoryResponse
+    {
+    }
+}

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityUploadDirectoryResponse.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityUploadDirectoryResponse.cs
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License. A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file.
+ *  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ * *****************************************************************************
+ *    __  _    _  ___
+ *   (  )( \/\/ )/ __)
+ *   /__\ \    / \__ \
+ *  (_)(_) \/\/  (___/
+ *
+ *  AWS SDK for .NET
+ *  API Version: 2006-03-01
+ *
+ */
+
+using Amazon.Runtime;
+
+namespace Amazon.S3.Transfer
+{
+    /// <summary>
+    /// Response object for Transfer Utility upload directory operations.
+    /// Contains response metadata from upload directory operations.
+    /// </summary>
+    public class TransferUtilityUploadDirectoryResponse
+    {
+        // Empty placeholder class - properties will be added in future iterations
+    }
+}

--- a/sdk/src/Services/S3/Custom/Transfer/_async/TransferUtility.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_async/TransferUtility.async.cs
@@ -217,6 +217,167 @@ namespace Amazon.S3.Transfer
                 await command.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             }
         }
+
+        /// <summary>
+        /// 	Uploads the specified file and returns response metadata.  
+        /// 	The object key is derived from the file's name.
+        /// 	Multiple threads are used to read the file and perform multiple uploads in parallel.  
+        /// 	For large uploads, the file will be divided and uploaded in parts using 
+        /// 	Amazon S3's multipart API.  The parts will be reassembled as one object in
+        /// 	Amazon S3.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you are uploading large files, TransferUtility will use multipart upload to fulfill the request. 
+        /// If a multipart upload is interrupted, TransferUtility will attempt to abort the multipart upload. 
+        /// Under certain circumstances (network outage, power failure, etc.), TransferUtility will not be able 
+        /// to abort the multipart upload. In this case, in order to stop getting charged for the storage of uploaded parts,
+        /// you should manually invoke TransferUtility.AbortMultipartUploadsAsync() to abort the incomplete multipart uploads.
+        /// </para>
+        /// <para>
+        /// For nonseekable streams or streams with an unknown length, TransferUtility will use multipart upload and buffer up to a part size in memory
+        /// until the final part is reached and complete the upload. The buffer for the multipart upload is controlled by S3Constants.MinPartSize
+        /// and the default value is 5 megabytes. You can also adjust the read buffer size(i.e.how many bytes to read before writing to the part buffer)
+        /// via the BufferSize property on the ClientConfig.The default value for this is 8192 bytes.
+        /// </para>
+        /// </remarks>
+        /// <param name="filePath">
+        /// 	The file path of the file to upload.
+        /// </param>
+        /// <param name="bucketName">
+        /// 	The target Amazon S3 bucket, that is, the name of the bucket to upload the file to.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The task object representing the asynchronous operation with upload response metadata.</returns>
+        public async Task<TransferUtilityUploadResponse> UploadWithResponseAsync(string filePath, string bucketName, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var request = ConstructUploadRequest(filePath, bucketName);
+            return await UploadWithResponseAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// 	Uploads the specified file and returns response metadata.  
+        /// 	Multiple threads are used to read the file and perform multiple uploads in parallel.  
+        /// 	For large uploads, the file will be divided and uploaded in parts using 
+        /// 	Amazon S3's multipart API.  The parts will be reassembled as one object in
+        /// 	Amazon S3.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you are uploading large files, TransferUtility will use multipart upload to fulfill the request. 
+        /// If a multipart upload is interrupted, TransferUtility will attempt to abort the multipart upload. 
+        /// Under certain circumstances (network outage, power failure, etc.), TransferUtility will not be able 
+        /// to abort the multipart upload. In this case, in order to stop getting charged for the storage of uploaded parts,
+        /// you should manually invoke TransferUtility.AbortMultipartUploadsAsync() to abort the incomplete multipart uploads.
+        /// </para>
+        /// <para>
+        /// For nonseekable streams or streams with an unknown length, TransferUtility will use multipart upload and buffer up to a part size in memory
+        /// until the final part is reached and complete the upload. The buffer for the multipart upload is controlled by S3Constants.MinPartSize
+        /// and the default value is 5 megabytes. You can also adjust the read buffer size(i.e.how many bytes to read before writing to the part buffer)
+        /// via the BufferSize property on the ClientConfig.The default value for this is 8192 bytes.
+        /// </para>
+        /// </remarks>
+        /// <param name="filePath">
+        /// 	The file path of the file to upload.
+        /// </param>
+        /// <param name="bucketName">
+        /// 	The target Amazon S3 bucket, that is, the name of the bucket to upload the file to.
+        /// </param>
+        /// <param name="key">
+        /// 	The key under which the Amazon S3 object is stored.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The task object representing the asynchronous operation with upload response metadata.</returns>
+        public async Task<TransferUtilityUploadResponse> UploadWithResponseAsync(string filePath, string bucketName, string key, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var request = ConstructUploadRequest(filePath, bucketName, key);
+            return await UploadWithResponseAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// 	Uploads the contents of the specified stream and returns response metadata.  
+        /// 	For large uploads, the file will be divided and uploaded in parts using 
+        /// 	Amazon S3's multipart API.  The parts will be reassembled as one object in
+        /// 	Amazon S3.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you are uploading large files, TransferUtility will use multipart upload to fulfill the request. 
+        /// If a multipart upload is interrupted, TransferUtility will attempt to abort the multipart upload. 
+        /// Under certain circumstances (network outage, power failure, etc.), TransferUtility will not be able 
+        /// to abort the multipart upload. In this case, in order to stop getting charged for the storage of uploaded parts,
+        /// you should manually invoke TransferUtility.AbortMultipartUploadsAsync() to abort the incomplete multipart uploads.
+        /// </para>
+        /// <para>
+        /// For nonseekable streams or streams with an unknown length, TransferUtility will use multipart upload and buffer up to a part size in memory
+        /// until the final part is reached and complete the upload. The buffer for the multipart upload is controlled by S3Constants.MinPartSize
+        /// and the default value is 5 megabytes. You can also adjust the read buffer size(i.e.how many bytes to read before writing to the part buffer)
+        /// via the BufferSize property on the ClientConfig.The default value for this is 8192 bytes.
+        /// </para>
+        /// </remarks>
+        /// <param name="stream">
+        /// 	The stream to read to obtain the content to upload.
+        /// </param>
+        /// <param name="bucketName">
+        /// 	The target Amazon S3 bucket, that is, the name of the bucket to upload the stream to.
+        /// </param>
+        /// <param name="key">
+        /// 	The key under which the Amazon S3 object is stored.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The task object representing the asynchronous operation with upload response metadata.</returns>
+        public async Task<TransferUtilityUploadResponse> UploadWithResponseAsync(Stream stream, string bucketName, string key, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var request = ConstructUploadRequest(stream, bucketName, key);
+            return await UploadWithResponseAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// 	Uploads the file or stream specified by the request and returns response metadata.  
+        /// 	To track the progress of the upload,
+        /// 	add an event listener to the request's <c>UploadProgressEvent</c>.
+        /// 	For large uploads, the file will be divided and uploaded in parts using 
+        /// 	Amazon S3's multipart API.  The parts will be reassembled as one object in
+        /// 	Amazon S3.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you are uploading large files, TransferUtility will use multipart upload to fulfill the request. 
+        /// If a multipart upload is interrupted, TransferUtility will attempt to abort the multipart upload. 
+        /// Under certain circumstances (network outage, power failure, etc.), TransferUtility will not be able 
+        /// to abort the multipart upload. In this case, in order to stop getting charged for the storage of uploaded parts,
+        /// you should manually invoke TransferUtility.AbortMultipartUploadsAsync() to abort the incomplete multipart uploads.
+        /// </para>
+        /// <para>
+        /// For nonseekable streams or streams with an unknown length, TransferUtility will use multipart upload and buffer up to a part size in memory 
+        /// until the final part is reached and complete the upload. The part size buffer for the multipart upload is controlled by the partSize
+        /// specified on the TransferUtilityUploadRequest, and if none is specified it defaults to S3Constants.MinPartSize (5 megabytes).
+        /// You can also adjust the read buffer size (i.e. how many bytes to read before adding it to the 
+        /// part buffer) via the BufferSize property on the ClientConfig. The default value for this is 8192 bytes.
+        /// </para>
+        /// </remarks>
+        /// <param name="request">
+        /// 	Contains all the parameters required to upload to Amazon S3.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The task object representing the asynchronous operation with upload response metadata.</returns>
+        public async Task<TransferUtilityUploadResponse> UploadWithResponseAsync(TransferUtilityUploadRequest request, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using(CreateSpan(nameof(UploadWithResponseAsync), null, Amazon.Runtime.Telemetry.Tracing.SpanKind.CLIENT))
+            {
+                CheckForBlockedArn(request.BucketName, "Upload");
+                var command = GetUploadCommand(request, null);
+                return await command.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
     #endregion
 
         #region AbortMultipartUploads
@@ -346,7 +507,7 @@ namespace Amazon.S3.Transfer
 
         #endregion
 
-        internal BaseCommand GetUploadCommand(TransferUtilityUploadRequest request, SemaphoreSlim asyncThrottler)
+        internal BaseCommand<TransferUtilityUploadResponse> GetUploadCommand(TransferUtilityUploadRequest request, SemaphoreSlim asyncThrottler)
         {
             validate(request);
             if (IsMultipartUpload(request))

--- a/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/TransferUtility.sync.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/TransferUtility.sync.cs
@@ -285,6 +285,154 @@ namespace Amazon.S3.Transfer
             }
         }
 
+        /// <summary>
+        /// 	Uploads the specified file and returns response metadata.
+        /// 	The object key is derived from the file's name.
+        /// 	Multiple threads are used to read the file and perform multiple uploads in parallel.  
+        /// 	For large uploads, the file will be divided and uploaded in parts using 
+        /// 	Amazon S3's multipart API.  The parts will be reassembled as one object in
+        /// 	Amazon S3.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you are uploading large files, TransferUtility will use multipart upload to fulfill the request. 
+        /// If a multipart upload is interrupted, TransferUtility will attempt to abort the multipart upload. 
+        /// Under certain circumstances (network outage, power failure, etc.), TransferUtility will not be able 
+        /// to abort the multipart upload. In this case, in order to stop getting charged for the storage of uploaded parts,
+        /// you should manually invoke TransferUtility.AbortMultipartUploads() to abort the incomplete multipart uploads.
+        /// </para>
+        /// </remarks>
+        /// <param name="filePath">
+        /// 	The file path of the file to upload.
+        /// </param>
+        /// <param name="bucketName">
+        /// 	The target Amazon S3 bucket, that is, the name of the bucket to upload the file to.
+        /// </param>
+        /// <returns>The upload response metadata.</returns>
+        public TransferUtilityUploadResponse UploadWithResponse(string filePath, string bucketName)
+        {
+            try
+            {
+                return UploadWithResponseAsync(filePath, bucketName).Result;
+            }
+            catch (AggregateException e)
+            {
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 	Uploads the specified file and returns response metadata.
+        /// 	Multiple threads are used to read the file and perform multiple uploads in parallel.  
+        /// 	For large uploads, the file will be divided and uploaded in parts using 
+        /// 	Amazon S3's multipart API.  The parts will be reassembled as one object in
+        /// 	Amazon S3.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you are uploading large files, TransferUtility will use multipart upload to fulfill the request. 
+        /// If a multipart upload is interrupted, TransferUtility will attempt to abort the multipart upload. 
+        /// Under certain circumstances (network outage, power failure, etc.), TransferUtility will not be able 
+        /// to abort the multipart upload. In this case, in order to stop getting charged for the storage of uploaded parts,
+        /// you should manually invoke TransferUtility.AbortMultipartUploads() to abort the incomplete multipart uploads.
+        /// </para>
+        /// </remarks>
+        /// <param name="filePath">
+        /// 	The file path of the file to upload.
+        /// </param>
+        /// <param name="bucketName">
+        /// 	The target Amazon S3 bucket, that is, the name of the bucket to upload the file to.
+        /// </param>
+        /// <param name="key">
+        /// 	The key under which the Amazon S3 object is stored.
+        /// </param>
+        /// <returns>The upload response metadata.</returns>
+        public TransferUtilityUploadResponse UploadWithResponse(string filePath, string bucketName, string key)
+        {
+            try
+            {
+                return UploadWithResponseAsync(filePath, bucketName, key).Result;
+            }
+            catch (AggregateException e)
+            {
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 	Uploads the contents of the specified stream and returns response metadata.
+        /// 	For large uploads, the file will be divided and uploaded in parts using 
+        /// 	Amazon S3's multipart API.  The parts will be reassembled as one object in
+        /// 	Amazon S3.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you are uploading large files, TransferUtility will use multipart upload to fulfill the request. 
+        /// If a multipart upload is interrupted, TransferUtility will attempt to abort the multipart upload. 
+        /// Under certain circumstances (network outage, power failure, etc.), TransferUtility will not be able 
+        /// to abort the multipart upload. In this case, in order to stop getting charged for the storage of uploaded parts,
+        /// you should manually invoke TransferUtility.AbortMultipartUploads() to abort the incomplete multipart uploads.
+        /// </para>
+        /// </remarks>
+        /// <param name="stream">
+        /// 	The stream to read to obtain the content to upload.
+        /// </param>
+        /// <param name="bucketName">
+        /// 	The target Amazon S3 bucket, that is, the name of the bucket to upload the stream to.
+        /// </param>
+        /// <param name="key">
+        /// 	The key under which the Amazon S3 object is stored.
+        /// </param>
+        /// <returns>The upload response metadata.</returns>
+        public TransferUtilityUploadResponse UploadWithResponse(Stream stream, string bucketName, string key)
+        {
+            try
+            {
+                return UploadWithResponseAsync(stream, bucketName, key).Result;
+            }
+            catch (AggregateException e)
+            {
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 	Uploads the file or stream specified by the request and returns response metadata.
+        /// 	To track the progress of the upload,
+        /// 	add an event listener to the request's <c>UploadProgressEvent</c>.
+        /// 	For large uploads, the file will be divided and uploaded in parts using 
+        /// 	Amazon S3's multipart API.  The parts will be reassembled as one object in
+        /// 	Amazon S3.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you are uploading large files, TransferUtility will use multipart upload to fulfill the request. 
+        /// If a multipart upload is interrupted, TransferUtility will attempt to abort the multipart upload. 
+        /// Under certain circumstances (network outage, power failure, etc.), TransferUtility will not be able 
+        /// to abort the multipart upload. In this case, in order to stop getting charged for the storage of uploaded parts,
+        /// you should manually invoke TransferUtility.AbortMultipartUploads() to abort the incomplete multipart uploads.
+        /// </para>
+        /// </remarks>
+        /// <param name="request">
+        /// 	Contains all the parameters required to upload to Amazon S3.
+        /// </param>
+        /// <returns>The upload response metadata.</returns>
+        public TransferUtilityUploadResponse UploadWithResponse(TransferUtilityUploadRequest request)
+        {
+            try
+            {
+                return UploadWithResponseAsync(request).Result;
+            }
+            catch (AggregateException e)
+            {
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                return null;
+            }
+        }
+
         #endregion
 
         #region OpenStream

--- a/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
@@ -13,6 +13,7 @@ using AWSSDK_DotNet.IntegrationTests.Utils;
 using Amazon.Util;
 using System.Net.Mime;
 using System.Runtime.InteropServices.ComTypes;
+using System.Threading.Tasks;
 
 namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
 {
@@ -1431,6 +1432,248 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             var downloadPath = path + ".download";
             var metadata = Client.GetObjectMetadata(new GetObjectMetadataRequest { BucketName = bucketName, Key = "test-content-type" });
             Assert.IsTrue(metadata.Headers.ContentType.Equals(MediaTypeNames.Text.Plain));
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public async Task UploadWithResponseAsyncSmallFileTest()
+        {
+            var fileName = UtilityMethods.GenerateName(@"UploadWithResponseTest\SmallFile");
+            var path = Path.Combine(BasePath, fileName);
+            var fileSize = 1 * MEG_SIZE; // Small file for single-part upload
+            UtilityMethods.GenerateFile(path, fileSize);
+
+            using (var transferUtility = new TransferUtility(Client))
+            {
+                var request = new TransferUtilityUploadRequest
+                {
+                    BucketName = bucketName,
+                    FilePath = path,
+                    Key = fileName,
+                    ContentType = octetStreamContentType
+                };
+
+                var response = await transferUtility.UploadWithResponseAsync(request);
+
+                // Validate response object is not null
+                Assert.IsNotNull(response, "Response should not be null");
+
+                // Validate essential response fields that should always be present
+                Assert.IsNotNull(response.ETag, "ETag should not be null");
+                Assert.IsTrue(response.ETag.Length > 0, "ETag should not be empty");
+
+                // For small files, we expect single-part upload behavior - ETag should be MD5 format (no quotes or dashes)
+                // ETag format varies, so we just ensure it's a valid non-empty string
+                Console.WriteLine($"ETag: {response.ETag}");
+                Console.WriteLine($"VersionId: {response.VersionId}");
+
+                // Validate file was actually uploaded by checking metadata
+                var metadata = await Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName
+                });
+                Assert.AreEqual(fileSize, metadata.ContentLength, "Uploaded file size should match original");
+                Assert.AreEqual(response.ETag, metadata.ETag, "ETag from response should match object metadata");
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public async Task UploadWithResponseAsyncLargeFileTest()
+        {
+            var fileName = UtilityMethods.GenerateName(@"UploadWithResponseTest\LargeFile");
+            var path = Path.Combine(BasePath, fileName);
+            var fileSize = 20 * MEG_SIZE; // Large file for multipart upload
+            UtilityMethods.GenerateFile(path, fileSize);
+
+            using (var transferUtility = new TransferUtility(Client))
+            {
+                var request = new TransferUtilityUploadRequest
+                {
+                    BucketName = bucketName,
+                    FilePath = path,
+                    Key = fileName,
+                    ContentType = octetStreamContentType
+                };
+
+                var response = await transferUtility.UploadWithResponseAsync(request);
+
+                // Validate response object is not null
+                Assert.IsNotNull(response, "Response should not be null");
+
+                // Validate essential response fields that should always be present
+                Assert.IsNotNull(response.ETag, "ETag should not be null");
+                Assert.IsTrue(response.ETag.Length > 0, "ETag should not be empty");
+
+                // For multipart uploads, ETag format is different (contains dashes)
+                // We just validate it's a valid string for now
+                Console.WriteLine($"ETag (multipart): {response.ETag}");
+                Console.WriteLine($"VersionId: {response.VersionId}");
+
+                // Validate file was actually uploaded by checking metadata
+                var metadata = await Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName
+                });
+                Assert.AreEqual(fileSize, metadata.ContentLength, "Uploaded file size should match original");
+                Assert.AreEqual(response.ETag, metadata.ETag, "ETag from response should match object metadata");
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public async Task UploadWithResponseAsyncStreamTest()
+        {
+            var fileName = UtilityMethods.GenerateName(@"UploadWithResponseTest\StreamFile");
+            var path = Path.Combine(BasePath, fileName);
+            var fileSize = 5 * MEG_SIZE;
+            UtilityMethods.GenerateFile(path, fileSize);
+
+            using (var transferUtility = new TransferUtility(Client))
+            using (var fileStream = File.OpenRead(path))
+            {
+                var request = new TransferUtilityUploadRequest
+                {
+                    BucketName = bucketName,
+                    InputStream = fileStream,
+                    Key = fileName,
+                    ContentType = octetStreamContentType
+                };
+
+                var response = await transferUtility.UploadWithResponseAsync(request);
+
+                // Validate response object is not null
+                Assert.IsNotNull(response, "Response should not be null");
+
+                // Validate essential response fields that should always be present
+                Assert.IsNotNull(response.ETag, "ETag should not be null");
+                Assert.IsTrue(response.ETag.Length > 0, "ETag should not be empty");
+
+                Console.WriteLine($"ETag (stream): {response.ETag}");
+                Console.WriteLine($"VersionId: {response.VersionId}");
+
+                // Validate file was actually streamed and uploaded correctly
+                var metadata = await Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName
+                });
+                Assert.AreEqual(fileSize, metadata.ContentLength, "Uploaded stream size should match original");
+                Assert.AreEqual(response.ETag, metadata.ETag, "ETag from response should match object metadata");
+
+                // Validate content by downloading and comparing
+                var downloadPath = path + ".download";
+                await transferUtility.DownloadAsync(new TransferUtilityDownloadRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName,
+                    FilePath = downloadPath
+                });
+                UtilityMethods.CompareFiles(path, downloadPath);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public async Task UploadWithResponseAsyncWithChecksumTest()
+        {
+            var fileName = UtilityMethods.GenerateName(@"UploadWithResponseTest\ChecksumFile");
+            var path = Path.Combine(BasePath, fileName);
+            var fileSize = 2 * MEG_SIZE;
+            UtilityMethods.GenerateFile(path, fileSize);
+
+            // Calculate checksum for the file
+            var fileBytes = File.ReadAllBytes(path);
+            var precalculatedChecksum = CryptoUtilFactory.CryptoInstance.ComputeCRC32Hash(fileBytes);
+
+            using (var transferUtility = new TransferUtility(Client))
+            {
+                var request = new TransferUtilityUploadRequest
+                {
+                    BucketName = bucketName,
+                    FilePath = path,
+                    Key = fileName,
+                    ContentType = octetStreamContentType,
+                    ChecksumCRC32 = precalculatedChecksum
+                };
+
+                var response = await transferUtility.UploadWithResponseAsync(request);
+
+                // Validate response object is not null
+                Assert.IsNotNull(response, "Response should not be null");
+
+                // Validate essential response fields
+                Assert.IsNotNull(response.ETag, "ETag should not be null");
+                Assert.IsTrue(response.ETag.Length > 0, "ETag should not be empty");
+
+                // Validate checksum fields if they should be present
+                // Note: Checksum fields in response may not always be set depending on S3 behavior
+                Console.WriteLine($"ETag: {response.ETag}");
+                Console.WriteLine($"ChecksumCRC32: {response.ChecksumCRC32}");
+                Console.WriteLine($"ChecksumType: {response.ChecksumType}");
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        public async Task UploadWithResponseAsyncCompareWithLegacyUploadTest()
+        {
+            var fileName = UtilityMethods.GenerateName(@"UploadWithResponseTest\CompareFile");
+            var path = Path.Combine(BasePath, fileName);
+            var fileSize = 8 * MEG_SIZE;
+            UtilityMethods.GenerateFile(path, fileSize);
+
+            using (var transferUtility = new TransferUtility(Client))
+            {
+                // Test the new UploadWithResponseAsync method
+                var responseRequest = new TransferUtilityUploadRequest
+                {
+                    BucketName = bucketName,
+                    FilePath = path,
+                    Key = fileName + "-with-response",
+                    ContentType = octetStreamContentType
+                };
+
+                var response = await transferUtility.UploadWithResponseAsync(responseRequest);
+
+                // Test the legacy Upload method for comparison
+                var legacyRequest = new TransferUtilityUploadRequest
+                {
+                    BucketName = bucketName,
+                    FilePath = path,
+                    Key = fileName + "-legacy",
+                    ContentType = octetStreamContentType
+                };
+
+                await transferUtility.UploadAsync(legacyRequest);
+
+                // Validate that both uploads resulted in the same file being uploaded
+                var responseMetadata = await Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName + "-with-response"
+                });
+
+                var legacyMetadata = await Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName + "-legacy"
+                });
+
+                // Both should have the same file size and content type
+                Assert.AreEqual(responseMetadata.ContentLength, legacyMetadata.ContentLength, "File sizes should match");
+                Assert.AreEqual(responseMetadata.Headers.ContentType, legacyMetadata.Headers.ContentType, "Content types should match");
+
+                // Validate the response contains the expected ETag
+                Assert.IsNotNull(response.ETag, "Response ETag should not be null");
+                Assert.AreEqual(response.ETag, responseMetadata.ETag, "Response ETag should match metadata ETag");
+
+                Console.WriteLine($"UploadWithResponseAsync ETag: {response.ETag}");
+                Console.WriteLine($"Legacy upload ETag: {legacyMetadata.ETag}");
+                Console.WriteLine($"File size: {fileSize}, Response metadata size: {responseMetadata.ContentLength}");
+            }
         }
 
 #if ASYNC_AWAIT


### PR DESCRIPTION
Stacked PRs:
 * #4109
 * #4079
 * __->__#4105


--- --- ---

## Description
This change creates a new api `UploadWithResponseAsync`. It is the same as the existing `UploadAsync` api but it returns the `TransferUtilityUploadResponse` object.

## How
In order to re-use as much as the existing code as possible, I made `BaseCommand` take in a generic which is the return type of the `ExecuteAsync` function. All commands `UploadCommand`, `DownloadCommand`, etc will pass in their expected return type `TransferUtilityUploadResponse`, `TransferUTilityDownloadResponse`, etc. 

In order to make this change in one go, I had to create place holder classes for `TransferUtilityDownloadDirectoryResponse` and other responses. These will eventually be populated in future PRs 

## Motivation and Context
1. To adhere to the SEP

## Testing
1.dry run -  36f635c4-0fbb-4d2c-9b9c-b977c7906aef  in progress
2. Integration tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement