### PR TITLE
Fix content language initialization and update to use headers backing field

### DIFF
--- a/sdk/src/Services/S3/Custom/Model/GetObjectResponse.cs
+++ b/sdk/src/Services/S3/Custom/Model/GetObjectResponse.cs
@@ -69,7 +69,6 @@ namespace Amazon.S3.Model
         private string _checksumSHA1;
         private string _checksumSHA256;
         private ChecksumType _checksumType;
-        private string _contentLanguage;
 
         /// <summary>
         /// The date and time at which the object is no longer cacheable.
@@ -175,14 +174,8 @@ namespace Amazon.S3.Model
         /// </summary>
         public string ContentLanguage
         {
-            get { return this._contentLanguage; }
-            set { this._contentLanguage = value; }
-        }
-
-        // Check to see if ContentLanguage property is set
-        internal bool IsSetContentLanguage()
-        {
-            return this._contentLanguage != null;
+            get { return this.Headers.ContentLanguage; }
+            set { this.Headers.ContentLanguage = value; }
         }
 
         /// <summary>

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetObjectResponseUnmarshaller.cs
@@ -86,7 +86,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (responseData.IsHeaderPresent("Content-Encoding"))
                 response.Headers.ContentEncoding = S3Transforms.ToString(responseData.GetHeaderValue("Content-Encoding"));
             if (responseData.IsHeaderPresent("Content-Language"))
-                response.ContentLanguage = S3Transforms.ToString(responseData.GetHeaderValue("Content-Language"));
                 response.Headers.ContentLanguage = S3Transforms.ToString(responseData.GetHeaderValue("Content-Language"));
             if (responseData.IsHeaderPresent("Content-Length"))
                 response.Headers.ContentLength = long.Parse(responseData.GetHeaderValue("Content-Length"), CultureInfo.InvariantCulture);


### PR DESCRIPTION
no dev config since its already in https://github.com/aws/aws-sdk-net/pull/4074

## Description
update the  backing field for content language to be in the headers instead so that for TransferUtilityDownloadResponse we can easily just copy the headers only instead of the response.ContentLanguage field.

Also was a bug in https://github.com/aws/aws-sdk-net/pull/4074 where it was always setting the content language in one case because the `if` statement didnt have brackets. So this fixes that bug and also makes it so the headers is the backing field

## Motivation and Context


## Testing
1. unit tests pass
2. need to run dry run

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement