### PR TITLE
Fix Unit test

### DIFF
--- a/sdk/test/Services/S3/UnitTests/Custom/MultipartUploadValidationTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/MultipartUploadValidationTests.cs
@@ -69,6 +69,18 @@ namespace AWSSDK.UnitTests
                     return new UploadPartResponse { PartNumber = request.PartNumber };
                 });
 
+            s3Client
+                .Setup(x => x.CompleteMultipartUploadAsync(
+                    It.IsAny<CompleteMultipartUploadRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CompleteMultipartUploadResponse
+                {
+                    BucketName = "test-bucket",
+                    Key = "test",
+                    ETag = "test-etag",
+                    Location = "https://test-bucket.s3.amazonaws.com/test"
+                });
+
             var uploadRequest = new TransferUtilityUploadRequest
             {
                 FilePath = _tempFilePath,


### PR DESCRIPTION
Fix unit tests. not sure how previous dry runs never failed.
```
test Run Failed.
     Passed: 1
     Failed: 1
 Total time: 2.6469 Seconds
  AWSSDK.UnitTests.S3.NetFramework test failed with 1 error(s) (3.3s)
    C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\Custom\Transfer\Internal\_async\MultipartUploadCommand.async.cs(156): error TESTERROR:
      Validation_HappyPath (1s 50ms): Error Message: Test method AWSSDK.UnitTests.MultipartUploadValidationTests.Validation_HappyPath threw except
      ion:
      Validation_HappyPath (1s 50ms): Error Message: Test method AWSSDK.UnitTests.MultipartUploadValidationTests.Validation_HappyPath threw      Validation_HappyPath (1s 50ms): Error Message: Test method AWSSDK.UnitTests.MultipartUploadValidationTests.Validation_HappyPath thr      Validation_HappyPath (1s 50ms): Error Message: Test method AWSSDK.UnitTests.MultipartUploadValidationTests.Validation_HappyPath threw except      ion:
      System.ArgumentNullException: Value cannot be null.
      Parameter name: source
      Stack Trace:
```


 the reason it was failing is because we never mocked CompleteMultipartUploadResponse response object. 

## Testing
re-ran unit test and it passed

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement