### PR TITLE
Add error message for multipart download when using Encryption Client

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
@@ -149,7 +149,7 @@ namespace Amazon.S3.Transfer.Internal
             // Validate that S3 encryption client is not being used for multipart downloads
             if (_s3Client is Amazon.S3.Internal.IAmazonS3Encryption)
             {
-                throw new NotSupportedException("Multipart download is not supported when using S3 encryption client. Please use the regular S3 encryption client for multipart download.");
+                throw new NotSupportedException("Multipart download is not supported when using Amazon.S3.Internal.IAmazonS3Encryption client. Please use the Amazon.S3.AmazonS3Client for multipart download.");
             }
 
             _requestEventHandler = requestEventHandler;

--- a/sdk/test/Services/S3/UnitTests/Custom/MultipartDownloadManagerTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/MultipartDownloadManagerTests.cs
@@ -186,7 +186,7 @@ namespace AWSSDK.UnitTests
             }
             catch (NotSupportedException ex)
             {
-                Assert.IsTrue(ex.Message.Contains("Multipart download is not supported when using S3 encryption client. Please use the regular S3 encryption client for multipart download."));
+                Assert.IsTrue(ex.Message.Contains("Multipart download is not supported when using Amazon.S3.Internal.IAmazonS3Encryption client. Please use the Amazon.S3.AmazonS3Client for multipart download."));
             }
         }
 


### PR DESCRIPTION
Add check where if encryption client is being used we give a friendly error to the user.

## Description
Out of the box the https://github.com/aws/amazon-s3-encryption-client-dotnet does not seem to work with PART GET. if the user attempts to use it with multi part download with PART get they get

```
ERROR: Failed to decrypt: mac check in GCM failed
Stack trace: at Amazon.Extensions.S3.Encryption.Util.AesGcmDecryptStream.ReadAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken) in C:\dev\repos\aws-sdk-net\amazon-s3-encryption-client-dotnet\src\Util\AesGcmDecryptStream.cs:line 123
```

This change makes it so we display a friendly error message instead of the above one. 

We also have the alternative option of updating the encryption client itself to add a message https://github.com/aws/amazon-s3-encryption-client-dotnet/blob/7f38b9e07575afb524e2e5b03899834ac8ce5d2c/src/Internal/SetupEncryptionHandler.cs#L237 similar to RANGED GET not being supported, however, to be extra cautious i have made the update in the SDK itself. The reason being is that maybe there is some configuration/edge case where PART GET _does work_ (and somehow i have not been able to figure it out), i didnt want to break those customers. **If we are confident that PART GET does not work, and we think the better solution is to update the encryption client to throw an error message, please let me know and i will do that instead**


I also checked with the java encryption client, and they also do not support PART GET.

ive made backlog item DOTNET-8419 to track adding PART GET support

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3806

## Testing
1. add unit tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement