### PR TITLE
make ChunkBufferSize public

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityOpenStreamRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityOpenStreamRequest.cs
@@ -50,9 +50,35 @@ namespace Amazon.S3.Transfer
         }
 
         /// <summary>
-        /// Gets or sets the chunk buffer size for ChunkedBufferStream.
-        /// When null, the default 64KB chunk size is used.
+        /// Gets or sets the chunk buffer size (in bytes) used for buffering out-of-order parts during multipart downloads.
         /// </summary>
-        internal int? ChunkBufferSize { get; set; }
+        /// <remarks>
+        /// <para>
+        /// This property controls the size of individual memory chunks allocated from the ArrayPool when buffering 
+        /// downloaded parts that arrive out of order. The default value is 64 KB (65,536 bytes), which is specifically 
+        /// chosen to avoid allocations on the Large Object Heap (LOH).
+        /// </para>
+        /// <para>
+        /// <b>Default Behavior (64 KB):</b>
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>Keeps allocations below the 85,000 byte LOH threshold</description></item>
+        /// <item><description>Prevents LOH fragmentation and reduces GC pressure</description></item>
+        /// </list>
+        /// <para>
+        /// <b>Using Larger Chunk Sizes:</b>
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>May improve throughput by reducing the number of ArrayPool rent/return operations</description></item>
+        /// <item><description>Larger chunks (≥85 KB) will be allocated on the LOH</description></item>
+        /// <item><description>Can lead to increased memory fragmentation and higher long-term memory usage</description></item>
+        /// <item><description>Consider this trade-off carefully based on your application's memory profile</description></item>
+        /// </list>
+        /// <para>
+        /// Set this property to null to use the default 64 KB chunk size. Only modify this value if you have 
+        /// specific performance requirements and understand the memory management implications.
+        /// </para>
+        /// </remarks>
+        public int? ChunkBufferSize { get; set; }
     }
 }


### PR DESCRIPTION
Make ChunkBufferSize public so users can tweak it


## Motivation and Context
https://github.com/aws/aws-sdk-net/issues/3806

## Testing
1. Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement