### PR TITLE
Fix DownloadPartProgressEventCallback race condition

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
@@ -63,7 +63,7 @@ namespace Amazon.S3.Transfer.Internal
         // Atomic flag to ensure completion event fires exactly once
         // Without this, concurrent parts completing simultaneously can both see
         // transferredBytes == _totalObjectSize and fire duplicate completion events
-        // Uses int instead of bool because Interlocked.CompareExchange requires reference types
+        // Uses long instead of bool for compatibility with Interlocked operations
         private long _completionEventFired = 0;  // 0 = false, 1 = true
 
         private readonly Logger _logger = Logger.GetLogger(typeof(MultipartDownloadManager));


### PR DESCRIPTION
Fixes the following race conditon.

**Old Code**

## Concrete Example with 2 Threads
### Thread A (Part 1 finishes) - Arrives First
```
// GetObjectResponse fires: e.IncrementTransferred = 0, e.IsCompleted = true
private void DownloadPartProgressEventCallback(object sender, WriteObjectProgressArgs e)
{
    // e.IncrementTransferred = 0 (stream finished, no new bytes)
    long transferredBytes = Interlocked.Add(ref _totalTransferredBytes, 0);
    // transferredBytes = 20 MB (unchanged)
    
    bool isComplete = false;
    if (transferredBytes >= _totalObjectSize)  // 20 MB >= 20 MB? YES
    {
        // Try to set _completionEventFired from 0 to 1
        int originalValue = Interlocked.CompareExchange(ref _completionEventFired, 1, 0);
        // originalValue = 0 (we're first!)
        // _completionEventFired is now 1
        
        if (originalValue == 0)  // TRUE - we won
        {
            isComplete = true;  // ✅ We will fire completion
        }
    }
    
    // Fire event
    var aggregatedArgs = CreateProgressArgs(0, 20MB, true);  // completed = true
    _userProgressCallback?.Invoke(this, aggregatedArgs);
    // ✅ COMPLETION EVENT FIRED
}

```

### Thread B (Part 2 finishes) - Arrives Microseconds Later

```
// GetObjectResponse fires: e.IncrementTransferred = 0, e.IsCompleted = true
private void DownloadPartProgressEventCallback(object sender, WriteObjectProgressArgs e)
{
    // e.IncrementTransferred = 0 (stream finished, no new bytes)
    long transferredBytes = Interlocked.Add(ref _totalTransferredBytes, 0);
    // transferredBytes = 20 MB (unchanged)
    
    bool isComplete = false;
    if (transferredBytes >= _totalObjectSize)  // 20 MB >= 20 MB? YES
    {
        // Try to set _completionEventFired from 0 to 1
        int originalValue = Interlocked.CompareExchange(ref _completionEventFired, 1, 0);
        // originalValue = 1 (Thread A already set it!)
        // _completionEventFired stays 1
        
        if (originalValue == 0)  // FALSE - we lost
        {
            isComplete = true;  // This line never executes
        }
        // isComplete is still false
        // ⚠️ BUT WE DON'T RETURN - WE CONTINUE!
    }
    
    // Fire event - THIS IS THE BUG
    var aggregatedArgs = CreateProgressArgs(0, 20MB, false);  // completed = false!
    _userProgressCallback?.Invoke(this, aggregatedArgs);
    // ❌ POST-COMPLETION EVENT FIRED: increment=0, total=20MB, completed=FALSE
    // This happens AFTER Thread A already fired the completion event!
}

```

__Thread B should have returned early__ after detecting that `_completionEventFired` was already set, but the old code had no early return. It continued to fire an event with `isComplete=false`, which violated the contract that no events should fire after completion. 

To answer the question on "Why did Thread B fire an event even though all the bytes  have been transferred?" its because in https://github.com/aws/aws-sdk-net/blob/cf2f0787d8149dfcfced66968bf713d5468f72b5/sdk/src/Services/S3/Custom/Model/GetObjectResponse.cs#L770 it will fire a final event at the end (0 bytes transferred). 

----
New  Code

```
private void DownloadPartProgressEventCallback(object sender, WriteObjectProgressArgs e)
{
    long transferredBytes = Interlocked.Add(ref _totalTransferredBytes, e.IncrementTransferred);
    
    // ✅ NEW: Check if completion already fired - exit immediately if so
    if (Interlocked.Read(ref _completionEventFired) == 1)
    {
        return;  // Don't fire any event - we're done!
    }
    
    bool isComplete = false;
    if (transferredBytes == _totalObjectSize)
    {
        int originalValue = Interlocked.CompareExchange(ref _completionEventFired, 1, 0);
        if (originalValue == 0)
        {
            isComplete = true;
        }
        else
        {
            // ✅ NEW: Also return here if we lost the race
            return;
        }
    }
    
    // Only fire event if we haven't completed yet
    var aggregatedArgs = CreateProgressArgs(e.IncrementTransferred, transferredBytes, isComplete);
    _userProgressCallback?.Invoke(this, aggregatedArgs);
}

```


## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3806

## Testing
I reran the affected test

```
Failed MultipartDownloadProgressTest [1 s]
  Error Message:
   Assert.Fail failed. A progress event was received after completion.

  Stack Trace:
   at AWSSDK_DotNet.IntegrationTests.Tests.S3.TransferUtilityTests.ProgressValidator`1.AssertOnCompletion() in C:\codebuild\tmp\output\src2637311874\src\aws-sdk-net\sdk\test\Services\S3\IntegrationTests\TransferUtilityTests.cs:line 2254
   at AWSSDK_DotNet.IntegrationTests.Tests.S3.TransferUtilityTests.<MultipartDownloadProgressTest>d__62.MoveNext() in C:\codebuild\tmp\output\src2637311874\src\aws-sdk-net\sdk\test\Services\S3\IntegrationTests\TransferUtilityTests.cs:line 1490
```

multiple times and it passed every time


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement