### PR TITLE
Improve ArrayPool chunk disposal

### DIFF
--- a/sdk/src/Services/S3/Custom/Transfer/Internal/ChunkedBufferStream.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/ChunkedBufferStream.cs
@@ -26,6 +26,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Runtime.Internal.Util;
 
 namespace Amazon.S3.Transfer.Internal
 {
@@ -79,6 +80,7 @@ namespace Amazon.S3.Transfer.Internal
         private readonly List<byte[]> _chunks;
         private readonly int _chunkSize;
         private readonly long _maxStreamSize;
+        private readonly Logger _logger = Logger.GetLogger(typeof(ChunkedBufferStream));
         private long _length = 0;
         private long _position = 0;
         private bool _isReadMode = false;
@@ -392,18 +394,20 @@ namespace Amazon.S3.Transfer.Internal
                     {
                         ArrayPool<byte>.Shared.Return(chunk);
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
                         // Suppress exceptions in Dispose - continue cleanup
+                        _logger.DebugFormat("ChunkedBufferStream.Dispose: Exception returning chunk to ArrayPool: {0}", ex.Message);
                     }
                 }
                 try
                 {
                     _chunks.Clear();
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     // Suppress exceptions in Dispose - continue cleanup
+                    _logger.DebugFormat("ChunkedBufferStream.Dispose: Exception clearing chunks list: {0}", ex.Message);
                 }
                 _disposed = true;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enhances error handling in the `ChunkedBufferStream.Dispose` method to ensure individual ArrayPool chunk cleanup failures don't prevent the disposal of remaining chunks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

There is potentially a memory leak in the `ChunkedBufferStream.Dispose` method. This PR addresses the potential issue.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Dry run succeeded: DRY_RUN-9d6f40e2-2000-4b79-996e-ca0b56bfee36
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement