### PR TITLE
Fix CloudWatch TestChecksumInvoke and TestCompressionCall unit tests

### DIFF
--- a/sdk/test/UnitTests/Custom/Runtime/ChecksumHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/ChecksumHandlerTests.cs
@@ -23,6 +23,7 @@ using Amazon.CloudWatch;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Util;
 using Amazon.Runtime.Internal.Util;
+using System.Linq;
 
 namespace AWSSDK.UnitTests
 {
@@ -93,7 +94,7 @@ namespace AWSSDK.UnitTests
             {
                 // Make sure that we don't set checksum header twice when it already exists
                 Assert.IsTrue(request.Headers[headerKey].Equals(JunkChecksumHeaderValue));
-                Assert.IsTrue(request.Headers.Count == 1);
+                Assert.IsTrue(request.Headers.Count(h => h.Key.StartsWith("x-amz-checksum-")) == 1);
             }
             else if (headerKey != null)
             {
@@ -109,7 +110,7 @@ namespace AWSSDK.UnitTests
             }
             else
             {
-                Assert.IsTrue(request.Headers.Count == 0);
+                Assert.IsTrue(request.Headers.Count(h => h.Key.StartsWith("x-amz-checksum-")) == 0);
             }
         }
 
@@ -174,7 +175,7 @@ namespace AWSSDK.UnitTests
             {
                 // Make sure that we don't set checksum header twice
                 Assert.IsTrue(request.Headers[headerKey].Equals(JunkChecksumHeaderValue));
-                Assert.IsTrue(request.Headers.Count == 1);
+                Assert.IsTrue(request.Headers.Count(h => h.Key.StartsWith("x-amz-checksum-")) == 1);
             }
             else if (headerKey != null)
             {
@@ -190,7 +191,7 @@ namespace AWSSDK.UnitTests
             }
             else
             {
-                Assert.IsTrue(request.Headers.Count == 0);
+                Assert.IsTrue(request.Headers.Count(h => h.Key.StartsWith("x-amz-checksum-")) == 0);
             }
         }
 #endif

--- a/sdk/test/UnitTests/Custom/Runtime/CompressionHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/CompressionHandlerTests.cs
@@ -76,7 +76,6 @@ namespace AWSSDK.UnitTests
 
             if (notCompressed)
             {
-                Assert.IsNull(request.Content);
                 CollectionAssert.AreEqual(originalInput, newInput);
             }
             else
@@ -121,7 +120,6 @@ namespace AWSSDK.UnitTests
 
             await handler.InvokeAsync<AmazonWebServiceResponse>(executionContext);
 
-            Assert.IsNull(request.Content);
             Assert.IsNotNull(request.ContentStream);
             Assert.AreEqual(originalInputLen, request.ContentStream.Length);
 
@@ -178,7 +176,6 @@ namespace AWSSDK.UnitTests
 
             if (notCompressed)
             {
-                Assert.IsNull(request.Content);
                 CollectionAssert.AreEqual(originalInput, newInput);
             }
             else
@@ -223,7 +220,6 @@ namespace AWSSDK.UnitTests
 
             handler.InvokeSync(executionContext);
 
-            Assert.IsNull(request.Content);
             Assert.IsNotNull(request.ContentStream);
             Assert.AreEqual(originalInputLen, request.ContentStream.Length);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- `TestChecksumInvoke`  sometime fails when additional headers are added during the marshalling, this change helps preventing that by only checking for checksum headers.
- `TestCompressionCall` tests were also failing in some cases when the request body is added to the `.Content`.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixing the unit tests.
https://github.com/aws/aws-sdk-net/pull/4217
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
- Ran the unit tests locally with different protocols.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement