### PR TITLE
Update initiated, complete and failed events to not fire in background

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadRequest.cs
@@ -193,7 +193,7 @@ namespace Amazon.S3.Transfer
         /// <param name="args">DownloadInitiatedEventArgs args</param>
         internal void OnRaiseTransferInitiatedEvent(DownloadInitiatedEventArgs args)
         {
-            AWSSDKUtils.InvokeInBackground(DownloadInitiatedEvent, args, this);
+            DownloadInitiatedEvent?.Invoke(this, args);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Amazon.S3.Transfer
         /// <param name="args">DownloadCompletedEventArgs args</param>
         internal void OnRaiseTransferCompletedEvent(DownloadCompletedEventArgs args)
         {
-            AWSSDKUtils.InvokeInBackground(DownloadCompletedEvent, args, this);
+            DownloadCompletedEvent?.Invoke(this, args);
         }
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace Amazon.S3.Transfer
         /// <param name="args">DownloadFailedEventArgs args</param>
         internal void OnRaiseTransferFailedEvent(DownloadFailedEventArgs args)
         {
-            AWSSDKUtils.InvokeInBackground(DownloadFailedEvent, args, this);
+            DownloadFailedEvent?.Invoke(this, args);
         }
     }
 

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityUploadRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityUploadRequest.cs
@@ -276,7 +276,7 @@ namespace Amazon.S3.Transfer
         /// <param name="args">UploadInitiatedEventArgs args</param>
         internal void OnRaiseTransferInitiatedEvent(UploadInitiatedEventArgs args)
         {
-            AWSSDKUtils.InvokeInBackground(UploadInitiatedEvent, args, this);
+            UploadInitiatedEvent?.Invoke(this, args);
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace Amazon.S3.Transfer
         /// <param name="args">UploadCompletedEventArgs args</param>
         internal void OnRaiseTransferCompletedEvent(UploadCompletedEventArgs args)
         {
-            AWSSDKUtils.InvokeInBackground(UploadCompletedEvent, args, this);
+            UploadCompletedEvent?.Invoke(this, args);
         }
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace Amazon.S3.Transfer
         /// <param name="args">UploadFailedEventArgs args</param>
         internal void OnRaiseTransferFailedEvent(UploadFailedEventArgs args)
         {
-            AWSSDKUtils.InvokeInBackground(UploadFailedEvent, args, this);
+            UploadFailedEvent?.Invoke(this, args);
         }
 
 

--- a/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/TransferUtilityTests.cs
@@ -2125,11 +2125,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 if (EventException != null)
                     throw EventException;
 
-                // Since  AWSSDKUtils.InvokeInBackground fires the event in the background it is possible that we check too early that the event has fired. In this case, we sleep and check again.
-                for (int retries = 1; retries < 5 && !EventFired; retries++)
-                {
-                    Thread.Sleep(1000 * retries);
-                }
+                // Since events are now fired synchronously, we can check immediately without retries
                 Assert.IsTrue(EventFired, $"{typeof(T).Name} event was not fired");
             }
         }


### PR DESCRIPTION
Updating as per https://github.com/aws/aws-sdk-net/pull/4151#discussion_r2566722462

Theres no dev config here because theres already an existing one for adding these events in this branch

## Motivation and Context
if events are fired in the background there was no guarantee they would be executed before the original task finishes or not. so we update to synchronous to ensure that they are.

## Testing
1. existing unit tests pass
2. existing integ tests pass


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement