### PR TITLE
Add missing overloads to `GenerateAuthToken` methods in RDS and DSQL

### DIFF
--- a/generator/.DevConfigs/41a87ae5-d316-40f2-a0ad-33dd22229a01.json
+++ b/generator/.DevConfigs/41a87ae5-d316-40f2-a0ad-33dd22229a01.json
@@ -1,0 +1,18 @@
+{
+    "services": [
+        {
+            "serviceName": "RDS",
+            "type": "patch",
+            "changeLogMessages": [
+                "Add missing overloads to the async versions of the `GenerateAuthToken` method (https://github.com/aws/aws-sdk-net/issues/3123)"
+            ]
+        },
+        {
+            "serviceName": "DSQL",
+            "type": "patch",
+            "changeLogMessages": [
+                "Add missing overloads to the async versions of the `GenerateDbConnect` and `GenerateDbConnectAdmin` methods (https://github.com/aws/aws-sdk-net/issues/3123)"
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
+++ b/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
@@ -121,6 +121,56 @@ namespace Amazon.DSQL.Util
 
         /// <summary>
         /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
+        /// <remarks>
+        /// The AWS region and credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateDbConnectAuthTokenAsync(string hostname)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return await GenerateDbConnectAuthTokenAsync(region, hostname).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
+        /// <remarks>
+        /// The AWS credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="region">The region of the DSQL database.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateDbConnectAuthTokenAsync(RegionEndpoint region, string hostname)
+        {
+            AWSCredentials credentials = DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
+            return await GenerateDbConnectAuthTokenAsync(credentials, region, hostname).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
+        /// <remarks>
+        /// The AWS region for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateDbConnectAuthTokenAsync(AWSCredentials credentials, string hostname)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return await GenerateDbConnectAuthTokenAsync(credentials, region, hostname).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
         /// </summary>
         /// <param name="credentials">The credentials for the token.</param>
         /// <param name="region">The region of the DSQL database.</param>
@@ -199,6 +249,56 @@ namespace Amazon.DSQL.Util
 
             var immutableCredentials = credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnectAdmin action.
+        /// <remarks>
+        /// The AWS region and credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateDbConnectAdminAuthTokenAsync(string hostname)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return await GenerateDbConnectAdminAuthTokenAsync(region, hostname).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnectAdmin action.
+        /// <remarks>
+        /// The AWS credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="region">The region of the DSQL database.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateDbConnectAdminAuthTokenAsync(RegionEndpoint region, string hostname)
+        {
+            AWSCredentials credentials = DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
+            return await GenerateDbConnectAdminAuthTokenAsync(credentials, region, hostname).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnectAdmin action.
+        /// <remarks>
+        /// The AWS region for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="hostname">Hostname of the DSQL database.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateDbConnectAdminAuthTokenAsync(AWSCredentials credentials, string hostname)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return await GenerateDbConnectAdminAuthTokenAsync(credentials, region, hostname).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
+++ b/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
@@ -16,7 +16,6 @@
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
-using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.Credentials.Internal;
 using System;
@@ -125,6 +124,62 @@ namespace Amazon.RDS.Util
 
             var immutableCredentials = credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, port, dbUser);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to an RDS database.
+        /// <remarks>
+        /// The AWS region and credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="hostname">Hostname of the RDS database.</param>
+        /// <param name="port">Port of the RDS database.</param>
+        /// <param name="dbUser">Database user for the token.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateAuthTokenAsync(string hostname, int port, string dbUser)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return await GenerateAuthTokenAsync(region, hostname, port, dbUser).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to an RDS database.
+        /// <remarks>
+        /// The AWS credentials for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="region">The region of the RDS database.</param>
+        /// <param name="hostname">Hostname of the RDS database.</param>
+        /// <param name="port">Port of the RDS database.</param>
+        /// <param name="dbUser">Database user for the token.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateAuthTokenAsync(RegionEndpoint region, string hostname, int port, string dbUser)
+        {
+            AWSCredentials credentials = DefaultIdentityResolverConfiguration.ResolveDefaultIdentity<AWSCredentials>();
+            return await GenerateAuthTokenAsync(credentials, region, hostname, port, dbUser).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Generate a token for IAM authentication to an RDS database.
+        /// <remarks>
+        /// The AWS region for creating the auth token will be searched for
+        /// using the SDK's standard environment search pattern. This includes using
+        /// default profile configuration and AWS Compute environment settings.
+        /// </remarks>
+        /// </summary>
+        /// <param name="credentials">The credentials for the token.</param>
+        /// <param name="hostname">Hostname of the RDS database.</param>
+        /// <param name="port">Port of the RDS database.</param>
+        /// <param name="dbUser">Database user for the token.</param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<string> GenerateAuthTokenAsync(AWSCredentials credentials, string hostname, int port, string dbUser)
+        {
+            RegionEndpoint region = FallbackRegionFactory.GetRegionEndpoint();
+            return await GenerateAuthTokenAsync(credentials, region, hostname, port, dbUser).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves https://github.com/aws/aws-sdk-net/issues/3123

## Testing
- Dry-run: `DRY_RUN-334ffaa7-ac9d-4b3e-a922-a58f4bbf99f6`

## Screenshots (if appropriate)
Before:
<img width="979" height="117" alt="before" src="https://github.com/user-attachments/assets/b6ed99c2-84b4-4ede-8437-568b67dff941" />

After:
<img width="984" height="141" alt="after" src="https://github.com/user-attachments/assets/bd60130b-a2ac-46b0-8c6b-aaeb9c4e5b99" />

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
