### PR TITLE
Add DownloadDirectoryWithResponse

### DIFF
--- a/generator/.DevConfigs/55fe9e14-c79e-4426-9828-deae0451d4f6.json
+++ b/generator/.DevConfigs/55fe9e14-c79e-4426-9828-deae0451d4f6.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "minor",
+      "changeLogMessages": [
+        "Created new DownloadDirectoryWithResponseAsync methods on the Amazon.S3.Transfer.TransferUtility class. The new operations support downloading directories using multipart download for files and return response metadata."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
@@ -42,6 +42,7 @@ namespace Amazon.S3.Transfer.Internal
         private readonly IAmazonS3 _s3Client;
         private readonly TransferUtilityDownloadDirectoryRequest _request;
         private readonly bool _skipEncryptionInstructionFiles;
+        private readonly bool _useMultipartDownload;
         int _totalNumberOfFilesToDownload;
         int _numberOfFilesDownloaded;
         long _totalBytes;
@@ -49,9 +50,16 @@ namespace Amazon.S3.Transfer.Internal
         string _currentFile;
 
         internal DownloadDirectoryCommand(IAmazonS3 s3Client, TransferUtilityDownloadDirectoryRequest request)
+            : this(s3Client, request, useMultipartDownload: false)
+        {
+        }
+
+        internal DownloadDirectoryCommand(IAmazonS3 s3Client, TransferUtilityDownloadDirectoryRequest request, bool useMultipartDownload)
         {
             if (s3Client == null)
-                throw new ArgumentNullException("s3Client");
+                throw new ArgumentNullException(nameof(s3Client));
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
 
             this._s3Client = s3Client;
             this._request = request;
@@ -60,6 +68,13 @@ namespace Amazon.S3.Transfer.Internal
                 request.FailurePolicy == FailurePolicy.AbortOnFailure
                     ? new AbortOnFailurePolicy()
                     : new ContinueOnFailurePolicy(_errors);
+            this._useMultipartDownload = useMultipartDownload;
+        }
+
+        internal DownloadDirectoryCommand(IAmazonS3 s3Client, TransferUtilityDownloadDirectoryRequest request, TransferUtilityConfig config, bool useMultipartDownload)
+            : this(s3Client, request, useMultipartDownload)
+        {
+            this._config = config;
         }
 
         private void downloadedProgressEventCallback(object sender, WriteObjectProgressArgs e)

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/FilePartDataHandler.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/FilePartDataHandler.cs
@@ -47,6 +47,10 @@ namespace Amazon.S3.Transfer.Internal
             get { return Logger.GetLogger(typeof(TransferUtility)); }
         }
 
+        /// <summary>
+        /// Initializes a new instance for file downloads.
+        /// Writes parts directly to disk without memory buffering.
+        /// </summary>
         public FilePartDataHandler(FileDownloadConfiguration config)
         {
             _config = config ?? throw new ArgumentNullException(nameof(config));
@@ -90,14 +94,16 @@ namespace Amazon.S3.Transfer.Internal
         /// <inheritdoc/>
         public Task WaitForCapacityAsync(CancellationToken cancellationToken)
         {
-            // No backpressure needed - OS handles concurrent file access
+            // No-op: FilePartDataHandler writes directly to disk without buffering parts in memory.
+            // Memory throttling is only needed for BufferedPartDataHandler which keeps parts in memory.
             return Task.CompletedTask;
         }
 
         /// <inheritdoc/>
         public void ReleaseCapacity()
         {
-            // No-op
+            // No-op: FilePartDataHandler writes directly to disk without buffering parts in memory.
+            // Memory throttling is only needed for BufferedPartDataHandler which keeps parts in memory.
         }
 
         /// <inheritdoc/>

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/MultipartDownloadCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/MultipartDownloadCommand.async.cs
@@ -50,12 +50,14 @@ namespace Amazon.S3.Transfer.Internal
             using (var dataHandler = new FilePartDataHandler(config))
             {
                 // Create coordinator to manage the download process
+                // Pass shared HTTP throttler to control concurrency across files
                 using (var coordinator = new MultipartDownloadManager(
                     _s3Client,
                     _request,
                     config,
                     dataHandler,
-                    RequestEventHandler))
+                    RequestEventHandler,
+                    _sharedHttpThrottler))
                 {
                     long totalBytes = -1;
                     try

--- a/sdk/src/Services/S3/Custom/Transfer/_async/ITransferUtility.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_async/ITransferUtility.async.cs
@@ -432,6 +432,41 @@ namespace Amazon.S3.Transfer
         /// <returns>The task object representing the asynchronous operation with download response metadata.</returns>
         Task<TransferUtilityDownloadResponse> DownloadWithResponseAsync(TransferUtilityDownloadRequest request, CancellationToken cancellationToken = default(CancellationToken));
 
+        /// <summary>
+        /// 	Downloads the objects in Amazon S3 that have a key that starts with the value 
+        /// 	specified by <c>s3Directory</c> and returns response metadata.
+        /// 	Uses enhanced multipart download with concurrent part downloads for improved performance.
+        /// </summary>
+        /// <param name="bucketName">
+        /// 	The name of the bucket containing the Amazon S3 objects to download.
+        /// </param>
+        /// <param name="s3Directory">
+        /// 	The directory in Amazon S3 to download.
+        /// </param>
+        /// <param name="localDirectory">
+        /// 	The local directory to download the objects to.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The task object representing the asynchronous operation with download response metadata.</returns>
+        Task<TransferUtilityDownloadDirectoryResponse> DownloadDirectoryWithResponseAsync(string bucketName, string s3Directory, string localDirectory, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// 	Downloads the objects in Amazon S3 that have a key that starts with the value 
+        /// 	specified by the <c>S3Directory</c> property and returns response metadata.
+        /// 	Uses enhanced multipart download with concurrent part downloads for improved performance.
+        /// </summary>
+        /// <param name="request">
+        /// 	Contains all the parameters required to download objects from Amazon S3 
+        /// 	into a local directory.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The task object representing the asynchronous operation with download response metadata.</returns>
+        Task<TransferUtilityDownloadDirectoryResponse> DownloadDirectoryWithResponseAsync(TransferUtilityDownloadDirectoryRequest request, CancellationToken cancellationToken = default(CancellationToken));
+
         #endregion
 
         #region OpenStream

--- a/sdk/src/Services/S3/Custom/Transfer/_async/TransferUtility.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_async/TransferUtility.async.cs
@@ -232,6 +232,29 @@ namespace Amazon.S3.Transfer
 
         #endregion
 
+        #region DownloadDirectory
+
+        /// <inheritdoc/>
+        public async Task<TransferUtilityDownloadDirectoryResponse> DownloadDirectoryWithResponseAsync(string bucketName, string s3Directory, string localDirectory, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var request = ConstructDownloadDirectoryRequest(bucketName, s3Directory, localDirectory);
+            return await DownloadDirectoryWithResponseAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task<TransferUtilityDownloadDirectoryResponse> DownloadDirectoryWithResponseAsync(TransferUtilityDownloadDirectoryRequest request, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using(CreateSpan(nameof(DownloadDirectoryWithResponseAsync), null, Amazon.Runtime.Telemetry.Tracing.SpanKind.CLIENT))
+            {
+                CheckForBlockedArn(request.BucketName, "DownloadDirectory");
+                var command = new DownloadDirectoryCommand(this._s3Client, request, this._config, true);
+                command.DownloadFilesConcurrently = request.DownloadFilesConcurrently;
+                return await command.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        #endregion
+
         internal BaseCommand<TransferUtilityUploadResponse> GetUploadCommand(TransferUtilityUploadRequest request, SemaphoreSlim asyncThrottler)
         {
             validate(request);

--- a/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/ITransferUtility.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/ITransferUtility.async.cs
@@ -152,6 +152,13 @@ namespace Amazon.S3.Transfer
         /// 	Downloads the objects in Amazon S3 that have a key that starts with the value 
         /// 	specified by <c>s3Directory</c>.
         /// </summary>
+        /// <remarks>
+        /// 	<para>
+        /// 	<b>Note:</b> Consider using <see cref="DownloadDirectoryWithResponseAsync(string, string, string, CancellationToken)"/> 
+        /// 	instead. The newer operation uses enhanced multipart download with concurrent part downloads 
+        /// 	for improved performance and returns response metadata including the total number of objects downloaded.
+        /// 	</para>
+        /// </remarks>
         /// <param name="bucketName">
         /// 	The name of the bucket containing the Amazon S3 objects to download.
         /// </param>
@@ -172,6 +179,13 @@ namespace Amazon.S3.Transfer
         /// 	specified by the <c>S3Directory</c>
         /// 	property of the passed in <c>TransferUtilityDownloadDirectoryRequest</c> object.
         /// </summary>
+        /// <remarks>
+        /// 	<para>
+        /// 	<b>Note:</b> Consider using <see cref="DownloadDirectoryWithResponseAsync(TransferUtilityDownloadDirectoryRequest, CancellationToken)"/> 
+        /// 	instead. The newer operation uses enhanced multipart download with concurrent part downloads 
+        /// 	for improved performance and returns response metadata including the total number of objects downloaded.
+        /// 	</para>
+        /// </remarks>
         /// <param name="request">
         /// 	Contains all the parameters required to download objects from Amazon S3 
         /// 	into a local directory.

--- a/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/ITransferUtility.sync.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/ITransferUtility.sync.cs
@@ -534,6 +534,13 @@ namespace Amazon.S3.Transfer
         /// 	Downloads the objects in Amazon S3 that have a key that starts with the value 
         /// 	specified by <c>s3Directory</c>.
         /// </summary>
+        /// <remarks>
+        /// 	<para>
+        /// 	<b>Note:</b> Consider using <see cref="DownloadDirectoryWithResponse(string, string, string)"/> 
+        /// 	instead. The newer operation uses enhanced multipart download with concurrent part downloads 
+        /// 	for improved performance and returns response metadata including the total number of objects downloaded.
+        /// 	</para>
+        /// </remarks>
         /// <param name="bucketName">
         /// 	The name of the bucket containing the Amazon S3 objects to download.
         /// </param>
@@ -550,11 +557,48 @@ namespace Amazon.S3.Transfer
         /// 	specified by the <c>S3Directory</c>
         /// 	property of the passed in <c>TransferUtilityDownloadDirectoryRequest</c> object.
         /// </summary>
+        /// <remarks>
+        /// 	<para>
+        /// 	<b>Note:</b> Consider using <see cref="DownloadDirectoryWithResponse(TransferUtilityDownloadDirectoryRequest)"/> 
+        /// 	instead. The newer operation uses enhanced multipart download with concurrent part downloads 
+        /// 	for improved performance and returns response metadata including the total number of objects downloaded.
+        /// 	</para>
+        /// </remarks>
         /// <param name="request">
         /// 	Contains all the parameters required to download objects from Amazon S3 
         /// 	into a local directory.
         /// </param>
         void DownloadDirectory(TransferUtilityDownloadDirectoryRequest request);
+
+        /// <summary>
+        /// 	Downloads the objects in Amazon S3 that have a key that starts with the value 
+        /// 	specified by <c>s3Directory</c>, returning response metadata.
+        /// 	Uses enhanced multipart download with concurrent part downloads for improved performance.
+        /// </summary>
+        /// <param name="bucketName">
+        /// 	The name of the bucket containing the Amazon S3 objects to download.
+        /// </param>
+        /// <param name="s3Directory">
+        /// 	The directory in Amazon S3 to download.
+        /// </param>
+        /// <param name="localDirectory">
+        /// 	The local directory to download the objects to.
+        /// </param>
+        /// <returns>Response metadata including the number of objects downloaded.</returns>
+        TransferUtilityDownloadDirectoryResponse DownloadDirectoryWithResponse(string bucketName, string s3Directory, string localDirectory);
+
+        /// <summary>
+        /// 	Downloads the objects in Amazon S3 that have a key that starts with the value 
+        /// 	specified by the <c>S3Directory</c> property of the passed in 
+        /// 	<c>TransferUtilityDownloadDirectoryRequest</c> object, returning response metadata.
+        /// 	Uses enhanced multipart download with concurrent part downloads for improved performance.
+        /// </summary>
+        /// <param name="request">
+        /// 	Contains all the parameters required to download objects from Amazon S3 
+        /// 	into a local directory.
+        /// </param>
+        /// <returns>Response metadata including the number of objects downloaded.</returns>
+        TransferUtilityDownloadDirectoryResponse DownloadDirectoryWithResponse(TransferUtilityDownloadDirectoryRequest request);
         #endregion
 
         #region AbortMultipartUploads

--- a/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/TransferUtility.sync.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/TransferUtility.sync.cs
@@ -327,6 +327,34 @@ namespace Amazon.S3.Transfer
                 ExceptionDispatchInfo.Capture(e.InnerException).Throw();
             }
         }
+
+        /// <inheritdoc/>
+        public TransferUtilityDownloadDirectoryResponse DownloadDirectoryWithResponse(string bucketName, string s3Directory, string localDirectory)
+        {
+            try
+            {
+                return DownloadDirectoryWithResponseAsync(bucketName, s3Directory, localDirectory).Result;
+            }
+            catch (AggregateException e)
+            {
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                return null;
+            }
+        }
+
+        /// <inheritdoc/>
+        public TransferUtilityDownloadDirectoryResponse DownloadDirectoryWithResponse(TransferUtilityDownloadDirectoryRequest request)
+        {
+            try
+            {
+                return DownloadDirectoryWithResponseAsync(request).Result;
+            }
+            catch (AggregateException e)
+            {
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                return null;
+            }
+        }
         #endregion
 
         #region AbortMultipartUploads

--- a/sdk/test/Services/S3/IntegrationTests/TransferUtilityDownloadDirectoryWithResponseTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/TransferUtilityDownloadDirectoryWithResponseTests.cs
@@ -1,0 +1,632 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Transfer;
+using Amazon.S3.Util;
+using AWSSDK_DotNet.IntegrationTests.Utils;
+
+namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
+{
+    /// <summary>
+    /// Integration tests for TransferUtility.DownloadDirectoryWithResponseAsync functionality.
+    /// These tests verify end-to-end functionality with actual S3 operations and directory I/O.
+    /// 
+    /// These integration tests focus on:
+    /// - Basic directory downloads with response object
+    /// - Progress tracking with response
+    /// - Multipart downloads in directory context
+    /// - Concurrent vs sequential downloads
+    /// - Nested directory structures
+    /// - Response validation
+    /// </summary>
+    [TestClass]
+    public class TransferUtilityDownloadDirectoryWithResponseTests : TestBase<AmazonS3Client>
+    {
+        private static readonly long MB = 1024 * 1024;
+        private static readonly long KB = 1024;
+        private static string bucketName;
+        private static string tempDirectory;
+
+        [ClassInitialize()]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            bucketName = S3TestUtils.CreateBucketWithWait(Client);
+            tempDirectory = Path.Combine(Path.GetTempPath(), "S3DownloadDirectoryTests-" + Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDirectory);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            AmazonS3Util.DeleteS3BucketWithObjects(Client, bucketName);
+            
+            // Clean up temp directory
+            if (Directory.Exists(tempDirectory))
+            {
+                try
+                {
+                    Directory.Delete(tempDirectory, recursive: true);
+                }
+                catch
+                {
+                    // Best effort cleanup
+                }
+            }
+            
+            BaseClean();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            // Clean up any test directories after each test
+            if (Directory.Exists(tempDirectory))
+            {
+                foreach (var subDir in Directory.GetDirectories(tempDirectory))
+                {
+                    try
+                    {
+                        Directory.Delete(subDir, recursive: true);
+                    }
+                    catch
+                    {
+                        // Best effort cleanup
+                    }
+                }
+            }
+        }
+
+        #region Basic Download Tests
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        public async Task DownloadDirectoryWithResponse_BasicDownload_ReturnsCorrectResponse()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("basic-download");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+            var fileCount = 5;
+            
+            // Upload test directory
+            await UploadTestDirectory(keyPrefix, 2 * MB, fileCount);
+
+            // Act
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response, "Response should not be null");
+            Assert.AreEqual(fileCount, response.ObjectsDownloaded, "ObjectsDownloaded should match file count");
+            
+            // Verify all files were downloaded
+            var downloadedFiles = Directory.GetFiles(downloadPath, "*", SearchOption.AllDirectories);
+            Assert.AreEqual(fileCount, downloadedFiles.Length, "Downloaded file count should match");
+            
+            // Verify no temp files remain
+            VerifyNoTempFilesExist(downloadPath);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        public async Task DownloadDirectoryWithResponse_EmptyDirectory_ReturnsZeroObjectsDownloaded()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("empty-directory");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+
+            // Act - Download non-existent directory
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response, "Response should not be null");
+            Assert.AreEqual(0, response.ObjectsDownloaded, "ObjectsDownloaded should be 0 for empty directory");
+            
+            // Directory may or may not exist, but should have no files
+            if (Directory.Exists(downloadPath))
+            {
+                var downloadedFiles = Directory.GetFiles(downloadPath, "*", SearchOption.AllDirectories);
+                Assert.AreEqual(0, downloadedFiles.Length, "No files should be downloaded");
+            }
+        }
+
+        #endregion
+
+        #region Progress Tracking Tests
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        public async Task DownloadDirectoryWithResponse_WithProgressTracking_FiresProgressEvents()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("progress-tracking");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+            var fileCount = 3;
+            
+            await UploadTestDirectory(keyPrefix, 5 * MB, fileCount);
+
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+            var progressLock = new object();
+
+            // Act
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath
+            };
+            
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                lock (progressLock)
+                {
+                    progressEvents.Add(args);
+                }
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response, "Response should not be null");
+            Assert.AreEqual(fileCount, response.ObjectsDownloaded);
+            Assert.IsTrue(progressEvents.Count > 0, "Progress events should have fired");
+            
+            // Verify final progress event
+            var finalEvent = progressEvents.Last();
+            Assert.AreEqual(fileCount, finalEvent.NumberOfFilesDownloaded);
+            Assert.AreEqual(fileCount, finalEvent.TotalNumberOfFiles);
+            Assert.AreEqual(finalEvent.TransferredBytes, finalEvent.TotalBytes);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        public async Task DownloadDirectoryWithResponse_SequentialMode_IncludesCurrentFileDetails()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("sequential-progress");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+            
+            await UploadTestDirectory(keyPrefix, 3 * MB, 3);
+
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+
+            // Act
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath,
+                DownloadFilesConcurrently = false // Sequential mode
+            };
+            
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                progressEvents.Add(args);
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(3, response.ObjectsDownloaded);
+            
+            // In sequential mode, should have CurrentFile populated
+            var eventsWithFile = progressEvents.Where(e => e.CurrentFile != null).ToList();
+            Assert.IsTrue(eventsWithFile.Count > 0, "Should have events with CurrentFile populated");
+            
+            foreach (var evt in eventsWithFile)
+            {
+                Assert.IsNotNull(evt.CurrentFile);
+                Assert.IsTrue(evt.TotalNumberOfBytesForCurrentFile > 0);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        public async Task DownloadDirectoryWithResponse_ConcurrentMode_OmitsCurrentFileDetails()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("concurrent-progress");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+            
+            await UploadTestDirectory(keyPrefix, 3 * MB, 4);
+
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+            var progressLock = new object();
+
+            // Act
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath,
+                DownloadFilesConcurrently = true // Concurrent mode
+            };
+            
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                lock (progressLock)
+                {
+                    progressEvents.Add(args);
+                }
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(4, response.ObjectsDownloaded);
+            Assert.IsTrue(progressEvents.Count > 0);
+            
+            // In concurrent mode, CurrentFile should be null
+            foreach (var evt in progressEvents)
+            {
+                Assert.IsNull(evt.CurrentFile, "CurrentFile should be null in concurrent mode");
+                Assert.AreEqual(0, evt.TransferredBytesForCurrentFile);
+                Assert.AreEqual(0, evt.TotalNumberOfBytesForCurrentFile);
+            }
+        }
+
+        #endregion
+
+        #region Multipart Download Tests
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        [TestCategory("Multipart")]
+        public async Task DownloadDirectoryWithResponse_WithMultipartFiles_DownloadsSuccessfully()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("multipart-directory");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+            var fileCount = 3;
+            
+            // Upload directory with large files to trigger multipart (>16MB threshold)
+            await UploadTestDirectory(keyPrefix, 20 * MB, fileCount);
+
+            // Act
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(fileCount, response.ObjectsDownloaded);
+            
+            // Verify all files downloaded with correct sizes
+            var downloadedFiles = Directory.GetFiles(downloadPath, "*", SearchOption.AllDirectories);
+            Assert.AreEqual(fileCount, downloadedFiles.Length);
+            
+            foreach (var file in downloadedFiles)
+            {
+                var fileInfo = new FileInfo(file);
+                Assert.AreEqual(20 * MB, fileInfo.Length, $"File {file} should be 20MB");
+            }
+            
+            VerifyNoTempFilesExist(downloadPath);
+        }
+
+        #endregion
+
+        #region Nested Directory Tests
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        public async Task DownloadDirectoryWithResponse_NestedDirectories_PreservesStructure()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("nested-structure");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+            
+            // Upload nested directory structure
+            var nestedFiles = new Dictionary<string, long>
+            {
+                { "level1/file1.txt", 1 * MB },
+                { "level1/level2/file2.txt", 2 * MB },
+                { "level1/level2/level3/file3.txt", 3 * MB }
+            };
+            
+            await UploadTestFilesWithStructure(keyPrefix, nestedFiles);
+
+            // Act
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(nestedFiles.Count, response.ObjectsDownloaded);
+            
+            // Verify directory structure
+            foreach (var kvp in nestedFiles)
+            {
+                var expectedPath = Path.Combine(downloadPath, kvp.Key.Replace('/', Path.DirectorySeparatorChar));
+                Assert.IsTrue(File.Exists(expectedPath), $"File should exist: {expectedPath}");
+                
+                var fileInfo = new FileInfo(expectedPath);
+                Assert.AreEqual(kvp.Value, fileInfo.Length, $"File size should match: {expectedPath}");
+            }
+        }
+
+        #endregion
+
+        #region Concurrent vs Sequential Tests
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        public async Task DownloadDirectoryWithResponse_ConcurrentMode_DownloadsAllFiles()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("concurrent-download");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+            var fileCount = 10;
+            
+            await UploadTestDirectory(keyPrefix, 2 * MB, fileCount);
+
+            // Act
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath,
+                DownloadFilesConcurrently = true
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(fileCount, response.ObjectsDownloaded);
+            
+            var downloadedFiles = Directory.GetFiles(downloadPath, "*", SearchOption.AllDirectories);
+            Assert.AreEqual(fileCount, downloadedFiles.Length);
+        }
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        public async Task DownloadDirectoryWithResponse_SequentialMode_DownloadsAllFiles()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("sequential-download");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+            var fileCount = 5;
+            
+            await UploadTestDirectory(keyPrefix, 3 * MB, fileCount);
+
+            // Act
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath,
+                DownloadFilesConcurrently = false
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(fileCount, response.ObjectsDownloaded);
+            
+            var downloadedFiles = Directory.GetFiles(downloadPath, "*", SearchOption.AllDirectories);
+            Assert.AreEqual(fileCount, downloadedFiles.Length);
+        }
+
+        #endregion
+
+        #region Mixed File Size Tests
+
+        [TestMethod]
+        [TestCategory("S3")]
+        [TestCategory("DownloadDirectory")]
+        public async Task DownloadDirectoryWithResponse_MixedFileSizes_DownloadsAll()
+        {
+            // Arrange
+            var keyPrefix = UtilityMethods.GenerateName("mixed-sizes");
+            var downloadPath = Path.Combine(tempDirectory, keyPrefix + "-download");
+            
+            var mixedFiles = new Dictionary<string, long>
+            {
+                { "tiny.txt", 100 },                // 100 bytes
+                { "small.txt", 512 * KB },          // 512 KB
+                { "medium.txt", 5 * MB },           // 5 MB
+                { "large.txt", 20 * MB }            // 20 MB (multipart)
+            };
+            
+            await UploadTestFilesWithStructure(keyPrefix, mixedFiles);
+
+            // Act
+            var transferUtility = new TransferUtility(Client);
+            var request = new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = keyPrefix,
+                LocalDirectory = downloadPath
+            };
+            
+            var response = await transferUtility.DownloadDirectoryWithResponseAsync(request);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(mixedFiles.Count, response.ObjectsDownloaded);
+            
+            // Verify each file's size
+            foreach (var kvp in mixedFiles)
+            {
+                var filePath = Path.Combine(downloadPath, kvp.Key);
+                Assert.IsTrue(File.Exists(filePath), $"File should exist: {filePath}");
+                
+                var fileInfo = new FileInfo(filePath);
+                Assert.AreEqual(kvp.Value, fileInfo.Length, $"File size should match: {filePath}");
+            }
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Uploads a test directory with specified number of files using TransferUtility.UploadDirectory
+        /// </summary>
+        private static async Task UploadTestDirectory(string keyPrefix, long fileSize, int fileCount)
+        {
+            // Create local temp directory structure
+            var tempUploadDir = Path.Combine(Path.GetTempPath(), "upload-" + Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempUploadDir);
+            
+            try
+            {
+                // Generate files locally
+                for (int i = 0; i < fileCount; i++)
+                {
+                    var fileName = $"file{i}.dat";
+                    var localPath = Path.Combine(tempUploadDir, fileName);
+                    UtilityMethods.GenerateFile(localPath, fileSize);
+                }
+                
+                // Upload entire directory using TransferUtility
+                var transferUtility = new TransferUtility(Client);
+                var request = new TransferUtilityUploadDirectoryRequest
+                {
+                    BucketName = bucketName,
+                    Directory = tempUploadDir,
+                    KeyPrefix = keyPrefix,
+                    SearchPattern = "*.dat",  // Only match test data files, not system files
+                    SearchOption = SearchOption.AllDirectories
+                };
+                
+                await transferUtility.UploadDirectoryAsync(request);
+            }
+            finally
+            {
+                // Cleanup temp directory
+                if (Directory.Exists(tempUploadDir))
+                {
+                    try
+                    {
+                        Directory.Delete(tempUploadDir, recursive: true);
+                    }
+                    catch
+                    {
+                        // Best effort cleanup
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Uploads test files with specific structure using TransferUtility.UploadDirectory
+        /// </summary>
+        private static async Task UploadTestFilesWithStructure(string keyPrefix, Dictionary<string, long> files)
+        {
+            // Create local temp directory structure
+            var tempUploadDir = Path.Combine(Path.GetTempPath(), "upload-struct-" + Guid.NewGuid().ToString());
+            
+            try
+            {
+                // Generate files with directory structure locally
+                foreach (var kvp in files)
+                {
+                    var localPath = Path.Combine(tempUploadDir, kvp.Key.Replace('/', Path.DirectorySeparatorChar));
+                    var directory = Path.GetDirectoryName(localPath);
+                    
+                    if (!string.IsNullOrEmpty(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                    }
+                    
+                    UtilityMethods.GenerateFile(localPath, kvp.Value);
+                }
+                
+                // Upload entire directory using TransferUtility
+                var transferUtility = new TransferUtility(Client);
+                var request = new TransferUtilityUploadDirectoryRequest
+                {
+                    BucketName = bucketName,
+                    Directory = tempUploadDir,
+                    KeyPrefix = keyPrefix,
+                    SearchPattern = "*",
+                    SearchOption = SearchOption.AllDirectories
+                };
+                
+                await transferUtility.UploadDirectoryAsync(request);
+            }
+            finally
+            {
+                // Cleanup temp directory
+                if (Directory.Exists(tempUploadDir))
+                {
+                    try
+                    {
+                        Directory.Delete(tempUploadDir, recursive: true);
+                    }
+                    catch
+                    {
+                        // Best effort cleanup
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that no temporary files remain after download completion.
+        /// Temp files use the pattern: {originalPath}.s3tmp.{8-char-id}
+        /// </summary>
+        private static void VerifyNoTempFilesExist(string directoryPath)
+        {
+            if (Directory.Exists(directoryPath))
+            {
+                var tempFiles = Directory.GetFiles(directoryPath, "*.s3tmp.*", SearchOption.AllDirectories);
+                Assert.AreEqual(0, tempFiles.Length, 
+                    $"No temporary files should remain. Found: {string.Join(", ", tempFiles)}");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/sdk/test/Services/S3/UnitTests/Custom/DownloadDirectoryCommandTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/DownloadDirectoryCommandTests.cs
@@ -1,0 +1,994 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Transfer;
+using Amazon.S3.Transfer.Internal;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AWSSDK.UnitTests
+{
+    [TestClass]
+    public class DownloadDirectoryCommandTests
+    {
+        private string _testDirectory;
+        private Mock<IAmazonS3> _mockS3Client;
+        private TransferUtilityConfig _config;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _testDirectory = MultipartDownloadTestHelpers.CreateTempDirectory();
+            _mockS3Client = new Mock<IAmazonS3>();
+            _config = new TransferUtilityConfig
+            {
+                ConcurrentServiceRequests = 4
+            };
+
+            // Setup default S3 client config
+            var s3Config = new AmazonS3Config
+            {
+                BufferSize = 8192,
+            };
+            _mockS3Client.Setup(c => c.Config).Returns(s3Config);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            MultipartDownloadTestHelpers.CleanupTempDirectory(_testDirectory);
+        }
+
+        #region Constructor Tests
+
+        [TestMethod]
+        public void Constructor_WithValidParameters_CreatesCommand()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+
+            // Act
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request);
+
+            // Assert
+            Assert.IsNotNull(command);
+        }
+
+        [TestMethod]
+        public void Constructor_WithUseMultipartDownload_CreatesCommand()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+
+            // Act
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, useMultipartDownload: true);
+
+            // Assert
+            Assert.IsNotNull(command);
+        }
+
+        [TestMethod]
+        public void Constructor_WithConfigAndMultipart_CreatesCommand()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+
+            // Act
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Assert
+            Assert.IsNotNull(command);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_WithNullS3Client_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+
+            // Act
+            var command = new DownloadDirectoryCommand(null, request);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_WithNullRequest_ThrowsArgumentNullException()
+        {
+            // Act
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, null);
+        }
+
+        #endregion
+
+        #region ValidateRequest Tests
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task ExecuteAsync_WithMissingBucketName_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.BucketName = null;
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task ExecuteAsync_WithEmptyBucketName_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.BucketName = "";
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task ExecuteAsync_WithMissingS3Directory_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.S3Directory = null;
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task ExecuteAsync_WithEmptyS3Directory_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.S3Directory = "";
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task ExecuteAsync_WithMissingLocalDirectory_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.LocalDirectory = null;
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+        }
+
+        #endregion
+
+        #region ExecuteAsync Tests - Empty Directory
+
+        [TestMethod]
+        public async Task ExecuteAsync_EmptyDirectory_ReturnsZeroObjectsDownloaded()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            SetupEmptyDirectoryListing();
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(0, response.ObjectsDownloaded);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_EmptyDirectoryWithMultipart_ReturnsZeroObjectsDownloaded()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            SetupEmptyDirectoryListing();
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(0, response.ObjectsDownloaded);
+        }
+
+        #endregion
+
+        #region ExecuteAsync Tests - Single File
+
+        [TestMethod]
+        public async Task ExecuteAsync_SingleFile_DownloadsSuccessfully()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            var fileSize = 1024;
+            SetupSingleFileDirectoryListing("test-file.txt", fileSize);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, response.ObjectsDownloaded);
+            
+            var downloadedFile = Path.Combine(_testDirectory, "test-file.txt");
+            Assert.IsTrue(File.Exists(downloadedFile));
+            Assert.IsTrue(MultipartDownloadTestHelpers.VerifyFileSize(downloadedFile, fileSize));
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_SingleFileWithMultipart_DownloadsSuccessfully()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            var fileSize = 1024;
+            SetupSingleFileDirectoryListing("test-file.txt", fileSize, setupForMultipart: true);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, response.ObjectsDownloaded);
+            
+            var downloadedFile = Path.Combine(_testDirectory, "test-file.txt");
+            Assert.IsTrue(File.Exists(downloadedFile));
+            Assert.IsTrue(MultipartDownloadTestHelpers.VerifyFileSize(downloadedFile, fileSize));
+        }
+
+        #endregion
+
+        #region ExecuteAsync Tests - Multiple Files
+
+        [TestMethod]
+        public async Task ExecuteAsync_MultipleFiles_DownloadsAll()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = false; // Sequential for predictable testing
+            
+            var files = new Dictionary<string, long>
+            {
+                { "file1.txt", 512 },
+                { "file2.txt", 1024 },
+                { "file3.txt", 2048 }
+            };
+            
+            SetupMultipleFilesDirectoryListing(files);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(files.Count, response.ObjectsDownloaded);
+            
+            foreach (var file in files)
+            {
+                var downloadedFile = Path.Combine(_testDirectory, file.Key);
+                Assert.IsTrue(File.Exists(downloadedFile), $"File {file.Key} should exist");
+                Assert.IsTrue(MultipartDownloadTestHelpers.VerifyFileSize(downloadedFile, file.Value), 
+                    $"File {file.Key} should have size {file.Value}");
+            }
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_MultipleFilesWithMultipart_DownloadsAll()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = false; // Sequential for predictable testing
+            
+            var files = new Dictionary<string, long>
+            {
+                { "large1.dat", 10 * 1024 * 1024 }, // 10MB
+                { "large2.dat", 15 * 1024 * 1024 }  // 15MB
+            };
+            
+            SetupMultipleFilesDirectoryListing(files, setupForMultipart: true);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(files.Count, response.ObjectsDownloaded);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_MultipleFilesConcurrent_DownloadsAll()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = true; // Concurrent downloads
+            
+            var files = new Dictionary<string, long>
+            {
+                { "file1.txt", 512 },
+                { "file2.txt", 1024 },
+                { "file3.txt", 2048 },
+                { "file4.txt", 4096 }
+            };
+            
+            SetupMultipleFilesDirectoryListing(files);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(files.Count, response.ObjectsDownloaded);
+            
+            foreach (var file in files)
+            {
+                var downloadedFile = Path.Combine(_testDirectory, file.Key);
+                Assert.IsTrue(File.Exists(downloadedFile), $"File {file.Key} should exist");
+            }
+        }
+
+        #endregion
+
+        #region ExecuteAsync Tests - Nested Directories
+
+        [TestMethod]
+        public async Task ExecuteAsync_NestedDirectories_CreatesStructure()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = false;
+            
+            var files = new Dictionary<string, long>
+            {
+                { "level1/file1.txt", 512 },
+                { "level1/level2/file2.txt", 1024 },
+                { "level1/level2/level3/file3.txt", 2048 }
+            };
+            
+            SetupMultipleFilesDirectoryListing(files);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(files.Count, response.ObjectsDownloaded);
+            
+            foreach (var file in files)
+            {
+                var downloadedFile = Path.Combine(_testDirectory, file.Key.Replace('/', Path.DirectorySeparatorChar));
+                Assert.IsTrue(File.Exists(downloadedFile), $"File {file.Key} should exist at {downloadedFile}");
+                Assert.IsTrue(MultipartDownloadTestHelpers.VerifyFileSize(downloadedFile, file.Value));
+            }
+        }
+
+        #endregion
+
+        #region ExecuteAsync Tests - Cancellation
+
+        [TestMethod]
+        public async Task ExecuteAsync_WithCancelledToken_ThrowsOperationCanceledException()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            SetupSingleFileDirectoryListing("test.txt", 1024);
+            
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act & Assert
+            try
+            {
+                await command.ExecuteAsync(cts.Token);
+                Assert.Fail("Expected an OperationCanceledException to be thrown");
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected - TaskCanceledException inherits from OperationCanceledException
+                // This is the correct behavior
+            }
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_CancellationDuringDownload_CleansUpProperly()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            var files = new Dictionary<string, long>
+            {
+                { "file1.txt", 512 },
+                { "file2.txt", 1024 }
+            };
+            
+            var cts = new CancellationTokenSource();
+            
+            // Setup to cancel after first file starts downloading
+            var callCount = 0;
+            _mockS3Client.Setup(c => c.ListObjectsAsync(
+                It.IsAny<ListObjectsRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => CreateListObjectsResponse(files));
+            
+            _mockS3Client.Setup(c => c.GetObjectAsync(
+                It.IsAny<GetObjectRequest>(),
+                It.IsAny<CancellationToken>()))
+                .Callback(() =>
+                {
+                    callCount++;
+                    if (callCount == 1)
+                        cts.Cancel();
+                })
+                .ThrowsAsync(new OperationCanceledException());
+
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            try
+            {
+                await command.ExecuteAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected
+            }
+
+            // Assert - partial files should be cleaned up
+            await Task.Delay(100); // Give cleanup time to complete
+        }
+
+        #endregion
+
+        #region ExecuteAsync Tests - Edge Cases
+
+        [TestMethod]
+        public async Task ExecuteAsync_DirectoryMarkers_SkipsDirectoryObjects()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            
+            // Include directory markers (keys ending with /)
+            var listResponse = new ListObjectsResponse
+            {
+                S3Objects = new List<S3Object>
+                {
+                    new S3Object { Key = "prefix/subdir/", Size = 0 },
+                    new S3Object { Key = "prefix/file.txt", Size = 1024 }
+                }
+            };
+            
+            _mockS3Client.Setup(c => c.ListObjectsAsync(
+                It.IsAny<ListObjectsRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(listResponse);
+            
+            SetupGetObjectForFile("prefix/file.txt", 1024);
+            
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(1, response.ObjectsDownloaded); // Only the file, not the directory marker
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ExistingFiles_OverwritesCorrectly()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            var fileName = "existing-file.txt";
+            var filePath = Path.Combine(_testDirectory, fileName);
+            
+            // Create existing file with old content
+            var oldData = MultipartDownloadTestHelpers.GenerateTestData(512, 999);
+            File.WriteAllBytes(filePath, oldData);
+            
+            var newFileSize = 1024;
+            SetupSingleFileDirectoryListing(fileName, newFileSize);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(1, response.ObjectsDownloaded);
+            Assert.IsTrue(MultipartDownloadTestHelpers.VerifyFileSize(filePath, newFileSize));
+            
+            // Verify content was overwritten
+            var newData = File.ReadAllBytes(filePath);
+            Assert.AreNotEqual(oldData.Length, newData.Length);
+        }
+
+        #endregion
+
+        #region Progress Tracking Tests
+
+        [TestMethod]
+        public async Task ExecuteAsync_SingleFileMultipart_FiresProgressEvents()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+            
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                progressEvents.Add(args);
+            };
+            
+            var fileSize = 10 * 1024 * 1024; // 10MB
+            SetupSingleFileDirectoryListing("test.dat", fileSize, setupForMultipart: true);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(progressEvents.Count > 0, "Should fire progress events");
+            
+            // Verify final event
+            var finalEvent = progressEvents.Last();
+            Assert.AreEqual(1, finalEvent.NumberOfFilesDownloaded, "Should have downloaded 1 file");
+            Assert.AreEqual(1, finalEvent.TotalNumberOfFiles, "Should have 1 total file");
+            Assert.AreEqual(fileSize, finalEvent.TransferredBytes, "All bytes should be transferred");
+            Assert.AreEqual(fileSize, finalEvent.TotalBytes, "Total bytes should match file size");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_MultipleFilesMultipart_AggregatesProgressCorrectly()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = false; // Sequential for predictable testing
+            
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                progressEvents.Add(args);
+            };
+            
+            var files = new Dictionary<string, long>
+            {
+                { "file1.dat", 5 * 1024 * 1024 },  // 5MB
+                { "file2.dat", 10 * 1024 * 1024 }  // 10MB
+            };
+            
+            var totalBytes = files.Values.Sum();
+            SetupMultipleFilesDirectoryListing(files, setupForMultipart: true);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(progressEvents.Count > 0, "Should fire progress events");
+            
+            var finalEvent = progressEvents.Last();
+            Assert.AreEqual(2, finalEvent.NumberOfFilesDownloaded, "Should have downloaded 2 files");
+            Assert.AreEqual(2, finalEvent.TotalNumberOfFiles, "Should have 2 total files");
+            Assert.AreEqual(totalBytes, finalEvent.TransferredBytes, "All bytes should be transferred");
+            Assert.AreEqual(totalBytes, finalEvent.TotalBytes, "Total bytes should match sum of all files");
+            
+            // Verify progress increases monotonically
+            long lastTransferred = 0;
+            foreach (var evt in progressEvents)
+            {
+                Assert.IsTrue(evt.TransferredBytes >= lastTransferred, 
+                    "TransferredBytes should never decrease");
+                lastTransferred = evt.TransferredBytes;
+            }
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ConcurrentMultipart_FiresProgressCorrectly()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = true; // Concurrent
+            
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+            var progressLock = new object();
+            
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                lock (progressLock)
+                {
+                    progressEvents.Add(args);
+                }
+            };
+            
+            var files = new Dictionary<string, long>
+            {
+                { "file1.dat", 8 * 1024 * 1024 },  // 8MB
+                { "file2.dat", 8 * 1024 * 1024 },  // 8MB
+                { "file3.dat", 8 * 1024 * 1024 }   // 8MB
+            };
+            
+            var totalBytes = files.Values.Sum();
+            SetupMultipleFilesDirectoryListing(files, setupForMultipart: true);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(progressEvents.Count > 0, "Should fire progress events");
+            
+            // Verify monotonic increase in transferred bytes despite concurrent execution
+            long lastTransferred = 0;
+            foreach (var evt in progressEvents)
+            {
+                Assert.IsTrue(evt.TransferredBytes >= lastTransferred, 
+                    "TransferredBytes should never decrease even in concurrent mode");
+                lastTransferred = evt.TransferredBytes;
+            }
+            
+            var finalEvent = progressEvents.Last();
+            Assert.AreEqual(3, finalEvent.NumberOfFilesDownloaded, "Should have downloaded 3 files");
+            Assert.AreEqual(totalBytes, finalEvent.TransferredBytes, "All bytes should be transferred");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ConcurrentMode_OmitsCurrentFileDetails()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = true;
+            
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+            var progressLock = new object();
+            
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                lock (progressLock)
+                {
+                    progressEvents.Add(args);
+                }
+            };
+            
+            SetupSingleFileDirectoryListing("test.dat", 8 * 1024 * 1024, setupForMultipart: true);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(progressEvents.Count > 0, "Should fire progress events");
+            
+            // In concurrent mode, current file details should be null/zero
+            foreach (var evt in progressEvents)
+            {
+                Assert.IsNull(evt.CurrentFile, "CurrentFile should be null in concurrent mode");
+                Assert.AreEqual(0, evt.TransferredBytesForCurrentFile, 
+                    "TransferredBytesForCurrentFile should be 0 in concurrent mode");
+                Assert.AreEqual(0, evt.TotalNumberOfBytesForCurrentFile, 
+                    "TotalNumberOfBytesForCurrentFile should be 0 in concurrent mode");
+            }
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_SequentialMode_IncludesCurrentFileDetails()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = false; // Sequential
+            
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                progressEvents.Add(args);
+            };
+            
+            var fileSize = 5 * 1024 * 1024; // 5MB
+            SetupSingleFileDirectoryListing("test-file.dat", fileSize, setupForMultipart: true);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(progressEvents.Count > 0, "Should fire progress events");
+            
+            // In sequential mode, current file details should be populated
+            var eventsWithFile = progressEvents.Where(e => e.CurrentFile != null).ToList();
+            Assert.IsTrue(eventsWithFile.Count > 0, "Should have events with CurrentFile populated");
+            
+            foreach (var evt in eventsWithFile)
+            {
+                Assert.AreEqual("test-file.dat", evt.CurrentFile, "CurrentFile should be set");
+                Assert.IsTrue(evt.TotalNumberOfBytesForCurrentFile > 0, 
+                    "TotalNumberOfBytesForCurrentFile should be greater than 0");
+            }
+            
+            // Verify final event has complete file details
+            var finalEvent = progressEvents.Last();
+            Assert.AreEqual("test-file.dat", finalEvent.CurrentFile);
+            Assert.AreEqual(fileSize, finalEvent.TotalNumberOfBytesForCurrentFile);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_MultipleFilesSequential_TracksPerFileProgress()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = false;
+            
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                progressEvents.Add(args);
+            };
+            
+            var files = new Dictionary<string, long>
+            {
+                { "small.dat", 2 * 1024 * 1024 },   // 2MB
+                { "medium.dat", 5 * 1024 * 1024 },  // 5MB
+                { "large.dat", 10 * 1024 * 1024 }   // 10MB
+            };
+            
+            SetupMultipleFilesDirectoryListing(files, setupForMultipart: true);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(progressEvents.Count > 0, "Should fire progress events");
+            
+            // Verify we see progress for each file
+            var filesTracked = progressEvents
+                .Where(e => e.CurrentFile != null)
+                .Select(e => e.CurrentFile)
+                .Distinct()
+                .ToList();
+            
+            Assert.AreEqual(3, filesTracked.Count, "Should track progress for all 3 files");
+            Assert.IsTrue(filesTracked.Contains("small.dat"), "Should track small.dat");
+            Assert.IsTrue(filesTracked.Contains("medium.dat"), "Should track medium.dat");
+            Assert.IsTrue(filesTracked.Contains("large.dat"), "Should track large.dat");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ProgressEventsCancellation_StopsProgressTracking()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = false;
+            
+            var progressEvents = new List<DownloadDirectoryProgressArgs>();
+            var cts = new CancellationTokenSource();
+            
+            request.DownloadedDirectoryProgressEvent += (sender, args) =>
+            {
+                progressEvents.Add(args);
+                // Cancel after first progress event
+                if (progressEvents.Count == 1)
+                {
+                    cts.Cancel();
+                }
+            };
+            
+            var files = new Dictionary<string, long>
+            {
+                { "file1.dat", 5 * 1024 * 1024 },
+                { "file2.dat", 5 * 1024 * 1024 }
+            };
+            
+            SetupMultipleFilesDirectoryListing(files, setupForMultipart: true);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: true);
+
+            // Act & Assert
+            try
+            {
+                await command.ExecuteAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected
+            }
+            
+            // Verify we got at least one progress event before cancellation
+            Assert.IsTrue(progressEvents.Count >= 1, "Should have fired at least one progress event");
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private TransferUtilityDownloadDirectoryRequest CreateDownloadDirectoryRequest(
+            string bucketName = "test-bucket",
+            string s3Directory = "prefix",
+            string localDirectory = null)
+        {
+            localDirectory = localDirectory ?? _testDirectory;
+            
+            return new TransferUtilityDownloadDirectoryRequest
+            {
+                BucketName = bucketName,
+                S3Directory = s3Directory,
+                LocalDirectory = localDirectory
+            };
+        }
+
+        private void SetupEmptyDirectoryListing()
+        {
+            var listResponse = new ListObjectsResponse
+            {
+                S3Objects = new List<S3Object>()
+            };
+            
+            _mockS3Client.Setup(c => c.ListObjectsAsync(
+                It.IsAny<ListObjectsRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(listResponse);
+        }
+
+        private void SetupSingleFileDirectoryListing(string fileName, long fileSize, bool setupForMultipart = false)
+        {
+            var files = new Dictionary<string, long> { { fileName, fileSize } };
+            SetupMultipleFilesDirectoryListing(files, setupForMultipart);
+        }
+
+        private void SetupMultipleFilesDirectoryListing(Dictionary<string, long> files, bool setupForMultipart = false)
+        {
+            var listResponse = CreateListObjectsResponse(files);
+            
+            _mockS3Client.Setup(c => c.ListObjectsAsync(
+                It.IsAny<ListObjectsRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(listResponse);
+            
+            // Setup GetObject for each file
+            foreach (var file in files)
+            {
+                SetupGetObjectForFile($"prefix/{file.Key}", file.Value, setupForMultipart);
+            }
+        }
+
+        private ListObjectsResponse CreateListObjectsResponse(Dictionary<string, long> files)
+        {
+            var s3Objects = files.Select(f => new S3Object
+            {
+                Key = $"prefix/{f.Key}",
+                Size = f.Value
+            }).ToList();
+            
+            return new ListObjectsResponse
+            {
+                S3Objects = s3Objects
+            };
+        }
+
+        private void SetupGetObjectForFile(string key, long fileSize, bool setupForMultipart = false)
+        {
+            var data = MultipartDownloadTestHelpers.GenerateTestData((int)fileSize, 0);
+            
+            if (setupForMultipart)
+            {
+                // For multipart downloads using PART strategy, we need to:
+                // 1. First request (PartNumber=1) returns PartsCount > 1
+                // 2. Subsequent requests for each part
+                
+                var partsCount = (int)Math.Ceiling((double)fileSize / (8 * 1024 * 1024)); // 8MB parts
+                if (partsCount < 2) partsCount = 2; // Force multipart for testing
+                
+                var partSize = fileSize / partsCount;
+                var lastPartSize = fileSize - (partSize * (partsCount - 1));
+                
+                // Setup first part request (discovery)
+                var firstPartData = MultipartDownloadTestHelpers.GenerateTestData((int)partSize, 0);
+                var firstPartResponse = new GetObjectResponse
+                {
+                    BucketName = "test-bucket",
+                    Key = key,
+                    ContentLength = partSize,
+                    ResponseStream = new MemoryStream(firstPartData),
+                    ContentRange = $"bytes 0-{partSize - 1}/{fileSize}",
+                    ETag = "\"test-etag\"",
+                    PartsCount = partsCount
+                };
+                
+                _mockS3Client.Setup(c => c.GetObjectAsync(
+                    It.Is<GetObjectRequest>(r => r.Key == key && r.PartNumber == 1),
+                    It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => 
+                    {
+                        // Return new stream each time to avoid disposed stream issues
+                        var newData = MultipartDownloadTestHelpers.GenerateTestData((int)partSize, 0);
+                        return new GetObjectResponse
+                        {
+                            BucketName = "test-bucket",
+                            Key = key,
+                            ContentLength = partSize,
+                            ResponseStream = new MemoryStream(newData),
+                            ContentRange = $"bytes 0-{partSize - 1}/{fileSize}",
+                            ETag = "\"test-etag\"",
+                            PartsCount = partsCount
+                        };
+                    });
+                
+                // Setup subsequent part requests
+                for (int i = 2; i <= partsCount; i++)
+                {
+                    var partNum = i;
+                    var currentPartSize = (partNum == partsCount) ? lastPartSize : partSize;
+                    var startByte = (partNum - 1) * partSize;
+                    var endByte = startByte + currentPartSize - 1;
+                    
+                    _mockS3Client.Setup(c => c.GetObjectAsync(
+                        It.Is<GetObjectRequest>(r => r.Key == key && r.PartNumber == partNum),
+                        It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(() =>
+                        {
+                            var partData = MultipartDownloadTestHelpers.GenerateTestData((int)currentPartSize, (int)startByte);
+                            return new GetObjectResponse
+                            {
+                                BucketName = "test-bucket",
+                                Key = key,
+                                ContentLength = currentPartSize,
+                                ResponseStream = new MemoryStream(partData),
+                                ContentRange = $"bytes {startByte}-{endByte}/{fileSize}",
+                                ETag = "\"test-etag\"",
+                                PartsCount = partsCount
+                            };
+                        });
+                }
+            }
+            else
+            {
+                // For non-multipart (simple) downloads
+                var response = new GetObjectResponse
+                {
+                    BucketName = "test-bucket",
+                    Key = key,
+                    ContentLength = fileSize,
+                    ResponseStream = new MemoryStream(data),
+                    ETag = "\"test-etag\""
+                };
+                
+                _mockS3Client.Setup(c => c.GetObjectAsync(
+                    It.Is<GetObjectRequest>(r => r.Key == key),
+                    It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() =>
+                    {
+                        // Return new stream each time to avoid disposed stream issues
+                        var newData = MultipartDownloadTestHelpers.GenerateTestData((int)fileSize, 0);
+                        return new GetObjectResponse
+                        {
+                            BucketName = "test-bucket",
+                            Key = key,
+                            ContentLength = fileSize,
+                            ResponseStream = new MemoryStream(newData),
+                            ETag = "\"test-etag\""
+                        };
+                    });
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR adds DownloadDirectoryWithResponse api, which allows a user to download a directory but invokes the new multi part download command.

## Description
1. This api follows the same pattern as multi part upload, where the http throttler is shared across all files in the directory. To match this behavior, i also share the maxInMemoryParts across all files in the directory

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3806

## Testing
1. Unit Test
2. Integration Test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement