### PR TITLE
fix http concurrency

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/FilePartDataHandler.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/FilePartDataHandler.cs
@@ -90,7 +90,7 @@ namespace Amazon.S3.Transfer.Internal
                     partNumber, offset);
 
                 // Write part data to file at the calculated offset
-                await WritePartToFileAsync(offset, response, cancellationToken)
+                await WritePartToFileAsync(partNumber, offset, response, cancellationToken)
                     .ConfigureAwait(false);
 
                 _logger.DebugFormat("FilePartDataHandler: [Part {0}] File write completed successfully",
@@ -192,6 +192,7 @@ namespace Amazon.S3.Transfer.Internal
         /// Writes part data from GetObjectResponse ResponseStream to the file at the specified offset.
         /// </summary>
         private async Task WritePartToFileAsync(
+            int partNumber,
             long offset,
             GetObjectResponse response,
             CancellationToken cancellationToken)
@@ -213,7 +214,7 @@ namespace Amazon.S3.Transfer.Internal
                 // Seek to the correct offset for this part
                 fileStream.Seek(offset, SeekOrigin.Begin);
 
-                _logger.DebugFormat("FilePartDataHandler: Writing {0} bytes to file at offset {1}",
+                _logger.DebugFormat("FilePartDataHandler: [Part {0}] Writing {1} bytes to file at offset {2}", partNumber,
                     response.ContentLength, offset);
 
                 // Use GetObjectResponse's stream copy logic which includes:
@@ -232,7 +233,7 @@ namespace Amazon.S3.Transfer.Internal
                 await fileStream.FlushAsync(cancellationToken)
                     .ConfigureAwait(false);
 
-                _logger.DebugFormat("FilePartDataHandler: Successfully wrote {0} bytes at offset {1}",
+                _logger.DebugFormat("FilePartDataHandler: [Part {0}] Successfully wrote {1} bytes at offset {2}", partNumber,
                     response.ContentLength, offset);
             }
         }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
@@ -173,6 +173,41 @@ namespace Amazon.S3.Transfer.Internal
             }
         }
 
+        /// <summary>
+        /// Discovers the download strategy (single-part vs multipart) by making an initial GetObject request.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token to cancel the discovery operation.</param>
+        /// <returns>
+        /// A <see cref="DownloadDiscoveryResult"/> containing information about the object size, part count,
+        /// and the initial GetObject response.
+        /// </returns>
+        /// <remarks>
+        /// <para><strong>IMPORTANT - HTTP Semaphore Lifecycle:</strong></para>
+        /// <para>
+        /// This method acquires an HTTP concurrency slot from the configured semaphore and downloads Part 1.
+        /// The semaphore slot is <strong>HELD</strong> until <see cref="StartDownloadsAsync"/> completes processing Part 1.
+        /// Callers <strong>MUST</strong> call <see cref="StartDownloadsAsync"/> after this method to release the semaphore.
+        /// Failure to call <see cref="StartDownloadsAsync"/> will cause the semaphore slot to remain held indefinitely,
+        /// potentially blocking other downloads and causing deadlocks.
+        /// </para>
+        /// <para><strong>Concurrency Implications:</strong></para>
+        /// <para>
+        /// With limited HTTP concurrency (e.g., <c>ConcurrentServiceRequests=1</c> for shared throttlers in directory downloads),
+        /// concurrent calls to this method will block until previous downloads complete their full lifecycle
+        /// (discover → start). This is by design to ensure the entire I/O operation (network + disk) is
+        /// within the concurrency limit. For single-slot throttlers, downloads must be processed sequentially:
+        /// complete one download's full lifecycle before starting the next.
+        /// </para>
+        /// <para><strong>Typical Usage Pattern:</strong></para>
+        /// <code>
+        /// var discovery = await manager.DiscoverDownloadStrategyAsync(cancellationToken);
+        /// await manager.StartDownloadsAsync(discovery, progressCallback, cancellationToken);
+        /// await manager.DownloadCompletionTask; // Wait for multipart downloads to finish
+        /// </code>
+        /// </remarks>
+        /// <exception cref="ObjectDisposedException">Thrown if the manager has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if discovery has already been performed.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if the operation is cancelled.</exception>
         /// <inheritdoc/>
         public async Task<DownloadDiscoveryResult> DiscoverDownloadStrategyAsync(CancellationToken cancellationToken)
         {
@@ -209,6 +244,50 @@ namespace Amazon.S3.Transfer.Internal
             }
         }
 
+        /// <summary>
+        /// Processes Part 1 and starts downloading remaining parts for multipart downloads.
+        /// Returns immediately after processing Part 1 to allow the consumer to begin reading.
+        /// </summary>
+        /// <param name="discoveryResult">
+        /// The discovery result from <see cref="DiscoverDownloadStrategyAsync"/> containing object metadata
+        /// and the initial GetObject response.
+        /// </param>
+        /// <param name="progressCallback">
+        /// Optional progress callback that will be invoked as parts are downloaded. For multipart downloads,
+        /// progress is aggregated across all concurrent part downloads.
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token to cancel the download operation.</param>
+        /// <returns>
+        /// A task that completes after Part 1 is processed. For multipart downloads, remaining parts
+        /// continue downloading in the background (monitor via <see cref="DownloadCompletionTask"/>).
+        /// </returns>
+        /// <remarks>
+        /// <para><strong>HTTP Semaphore Release:</strong></para>
+        /// <para>
+        /// This method processes Part 1 (downloaded during <see cref="DiscoverDownloadStrategyAsync"/>)
+        /// and <strong>releases the HTTP semaphore slot</strong> that was acquired during discovery.
+        /// The semaphore is released <strong>after</strong> both the network download and disk write
+        /// operations complete for Part 1. This ensures the <c>ConcurrentServiceRequests</c> limit
+        /// controls the entire I/O operation (network + disk), not just the network download.
+        /// </para>
+        /// <para><strong>Background Processing (Multipart Only):</strong></para>
+        /// <para>
+        /// For multipart downloads (when <c>TotalParts > 1</c>), this method starts a background task
+        /// to download and process remaining parts (Part 2+) and returns immediately. This allows the
+        /// consumer to start reading from the buffer without waiting for all downloads to complete,
+        /// which prevents deadlocks when the buffer fills up before the consumer begins reading.
+        /// Monitor <see cref="DownloadCompletionTask"/> to detect when all background downloads have finished.
+        /// </para>
+        /// <para><strong>Single-Part Downloads:</strong></para>
+        /// <para>
+        /// For single-part downloads (when <c>TotalParts = 1</c>), this method processes Part 1 synchronously
+        /// and returns immediately. No background task is created, and <see cref="DownloadCompletionTask"/>
+        /// will already be completed when this method returns.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="ObjectDisposedException">Thrown if the manager has been disposed.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="discoveryResult"/> is null.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if the operation is cancelled.</exception>
         /// <inheritdoc/>
         public async Task StartDownloadsAsync(DownloadDiscoveryResult discoveryResult, EventHandler<WriteObjectProgressArgs> progressCallback, CancellationToken cancellationToken)
         {
@@ -229,9 +308,6 @@ namespace Amazon.S3.Transfer.Internal
 
             try
             {
-                // Prepare the data handler (e.g., create temp files for file-based downloads)
-                await _dataHandler.PrepareAsync(discoveryResult, cancellationToken).ConfigureAwait(false);
-                
                 // Create delegate once and reuse for all parts
                 var wrappedCallback = progressCallback != null 
                     ? new EventHandler<WriteObjectProgressArgs>(DownloadPartProgressEventCallback)
@@ -239,6 +315,9 @@ namespace Amazon.S3.Transfer.Internal
                 
                 try
                 {
+                    // Prepare the data handler (e.g., create temp files for file-based downloads)
+                    await _dataHandler.PrepareAsync(discoveryResult, cancellationToken).ConfigureAwait(false);
+                    
                     // Attach progress callback to Part 1's response if provided
                     if (wrappedCallback != null)
                     {
@@ -246,17 +325,26 @@ namespace Amazon.S3.Transfer.Internal
                     }
                     
                     // Process Part 1 from InitialResponse (applies to both single-part and multipart)
-                    _logger.DebugFormat("MultipartDownloadManager: Buffering Part 1 from discovery response");
+                    // NOTE: Semaphore is still held from discovery phase and will be released in finally block
+                    _logger.DebugFormat("MultipartDownloadManager: Processing Part 1 from discovery response");
                     await _dataHandler.ProcessPartAsync(1, discoveryResult.InitialResponse, cancellationToken).ConfigureAwait(false);
+                    
+                    _logger.DebugFormat("MultipartDownloadManager: Part 1 processing completed");
                 }
                 finally
                 {
                     // Always detach the event handler to prevent memory leak
-                    // This runs whether ProcessPartAsync succeeds or throws
                     if (wrappedCallback != null)
                     {
                         discoveryResult.InitialResponse.WriteObjectProgressEvent -= wrappedCallback;
                     }
+                    
+                    // Release semaphore after BOTH network download AND disk write complete for Part 1
+                    // This ensures ConcurrentServiceRequests controls the entire I/O operation,
+                    // consistent with Parts 2+ (see CreateDownloadTaskAsync)
+                    _httpConcurrencySlots.Release();
+                    _logger.DebugFormat("MultipartDownloadManager: [Part 1] HTTP concurrency slot released (Available: {0}/{1})",
+                        _httpConcurrencySlots.CurrentCount, _config.ConcurrentServiceRequests);
                 }
 
                 if (discoveryResult.IsSinglePart)
@@ -374,7 +462,9 @@ namespace Amazon.S3.Transfer.Internal
                 _logger.DebugFormat("MultipartDownloadManager: [Part {0}] Waiting for HTTP concurrency slot (Available: {1}/{2})",
                     partNumber, _httpConcurrencySlots.CurrentCount, _config.ConcurrentServiceRequests);
 
-                // Limit HTTP concurrency
+                // Limit HTTP concurrency for both network download AND disk write
+                // The semaphore is held until AFTER ProcessPartAsync completes to ensure
+                // ConcurrentServiceRequests controls the entire I/O operation
                 await _httpConcurrencySlots.WaitAsync(cancellationToken).ConfigureAwait(false);
 
                 _logger.DebugFormat("MultipartDownloadManager: [Part {0}] HTTP concurrency slot acquired", partNumber);
@@ -438,25 +528,27 @@ namespace Amazon.S3.Transfer.Internal
                     }
 
                     _logger.DebugFormat("MultipartDownloadManager: [Part {0}] ETag validation passed", partNumber);
+
+                    _logger.DebugFormat("MultipartDownloadManager: [Part {0}] Processing part (handler will decide: stream or buffer)", partNumber);
+                    
+                    // Delegate data handling to the handler
+                    // IMPORTANT: Handler takes ownership of response and is responsible for disposing it in ALL cases:
+                    // - If streaming: StreamingDataSource takes ownership and disposes when consumer finishes reading
+                    // - If buffering: Handler disposes immediately after copying data to buffer
+                    // - On error: Handler disposes in its catch block before rethrowing
+                    await _dataHandler.ProcessPartAsync(partNumber, response, cancellationToken).ConfigureAwait(false);
+                    ownsResponse = false;  // Ownership transferred to handler
+
+                    _logger.DebugFormat("MultipartDownloadManager: [Part {0}] Processing completed successfully", partNumber);
                 }
                 finally
                 {
+                    // Release semaphore after BOTH network download AND disk write complete
+                    // This ensures ConcurrentServiceRequests limits the entire I/O operation
                     _httpConcurrencySlots.Release();
                     _logger.DebugFormat("MultipartDownloadManager: [Part {0}] HTTP concurrency slot released (Available: {1}/{2})",
                         partNumber, _httpConcurrencySlots.CurrentCount, _config.ConcurrentServiceRequests);
                 }
-
-                _logger.DebugFormat("MultipartDownloadManager: [Part {0}] Processing part (handler will decide: stream or buffer)", partNumber);
-                
-                // Delegate data handling to the handler
-                // IMPORTANT: Handler takes ownership of response and is responsible for disposing it in ALL cases:
-                // - If streaming: StreamingDataSource takes ownership and disposes when consumer finishes reading
-                // - If buffering: Handler disposes immediately after copying data to buffer
-                // - On error: Handler disposes in its catch block before rethrowing
-                await _dataHandler.ProcessPartAsync(partNumber, response, cancellationToken).ConfigureAwait(false);
-                ownsResponse = false;  // Ownership transferred to handler
-
-                _logger.DebugFormat("MultipartDownloadManager: [Part {0}] Processing completed successfully", partNumber);
             }
             catch (Exception ex)
             {
@@ -491,59 +583,66 @@ namespace Amazon.S3.Transfer.Internal
             await _httpConcurrencySlots.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             GetObjectResponse firstPartResponse = null;
+            
+            // NOTE: Semaphore is NOT released here - it will be released in StartDownloadsAsync
+            // after Part 1 is processed. This ensures the semaphore controls both network download
+            // AND disk write for Part 1, consistent with Parts 2+ (see CreateDownloadTaskAsync)
+            
             try
             {
                 // SEP Part GET Step 2: "send the request and wait for the response in a non-blocking fashion"
                 firstPartResponse = await _s3Client.GetObjectAsync(firstPartRequest, cancellationToken).ConfigureAwait(false);
+                
+                if (firstPartResponse == null)
+                    throw new InvalidOperationException("Failed to retrieve object from S3");
+                
+                // SEP Part GET Step 3: Save ETag for later IfMatch validation in subsequent requests
+                _savedETag = firstPartResponse.ETag;
+                
+                // SEP Part GET Step 3: "check the response. First parse total content length from ContentRange 
+                // of the GetObject response and save the value in a variable. The length is the numeric value 
+                // after / delimiter. For example, given ContentRange=bytes 0-1/5, 5 is the total content length. 
+                // Then check PartsCount."
+                if (firstPartResponse.PartsCount.HasValue && firstPartResponse.PartsCount.Value > 1)
+                {
+                    // SEP Part GET Step 3: "If PartsCount in the response is larger than 1, it indicates there 
+                    // are more parts available to download. The S3 Transfer Manager MUST save etag from the 
+                    // response to a variable."
+                    _discoveredPartCount = firstPartResponse.PartsCount.Value;
+                    
+                    // Parse total content length from ContentRange header
+                    // For example, "bytes 0-5242879/52428800" -> extract 52428800
+                    var totalObjectSize = ExtractTotalSizeFromContentRange(firstPartResponse.ContentRange);
+                    
+                    // SEP Part GET Step 7 will use this response for creating DownloadResponse
+                    // Keep the response with its stream (will be buffered in StartDownloadsAsync)
+                    return new DownloadDiscoveryResult
+                    {
+                        TotalParts = firstPartResponse.PartsCount.Value,
+                        ObjectSize = totalObjectSize,
+                        InitialResponse = firstPartResponse  // Keep response with stream
+                    };
+                }
+                else
+                {
+                    // SEP Part GET Step 3: "If PartsCount is 1, go to Step 7."
+                    _discoveredPartCount = 1;
+                    
+                    // Single part upload - return the response for immediate use (SEP Step 7)
+                    return new DownloadDiscoveryResult
+                    {
+                        TotalParts = 1,
+                        ObjectSize = firstPartResponse.ContentLength,
+                        InitialResponse = firstPartResponse  // Keep response with stream
+                    };
+                }
             }
-            finally
+            catch
             {
+                // On error, release semaphore and dispose response before rethrowing
                 _httpConcurrencySlots.Release();
-                _logger.DebugFormat("MultipartDownloadManager: [Part 1 Discovery] HTTP concurrency slot released");
-            }
-            
-            if (firstPartResponse == null)
-                throw new InvalidOperationException("Failed to retrieve object from S3");
-            
-            // SEP Part GET Step 3: Save ETag for later IfMatch validation in subsequent requests
-            _savedETag = firstPartResponse.ETag;
-            
-            // SEP Part GET Step 3: "check the response. First parse total content length from ContentRange 
-            // of the GetObject response and save the value in a variable. The length is the numeric value 
-            // after / delimiter. For example, given ContentRange=bytes 0-1/5, 5 is the total content length. 
-            // Then check PartsCount."
-            if (firstPartResponse.PartsCount.HasValue && firstPartResponse.PartsCount.Value > 1)
-            {
-                // SEP Part GET Step 3: "If PartsCount in the response is larger than 1, it indicates there 
-                // are more parts available to download. The S3 Transfer Manager MUST save etag from the 
-                // response to a variable."
-                _discoveredPartCount = firstPartResponse.PartsCount.Value;
-                
-                // Parse total content length from ContentRange header
-                // For example, "bytes 0-5242879/52428800" -> extract 52428800
-                var totalObjectSize = ExtractTotalSizeFromContentRange(firstPartResponse.ContentRange);
-                
-                // SEP Part GET Step 7 will use this response for creating DownloadResponse
-                // Keep the response with its stream (will be buffered in StartDownloadsAsync)
-                return new DownloadDiscoveryResult
-                {
-                    TotalParts = firstPartResponse.PartsCount.Value,
-                    ObjectSize = totalObjectSize,
-                    InitialResponse = firstPartResponse  // Keep response with stream
-                };
-            }
-            else
-            {
-                // SEP Part GET Step 3: "If PartsCount is 1, go to Step 7."
-                _discoveredPartCount = 1;
-                
-                // Single part upload - return the response for immediate use (SEP Step 7)
-                return new DownloadDiscoveryResult
-                {
-                    TotalParts = 1,
-                    ObjectSize = firstPartResponse.ContentLength,
-                    InitialResponse = firstPartResponse  // Keep response with stream
-                };
+                firstPartResponse?.Dispose();
+                throw;
             }
         }
 
@@ -568,84 +667,91 @@ namespace Amazon.S3.Transfer.Internal
             await _httpConcurrencySlots.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             GetObjectResponse firstRangeResponse = null;
+            
+            // NOTE: Semaphore is NOT released here - it will be released in StartDownloadsAsync
+            // after Part 1 is processed. This ensures the semaphore controls both network download
+            // AND disk write for Part 1, consistent with Parts 2+ (see CreateDownloadTaskAsync)
+            
             try
             {
                 // SEP Ranged GET Step 2: "send the request and wait for the response in a non-blocking fashion"
                 firstRangeResponse = await _s3Client.GetObjectAsync(firstRangeRequest, cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                _httpConcurrencySlots.Release();
-                _logger.DebugFormat("MultipartDownloadManager: [Part 1 Discovery] HTTP concurrency slot released");
-            }
-            
-            // Defensive null check
-            if (firstRangeResponse == null)
-                throw new InvalidOperationException("Failed to retrieve object from S3");
-            
-            // SEP Ranged GET Step 5: "save Etag from the response to a variable" 
-            // (for IfMatch validation in subsequent requests)
-            _savedETag = firstRangeResponse.ETag;
-            
-            // SEP Ranged GET Step 3: "parse total content length from ContentRange of the GetObject response 
-            // and save the value in a variable. The length is the numeric value after / delimiter. 
-            // For example, given ContentRange=bytes0-1/5, 5 is the total content length."
-            // Check if ContentRange is null (object smaller than requested range)
-            if (firstRangeResponse.ContentRange == null)
-            {
-                // No ContentRange means we got the entire small object
-                _discoveredPartCount = 1;
                 
+                // Defensive null check
+                if (firstRangeResponse == null)
+                    throw new InvalidOperationException("Failed to retrieve object from S3");
+                
+                // SEP Ranged GET Step 5: "save Etag from the response to a variable" 
+                // (for IfMatch validation in subsequent requests)
+                _savedETag = firstRangeResponse.ETag;
+                
+                // SEP Ranged GET Step 3: "parse total content length from ContentRange of the GetObject response 
+                // and save the value in a variable. The length is the numeric value after / delimiter. 
+                // For example, given ContentRange=bytes0-1/5, 5 is the total content length."
+                // Check if ContentRange is null (object smaller than requested range)
+                if (firstRangeResponse.ContentRange == null)
+                {
+                    // No ContentRange means we got the entire small object
+                    _discoveredPartCount = 1;
+                    
+                    return new DownloadDiscoveryResult
+                    {
+                        TotalParts = 1,
+                        ObjectSize = firstRangeResponse.ContentLength,
+                        InitialResponse = firstRangeResponse  // Keep response with stream
+                    };
+                }
+                
+                
+                // Parse total object size from ContentRange (e.g., "bytes 0-5242879/52428800" -> 52428800)
+                var totalContentLength = ExtractTotalSizeFromContentRange(firstRangeResponse.ContentRange);
+                
+                // SEP Ranged GET Step 4: "compare the parsed total content length from Step 3 with ContentLength 
+                // of the response. If the parsed total content length equals to the value from ContentLength, 
+                // it indicates this request contains all of the data. The request is finished, return the response."
+                if (totalContentLength == firstRangeResponse.ContentLength)
+                {
+                    // Single part: total size equals returned ContentLength
+                    // This request contains all of the data
+                    _discoveredPartCount = 1;
+                    
+                    return new DownloadDiscoveryResult
+                    {
+                        TotalParts = 1,
+                        ObjectSize = totalContentLength,
+                        InitialResponse = firstRangeResponse  // Keep response with stream
+                    };
+                }
+                
+                // SEP Ranged GET Step 4: "If they do not match, it indicates there are more parts available 
+                // to download. Add a validation to verify that ContentLength equals to the targetPartSizeBytes."
+                if (firstRangeResponse.ContentLength != targetPartSize)
+                {
+                    throw new InvalidOperationException(
+                        $"Expected first part size {targetPartSize} bytes, but received {firstRangeResponse.ContentLength} bytes. " +
+                        $"Total object size is {totalContentLength} bytes.");
+                }
+                
+                // SEP Ranged GET Step 5: "calculate number of requests required by performing integer division 
+                // of total contentLength/targetPartSizeBytes. Save the number of ranged GET requests in a variable."
+                _discoveredPartCount = (int)Math.Ceiling((double)totalContentLength / targetPartSize);
+                
+                // SEP Ranged GET Step 9 will use this response for creating DownloadResponse
+                // Keep the response with its stream (will be buffered in StartDownloadsAsync)
                 return new DownloadDiscoveryResult
                 {
-                    TotalParts = 1,
-                    ObjectSize = firstRangeResponse.ContentLength,
-                    InitialResponse = firstRangeResponse  // Keep response with stream
-                };
-            }
-            
-            
-            // Parse total object size from ContentRange (e.g., "bytes 0-5242879/52428800" -> 52428800)
-            var totalContentLength = ExtractTotalSizeFromContentRange(firstRangeResponse.ContentRange);
-            
-            // SEP Ranged GET Step 4: "compare the parsed total content length from Step 3 with ContentLength 
-            // of the response. If the parsed total content length equals to the value from ContentLength, 
-            // it indicates this request contains all of the data. The request is finished, return the response."
-            if (totalContentLength == firstRangeResponse.ContentLength)
-            {
-                // Single part: total size equals returned ContentLength
-                // This request contains all of the data
-                _discoveredPartCount = 1;
-                
-                return new DownloadDiscoveryResult
-                {
-                    TotalParts = 1,
+                    TotalParts = _discoveredPartCount,
                     ObjectSize = totalContentLength,
                     InitialResponse = firstRangeResponse  // Keep response with stream
                 };
             }
-            
-            // SEP Ranged GET Step 4: "If they do not match, it indicates there are more parts available 
-            // to download. Add a validation to verify that ContentLength equals to the targetPartSizeBytes."
-            if (firstRangeResponse.ContentLength != targetPartSize)
+            catch
             {
-                throw new InvalidOperationException(
-                    $"Expected first part size {targetPartSize} bytes, but received {firstRangeResponse.ContentLength} bytes. " +
-                    $"Total object size is {totalContentLength} bytes.");
+                // On error, release semaphore and dispose response before rethrowing
+                _httpConcurrencySlots.Release();
+                firstRangeResponse?.Dispose();
+                throw;
             }
-            
-            // SEP Ranged GET Step 5: "calculate number of requests required by performing integer division 
-            // of total contentLength/targetPartSizeBytes. Save the number of ranged GET requests in a variable."
-            _discoveredPartCount = (int)Math.Ceiling((double)totalContentLength / targetPartSize);
-            
-            // SEP Ranged GET Step 9 will use this response for creating DownloadResponse
-            // Keep the response with its stream (will be buffered in StartDownloadsAsync)
-            return new DownloadDiscoveryResult
-            {
-                TotalParts = _discoveredPartCount,
-                ObjectSize = totalContentLength,
-                InitialResponse = firstRangeResponse  // Keep response with stream
-            };
         }
 
         private GetObjectRequest CreateGetObjectRequest()


### PR DESCRIPTION
Stacked PRs:
 * #4224
 * #4220
 * #4219
 * __->__#4218


--- --- ---

## Description
Fix HTTP concurrency for multi part download. Previously we were releasing the http semaphore slot after we got the http response but _before_ we read the response body (wrote it to a file/stream). This meant that it was possible for there to be more active `ConcurrentServiceRequests` than the user actually wanted.

The fix was to move the releasing of the http semaphore slot _after_ processing the part. This ensured that its only released once its written to the file/stream and ensures only `ConcurrentServiceRequests` are active at a time.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3806

## Testing
1. I added unit tests such as `HttpSemaphore_HeldThroughProcessPartAsync` which verify that the http semaphore is only released after process part is executed. In order to ensure this test actually checks the issue, i ran it before my fix and the test failed (as expected). After my fix, the test passes. 
2. dry run 

```
"build_id": "7e8b2922-9aab-4b1c-8cf2-ee8c6ad6b8d1",
    "build_type": "DRY_RUN",
    "build_status": "SUCCEEDED",
    "created_time": "2025-12-09T19:44:19.400Z",
    "last_modified_time": "2025-12-09T22:47:24.680Z",
```

## Screenshots (if appropriate)

Before (we can see concurrency is over the set 10)
<img width="2209" height="3873" alt="image" src="https://github.com/user-attachments/assets/a764fc51-d1d5-4128-8e05-836552ee768f" />

After, we can see concurrency stays at or below 10
<img width="2682" height="1408" alt="image" src="https://github.com/user-attachments/assets/95b4afba-1797-4653-ade9-a0da9e421bfe" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement