### PR TITLE
Add SEO meta tags and canonical URL to frameset page

### DIFF
--- a/docgenerator/SDKDocGeneratorLib/output-files/index.html
+++ b/docgenerator/SDKDocGeneratorLib/output-files/index.html
@@ -5,6 +5,10 @@
     <head>
         <title>AWS SDK for .NET Version 4 Documentation</title>
         <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+        <meta name="description" content="AWS SDK for .NET Version 4 API Reference Documentation">
+        <meta name="guide-name" content="API Reference">
+        <meta name="service-name" content="AWS SDK for .NET Version 4">
+        <link rel="canonical" href="https://docs.aws.amazon.com/sdkfornet/v4/apidocs/index.html">
         <link rel="stylesheet" type="text/css" href="./resources/style.css" media="screen">
         <link rel="stylesheet" type="text/css" href="./resources/sdkstyle.css" media="screen">
 		<link rel="shortcut icon" href="favicon.ico"/>


### PR DESCRIPTION
Add SEO meta tags and canonical URL to frameset page

## Description
Added TCX-required SEO meta tags to the documentation frameset index.html:
- `<meta name="description">` - API reference description
- `<meta name="guide-name">` - Guide name for search indexing
- `<meta name="service-name">` - Service name for search indexing
- `<link rel="canonical">` - Canonical URL for SEO

These tags were added to `docgenerator/SDKDocGeneratorLib/output-files/index.html` (lines 8-11) after the Content-Type meta tag and before the stylesheet links.

## Motivation and Context
TCX SEO requirements mandate these meta tags for proper search indexing and SEO optimization of AWS documentation pages. The frameset page (index.html) was missing these tags while other documentation pages already had them.

## Testing
- Built documentation generator: `dotnet build` - succeeded with 0 errors
- Verified meta tags copied to build output directories
- Confirmed all 4 tags present in generated index.html files
- Verified correct tag order and content in `SDKDocGeneratorLib/bin/Debug/netstandard2.0/output-files/index.html`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
