### PR TITLE
Move maxInMemoryParts to request object

### DIFF
--- a/generator/.DevConfigs/19ed68ce-9f46-4e1e-a0ff-45a2b3641946.json
+++ b/generator/.DevConfigs/19ed68ce-9f46-4e1e-a0ff-45a2b3641946.json
@@ -4,7 +4,7 @@
       "serviceName": "S3",
       "type": "patch",
       "changeLogMessages": [
-        "Added MaxInMemoryParts property to TransferUtilityConfig for controlling memory usage during multipart downloads",
+        "Added MaxInMemoryParts property to TransferUtilityOpenStreamRequest for controlling memory usage during multipart downloads",
         "Added PartSize property to BaseDownloadRequest for configuring multipart download part sizes",
         "Added MultipartDownloadType enum and property to BaseDownloadRequest for selecting download strategy"
       ]

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/BufferedMultipartStream.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/BufferedMultipartStream.cs
@@ -91,7 +91,7 @@ namespace Amazon.S3.Transfer.Internal
             
             var config = new BufferedDownloadConfiguration(
                 transferConfig.ConcurrentServiceRequests,
-                transferConfig.MaxInMemoryParts,
+                request.MaxInMemoryParts,
                 s3Client.Config.BufferSize,
                 targetPartSize);
             

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/OpenStreamWithResponseCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/OpenStreamWithResponseCommand.async.cs
@@ -39,7 +39,7 @@ namespace Amazon.S3.Transfer.Internal
 
             Logger.DebugFormat("OpenStreamWithResponseCommand: Configuration - ConcurrentServiceRequests={0}, MaxInMemoryParts={1}, BufferSize={2}",
                 _config.ConcurrentServiceRequests,
-                _config.MaxInMemoryParts,
+                _request.MaxInMemoryParts,
                 _s3Client.Config.BufferSize
                 );
 

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityConfig.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityConfig.cs
@@ -42,7 +42,6 @@ namespace Amazon.S3.Transfer
     {
         long _minSizeBeforePartUpload = 16 * (long)Math.Pow(2, 20);
         int _concurrentServiceRequests;
-        int _maxInMemoryParts = 1024; // When combined with the default part size of 8MB, we get 8GB of memory being utilized as the default.
 
         /// <summary>
         /// Default constructor.
@@ -80,22 +79,6 @@ namespace Amazon.S3.Transfer
                     value = 1;
 
                 this._concurrentServiceRequests = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the maximum number of parts to buffer in memory during multipart downloads.
-        /// The default value is 1024.
-        /// </summary>
-        public int MaxInMemoryParts
-        {
-            get { return this._maxInMemoryParts; }
-            set
-            {
-                if (value < 1)
-                    value = 1;
-
-                this._maxInMemoryParts = value;
             }
         }
     }

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityOpenStreamRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityOpenStreamRequest.cs
@@ -32,7 +32,21 @@ namespace Amazon.S3.Transfer
     /// </summary>
     public class TransferUtilityOpenStreamRequest : BaseDownloadRequest
     {
+        private int _maxInMemoryParts = 1024;
 
-
+        /// <summary>
+        /// Gets or sets the maximum number of parts to buffer in memory during multipart downloads.
+        /// The default value is 1024.
+        /// </summary>
+        /// <remarks>
+        /// This property controls memory usage during streaming downloads. When combined with the 
+        /// default part size of 8MB, the default value of 1024 parts allows up to 8GB of memory usage.
+        /// Adjust this value based on your application's memory constraints and performance requirements.
+        /// </remarks>
+        public int MaxInMemoryParts
+        {
+            get { return this._maxInMemoryParts; }
+            set { this._maxInMemoryParts = value; }
+        }
     }
 }

--- a/sdk/src/Services/S3/Custom/Transfer/_async/ITransferUtility.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_async/ITransferUtility.async.cs
@@ -543,22 +543,18 @@ namespace Amazon.S3.Transfer
         /// 	var config = new TransferUtilityConfig
         /// 	{
         /// 	    // Control how many parts download in parallel (default: 10)
-        /// 	    ConcurrentServiceRequests = 20,
-        /// 	    
-        /// 	    // Limit memory usage by capping buffered parts (default: 1024)
-        /// 	    // With 8MB parts, 1024 parts = 8GB max memory
-        /// 	    MaxInMemoryParts = 512
+        /// 	    ConcurrentServiceRequests = 20
         /// 	};
         /// 	var transferUtility = new TransferUtility(s3Client, config);
         /// 	</code>
         /// 	<para>
         /// 	Use <see cref="TransferUtilityConfig.ConcurrentServiceRequests"/> to control parallel download threads.
-        /// 	Use <see cref="TransferUtilityConfig.MaxInMemoryParts"/> to limit memory consumption by capping the number 
+        /// 	Use <see cref="TransferUtilityOpenStreamRequest.MaxInMemoryParts"/> to limit memory consumption by capping the number 
         /// 	of buffered parts in memory.
         /// 	</para>
         /// 	<para>
         /// 	<b>Memory Considerations:</b> The buffering mechanism uses memory to store downloaded parts. 
-        /// 	Adjust <see cref="TransferUtilityConfig.MaxInMemoryParts"/> if you need to limit memory usage, 
+        /// 	Adjust <see cref="TransferUtilityOpenStreamRequest.MaxInMemoryParts"/> if you need to limit memory usage, 
         /// 	especially when downloading very large files or multiple files concurrently.
         /// 	</para>
         /// </remarks>
@@ -602,17 +598,13 @@ namespace Amazon.S3.Transfer
         /// 	var config = new TransferUtilityConfig
         /// 	{
         /// 	    // Control how many parts download in parallel (default: 10)
-        /// 	    ConcurrentServiceRequests = 20,
-        /// 	    
-        /// 	    // Limit memory usage by capping buffered parts (default: 1024)
-        /// 	    // With 8MB parts, 1024 parts = 8GB max memory
-        /// 	    MaxInMemoryParts = 512
+        /// 	    ConcurrentServiceRequests = 20
         /// 	};
         /// 	var transferUtility = new TransferUtility(s3Client, config);
         /// 	</code>
         /// 	<para>
         /// 	Use <see cref="TransferUtilityConfig.ConcurrentServiceRequests"/> to control parallel download threads.
-        /// 	Use <see cref="TransferUtilityConfig.MaxInMemoryParts"/> to limit memory consumption by capping the number 
+        /// 	Use <see cref="TransferUtilityOpenStreamRequest.MaxInMemoryParts"/> to limit memory consumption by capping the number 
         /// 	of buffered parts in memory.
         /// 	</para>
         /// 	<para>
@@ -629,7 +621,7 @@ namespace Amazon.S3.Transfer
         /// 	</code>
         /// 	<para>
         /// 	<b>Memory Considerations:</b> The buffering mechanism uses memory to store downloaded parts. 
-        /// 	Adjust <see cref="TransferUtilityConfig.MaxInMemoryParts"/> if you need to limit memory usage, 
+        /// 	Adjust <see cref="TransferUtilityOpenStreamRequest.MaxInMemoryParts"/> if you need to limit memory usage, 
         /// 	especially when downloading very large files or multiple files concurrently.
         /// 	</para>
         /// </remarks>

--- a/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/ITransferUtility.sync.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/ITransferUtility.sync.cs
@@ -290,22 +290,18 @@ namespace Amazon.S3.Transfer
         /// 	var config = new TransferUtilityConfig
         /// 	{
         /// 	    // Control how many parts download in parallel (default: 10)
-        /// 	    ConcurrentServiceRequests = 20,
-        /// 	    
-        /// 	    // Limit memory usage by capping buffered parts (default: 1024)
-        /// 	    // With 8MB parts, 1024 parts = 8GB max memory
-        /// 	    MaxInMemoryParts = 512
+        /// 	    ConcurrentServiceRequests = 20
         /// 	};
         /// 	var transferUtility = new TransferUtility(s3Client, config);
         /// 	</code>
         /// 	<para>
         /// 	Use <see cref="TransferUtilityConfig.ConcurrentServiceRequests"/> to control parallel download threads.
-        /// 	Use <see cref="TransferUtilityConfig.MaxInMemoryParts"/> to limit memory consumption by capping the number 
+        /// 	Use <see cref="TransferUtilityOpenStreamRequest.MaxInMemoryParts"/> to limit memory consumption by capping the number 
         /// 	of buffered parts in memory.
         /// 	</para>
         /// 	<para>
         /// 	<b>Memory Considerations:</b> The buffering mechanism uses memory to store downloaded parts. 
-        /// 	Adjust <see cref="TransferUtilityConfig.MaxInMemoryParts"/> if you need to limit memory usage, 
+        /// 	Adjust <see cref="TransferUtilityOpenStreamRequest.MaxInMemoryParts"/> if you need to limit memory usage, 
         /// 	especially when downloading very large files or multiple files concurrently.
         /// 	</para>
         /// </remarks>
@@ -348,17 +344,13 @@ namespace Amazon.S3.Transfer
         /// 	var config = new TransferUtilityConfig
         /// 	{
         /// 	    // Control how many parts download in parallel (default: 10)
-        /// 	    ConcurrentServiceRequests = 20,
-        /// 	    
-        /// 	    // Limit memory usage by capping buffered parts (default: 1024)
-        /// 	    // With 8MB parts, 1024 parts = 8GB max memory
-        /// 	    MaxInMemoryParts = 512
+        /// 	    ConcurrentServiceRequests = 20
         /// 	};
         /// 	var transferUtility = new TransferUtility(s3Client, config);
         /// 	</code>
         /// 	<para>
         /// 	Use <see cref="TransferUtilityConfig.ConcurrentServiceRequests"/> to control parallel download threads.
-        /// 	Use <see cref="TransferUtilityConfig.MaxInMemoryParts"/> to limit memory consumption by capping the number 
+        /// 	Use <see cref="TransferUtilityOpenStreamRequest.MaxInMemoryParts"/> to limit memory consumption by capping the number 
         /// 	of buffered parts in memory.
         /// 	</para>
         /// 	<para>
@@ -375,7 +367,7 @@ namespace Amazon.S3.Transfer
         /// 	</code>
         /// 	<para>
         /// 	<b>Memory Considerations:</b> The buffering mechanism uses memory to store downloaded parts. 
-        /// 	Adjust <see cref="TransferUtilityConfig.MaxInMemoryParts"/> if you need to limit memory usage, 
+        /// 	Adjust <see cref="TransferUtilityOpenStreamRequest.MaxInMemoryParts"/> if you need to limit memory usage, 
         /// 	especially when downloading very large files or multiple files concurrently.
         /// 	</para>
         /// </remarks>

--- a/sdk/test/Services/S3/UnitTests/Custom/MultipartDownloadTestHelpers.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/MultipartDownloadTestHelpers.cs
@@ -345,7 +345,8 @@ namespace AWSSDK.UnitTests
             string bucketName = "test-bucket",
             string key = "test-key",
             long? partSize = null,
-            MultipartDownloadType downloadType = MultipartDownloadType.PART)
+            MultipartDownloadType downloadType = MultipartDownloadType.PART,
+            int? maxInMemoryParts = null)
         {
             var request = new TransferUtilityOpenStreamRequest
             {
@@ -357,6 +358,11 @@ namespace AWSSDK.UnitTests
             if (partSize.HasValue)
             {
                 request.PartSize = partSize.Value;
+            }
+            
+            if (maxInMemoryParts.HasValue)
+            {
+                request.MaxInMemoryParts = maxInMemoryParts.Value;
             }
             
             return request;


### PR DESCRIPTION
Moving `maxInMemoryParts`  to the individual request object instead of the TransferUtilityConfig.

Why? Previously i mistakenly  put it in  the `TransferUtilityConfig` thinking that `maxInMemoryParts` would be utilized in directory downloads (and therefore the value would apply at the config level). However, this is not the case, since maxInMemoryParts is only used for `OpenStreamWithResponse` which is not applicable for directories.

## Motivation and Context
To accurately reflect the scope of the maxInMemoryParts value.

## Testing
1. Re-ran unit tests
2. Re-ran integ tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement