### PR TITLE
[V4] Add missing SkipVersionCheck to TransactWriteConfig

### DIFF
--- a/generator/.DevConfigs/fde42955-138d-44dc-8373-e98e836b33e3.json
+++ b/generator/.DevConfigs/fde42955-138d-44dc-8373-e98e836b33e3.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "DynamoDBv2",
+            "type": "patch",
+            "changeLogMessages": [
+                "Add missing `SkipVersionCheck` property to the `TransactWriteConfig` class (https://github.com/aws/aws-sdk-net/issues/4243)"
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWrite.cs
@@ -409,7 +409,7 @@ namespace Amazon.DynamoDBv2.DataModel
             if (_config.SkipVersionCheck == true)
             {
                 throw new InvalidOperationException(
-                    "Using DynamoDBContextConfig.SkipVersionCheck property with true value is not supported for this operation.");
+                    "Using the SkipVersionCheck property with true value is not supported for this operation.");
             }
 
             if (!_storageConfig.HasVersion)

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWriteConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/TransactWriteConfig.cs
@@ -28,11 +28,19 @@ namespace Amazon.DynamoDBv2.DataModel
         /// </summary>
         public bool? IgnoreNullValues { get; set; }
 
+        /// <summary>
+        /// Property that directs <see cref="DynamoDBContext"/> to skip version checks
+        /// when saving or deleting an object with a version attribute.
+        /// If property is not set, version checks are performed.
+        /// </summary>
+        public bool? SkipVersionCheck { get; set; }
+
         /// <inheritdoc/>
         internal override DynamoDBOperationConfig ToDynamoDBOperationConfig()
         {
             var config = base.ToDynamoDBOperationConfig();
             config.IgnoreNullValues = IgnoreNullValues;
+            config.SkipVersionCheck = SkipVersionCheck;
 
             return config;
         }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
@@ -203,7 +203,7 @@ namespace AWSSDK_DotNet.UnitTests
         {
             // If this fails because you've added a property, be sure to add it to
             // `ToDynamoDBOperationConfig` before updating this unit test
-            Assert.AreEqual(5, typeof(TransactWriteConfig).GetProperties().Length);
+            Assert.AreEqual(6, typeof(TransactWriteConfig).GetProperties().Length);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #4243

## Description
The `TransactWriteConfig` class introduced in V4 for DynamoDB did not include the `SkipVersionCheck` option, requiring customers to use the overloads that accept a `DynamoDBOperationConfig` instead (which have been marked as deprecated).

## Testing
Dry-run: `DRY_RUN-89adcabb-d0d4-44a9-bdad-31823b3e6f9d`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license