### PR TITLE
Multi part download: Stop queueing more tasks if in progress one fails

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/IDownloadManager.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/IDownloadManager.cs
@@ -55,11 +55,6 @@ namespace Amazon.S3.Transfer.Internal
         /// with the previous two-method API.
         /// </remarks>
         Task<DownloadResult> StartDownloadAsync(EventHandler<WriteObjectProgressArgs> progressCallback, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Exception that occurred during downloads, if any.
-        /// </summary>
-        Exception DownloadException { get; }
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
Previously if an error occurred when for a part, we would still queue the next parts, even though a previous part failed. 

This would result in the behavior where, part 2 failed, queues part 3, part 3 fails, queues part 4, etc.. 

This change adds a check so that if a part fails with some exception, it will cancel the internal cancellation token to prevent other parts from getting queued.

Now the new behavior is part 2 failed, dont queue part 3.

## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3806

## Testing
1. Unit test

Before my fix the unit test failed on 

```
                    $"Part 10 should NOT be queued after Part 3 fails. Queued parts: {string.Join(", ", queuedPartsList)}");

```

after my fix, the test passes.

2. I also re-ran this fix on the ec2 instance where i originally saw this error and i verified that the program was successfully cancelled immediately instead of going through all of the parts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement