### PR TITLE
[V4] Fix UpdateItem to handle empty ExpressionAttributeValues

### DIFF
--- a/generator/.DevConfigs/5bb5985e-87f2-493b-8b57-892a5547784e.json
+++ b/generator/.DevConfigs/5bb5985e-87f2-493b-8b57-892a5547784e.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fix `UpdateItem` not to throw an error when `ExpressionAttributeValues` is empty (https://github.com/aws/aws-sdk-net/issues/4144)"
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Table.cs
@@ -1421,30 +1421,49 @@ namespace Amazon.DynamoDBv2.DocumentModel
             else if (currentConfig.ConditionalExpression is { IsSet: true } || updateExpression is { IsSet: true })
             {
                 currentConfig.ConditionalExpression.ApplyExpression(req, this);
-
-                string statement;
-                Dictionary<string, AttributeValue> expressionAttributeValues;
-                Dictionary<string, string> expressionAttributeNames;
-
-                Common.ConvertAttributeUpdatesToUpdateExpression(attributeUpdates, updateExpression, this, out statement, out expressionAttributeValues, out expressionAttributeNames);
+                Common.ConvertAttributeUpdatesToUpdateExpression(
+                    attributeUpdates,
+                    updateExpression,
+                    this,
+                    out string statement,
+                    out Dictionary<string, AttributeValue> expressionAttributeValues,
+                    out Dictionary<string, string> expressionAttributeNames
+                );
 
                 req.AttributeUpdates = null;
                 req.UpdateExpression = statement;
 
-                if (req.ExpressionAttributeValues == null)
-                    req.ExpressionAttributeValues = expressionAttributeValues;
-                else
+                // Common.ConvertAttributeUpdatesToUpdateExpression initializes the expression dictionaries as empty,
+                // so we'll only add them to the request if there are values.
+
+                if (expressionAttributeValues.Count > 0)
                 {
-                    foreach (var kvp in expressionAttributeValues)
-                        req.ExpressionAttributeValues.Add(kvp.Key, kvp.Value);
+                    if (req.ExpressionAttributeValues == null)
+                    {
+                        req.ExpressionAttributeValues = expressionAttributeValues;
+                    }
+                    else
+                    {
+                        foreach (var kvp in expressionAttributeValues)
+                        {
+                            req.ExpressionAttributeValues.Add(kvp.Key, kvp.Value);
+                        }
+                    }
                 }
 
-                if (req.ExpressionAttributeNames == null)
-                    req.ExpressionAttributeNames = expressionAttributeNames;
-                else
+                if (expressionAttributeNames.Count > 0)
                 {
-                    foreach (var kvp in expressionAttributeNames)
-                        req.ExpressionAttributeNames.Add(kvp.Key, kvp.Value);
+                    if (req.ExpressionAttributeNames == null)
+                    {
+                        req.ExpressionAttributeNames = expressionAttributeNames;
+                    }
+                    else
+                    {
+                        foreach (var kvp in expressionAttributeNames)
+                        {
+                            req.ExpressionAttributeNames.Add(kvp.Key, kvp.Value);
+                        }
+                    }
                 }
             }
 #if NETSTANDARD
@@ -1512,30 +1531,49 @@ namespace Amazon.DynamoDBv2.DocumentModel
             else if (currentConfig.ConditionalExpression is { IsSet: true } || updateExpression is { IsSet: true })
             {
                 currentConfig.ConditionalExpression?.ApplyExpression(req, this);
-
-                string statement;
-                Dictionary<string, AttributeValue> expressionAttributeValues;
-                Dictionary<string, string> expressionAttributeNames;
-
-                Common.ConvertAttributeUpdatesToUpdateExpression(attributeUpdates, updateExpression,this, out statement, out expressionAttributeValues, out expressionAttributeNames);
+                Common.ConvertAttributeUpdatesToUpdateExpression(
+                    attributeUpdates,
+                    updateExpression,
+                    this,
+                    out string statement,
+                    out Dictionary<string, AttributeValue> expressionAttributeValues,
+                    out Dictionary<string, string> expressionAttributeNames
+                );
 
                 req.AttributeUpdates = null;
                 req.UpdateExpression = statement;
 
-                if (req.ExpressionAttributeValues == null)
-                    req.ExpressionAttributeValues = expressionAttributeValues;
-                else
+                // Common.ConvertAttributeUpdatesToUpdateExpression initializes the expression dictionaries as empty,
+                // so we'll only add them to the request if there are values.
+
+                if (expressionAttributeValues.Count > 0)
                 {
-                    foreach (var kvp in expressionAttributeValues)
-                        req.ExpressionAttributeValues.Add(kvp.Key, kvp.Value);
+                    if (req.ExpressionAttributeValues == null)
+                    {
+                        req.ExpressionAttributeValues = expressionAttributeValues;
+                    }
+                    else
+                    {
+                        foreach (var kvp in expressionAttributeValues)
+                        {
+                            req.ExpressionAttributeValues.Add(kvp.Key, kvp.Value);
+                        }
+                    }
                 }
 
-                if (req.ExpressionAttributeNames == null)
-                    req.ExpressionAttributeNames = expressionAttributeNames;
-                else
+                if (expressionAttributeNames.Count > 0)
                 {
-                    foreach (var kvp in expressionAttributeNames)
-                        req.ExpressionAttributeNames.Add(kvp.Key, kvp.Value);
+                    if (req.ExpressionAttributeNames == null)
+                    {
+                        req.ExpressionAttributeNames = expressionAttributeNames;
+                    }
+                    else
+                    {
+                        foreach (var kvp in expressionAttributeNames)
+                        {
+                            req.ExpressionAttributeNames.Add(kvp.Key, kvp.Value);
+                        }
+                    }
                 }
             }
 

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DocumentTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DocumentTests.cs
@@ -59,6 +59,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
                 // Test expressions for update
                 TestExpressionUpdate(hashTable);
+                TestExpressionUpdateWithoutValues(hashTable);
 
                 // Test expressions for put
                 TestExpressionPut(hashTable);
@@ -142,6 +143,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
 
                 // Test expressions for update
                 TestExpressionUpdate(hashTable);
+                TestExpressionUpdateWithoutValues(hashTable);
 
                 // Test expressions for put
                 TestExpressionPut(hashTable);
@@ -2296,6 +2298,26 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
             doc = hashTable.GetItem(doc);
             Assert.IsFalse(doc.Contains("update-test"));
 
+            hashTable.DeleteItem(doc);
+        }
+
+        private void TestExpressionUpdateWithoutValues(ITable hashTable)
+        {
+            var doc = new Document
+            {
+                ["Id"] = DateTime.UtcNow.Ticks,
+                ["currentVersion"] = null,
+            };
+
+            var config = new UpdateItemOperationConfig
+            {
+                ConditionalExpression = new Expression
+                {
+                    ExpressionStatement = "attribute_not_exists(updateVersion)",
+                }
+            };
+
+            Assert.IsTrue(hashTable.TryUpdateItem(doc, config));
             hashTable.DeleteItem(doc);
         }
 


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-net/issues/4144

## Testing
Dry-runs: SDK (`DRY_RUN-2750427a-fe9a-4c23-87df-038536d01075`) and PowerShell (`DRY_RUN-b0dfbf35-217b-474b-9b0c-81de1c811eec`)

Also ran the latest reproduction code from the issue and confirmed the V4 request matches V3.

V4 before:
```
{
    "ConditionExpression": "attribute_not_exists(updateVersion)",
    "ExpressionAttributeNames": {
        "#awsavar1": "currentVersion"
    },
    "ExpressionAttributeValues": {},
    "Key": {
        "pk": {
            "S": "test"
        },
        "sk": {
            "S": "testing"
        }
    },
    "ReturnValues": "NONE",
    "TableName": "TestTable",
    "UpdateExpression": "REMOVE #awsavar1"
}
```

V4 after (same as V3):
```
{
    "ConditionExpression": "attribute_not_exists(updateVersion)",
    "ExpressionAttributeNames": {
        "#awsavar1": "currentVersion"
    },
    "Key": {
        "pk": {
            "S": "test"
        },
        "sk": {
            "S": "testing"
        }
    },
    "ReturnValues": "NONE",
    "TableName": "TestTable",
    "UpdateExpression": "REMOVE #awsavar1"
}
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license