### PR TITLE
Update TransferUtilityConfig and BaseDownloadRequest to add multipartdownload config options

### DIFF
--- a/generator/.DevConfigs/19ed68ce-9f46-4e1e-a0ff-45a2b3641946.json
+++ b/generator/.DevConfigs/19ed68ce-9f46-4e1e-a0ff-45a2b3641946.json
@@ -1,0 +1,13 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Added MaxInMemoryParts property to TransferUtilityConfig for controlling memory usage during multipart downloads",
+        "Added PartSize property to BaseDownloadRequest for configuring multipart download part sizes",
+        "Added MultipartDownloadType enum and property to BaseDownloadRequest for selecting download strategy"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/BaseDownloadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/BaseDownloadRequest.cs
@@ -29,6 +29,22 @@ using Amazon.S3.Model;
 namespace Amazon.S3.Transfer
 {
     /// <summary>
+    /// Specifies the strategy for multipart downloads
+    /// </summary>
+    public enum MultipartDownloadType
+    {
+        /// <summary>
+        /// Use part-based downloads with original upload part boundaries
+        /// </summary>
+        PART,
+        
+        /// <summary>
+        /// Use range-based downloads with configurable part sizes
+        /// </summary>
+        RANGE
+    }
+
+    /// <summary>
     /// The base class for requests that return Amazon S3 objects.
     /// </summary>
     public abstract class BaseDownloadRequest
@@ -50,6 +66,8 @@ namespace Amazon.S3.Transfer
         private string ifMatch;
         private string ifNoneMatch;
         private ResponseHeaderOverrides responseHeaders;
+        private long? partSize;
+        private MultipartDownloadType multipartDownloadType = MultipartDownloadType.PART;
         
         /// <summary>
         /// 	Gets or sets the name of the bucket.
@@ -329,6 +347,46 @@ namespace Amazon.S3.Transfer
             {
                 this.responseHeaders = value;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the part size of the download in bytes.
+        /// The downloaded file will be divided into 
+        /// parts the size specified and
+        /// downloaded from Amazon S3 individually.
+        /// This is used when MultipartDownloadType is set to RANGE.
+        /// </summary>
+        /// <value>
+        /// The part size of the download.
+        /// </value>
+        public long PartSize
+        {
+            get { return this.partSize.GetValueOrDefault(); }
+            set { this.partSize = value; }
+        }
+
+        /// <summary>
+        /// Checks if PartSize property is set.
+        /// </summary>
+        /// <returns>true if PartSize property is set.</returns>
+        internal bool IsSetPartSize()
+        {
+            return this.partSize.HasValue;
+        }
+
+        /// <summary>
+        /// Gets or sets the type of multipart download to use.
+        /// PART: Uses part GET with original part sizes from upload (ignores PartSize)
+        /// RANGE: Uses ranged GET with PartSize to determine ranges
+        /// Default is PART
+        /// </summary>
+        /// <value>
+        /// The multipart download type.
+        /// </value>
+        public MultipartDownloadType MultipartDownloadType
+        {
+            get { return this.multipartDownloadType; }
+            set { this.multipartDownloadType = value; }
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityConfig.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityConfig.cs
@@ -42,6 +42,7 @@ namespace Amazon.S3.Transfer
     {
         long _minSizeBeforePartUpload = 16 * (long)Math.Pow(2, 20);
         int _concurrentServiceRequests;
+        int _maxInMemoryParts = 1024; // When combined with the default part size of 8MB, we get 8GB of memory being utilized as the default.
 
         /// <summary>
         /// Default constructor.
@@ -79,6 +80,22 @@ namespace Amazon.S3.Transfer
                     value = 1;
 
                 this._concurrentServiceRequests = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of parts to buffer in memory during multipart downloads.
+        /// The default value is 1024.
+        /// </summary>
+        public int MaxInMemoryParts
+        {
+            get { return this._maxInMemoryParts; }
+            set
+            {
+                if (value < 1)
+                    value = 1;
+
+                this._maxInMemoryParts = value;
             }
         }
     }


### PR DESCRIPTION
This change adds config options for multi part download.


## Description

The three config options we are adding are

1. MultiPartDownloadType - this is self explanatory, it determines which strategy we will use to call s3 to get each file part.
2. PartSize - This is the part size to use when MultipartDownloadType is set to RANGE. The default value will eventually be set to 8MB. 
3. MaxInMemoryParts - this is the number of parts that will be buffered in memory when using stream based downloading. The reason that this value is in the TransferUtilityConfig instead of the individual request is because it will follow the same pattern of MultiPartUpload and ConcurrentServiceRequests, where MaxInMemoryParts will be shared across all files in a directory download.


## Motivation and Context
1. This is the first PR in implementing multi part download. 
5. https://github.com/aws/aws-sdk-net/issues/3806

## Testing
1. Dry Run f4f3a190-0165-4432-ab54-11ec09e43a90 pass


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement