### PR TITLE
add case sensitivity check to download directory command

### DIFF
--- a/generator/.DevConfigs/922d5cff-5eaf-43f8-82bc-6b8f6ffac4da.json
+++ b/generator/.DevConfigs/922d5cff-5eaf-43f8-82bc-6b8f6ffac4da.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "minor",
+      "changeLogMessages": [
+        "BREAKING CHANGE: A security fix has been applied to the Transfer Utility Download Directory command which now checks if the directory is case-sensitive before proceeding with the download. This prevents potential overwriting of files in case-insensitive file systems. If you would like to revert to the previous behavior, you can set the 'SkipDirectoryCaseSensitivityCheck' property on the 'TransferUtilityConfig' to true."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityConfig.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityConfig.cs
@@ -49,6 +49,7 @@ namespace Amazon.S3.Transfer
         public TransferUtilityConfig()
         {
             this.ConcurrentServiceRequests = 10;
+            this.SkipDirectoryCaseSensitivityCheck = false;
         }
 
         /// <summary>
@@ -81,5 +82,12 @@ namespace Amazon.S3.Transfer
                 this._concurrentServiceRequests = value;
             }
         }
+
+        /// <summary>
+        /// When true, disables directory case-sensitivity checks that are used to detect
+        /// potential filename collisions (for example, S3 keys that differ only by case
+        /// on a case-insensitive filesystem). The default is false.
+        /// </summary>
+        public bool SkipDirectoryCaseSensitivityCheck { get; set; }
     }
 }

--- a/sdk/src/Services/S3/Custom/Util/FileSystemHelper.cs
+++ b/sdk/src/Services/S3/Custom/Util/FileSystemHelper.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.IO;
+
+namespace Amazon.S3.Util
+{
+    internal static class FileSystemHelper
+    {
+        /// <summary>
+        /// Determines if the specified directory path is case-sensitive.
+        /// </summary>
+        /// <param name="directoryPath">The full path to the directory to check.</param>
+        /// <remarks>
+        /// Case-sensitivity can vary by directory or volume depending on the platform and configuration:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>
+        /// On Windows, NTFS is case-preserving but usually case-insensitive; however, case-sensitivity
+        /// can be enabled per-directory (for example via WSL tooling), so two directories on the same
+        /// volume may behave differently.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>
+        /// On Unix-like systems and macOS, different mount points or volumes can have different
+        /// case-sensitivity semantics.
+        /// </description>
+        /// </item>
+        /// </list>
+        /// Because of this, the check is performed against the actual target directory instead of a
+        /// global temporary location. This ensures we detect collisions (such as S3 keys that differ
+        /// only by case) according to the behavior of the specific filesystem where we will create files.
+        /// </remarks>
+        /// <returns>
+        /// True if the file system at the path is case-sensitive; False if case-insensitive.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">If the directoryPath is null or empty.</exception>
+        /// <exception cref="DirectoryNotFoundException">If the directory does not exist.</exception>
+        public static bool IsDirectoryCaseSensitive(string directoryPath)
+        {
+            if (string.IsNullOrEmpty(directoryPath))
+            {
+                throw new ArgumentNullException(nameof(directoryPath));
+            }
+
+            if (!Directory.Exists(directoryPath))
+            {
+                throw new DirectoryNotFoundException($"The directory '{directoryPath}' does not exist.");
+            }
+
+#pragma warning disable CA1308 // Normalize strings to uppercase
+            string tempFileLower = Path.Combine(directoryPath, Guid.NewGuid().ToString().ToLowerInvariant() + ".tmp");
+#pragma warning restore CA1308 // Normalize strings to uppercase
+            string tempFileUpper = Path.Combine(directoryPath, Path.GetFileName(tempFileLower).ToUpperInvariant());
+            bool isCaseSensitive = true; // Assume sensitive by default
+
+#pragma warning disable CA1031 // Do not catch general exception types
+            try
+            {
+                // Create the file with a lowercase name
+                using (File.Create(tempFileLower)) { }
+
+                // Check if the uppercase version of the file exists.
+                // If it does, the file system is case-insensitive.
+                if (File.Exists(tempFileUpper))
+                {
+                    isCaseSensitive = false;
+                }
+            }
+            catch (Exception)
+            {
+                // Fallback assumption is that the file system is case-sensitive
+                isCaseSensitive = true;
+            }
+            finally
+            {
+                try
+                {
+                    // Ensure temporary files are cleaned up in all cases
+                    if (File.Exists(tempFileLower)) File.Delete(tempFileLower);
+                    if (File.Exists(tempFileUpper)) File.Delete(tempFileUpper);
+                }
+                catch (Exception) { }
+            }
+#pragma warning restore CA1031 // Do not catch general exception types
+
+            return isCaseSensitive;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A security fix has been applied to the Transfer Utility Download Directory command which now checks if the directory is case-sensitive before proceeding with the download. This prevents potential overwriting of files in case-insensitive file systems. If you would like to revert to the previous behavior, you can set the 'SkipDirectoryCaseSensitivityCheck' property on the 'TransferUtilityConfig' to true.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
DOTNET-8392
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests locally
Ran dry run
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement