### PR TITLE
Optimize Part Stream for Multi part Download

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/BufferedPartDataHandler.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/BufferedPartDataHandler.cs
@@ -30,9 +30,26 @@ using Amazon.S3.Model;
 namespace Amazon.S3.Transfer.Internal
 {
     /// <summary>
-    /// Buffers downloaded parts in memory using <see cref="ArrayPool{T}"/> and <see cref="IPartBufferManager"/>.
-    /// Implements current streaming behavior for multipart downloads.
+    /// Handles multipart download data with intelligent stream-vs-buffer decision making.
+    /// Optimizes for sequential part arrival by streaming directly to consumer when possible,
+    /// while buffering out-of-order parts into memory using <see cref="ArrayPool{T}"/>.
     /// </summary>
+    /// <remarks>
+    /// <para><strong>Optimization Strategy:</strong></para>
+    /// <list type="bullet">
+    /// <item>Parts arriving in expected order (matching NextExpectedPartNumber) stream directly to consumer</item>
+    /// <item>Out-of-order parts buffer into ArrayPool memory for later sequential consumption</item>
+    /// <item>Best case: All parts in order → zero buffering → pure streaming</item>
+    /// <item>Worst case: All parts out of order → full buffering (original behavior)</item>
+    /// </list>
+    /// 
+    /// 
+    /// <para><strong>Response Ownership:</strong></para>
+    /// <list type="bullet">
+    /// <item>Streaming: StreamingDataSource takes ownership and disposes after reading</item>
+    /// <item>Buffering: Handler disposes response immediately after buffering completes</item>
+    /// </list>
+    /// </remarks>
     internal class BufferedPartDataHandler : IPartDataHandler
     {
         private readonly IPartBufferManager _partBufferManager;
@@ -64,28 +81,163 @@ namespace Amazon.S3.Transfer.Internal
         }
         
         /// <inheritdoc/>
+        /// <remarks>
+        /// <para>
+        /// Intelligently chooses between streaming and buffering based on part arrival order:
+        /// </para>
+        /// <list type="bullet">
+        /// <item>If partNumber matches NextExpectedPartNumber: Stream directly (no buffering)</item>
+        /// <item>Otherwise: Buffer into memory for later sequential consumption</item>
+        /// </list>
+        /// <para><strong>Response Ownership:</strong></para>
+        /// <para>
+        /// This method takes ownership of the response and is responsible for disposing it in ALL cases,
+        /// including error scenarios. Callers must NOT dispose the response after calling this method.
+        /// </para>
+        /// </remarks>
         public async Task ProcessPartAsync(
             int partNumber,
             GetObjectResponse response, 
             CancellationToken cancellationToken)
         {
-            Logger.DebugFormat("BufferedPartDataHandler: [Part {0}] Starting to buffer part from response stream - ContentLength={1}",
-                partNumber, response.ContentLength);
-
-            // Buffer the part from the response stream into memory
-            var buffer = await BufferPartFromResponseAsync(
-                partNumber, 
-                response, 
-                cancellationToken).ConfigureAwait(false);
-
-            Logger.DebugFormat("BufferedPartDataHandler: [Part {0}] Buffered {1} bytes into memory",
-                partNumber, buffer.Length);
-                
-            // Add the buffered part to the buffer manager
-            _partBufferManager.AddBuffer(buffer);
-
-            Logger.DebugFormat("BufferedPartDataHandler: [Part {0}] Added to buffer manager",
+            if (partNumber == _partBufferManager.NextExpectedPartNumber)
+            {
+                await ProcessStreamingPartAsync(partNumber, response, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await ProcessBufferedPartAsync(partNumber, response, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        
+        /// <summary>
+        /// Processes a part that arrives in expected order by streaming it directly without buffering.
+        /// Takes ownership of the response and transfers it to the StreamingDataSource.
+        /// </summary>
+        /// <param name="partNumber">The part number being processed.</param>
+        /// <param name="response">The GetObjectResponse containing the part data. Ownership is transferred to StreamingDataSource.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <remarks>
+        /// This method is called when the part arrives in the expected sequential order, allowing
+        /// for optimal zero-copy streaming directly to the consumer without buffering into memory.
+        /// 
+        /// OWNERSHIP TRANSFER:
+        /// 1. Response is passed to StreamingDataSource constructor (StreamingDataSource takes ownership)
+        /// 2. StreamingDataSource is added to buffer manager (buffer manager takes ownership)
+        /// 3. After successful AddBufferAsync, we null out our reference to mark ownership transfer
+        /// 4. Buffer manager will dispose StreamingDataSource (which disposes response) during cleanup
+        /// 
+        /// ERROR HANDLING:
+        /// - If StreamingDataSource constructor fails: We dispose the response (still our responsibility)
+        /// - If constructor succeeds but AddBufferAsync fails: StreamingDataSource.Dispose() handles the response
+        /// - If AddBufferAsync succeeds: Buffer manager owns everything and will clean up
+        /// </remarks>
+        private async Task ProcessStreamingPartAsync(
+            int partNumber,
+            GetObjectResponse response, 
+            CancellationToken cancellationToken)
+        {
+            Logger.DebugFormat("BufferedPartDataHandler: [Part {0}] Matches NextExpectedPartNumber - streaming directly without buffering",
                 partNumber);
+
+            StreamingDataSource streamingDataSource = null;
+            var ownsResponse = true; // Track if we still own the response
+            
+            try
+            {
+                // Create a StreamingDataSource that will stream directly from the response
+                // If successful, StreamingDataSource takes ownership of the response and will dispose it
+                streamingDataSource = new StreamingDataSource(partNumber, response);
+                ownsResponse = false; // Ownership transferred to StreamingDataSource
+
+                // Add the streaming data source to the buffer manager
+                // After this succeeds, the buffer manager owns the data source
+                _partBufferManager.AddBuffer(streamingDataSource);
+                
+                // Mark ownership transfer by nulling our reference
+                // If ReleaseBufferSpace() throws, we no longer own the data source, so we won't dispose it
+                streamingDataSource = null;
+
+                // Release capacity immediately since we're not holding anything in memory
+                _partBufferManager.ReleaseBufferSpace();
+
+                Logger.DebugFormat("BufferedPartDataHandler: [Part {0}] StreamingDataSource added and capacity released",
+                    partNumber);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "BufferedPartDataHandler: [Part {0}] Failed to process streaming part", partNumber);
+                
+                // Dispose response if we still own it (constructor failed before taking ownership)
+                if (ownsResponse)
+                    response?.Dispose();
+                
+                // Dispose StreamingDataSource if we created it but buffer manager doesn't own it yet
+                // If null, the buffer manager owns it and will handle cleanup
+                streamingDataSource?.Dispose();
+                
+                throw;
+            }
+        }
+        
+        /// <summary>
+        /// Processes a part that arrives out of order by buffering it into memory.
+        /// Takes ownership of the response and disposes it after buffering completes.
+        /// </summary>
+        /// <param name="partNumber">The part number being processed.</param>
+        /// <param name="response">The GetObjectResponse containing the part data. This method owns and disposes it.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <remarks>
+        /// This method is called when the part arrives out of the expected sequential order.
+        /// The part data is buffered into ArrayPool memory for later sequential consumption.
+        /// 
+        /// OWNERSHIP:
+        /// - Response is read and buffered into StreamPartBuffer
+        /// - Response is disposed immediately after buffering (no longer needed)
+        /// - StreamPartBuffer is added to buffer manager (buffer manager takes ownership)
+        /// - Buffer manager will dispose StreamPartBuffer during cleanup
+        /// 
+        /// ERROR HANDLING:
+        /// - Always dispose response in catch block since we own it throughout this method
+        /// - BufferPartFromResponseAsync handles its own cleanup of StreamPartBuffer on error
+        /// </remarks>
+        private async Task ProcessBufferedPartAsync(
+            int partNumber,
+            GetObjectResponse response, 
+            CancellationToken cancellationToken)
+        {
+            Logger.DebugFormat("BufferedPartDataHandler: [Part {0}] Out of order (NextExpected={1}) - buffering to memory",
+                partNumber, _partBufferManager.NextExpectedPartNumber);
+
+            try
+            {
+                // Buffer the part from the response stream into memory
+                var buffer = await BufferPartFromResponseAsync(
+                    partNumber, 
+                    response, 
+                    cancellationToken).ConfigureAwait(false);
+
+                // Response has been fully read and buffered - dispose it now
+                response?.Dispose();
+
+                Logger.DebugFormat("BufferedPartDataHandler: [Part {0}] Buffered {1} bytes into memory",
+                    partNumber, buffer.Length);
+                    
+                // Add the buffered part to the buffer manager
+                _partBufferManager.AddBuffer(buffer);
+
+                Logger.DebugFormat("BufferedPartDataHandler: [Part {0}] Added to buffer manager (capacity will be released after consumption)",
+                    partNumber);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "BufferedPartDataHandler: [Part {0}] Failed to process buffered part", partNumber);
+                
+                // We own the response throughout this method, so dispose it on error
+                response?.Dispose();
+                
+                throw;
+            }
         }
         
         /// <inheritdoc/>
@@ -112,6 +264,15 @@ namespace Amazon.S3.Transfer.Internal
             // _partBufferManager is owned by caller, don't dispose
         }
         
+        /// <summary>
+        /// Buffers a part from the GetObjectResponse stream into ArrayPool memory.
+        /// Used when a part arrives out of order and cannot be streamed directly.
+        /// </summary>
+        /// <param name="partNumber">The part number being buffered.</param>
+        /// <param name="response">The GetObjectResponse containing the part data stream.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>A <see cref="StreamPartBuffer"/> containing the buffered part data.</returns>
+        /// <exception cref="Exception">Thrown when buffering fails. The StreamPartBuffer will be disposed automatically.</exception>
         private async Task<StreamPartBuffer> BufferPartFromResponseAsync(
             int partNumber, 
             GetObjectResponse response, 

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/IPartBufferManager.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/IPartBufferManager.cs
@@ -51,6 +51,13 @@ namespace Amazon.S3.Transfer.Internal
         void AddBuffer(StreamPartBuffer buffer);
         
         /// <summary>
+        /// Adds a part data source (streaming or buffered) and signals readers when next expected part arrives.
+        /// </summary>
+        /// <param name="dataSource">The part data source to add (can be StreamingDataSource or BufferedDataSource).</param>
+        /// <returns>A task that completes when the data source has been added and signaling is complete.</returns>
+        void AddBuffer(IPartDataSource dataSource);
+        
+        /// <summary>
         /// Reads data from the buffer manager. Automatically handles sequential part consumption
         /// and reads across part boundaries to fill the buffer when possible, matching standard Stream.Read() behavior.
         /// </summary>

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/StreamingDataSource.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/StreamingDataSource.cs
@@ -1,0 +1,230 @@
+/*******************************************************************************
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License. A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file.
+ *  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ * *****************************************************************************
+ *    __  _    _  ___
+ *   (  )( \/\/ )/ __)
+ *   /__\ \    / \__ \
+ *  (_)(_) \/\/  (___/
+ *
+ *  AWS SDK for .NET
+ *  API Version: 2006-03-01
+ *
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime.Internal.Util;
+using Amazon.S3.Model;
+
+namespace Amazon.S3.Transfer.Internal
+{
+    /// <summary>
+    /// Stream-based data source that reads directly from GetObjectResponse without buffering.
+    /// Provides pass-through access to the response stream for optimal memory efficiency when parts arrive in order.
+    /// </summary>
+    /// <remarks>
+    /// This class enables direct streaming optimization for multipart downloads. When a part arrives
+    /// and happens to be the next expected part in the sequence, we can bypass buffering entirely
+    /// and stream the response directly to the consumer.
+    /// 
+    /// OWNERSHIP AND LIFECYCLE:
+    /// - Takes ownership of the GetObjectResponse and its stream
+    /// - Responsible for disposing the response (releases HTTP connection)
+    /// - Consumer reads directly from response stream via ReadAsync
+    /// - Must be disposed to release network resources
+    /// 
+    /// THREAD SAFETY:
+    /// - Designed for single-threaded consumption by PartBufferManager
+    /// - PartBufferManager guarantees sequential access to each part
+    /// - No internal synchronization needed
+    /// 
+    /// COMPLETION TRACKING:
+    /// - Tracks bytes read vs ContentLength to detect completion
+    /// - Sets IsComplete when stream exhausted OR expected bytes reached
+    /// - Handles both normal completion and premature stream closure
+    /// </remarks>
+    internal class StreamingDataSource : IPartDataSource
+    {
+        private readonly GetObjectResponse _response;
+        private readonly Stream _responseStream;
+        private readonly long _expectedBytes;
+        private readonly int _partNumber;
+        private long _bytesRead;
+        private bool _isComplete;
+        private bool _disposed;
+
+        #region Logger
+
+        private Logger Logger
+        {
+            get
+            {
+                return Logger.GetLogger(typeof(TransferUtility));
+            }
+        }
+
+        #endregion
+
+        /// <inheritdoc/>
+        public int PartNumber
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _partNumber;
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsComplete
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _isComplete;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamingDataSource"/> class.
+        /// Takes ownership of the GetObjectResponse and its stream.
+        /// </summary>
+        /// <param name="partNumber">The 1-based part number this source represents.</param>
+        /// <param name="response">The GetObjectResponse containing the stream to read from. Ownership is transferred.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="response"/> is null.</exception>
+        /// <remarks>
+        /// CRITICAL: This constructor takes ownership of the response. The caller must NOT dispose it.
+        /// The StreamingDataSource will dispose the response when it is disposed.
+        /// </remarks>
+        public StreamingDataSource(int partNumber, GetObjectResponse response)
+        {
+            if (response == null)
+                throw new ArgumentNullException(nameof(response));
+
+            _partNumber = partNumber;
+            _response = response;
+            _responseStream = response.ResponseStream;
+            _expectedBytes = response.ContentLength;
+            _bytesRead = 0;
+            _isComplete = false;
+
+            Logger.DebugFormat("StreamingDataSource: Created for part {0} (ExpectedBytes={1}, streaming directly from response)",
+                _partNumber, _expectedBytes);
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Reads directly from the underlying response stream without any buffering or copying.
+        /// This provides optimal memory efficiency and minimal latency for in-order part arrivals.
+        /// 
+        /// COMPLETION DETECTION:
+        /// The source is marked complete when:
+        /// 1. Stream returns 0 bytes (normal EOF), OR
+        /// 2. We've read the expected number of bytes (ContentLength)
+        /// 
+        /// ERROR HANDLING:
+        /// Any exceptions from the underlying stream (network errors, timeout, etc.) propagate directly
+        /// to the caller. The PartBufferManager will handle cleanup and error recovery.
+        /// </remarks>
+        public async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            if (buffer == null)
+                throw new ArgumentNullException(nameof(buffer));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), "Offset must be non-negative");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), "Count must be non-negative");
+            if (offset + count > buffer.Length)
+                throw new ArgumentException("Offset and count exceed buffer bounds");
+
+            if (_isComplete)
+            {
+                Logger.DebugFormat("StreamingDataSource: [Part {0}] Already complete, returning 0 bytes", PartNumber);
+                return 0;
+            }
+
+            try
+            {
+                Logger.DebugFormat("StreamingDataSource: [Part {0}] Reading up to {1} bytes from response stream (BytesRead={2}/{3})",
+                    PartNumber, count, _bytesRead, _expectedBytes);
+
+                // Direct delegation to response stream - no buffering, just pass-through
+                var bytesRead = await _responseStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+
+                _bytesRead += bytesRead;
+
+                Logger.DebugFormat("StreamingDataSource: [Part {0}] Read {1} bytes from response stream (TotalBytesRead={2}/{3})",
+                    PartNumber, bytesRead, _bytesRead, _expectedBytes);
+
+                // Mark complete when stream exhausted OR we've read expected bytes
+                if (bytesRead == 0 || _bytesRead >= _expectedBytes)
+                {
+                    _isComplete = true;
+                    Logger.DebugFormat("StreamingDataSource: [Part {0}] Marked complete (BytesRead=0: {1}, ReachedExpected: {2})",
+                        PartNumber, bytesRead == 0, _bytesRead >= _expectedBytes);
+                }
+
+                return bytesRead;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "StreamingDataSource: [Part {0}] Error reading from response stream: {1}",
+                    PartNumber, ex.Message);
+
+                // Mark as complete on error to prevent further read attempts
+                _isComplete = true;
+                throw;
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(StreamingDataSource));
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// CRITICAL: Disposes the GetObjectResponse, which releases the HTTP connection back to the connection pool.
+        /// Failure to dispose will cause connection leaks and eventual connection pool exhaustion.
+        /// </remarks>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Dispose methods should not throw exceptions")]
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                try
+                {
+                    Logger.DebugFormat("StreamingDataSource: [Part {0}] Disposing (Releasing HTTP connection, BytesRead={1}/{2})",
+                        PartNumber, _bytesRead, _expectedBytes);
+
+                    // Dispose the response - this releases the HTTP connection
+                    _response?.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "StreamingDataSource: [Part {0}] Error during disposal: {1}",
+                        PartNumber, ex.Message);
+
+                    // Suppressing CA1031: Dispose methods should not throw exceptions
+                    // Continue disposal process silently on any errors
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/sdk/test/Services/S3/UnitTests/Custom/StreamingDataSourceTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/StreamingDataSourceTests.cs
@@ -1,0 +1,708 @@
+using Amazon.S3.Model;
+using Amazon.S3.Transfer.Internal;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AWSSDK.UnitTests
+{
+    /// <summary>
+    /// Unit tests for StreamingDataSource class.
+    /// Tests direct streaming from GetObjectResponse without buffering.
+    /// </summary>
+    [TestClass]
+    public class StreamingDataSourceTests
+    {
+        #region Constructor Tests
+
+        [TestMethod]
+        public void Constructor_WithValidResponse_CreatesDataSource()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+
+            // Act
+            var dataSource = new StreamingDataSource(1, response);
+
+            // Assert
+            Assert.IsNotNull(dataSource);
+            Assert.AreEqual(1, dataSource.PartNumber);
+            Assert.IsFalse(dataSource.IsComplete);
+
+            // Cleanup
+            dataSource.Dispose();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_WithNullResponse_ThrowsArgumentNullException()
+        {
+            // Act
+            var dataSource = new StreamingDataSource(1, null);
+
+            // Assert - ExpectedException
+        }
+
+        [TestMethod]
+        public void Constructor_SetsPartNumberCorrectly()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+
+            // Act
+            var dataSource = new StreamingDataSource(5, response);
+
+            // Assert
+            Assert.AreEqual(5, dataSource.PartNumber);
+
+            // Cleanup
+            dataSource.Dispose();
+        }
+
+        #endregion
+
+        #region Property Tests
+
+        [TestMethod]
+        public void PartNumber_ReturnsConstructorValue()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(3, response);
+
+            try
+            {
+                // Act & Assert
+                Assert.AreEqual(3, dataSource.PartNumber);
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public void IsComplete_InitiallyFalse()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act & Assert
+                Assert.IsFalse(dataSource.IsComplete);
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task IsComplete_BecomesTrue_AfterFullRead()
+        {
+            // Arrange
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(512, 0);
+            var response = CreateMockGetObjectResponse(512, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act - Read all data
+                byte[] buffer = new byte[512];
+                await dataSource.ReadAsync(buffer, 0, 512, CancellationToken.None);
+
+                // Assert
+                Assert.IsTrue(dataSource.IsComplete);
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task IsComplete_BecomesTrue_WhenExpectedBytesReached()
+        {
+            // Arrange
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(1000, 0);
+            var response = CreateMockGetObjectResponse(1000, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act - Read in chunks
+                byte[] buffer = new byte[400];
+                await dataSource.ReadAsync(buffer, 0, 400, CancellationToken.None);
+                await dataSource.ReadAsync(buffer, 0, 400, CancellationToken.None);
+                await dataSource.ReadAsync(buffer, 0, 200, CancellationToken.None);
+
+                // Assert
+                Assert.IsTrue(dataSource.IsComplete);
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        #endregion
+
+        #region ReadAsync Tests - Basic Functionality
+
+        [TestMethod]
+        public async Task ReadAsync_ReadsDataFromResponseStream()
+        {
+            // Arrange
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(512, 0);
+            var response = CreateMockGetObjectResponse(512, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act
+                byte[] buffer = new byte[512];
+                int bytesRead = await dataSource.ReadAsync(buffer, 0, 512, CancellationToken.None);
+
+                // Assert
+                Assert.AreEqual(512, bytesRead);
+                Assert.IsTrue(MultipartDownloadTestHelpers.VerifyDataMatch(testData, buffer, 0, 512));
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReadAsync_SupportsPartialReads()
+        {
+            // Arrange
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(1000, 0);
+            var response = CreateMockGetObjectResponse(1000, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act - Read first 300 bytes
+                byte[] buffer = new byte[300];
+                int bytesRead = await dataSource.ReadAsync(buffer, 0, 300, CancellationToken.None);
+
+                // Assert
+                Assert.AreEqual(300, bytesRead);
+                Assert.IsTrue(MultipartDownloadTestHelpers.VerifyDataMatch(testData, buffer, 0, 300));
+                Assert.IsFalse(dataSource.IsComplete);
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReadAsync_SupportsMultipleSequentialReads()
+        {
+            // Arrange
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(1000, 0);
+            var response = CreateMockGetObjectResponse(1000, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act - Read in chunks
+                byte[] buffer1 = new byte[400];
+                int bytesRead1 = await dataSource.ReadAsync(buffer1, 0, 400, CancellationToken.None);
+
+                byte[] buffer2 = new byte[400];
+                int bytesRead2 = await dataSource.ReadAsync(buffer2, 0, 400, CancellationToken.None);
+
+                byte[] buffer3 = new byte[200];
+                int bytesRead3 = await dataSource.ReadAsync(buffer3, 0, 200, CancellationToken.None);
+
+                // Assert
+                Assert.AreEqual(400, bytesRead1);
+                Assert.AreEqual(400, bytesRead2);
+                Assert.AreEqual(200, bytesRead3);
+                Assert.IsTrue(dataSource.IsComplete);
+
+                // Verify data correctness
+                Assert.IsTrue(MultipartDownloadTestHelpers.VerifyDataMatch(
+                    testData, buffer1, 0, 400));
+                
+                byte[] expectedData2 = new byte[400];
+                Array.Copy(testData, 400, expectedData2, 0, 400);
+                Assert.IsTrue(MultipartDownloadTestHelpers.VerifyDataMatch(
+                    expectedData2, buffer2, 0, 400));
+                
+                byte[] expectedData3 = new byte[200];
+                Array.Copy(testData, 800, expectedData3, 0, 200);
+                Assert.IsTrue(MultipartDownloadTestHelpers.VerifyDataMatch(
+                    expectedData3, buffer3, 0, 200));
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReadAsync_WithOffset_ReadsIntoBufferCorrectly()
+        {
+            // Arrange
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(300, 0);
+            var response = CreateMockGetObjectResponse(300, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act - Read into buffer with offset
+                byte[] buffer = new byte[500];
+                int bytesRead = await dataSource.ReadAsync(buffer, 100, 300, CancellationToken.None);
+
+                // Assert
+                Assert.AreEqual(300, bytesRead);
+                
+                // Verify data was written at correct offset
+                for (int i = 0; i < 300; i++)
+                {
+                    Assert.AreEqual(testData[i], buffer[100 + i]);
+                }
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        #endregion
+
+        #region ReadAsync Tests - Parameter Validation
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task ReadAsync_WithNullBuffer_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act
+                await dataSource.ReadAsync(null, 0, 512, CancellationToken.None);
+
+                // Assert - ExpectedException
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public async Task ReadAsync_WithNegativeOffset_ThrowsArgumentOutOfRangeException()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+            byte[] buffer = new byte[512];
+
+            try
+            {
+                // Act
+                await dataSource.ReadAsync(buffer, -1, 512, CancellationToken.None);
+
+                // Assert - ExpectedException
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public async Task ReadAsync_WithNegativeCount_ThrowsArgumentOutOfRangeException()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+            byte[] buffer = new byte[512];
+
+            try
+            {
+                // Act
+                await dataSource.ReadAsync(buffer, 0, -1, CancellationToken.None);
+
+                // Assert - ExpectedException
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task ReadAsync_WithOffsetCountExceedingBounds_ThrowsArgumentException()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+            byte[] buffer = new byte[512];
+
+            try
+            {
+                // Act - offset + count exceeds buffer length
+                await dataSource.ReadAsync(buffer, 400, 200, CancellationToken.None);
+
+                // Assert - ExpectedException
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        #endregion
+
+        #region ReadAsync Tests - Completion Detection
+
+        [TestMethod]
+        public async Task ReadAsync_ReturnsZero_WhenStreamExhausted()
+        {
+            // Arrange
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(100, 0);
+            var response = CreateMockGetObjectResponse(100, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act - Read all data
+                byte[] buffer1 = new byte[100];
+                int bytesRead1 = await dataSource.ReadAsync(buffer1, 0, 100, CancellationToken.None);
+
+                // Try to read more
+                byte[] buffer2 = new byte[100];
+                int bytesRead2 = await dataSource.ReadAsync(buffer2, 0, 100, CancellationToken.None);
+
+                // Assert
+                Assert.AreEqual(100, bytesRead1);
+                Assert.AreEqual(0, bytesRead2);
+                Assert.IsTrue(dataSource.IsComplete);
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReadAsync_AfterComplete_ReturnsZero()
+        {
+            // Arrange
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(512, 0);
+            var response = CreateMockGetObjectResponse(512, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act - Read all data to completion
+                byte[] buffer1 = new byte[512];
+                await dataSource.ReadAsync(buffer1, 0, 512, CancellationToken.None);
+
+                Assert.IsTrue(dataSource.IsComplete);
+
+                // Try to read again after completion
+                byte[] buffer2 = new byte[100];
+                int bytesRead = await dataSource.ReadAsync(buffer2, 0, 100, CancellationToken.None);
+
+                // Assert
+                Assert.AreEqual(0, bytesRead);
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReadAsync_MarksComplete_WhenExpectedBytesReached()
+        {
+            // Arrange - Create response with specific ContentLength
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(1000, 0);
+            var response = CreateMockGetObjectResponse(1000, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act - Read exactly expected bytes
+                byte[] buffer = new byte[1000];
+                int bytesRead = await dataSource.ReadAsync(buffer, 0, 1000, CancellationToken.None);
+
+                // Assert
+                Assert.AreEqual(1000, bytesRead);
+                Assert.IsTrue(dataSource.IsComplete);
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        #endregion
+
+        #region ReadAsync Tests - Progress Tracking
+
+        [TestMethod]
+        public async Task ReadAsync_TracksProgressCorrectly()
+        {
+            // Arrange
+            var testData = MultipartDownloadTestHelpers.GenerateTestData(1000, 0);
+            var response = CreateMockGetObjectResponse(1000, testData);
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act & Assert - Track progress through multiple reads
+                Assert.IsFalse(dataSource.IsComplete);
+
+                byte[] buffer = new byte[300];
+                await dataSource.ReadAsync(buffer, 0, 300, CancellationToken.None);
+                Assert.IsFalse(dataSource.IsComplete); // 300/1000
+
+                await dataSource.ReadAsync(buffer, 0, 300, CancellationToken.None);
+                Assert.IsFalse(dataSource.IsComplete); // 600/1000
+
+                await dataSource.ReadAsync(buffer, 0, 300, CancellationToken.None);
+                Assert.IsFalse(dataSource.IsComplete); // 900/1000
+
+                await dataSource.ReadAsync(buffer, 0, 100, CancellationToken.None);
+                Assert.IsTrue(dataSource.IsComplete); // 1000/1000
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        #endregion
+
+        #region ReadAsync Tests - Error Handling
+
+        [TestMethod]
+        public async Task ReadAsync_OnStreamError_MarksComplete()
+        {
+            // Arrange - Create a response with a stream that throws
+            var errorStream = new FaultyStream(new IOException("Stream read error"));
+            var response = new GetObjectResponse
+            {
+                ContentLength = 512,
+                ResponseStream = errorStream
+            };
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act & Assert
+                byte[] buffer = new byte[512];
+                await Assert.ThrowsExceptionAsync<IOException>(async () =>
+                {
+                    await dataSource.ReadAsync(buffer, 0, 512, CancellationToken.None);
+                });
+
+                // Should mark as complete on error
+                Assert.IsTrue(dataSource.IsComplete);
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReadAsync_PropagatesStreamExceptions()
+        {
+            // Arrange
+            var errorStream = new FaultyStream(new InvalidOperationException("Test error"));
+            var response = new GetObjectResponse
+            {
+                ContentLength = 512,
+                ResponseStream = errorStream
+            };
+            var dataSource = new StreamingDataSource(1, response);
+
+            try
+            {
+                // Act & Assert
+                byte[] buffer = new byte[512];
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+                {
+                    await dataSource.ReadAsync(buffer, 0, 512, CancellationToken.None);
+                });
+            }
+            finally
+            {
+                dataSource.Dispose();
+            }
+        }
+
+        #endregion
+
+        #region Disposal Tests
+
+        [TestMethod]
+        public void Dispose_ReleasesResponse()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+
+            // Act
+            dataSource.Dispose();
+
+            // Assert - Response stream should be disposed
+            // After disposal, stream is either null or no longer readable
+            Assert.IsTrue(response.ResponseStream == null || !response.ResponseStream.CanRead);
+        }
+
+        [TestMethod]
+        public void Dispose_MultipleCalls_IsIdempotent()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+
+            // Act - Dispose multiple times
+            dataSource.Dispose();
+            dataSource.Dispose();
+            dataSource.Dispose();
+
+            // Assert - Should not throw
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public async Task ReadAsync_AfterDispose_ThrowsObjectDisposedException()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+            dataSource.Dispose();
+
+            // Act
+            byte[] buffer = new byte[512];
+            await dataSource.ReadAsync(buffer, 0, 512, CancellationToken.None);
+
+            // Assert - ExpectedException
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void PartNumber_AfterDispose_ThrowsObjectDisposedException()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+            dataSource.Dispose();
+
+            // Act
+            var partNumber = dataSource.PartNumber;
+
+            // Assert - ExpectedException
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void IsComplete_AfterDispose_ThrowsObjectDisposedException()
+        {
+            // Arrange
+            var response = CreateMockGetObjectResponse(512);
+            var dataSource = new StreamingDataSource(1, response);
+            dataSource.Dispose();
+
+            // Act
+            var isComplete = dataSource.IsComplete;
+
+            // Assert - ExpectedException
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Creates a mock GetObjectResponse with test data.
+        /// </summary>
+        private GetObjectResponse CreateMockGetObjectResponse(long contentLength, byte[] testData = null)
+        {
+            if (testData == null)
+            {
+                testData = MultipartDownloadTestHelpers.GenerateTestData((int)contentLength, 0);
+            }
+
+            return new GetObjectResponse
+            {
+                ContentLength = contentLength,
+                ResponseStream = new MemoryStream(testData),
+                ETag = "test-etag"
+            };
+        }
+
+        /// <summary>
+        /// Stream that throws exceptions for testing error handling.
+        /// </summary>
+        private class FaultyStream : Stream
+        {
+            private readonly Exception _exception;
+
+            public FaultyStream(Exception exception)
+            {
+                _exception = exception;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw _exception;
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                throw _exception;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Previously in https://github.com/aws/aws-sdk-net/pull/4130, we would buffer every part, including the first part. This was not optimal because the first part can technically be streamed directly to the user because it will always be in order. Similarly, there is another case where if a part finishes downloading and is the next expected part, we can stream that right to the user instead of buffering.

This change adds support so that in those cases the part is streamed directly to the user instead of buffering in memory.

## Changes
1. Add support for direct streaming
2. Also fix potential resource leak in existing code. I discovered these issues while working on this PR and i figure they are small enough so i included them here


## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3806

## Testing
1. Unit Tests which validate no additional array pools are created for this scenario and the part is streamed to the user directly
4. Existing integration tests pass

Re-ran performance tests and got similar results

```
Total bytes per run: 5,368,709,120

Run:1 Secs:2.661879 Gb/s:16.135098
Run:2 Secs:1.455994 Gb/s:29.498529
Run:3 Secs:1.204284 Gb/s:35.664076
Run:4 Secs:1.119768 Gb/s:38.355867
Run:5 Secs:1.057126 Gb/s:40.628725
Run:6 Secs:1.055039 Gb/s:40.709082
Run:7 Secs:1.060168 Gb/s:40.512150
Run:8 Secs:1.053934 Gb/s:40.751759
Run:9 Secs:1.062503 Gb/s:40.423092
Run:10 Secs:1.094352 Gb/s:39.246664
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement