### PR TITLE
Add user agent header to ResponseMetadata

### DIFF
--- a/generator/.DevConfigs/117b0e1d-fda9-4809-a6cd-7227bfe3f665.json
+++ b/generator/.DevConfigs/117b0e1d-fda9-4809-a6cd-7227bfe3f665.json
@@ -1,0 +1,10 @@
+
+{
+  "core": {
+    "changeLogMessages": [
+      "Add user agent header to ResponseMetadata"
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Unmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Unmarshaller.cs
@@ -207,6 +207,14 @@ namespace Amazon.Runtime.Internal
                 if (response.ResponseMetadata != null)
                 {
                     requestContext.Metrics.AddProperty(Metric.AWSRequestID, response.ResponseMetadata.RequestId);
+
+                    var userAgentHeaderKey = requestContext.ClientConfig.UseAlternateUserAgentHeader
+                        ? HeaderKeys.XAmzUserAgentHeader : HeaderKeys.UserAgentHeader;
+
+                    if (requestContext.Request.Headers.ContainsKey(userAgentHeaderKey))
+                    {
+                        response.ResponseMetadata.Metadata.Add(userAgentHeaderKey, requestContext.Request.Headers[userAgentHeaderKey]);
+                    }
                 }
 
                 context.ValidateCRC32IfAvailable();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the `Unmarshaller` to include the user agent header in `ResponseMetadata`, providing a way in the SDK for callers to verify what was sent as the user agent header.
<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-8381`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
- Updated `UserAgentTests` to verify that the user agent is added to `ResponseMetadata`.
- `DRY_RUN-449149ca-fd1b-4a79-9ab3-5ae2f80f2e6b`
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement