### PR TITLE
Fix doc build

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/_async/ITransferUtility.async.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_async/ITransferUtility.async.cs
@@ -383,7 +383,7 @@ namespace Amazon.S3.Transfer
         /// 	<b>Additional Performance Settings:</b>
         /// 	</para>
         /// 	<para>
-        /// 	You can also tune the S3 client's <see cref="Amazon.S3.AmazonS3Config.BufferSize"/> property to control 
+        /// 	You can also tune the S3 client's <see cref="Amazon.Runtime.ClientConfig.BufferSize"/> property to control 
         /// 	the buffer size used when reading from S3 response streams and writing to the local file. The default buffer size 
         /// 	is 8KB. Increasing this value may improve throughput for large downloads at the cost of increased memory usage.
         /// 	</para>
@@ -483,7 +483,7 @@ namespace Amazon.S3.Transfer
         /// 	<b>Additional Performance Settings:</b>
         /// 	</para>
         /// 	<para>
-        /// 	You can also tune the S3 client's <see cref="Amazon.S3.AmazonS3Config.BufferSize"/> property to control 
+        /// 	You can also tune the S3 client's <see cref="Amazon.Runtime.ClientConfig.BufferSize"/> property to control 
         /// 	the buffer size used when reading from S3 response streams and writing to the local file. The default buffer size 
         /// 	is 8KB. Increasing this value may improve throughput for large downloads at the cost of increased memory usage.
         /// 	</para>
@@ -652,7 +652,7 @@ namespace Amazon.S3.Transfer
         /// 	<b>Additional Performance Settings:</b>
         /// 	</para>
         /// 	<para>
-        /// 	You can also tune the S3 client's <see cref="Amazon.S3.AmazonS3Config.BufferSize"/> property to control 
+        /// 	You can also tune the S3 client's <see cref="Amazon.Runtime.ClientConfig.BufferSize"/> property to control 
         /// 	the buffer size used when reading from S3 response streams and writing to the buffered stream. The default buffer size 
         /// 	is 8KB. Increasing this value may improve throughput for large downloads at the cost of increased memory usage.
         /// 	</para>
@@ -759,7 +759,7 @@ namespace Amazon.S3.Transfer
         /// 	<b>Additional Performance Settings:</b>
         /// 	</para>
         /// 	<para>
-        /// 	You can also tune the S3 client's <see cref="Amazon.S3.AmazonS3Config.BufferSize"/> property to control 
+        /// 	You can also tune the S3 client's <see cref="Amazon.Runtime.ClientConfig.BufferSize"/> property to control 
         /// 	the buffer size used when reading from S3 response streams and writing to the buffered stream. The default buffer size 
         /// 	is 8KB. Increasing this value may improve throughput for large downloads at the cost of increased memory usage.
         /// 	</para>

--- a/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/ITransferUtility.sync.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/_bcl+netstandard/ITransferUtility.sync.cs
@@ -405,7 +405,7 @@ namespace Amazon.S3.Transfer
         /// 	<b>Additional Performance Settings:</b>
         /// 	</para>
         /// 	<para>
-        /// 	You can also tune the S3 client's <see cref="Amazon.S3.AmazonS3Config.BufferSize"/> property to control 
+        /// 	You can also tune the S3 client's <see cref="Amazon.Runtime.ClientConfig.BufferSize"/> property to control 
         /// 	the buffer size used when reading from S3 response streams and writing to the buffered stream. The default buffer size 
         /// 	is 8KB. Increasing this value may improve throughput for large downloads at the cost of increased memory usage.
         /// 	</para>
@@ -511,7 +511,7 @@ namespace Amazon.S3.Transfer
         /// 	<b>Additional Performance Settings:</b>
         /// 	</para>
         /// 	<para>
-        /// 	You can also tune the S3 client's <see cref="Amazon.S3.AmazonS3Config.BufferSize"/> property to control 
+        /// 	You can also tune the S3 client's <see cref="Amazon.Runtime.ClientConfig.BufferSize"/> property to control 
         /// 	the buffer size used when reading from S3 response streams and writing to the buffered stream. The default buffer size 
         /// 	is 8KB. Increasing this value may improve throughput for large downloads at the cost of increased memory usage.
         /// 	</para>
@@ -635,7 +635,7 @@ namespace Amazon.S3.Transfer
         /// 	<b>Additional Performance Settings:</b>
         /// 	</para>
         /// 	<para>
-        /// 	You can also tune the S3 client's <see cref="Amazon.S3.AmazonS3Config.BufferSize"/> property to control 
+        /// 	You can also tune the S3 client's <see cref="Amazon.Runtime.ClientConfig.BufferSize"/> property to control 
         /// 	the buffer size used when reading from S3 response streams and writing to the local file. The default buffer size 
         /// 	is 8KB. Increasing this value may improve throughput for large downloads at the cost of increased memory usage.
         /// 	</para>
@@ -732,7 +732,7 @@ namespace Amazon.S3.Transfer
         /// 	<b>Additional Performance Settings:</b>
         /// 	</para>
         /// 	<para>
-        /// 	You can also tune the S3 client's <see cref="Amazon.S3.AmazonS3Config.BufferSize"/> property to control 
+        /// 	You can also tune the S3 client's <see cref="Amazon.Runtime.ClientConfig.BufferSize"/> property to control 
         /// 	the buffer size used when reading from S3 response streams and writing to the local file. The default buffer size 
         /// 	is 8KB. Increasing this value may improve throughput for large downloads at the cost of increased memory usage.
         /// 	</para>


### PR DESCRIPTION
fix 

```
C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\Custom\Transfer\_async\ITransferUtility.async.cs(655,59): error CS1574: XML comment has cref attribute 'BufferSize' that could not be resolved [C:
\dev\repos\aws-sdk-net\sdk\src\Services\S3\AwSSDK.S3.NetStandard.csproj::TargetFramework=net8.0]
C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\Custom\Transfer\_async\ITransferUtility.async.cs(762,59): error CS1574: XML comment has cref attribute 'BufferSize' that could not be resolved [C:
\dev\repos\aws-sdk-net\sdk\src\Services\S3\AwSSDK.S3.NetStandard.csproj::TargetFramework=net8.0]
C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\Custom\Transfer\_bcl+netstandard\ITransferUtility.sync.cs(408,59): error CS1574: XML comment has cref attribute 'BufferSize' that could not be res
olved [C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\AwSSDK.S3.NetStandard.csproj::TargetFramework=net8.0]
C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\Custom\Transfer\_bcl+netstandard\ITransferUtility.sync.cs(514,59): error CS1574: XML comment has cref attribute 'BufferSize' that could not be res
olved [C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\AwSSDK.S3.NetStandard.csproj::TargetFramework=net8.0]
C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\Custom\Transfer\_bcl+netstandard\ITransferUtility.sync.cs(638,59): error CS1574: XML comment has cref attribute 'BufferSize' that could not be res
olved [C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\AwSSDK.S3.NetStandard.csproj::TargetFramework=net8.0]
C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\Custom\Transfer\_bcl+netstandard\ITransferUtility.sync.cs(735,59): error CS1574: XML comment has cref attribute 'BufferSize' that could not be res
olved [C:\dev\repos\aws-sdk-net\sdk\src\Services\S3\AwSSDK.S3.NetStandard.csproj::TargetFramework=net8.0]
```
