### PR TITLE
Fix Logger Recursive property definition

### DIFF
--- a/generator/.DevConfigs/c49077d9-90b3-437f-b316-6d8d8833ae65.json
+++ b/generator/.DevConfigs/c49077d9-90b3-437f-b316-6d8d8833ae65.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fix Transfer Utility internal Logger recursive property definition"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadCommand.cs
@@ -42,13 +42,7 @@ namespace Amazon.S3.Transfer.Internal
         // Track last known transferred bytes from coordinator's progress events
         private long _lastKnownTransferredBytes;
 
-        private static Logger Logger
-        {
-            get
-            {
-                return Logger.GetLogger(typeof(TransferUtility));
-            }
-        }
+        private readonly Logger _logger = Logger.GetLogger(typeof(MultipartDownloadCommand));
 
         /// <summary>
         /// Initializes a new instance of the MultipartDownloadCommand class for single file downloads.
@@ -118,7 +112,7 @@ namespace Amazon.S3.Transfer.Internal
             // Use S3 client buffer size for I/O operations
             int bufferSize = _s3Client.Config.BufferSize;
 
-            Logger.DebugFormat("MultipartDownloadCommand: Creating configuration - PartSizeFromRequest={0}, UsingDefaultPartSize={1}",
+            _logger.DebugFormat("MultipartDownloadCommand: Creating configuration - PartSizeFromRequest={0}, UsingDefaultPartSize={1}",
                 _request.IsSetPartSize() ? _request.PartSize.ToString() : "Not Set",
                 !_request.IsSetPartSize());
 

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartUploadCommand.cs
@@ -50,13 +50,7 @@ namespace Amazon.S3.Transfer.Internal
         Queue<UploadPartRequest> _partsToUpload = new Queue<UploadPartRequest>();
 
         long _contentLength;
-        private static Logger Logger
-        {
-            get
-            {
-                return Logger.GetLogger(typeof(TransferUtility));
-            }
-        }
+        private readonly Logger _logger = Logger.GetLogger(typeof(MultipartUploadCommand));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MultipartUploadCommand"/> class.
@@ -70,11 +64,11 @@ namespace Amazon.S3.Transfer.Internal
 
             if (fileTransporterRequest.IsSetFilePath())
             {
-                Logger.DebugFormat("Beginning upload of file {0}.", fileTransporterRequest.FilePath);
+                _logger.DebugFormat("Beginning upload of file {0}.", fileTransporterRequest.FilePath);
             }
             else
             {
-                Logger.DebugFormat("Beginning upload of stream.");
+                _logger.DebugFormat("Beginning upload of stream.");
             }
 
             this._s3Client = s3Client;
@@ -95,7 +89,7 @@ namespace Amazon.S3.Transfer.Internal
                 }
             }
 
-            Logger.DebugFormat("Upload part size {0}.", this._partSize);
+            _logger.DebugFormat("Upload part size {0}.", this._partSize);
         }
 
         private static long calculatePartSize(long contentLength, long targetPartSize)

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/TaskHelpers.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/TaskHelpers.cs
@@ -27,11 +27,6 @@ namespace Amazon.S3.Transfer.Internal
     /// </summary>
     internal static class TaskHelpers
     {
-        private static Logger Logger
-        {
-            get { return Logger.GetLogger(typeof(TaskHelpers)); }
-        }
-
         /// <summary>
         /// Waits for all tasks to complete or till any task fails or is canceled.
         /// </summary>
@@ -43,7 +38,7 @@ namespace Amazon.S3.Transfer.Internal
             int processed = 0;
             int total = pendingTasks.Count;
             
-            Logger.DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync: Starting with TotalTasks={0}", total);
+            Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync: Starting with TotalTasks={0}", total);
             
             while (processed < total)
             {
@@ -60,11 +55,11 @@ namespace Amazon.S3.Transfer.Internal
                 pendingTasks.Remove(completedTask);
                 processed++;
                 
-                Logger.DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync: Task completed (Processed={0}/{1}, Remaining={2})",
+                Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync: Task completed (Processed={0}/{1}, Remaining={2})",
                     processed, total, pendingTasks.Count);
             }
             
-            Logger.DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync: All tasks completed (Total={0})", total);
+            Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync: All tasks completed (Total={0})", total);
         }
 
         /// <summary>
@@ -81,7 +76,7 @@ namespace Amazon.S3.Transfer.Internal
             int total = pendingTasks.Count;
             var responses = new List<T>();
             
-            Logger.DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync<T>: Starting with TotalTasks={0}", total);
+            Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync<T>: Starting with TotalTasks={0}", total);
             
             while (processed < total)
             {
@@ -99,11 +94,11 @@ namespace Amazon.S3.Transfer.Internal
                 pendingTasks.Remove(completedTask);
                 processed++;
                 
-                Logger.DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync<T>: Task completed (Processed={0}/{1}, Remaining={2})",
+                Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync<T>: Task completed (Processed={0}/{1}, Remaining={2})",
                     processed, total, pendingTasks.Count);
             }
             
-            Logger.DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync<T>: All tasks completed (Total={0})", total);
+            Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.WhenAllOrFirstExceptionAsync<T>: All tasks completed (Total={0})", total);
             
             return responses;
         }
@@ -134,11 +129,11 @@ namespace Amazon.S3.Transfer.Internal
             var itemList = items as IList<T> ?? items.ToList();
             if (itemList.Count == 0)
             {
-                Logger.DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: No items to process");
+                Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: No items to process");
                 return;
             }
 
-            Logger.DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: Starting with TotalItems={0}, MaxConcurrency={1}",
+            Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: Starting with TotalItems={0}, MaxConcurrency={1}",
                 itemList.Count, maxConcurrency);
 
             int nextIndex = 0;
@@ -146,7 +141,7 @@ namespace Amazon.S3.Transfer.Internal
 
             // Start initial batch up to concurrency limit
             int initialBatchSize = Math.Min(maxConcurrency, itemList.Count);
-            Logger.DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: Starting initial batch of {0} tasks", initialBatchSize);
+            Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: Starting initial batch of {0} tasks", initialBatchSize);
             
             for (int i = 0; i < initialBatchSize; i++)
             {
@@ -170,20 +165,20 @@ namespace Amazon.S3.Transfer.Internal
                 activeTasks.Remove(completedTask);
 
                 int itemsCompleted = nextIndex - activeTasks.Count;
-                Logger.DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: Task completed (Active={0}, Completed={1}/{2}, Remaining={3})",
+                Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: Task completed (Active={0}, Completed={1}/{2}, Remaining={3})",
                     activeTasks.Count, itemsCompleted, itemList.Count, itemList.Count - itemsCompleted);
 
                 // Start next task if more work remains
                 if (nextIndex < itemList.Count)
                 {
-                    Logger.DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: Starting next task (Index={0}/{1}, Active={2})",
+                    Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: Starting next task (Index={0}/{1}, Active={2})",
                         nextIndex + 1, itemList.Count, activeTasks.Count + 1);
                     var nextTask = processAsync(itemList[nextIndex++], cancellationToken);
                     activeTasks.Add(nextTask);
                 }
             }
             
-            Logger.DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: All items processed (Total={0})", itemList.Count);
+            Logger.GetLogger(typeof(TaskHelpers)).DebugFormat("TaskHelpers.ForEachWithConcurrencyAsync: All items processed (Total={0})", itemList.Count);
         }
     }
 }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_async/OpenStreamWithResponseCommand.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_async/OpenStreamWithResponseCommand.async.cs
@@ -27,17 +27,14 @@ namespace Amazon.S3.Transfer.Internal
 {
     internal partial class OpenStreamWithResponseCommand : BaseCommand<TransferUtilityOpenStreamResponse>
     {
-        private Logger Logger
-        {
-            get { return Logger.GetLogger(typeof(TransferUtility)); }
-        }
+        private readonly Logger _logger = Logger.GetLogger(typeof(OpenStreamWithResponseCommand));
 
         public override async Task<TransferUtilityOpenStreamResponse> ExecuteAsync(CancellationToken cancellationToken)
         {
-            Logger.DebugFormat("OpenStreamWithResponseCommand: Creating BufferedMultipartStream with MultipartDownloadType={0}",
+            _logger.DebugFormat("OpenStreamWithResponseCommand: Creating BufferedMultipartStream with MultipartDownloadType={0}",
                 _request.MultipartDownloadType);
 
-            Logger.DebugFormat("OpenStreamWithResponseCommand: Configuration - ConcurrentServiceRequests={0}, MaxInMemoryParts={1}, BufferSize={2}",
+            _logger.DebugFormat("OpenStreamWithResponseCommand: Configuration - ConcurrentServiceRequests={0}, MaxInMemoryParts={1}, BufferSize={2}",
                 _config.ConcurrentServiceRequests,
                 _request.MaxInMemoryParts,
                 _s3Client.Config.BufferSize
@@ -49,7 +46,7 @@ namespace Amazon.S3.Transfer.Internal
             // Populate metadata from the initial GetObject response (from discovery phase)
             var discoveryResult = bufferedStream.DiscoveryResult;
 
-            Logger.DebugFormat("OpenStreamWithResponseCommand: Stream initialized successfully - ObjectSize={0}, TotalParts={1}, IsSinglePart={2}",
+            _logger.DebugFormat("OpenStreamWithResponseCommand: Stream initialized successfully - ObjectSize={0}, TotalParts={1}, IsSinglePart={2}",
                 discoveryResult.ObjectSize,
                 discoveryResult.TotalParts,
                 discoveryResult.IsSinglePart);

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtility.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtility.cs
@@ -71,14 +71,7 @@ namespace Amazon.S3.Transfer
         {
             "s3-object-lambda"
         };
-        private static Logger Logger
-        {
-            get
-            {
-
-                return Logger.GetLogger(typeof(ITransferUtility));
-            }
-        }
+        private readonly Logger _logger = Logger.GetLogger(typeof(TransferUtility));
         #region Constructors
 
         /// <summary>


### PR DESCRIPTION
Fixing this warning i saw from copilot

```
         public bool DownloadFilesConcurrently { get; set; }
 
+        private Logger Logger
+        {
+            get { return Logger.GetLogger(typeof(DownloadDirectoryCommand)); }
Recursive property definition: the Logger property calls Logger.GetLogger() which references itself. This should be _logger field or use a different pattern.

```


## Testing
unit tests pass


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement