### PR TITLE
use max size semaphore

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/BufferedPartDataHandler.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/BufferedPartDataHandler.cs
@@ -153,9 +153,6 @@ namespace Amazon.S3.Transfer.Internal
                 // If ReleaseBufferSpace() throws, we no longer own the data source, so we won't dispose it
                 streamingDataSource = null;
 
-                // Release capacity immediately since we're not holding anything in memory
-                _partBufferManager.ReleaseBufferSpace();
-
                 _logger.DebugFormat("BufferedPartDataHandler: [Part {0}] StreamingDataSource added and capacity released",
                     partNumber);
             }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
@@ -159,7 +159,10 @@ namespace Amazon.S3.Transfer.Internal
             }
             else
             {
-                _httpConcurrencySlots = new SemaphoreSlim(_config.ConcurrentServiceRequests);
+                _httpConcurrencySlots = new SemaphoreSlim(
+                    _config.ConcurrentServiceRequests,  // initialCount
+                    _config.ConcurrentServiceRequests   // maxCount - prevents exceeding configured limit
+                );
                 _ownsHttpThrottler = true; // We own it, so we dispose it
             }
         }

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/PartBufferManager.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/PartBufferManager.cs
@@ -199,7 +199,10 @@ namespace Amazon.S3.Transfer.Internal
                 throw new ArgumentNullException(nameof(config));
             
             _partDataSources = new ConcurrentDictionary<int, IPartDataSource>();
-            _bufferSpaceAvailable = new SemaphoreSlim(config.MaxInMemoryParts);
+            _bufferSpaceAvailable = new SemaphoreSlim(
+                config.MaxInMemoryParts,  // initialCount
+                config.MaxInMemoryParts   // maxCount - prevents exceeding configured limit
+            );
             _partAvailable = new AutoResetEvent(false);
             
             Logger.DebugFormat("PartBufferManager initialized with MaxInMemoryParts={0}", config.MaxInMemoryParts);

--- a/sdk/test/Services/S3/UnitTests/Custom/PartBufferManagerTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/PartBufferManagerTests.cs
@@ -82,6 +82,7 @@ namespace AWSSDK.UnitTests
                 // Add part 1
                 byte[] testBuffer = ArrayPool<byte>.Shared.Rent(512);
                 var partBuffer = new StreamPartBuffer(1, testBuffer, 512);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer);
 
                 // Read part 1 completely
@@ -244,6 +245,8 @@ namespace AWSSDK.UnitTests
                 byte[] testBuffer = ArrayPool<byte>.Shared.Rent(512);
                 var partBuffer = new StreamPartBuffer(1, testBuffer, 512);
 
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
+
                 // Act
                 manager.AddBuffer(partBuffer);
 
@@ -301,6 +304,7 @@ namespace AWSSDK.UnitTests
                 // Add the part
                 byte[] testBuffer = ArrayPool<byte>.Shared.Rent(512);
                 var partBuffer = new StreamPartBuffer(1, testBuffer, 512);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer);
 
                 // Assert - Read should complete
@@ -331,6 +335,7 @@ namespace AWSSDK.UnitTests
                 var dataSource = new BufferedDataSource(partBuffer);
 
                 // Act
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddDataSource(dataSource);
 
                 // Assert - Should be able to read from part 1
@@ -415,6 +420,7 @@ namespace AWSSDK.UnitTests
                 Buffer.BlockCopy(testData, 0, testBuffer, 0, 512);
                 
                 var partBuffer = new StreamPartBuffer(1, testBuffer, 512);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer);
 
                 // Act
@@ -443,6 +449,7 @@ namespace AWSSDK.UnitTests
                 // Add part 1
                 byte[] testBuffer = ArrayPool<byte>.Shared.Rent(512);
                 var partBuffer = new StreamPartBuffer(1, testBuffer, 512);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer);
 
                 // Read part 1 completely
@@ -576,6 +583,7 @@ namespace AWSSDK.UnitTests
                 // Add the part asynchronously
                 byte[] testBuffer = ArrayPool<byte>.Shared.Rent(512);
                 var partBuffer = new StreamPartBuffer(1, testBuffer, 512);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer);
 
                 // Assert - Read should complete
@@ -657,6 +665,7 @@ namespace AWSSDK.UnitTests
                 byte[] testBuffer1 = ArrayPool<byte>.Shared.Rent(100);
                 Buffer.BlockCopy(testData1, 0, testBuffer1, 0, 100);
                 var partBuffer1 = new StreamPartBuffer(1, testBuffer1, 100);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer1);
 
                 // Add Part 2 (100 bytes) 
@@ -664,6 +673,7 @@ namespace AWSSDK.UnitTests
                 byte[] testBuffer2 = ArrayPool<byte>.Shared.Rent(100);
                 Buffer.BlockCopy(testData2, 0, testBuffer2, 0, 100);
                 var partBuffer2 = new StreamPartBuffer(2, testBuffer2, 100);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer2);
 
                 // Act - Request 150 bytes (spans both parts)
@@ -704,6 +714,7 @@ namespace AWSSDK.UnitTests
                     byte[] testBuffer = ArrayPool<byte>.Shared.Rent(50);
                     Buffer.BlockCopy(testData, 0, testBuffer, 0, 50);
                     var partBuffer = new StreamPartBuffer(i, testBuffer, 50);
+                    await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                     manager.AddBuffer(partBuffer);
                 }
 
@@ -733,6 +744,7 @@ namespace AWSSDK.UnitTests
                 // Add part 1
                 byte[] testBuffer1 = ArrayPool<byte>.Shared.Rent(100);
                 var partBuffer1 = new StreamPartBuffer(1, testBuffer1, 100);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer1);
 
                 // Read part 1 completely
@@ -745,6 +757,7 @@ namespace AWSSDK.UnitTests
                 // Add part 2
                 byte[] testBuffer2 = ArrayPool<byte>.Shared.Rent(100);
                 var partBuffer2 = new StreamPartBuffer(2, testBuffer2, 100);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer2);
 
                 // Read part 2
@@ -772,6 +785,7 @@ namespace AWSSDK.UnitTests
                 // Add empty part 1
                 byte[] testBuffer1 = ArrayPool<byte>.Shared.Rent(100);
                 var partBuffer1 = new StreamPartBuffer(1, testBuffer1, 0); // 0 bytes
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer1);
 
                 // Add part 2 with data
@@ -779,6 +793,7 @@ namespace AWSSDK.UnitTests
                 byte[] testBuffer2 = ArrayPool<byte>.Shared.Rent(100);
                 Buffer.BlockCopy(testData2, 0, testBuffer2, 0, 100);
                 var partBuffer2 = new StreamPartBuffer(2, testBuffer2, 100);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer2);
 
                 // Act - Try to read 100 bytes starting from part 1
@@ -959,6 +974,7 @@ namespace AWSSDK.UnitTests
                 var streamingSource = new StreamingDataSource(1, response);
 
                 // Act
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(streamingSource);
 
                 // Assert - Should be able to read from part 1
@@ -990,6 +1006,7 @@ namespace AWSSDK.UnitTests
                 var bufferedSource = new BufferedDataSource(partBuffer);
 
                 // Act
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(bufferedSource);
 
                 // Assert - Should be able to read from part 1
@@ -1054,6 +1071,7 @@ namespace AWSSDK.UnitTests
                 var streamingSource = new StreamingDataSource(1, response);
 
                 // Act
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(streamingSource);
 
                 // Assert - Read should complete
@@ -1087,6 +1105,7 @@ namespace AWSSDK.UnitTests
                     ResponseStream = new MemoryStream(testData)
                 };
                 var streamingSource = new StreamingDataSource(1, response);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(streamingSource);
 
                 // Act - Read in multiple chunks
@@ -1126,6 +1145,7 @@ namespace AWSSDK.UnitTests
                     ResponseStream = new MemoryStream(testData1)
                 };
                 var streamingSource = new StreamingDataSource(1, response1);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer((IPartDataSource)streamingSource);
 
                 // Add buffered source for part 2
@@ -1133,6 +1153,7 @@ namespace AWSSDK.UnitTests
                 byte[] testBuffer2 = ArrayPool<byte>.Shared.Rent(500);
                 Buffer.BlockCopy(testData2, 0, testBuffer2, 0, 500);
                 var partBuffer2 = new StreamPartBuffer(2, testBuffer2, 500);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(partBuffer2);
 
                 // Act - Read across both parts
@@ -1173,6 +1194,7 @@ namespace AWSSDK.UnitTests
                     ResponseStream = new MemoryStream(testData)
                 };
                 var streamingSource = new StreamingDataSource(1, response);
+                await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                 manager.AddBuffer(streamingSource);
 
                 // Act - Read all data
@@ -1208,6 +1230,7 @@ namespace AWSSDK.UnitTests
                         ResponseStream = new MemoryStream(testData)
                     };
                     var streamingSource = new StreamingDataSource(i, response);
+                    await manager.WaitForBufferSpaceAsync(CancellationToken.None);
                     manager.AddBuffer(streamingSource);
                 }
 
@@ -1368,6 +1391,9 @@ namespace AWSSDK.UnitTests
                 // by adding and reading parts sequentially
                 for (int partNum = 1; partNum <= NumIncrements; partNum++)
                 {
+                    // Wait for buffer space before adding part
+                    await manager.WaitForBufferSpaceAsync(CancellationToken.None);
+
                     // Add part
                     byte[] testBuffer = ArrayPool<byte>.Shared.Rent(100);
                     var partBuffer = new StreamPartBuffer(partNum, testBuffer, 100);
@@ -1409,6 +1435,219 @@ namespace AWSSDK.UnitTests
                 manager.Dispose();
                 startSignal.Dispose();
                 stopSignal.Dispose();
+            }
+        }
+
+        #endregion
+
+        #region Semaphore MaxCount Tests
+
+        [TestMethod]
+        public async Task WaitForBufferSpaceAsync_WithMaxCount_DoesNotExceedConfiguredLimit()
+        {
+            // This test verifies the fix for the double release bug.
+            // Before the fix: SemaphoreSlim without maxCount allowed unlimited Release() calls,
+            // which could corrupt the semaphore state and allow more concurrent operations than configured.
+            // After the fix: maxCount parameter prevents exceeding MaxInMemoryParts limit.
+
+            // Arrange
+            const int maxInMemoryParts = 3;
+            var config = MultipartDownloadTestHelpers.CreateBufferedDownloadConfiguration(maxInMemoryParts: maxInMemoryParts);
+            var manager = new PartBufferManager(config);
+
+            try
+            {
+                // Acquire all available slots
+                for (int i = 0; i < maxInMemoryParts; i++)
+                {
+                    await manager.WaitForBufferSpaceAsync(CancellationToken.None);
+                }
+
+                // Release all acquired slots
+                for (int i = 0; i < maxInMemoryParts; i++)
+                {
+                    manager.ReleaseBufferSpace();
+                }
+
+                // Attempt to release beyond maxCount (should throw)
+                Assert.ThrowsException<SemaphoreFullException>(() =>
+                {
+                    manager.ReleaseBufferSpace();
+                }, "Releasing beyond maxCount should throw SemaphoreFullException");
+
+                // Attempt one more release to confirm protection is consistent
+                Assert.ThrowsException<SemaphoreFullException>(() =>
+                {
+                    manager.ReleaseBufferSpace();
+                }, "Second excessive release should also throw SemaphoreFullException");
+
+                // Act - Try to acquire slots again
+                var acquiredSlots = 0;
+                for (int i = 0; i < maxInMemoryParts + 2; i++)
+                {
+                    var waitTask = manager.WaitForBufferSpaceAsync(CancellationToken.None);
+                    if (await Task.WhenAny(waitTask, Task.Delay(100)) == waitTask)
+                    {
+                        acquiredSlots++;
+                    }
+                    else
+                    {
+                        break; // Task didn't complete, no more slots available
+                    }
+                }
+
+                // Assert - Should only be able to acquire maxInMemoryParts slots, not more
+                // With maxCount fix: Can only acquire 3 slots (respects limit)
+                // Without maxCount fix: Could acquire 5 slots (2 extra from double releases)
+                Assert.AreEqual(maxInMemoryParts, acquiredSlots,
+                    $"Semaphore should respect maxCount={maxInMemoryParts} limit despite excessive releases");
+            }
+            finally
+            {
+                manager.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReleaseBufferSpace_ExcessiveReleases_MaintainsSemaphoreIntegrity()
+        {
+            // This test verifies that excessive Release() calls don't corrupt semaphore state.
+            // The maxCount parameter ensures CurrentCount never exceeds MaxInMemoryParts.
+
+            // Arrange
+            const int maxInMemoryParts = 5;
+            var config = MultipartDownloadTestHelpers.CreateBufferedDownloadConfiguration(maxInMemoryParts: maxInMemoryParts);
+            var manager = new PartBufferManager(config);
+
+            try
+            {
+                // Acquire half the slots
+                for (int i = 0; i < maxInMemoryParts / 2; i++)
+                {
+                    await manager.WaitForBufferSpaceAsync(CancellationToken.None);
+                }
+
+                // Release the acquired slots
+                for (int i = 0; i < maxInMemoryParts / 2; i++)
+                {
+                    manager.ReleaseBufferSpace();
+                }
+
+                // Now semaphore should be at full capacity (maxInMemoryParts)
+                // Attempt to release beyond maxCount - each should throw
+                var excessiveReleaseCount = 0;
+                for (int i = 0; i < 5; i++)
+                {
+                    try
+                    {
+                        manager.ReleaseBufferSpace();
+                        Assert.Fail($"Release #{i + 1} beyond maxCount should have thrown SemaphoreFullException");
+                    }
+                    catch (SemaphoreFullException)
+                    {
+                        excessiveReleaseCount++;
+                    }
+                }
+
+                // Assert - All excessive releases should have thrown
+                Assert.AreEqual(5, excessiveReleaseCount, "All excessive releases should throw SemaphoreFullException");
+
+                // Act - Count how many slots are now available
+                var availableSlots = 0;
+                for (int i = 0; i < maxInMemoryParts * 2; i++)
+                {
+                    var waitTask = manager.WaitForBufferSpaceAsync(CancellationToken.None);
+                    if (waitTask.IsCompleted)
+                    {
+                        availableSlots++;
+                        await waitTask;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                // Assert - Should never exceed maxInMemoryParts
+                Assert.IsTrue(availableSlots <= maxInMemoryParts,
+                    $"Available slots ({availableSlots}) should not exceed maxInMemoryParts ({maxInMemoryParts})");
+            }
+            finally
+            {
+                manager.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task BufferCapacity_ConcurrentOperations_RespectsMaxCountLimit()
+        {
+            // This test simulates the real-world scenario where multiple parts are being
+            // processed concurrently, verifying that the maxCount parameter prevents
+            // exceeding the configured buffer capacity limit.
+
+            // Arrange
+            const int maxInMemoryParts = 4;
+            const int totalParts = 10;
+            var config = MultipartDownloadTestHelpers.CreateBufferedDownloadConfiguration(maxInMemoryParts: maxInMemoryParts);
+            var manager = new PartBufferManager(config);
+
+            try
+            {
+                var activeParts = 0;
+                var maxActiveParts = 0;
+                var lockObj = new object();
+
+                // Simulate concurrent part processing
+                var tasks = new List<Task>();
+                for (int partNum = 1; partNum <= totalParts; partNum++)
+                {
+                    int capturedPartNum = partNum;
+                    tasks.Add(Task.Run(async () =>
+                    {
+                        // Wait for buffer space (enforces maxInMemoryParts limit)
+                        await manager.WaitForBufferSpaceAsync(CancellationToken.None);
+
+                        lock (lockObj)
+                        {
+                            activeParts++;
+                            if (activeParts > maxActiveParts)
+                            {
+                                maxActiveParts = activeParts;
+                            }
+                        }
+
+                        // Simulate buffering the part
+                        byte[] testBuffer = ArrayPool<byte>.Shared.Rent(100);
+                        var partBuffer = new StreamPartBuffer(capturedPartNum, testBuffer, 100);
+                        manager.AddBuffer(partBuffer);
+
+                        // Simulate some processing time
+                        await Task.Delay(10);
+
+                        // Consumer reads the part (happens asynchronously in real scenario)
+                        // For this test, we'll manually release after a delay
+                        await Task.Delay(20);
+                        
+                        lock (lockObj)
+                        {
+                            activeParts--;
+                        }
+
+                        // Release is normally done by consumer after reading part
+                        manager.ReleaseBufferSpace();
+                    }));
+                }
+
+                // Wait for all parts to be processed
+                await Task.WhenAll(tasks);
+
+                // Assert - Should never have exceeded maxInMemoryParts
+                Assert.IsTrue(maxActiveParts <= maxInMemoryParts,
+                    $"Maximum concurrent buffered parts ({maxActiveParts}) exceeded configured limit ({maxInMemoryParts})");
+            }
+            finally
+            {
+                manager.Dispose();
             }
         }
 


### PR DESCRIPTION
Stacked PRs:
 * #4224
 * __->__#4220


--- --- ---

## Description
I noticed during testing using AI that it said the maxinmemoryparts being used from the logs was 1026 even though i had configured it to 1024. this means i was:
1. Releasing the semaphore twice
2. Not enforcing a maximum amount for the sempahore

This change updates the code to fix the double release and also ensure the semaphores enforce a maximum.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3806

## Testing
1. Reran all unit tests and they pass
4. Reran performance tests and they have same performance
6. dry run in progress 16f30d8d-ec62-40bb-ab69-5f50383ed393 pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement