### PR TITLE
Populate TransferUtilityDownloadDirectoryResponse with total objects downloaded

### DIFF
--- a/generator/.DevConfigs/c49077d9-90b3-437f-b316-6d8d8833ae73.json
+++ b/generator/.DevConfigs/c49077d9-90b3-437f-b316-6d8d8833ae73.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Populate TransferUtilityDownloadDirectoryResponse with total objects downloaded"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
@@ -108,12 +108,16 @@ namespace Amazon.S3.Transfer.Internal
                     var command = new DownloadCommand(this._s3Client, downloadRequest);
 
                     var task = ExecuteCommandAsync(command, internalCts, asyncThrottler);
+                    
                     pendingTasks.Add(task);
                 }
                 await WhenAllOrFirstExceptionAsync(pendingTasks, cancellationToken)
                     .ConfigureAwait(continueOnCapturedContext: false);
 
-                return new TransferUtilityDownloadDirectoryResponse();
+                return new TransferUtilityDownloadDirectoryResponse
+                {
+                    ObjectsDownloaded = _numberOfFilesDownloaded
+                };
             }
             finally
             {

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryResponse.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryResponse.cs
@@ -22,5 +22,9 @@ namespace Amazon.S3.Transfer
     /// </summary>
     public class TransferUtilityDownloadDirectoryResponse
     {
+        /// <summary>
+        /// The number of objects that have been downloaded
+        /// </summary>
+        public long ObjectsDownloaded { get; set; }
     }
 }


### PR DESCRIPTION
Stacked PRs:
 * __->__#4109


--- --- ---

## Description
Create TransferUtililityDownloadResponse class which is populated with the number of successful downloads. 

## Motivation and Context
1. Eventually we will be creating new DownloadWithResponseAPI that will return this object. 

## Testing
1. dry run in progress
2. manually tested
<img width="1525" height="848" alt="image" src="https://github.com/user-attachments/assets/878304d3-e06d-4743-9ae6-0b3fb97361c7" />



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement