### PR TITLE
Added input sanitization for deprecatedMessage values from service models before they are emitted into generated C# code.

### DIFF
--- a/generator/ServiceClientGeneratorLib/GeneratorHelpers.cs
+++ b/generator/ServiceClientGeneratorLib/GeneratorHelpers.cs
@@ -452,6 +452,22 @@ namespace ServiceClientGenerator
             return s.Replace("\"", "\"\"");
         }
 
+        /// <summary>
+        /// Sanitizes a deprecation message by removing or replacing characters that could
+        /// break generated code (e.g. newlines, HTML tags, quotes in [Obsolete("...")] attributes).
+        /// </summary>
+        public static string SanitizeDeprecationMessage(this string s)
+        {
+            return s
+                .Replace("\r", string.Empty)
+                .Replace("\n", string.Empty)
+                .Replace("\"", "'")
+                .Replace("<p>", string.Empty)
+                .Replace("</p>", string.Empty)
+                .Replace("<code>", "<c>")
+                .Replace("</code>", "</c>");
+        }
+
         public static string ToVariableName(this string s)
         {
             return s.Replace("-", "_");

--- a/generator/ServiceClientGeneratorLib/Member.cs
+++ b/generator/ServiceClientGeneratorLib/Member.cs
@@ -1057,7 +1057,7 @@ namespace ServiceClientGenerator
                 if (message == null)
                     throw new Exception(string.Format("The 'message' property of the 'deprecated' trait is missing for member {0}.{1}.\nFor example: \"MemberName\":{{ ... \"deprecated\":true, \"deprecatedMessage\":\"This property is deprecated, use XXX instead.\"}}", this.OwningShape.Name, this._name));
 
-                return message ?? "";
+                return (message ?? "").SanitizeDeprecationMessage();
             }
         }
 

--- a/generator/ServiceClientGeneratorLib/Operation.cs
+++ b/generator/ServiceClientGeneratorLib/Operation.cs
@@ -115,7 +115,7 @@ namespace ServiceClientGenerator
                 if (message == null)
                     throw new Exception(string.Format("The 'message' property of the 'deprecated' trait is missing for operation {0}.\nFor example: \"OperationName\":{{\"name\":\"OperationName\", ... \"deprecated\":true, \"deprecatedMessage\":\"This operation is deprecated\"}}", this.name));          
 
-                return message;
+                return message.SanitizeDeprecationMessage();
             }
         }
 

--- a/generator/ServiceClientGeneratorLib/Shape.cs
+++ b/generator/ServiceClientGeneratorLib/Shape.cs
@@ -792,7 +792,7 @@ namespace ServiceClientGenerator
                 if (message == null)
                     throw new Exception(string.Format("The 'message' property of the 'deprecated' trait is missing for shape {0}.\nFor example: \"ShapeName\":{{ ... \"members\":{{ ... }}, \"deprecated\":true, \"deprecatedMessage\":\"This type is deprecated\"}}", this._name));
 
-                return message ?? "";
+                return (message ?? "").SanitizeDeprecationMessage();
             }
         }
 

--- a/generator/ServiceClientGeneratorLib/SimpleModels.cs
+++ b/generator/ServiceClientGeneratorLib/SimpleModels.cs
@@ -121,6 +121,7 @@ namespace ServiceClientGenerator
                 return string.Empty;
             }
         }
+
     }
 
     #endregion

--- a/generator/ServiceClientGeneratorTests/Content/TestModelDeprecated.json
+++ b/generator/ServiceClientGeneratorTests/Content/TestModelDeprecated.json
@@ -1,0 +1,43 @@
+{
+  "version": "1.0",
+  "metadata": {
+    "apiVersion": "2020-6-25",
+    "serviceAbbreviation": "TestService",
+    "serviceFullName": "TestService",
+    "signatureVersion": "v4",
+    "serviceId": "TestService"
+  },
+  "operations": {
+    "DeprecatedOperation": {
+      "name": "DeprecatedOperation",
+      "input": { "shape": "DeprecatedOperationInput" },
+      "output": { "shape": "DeprecatedOperationOutput" },
+      "documentation": "a deprecated operation",
+      "deprecated": true,
+      "deprecatedMessage": "This operation is deprecated.\nUse <code>NewOperation</code> instead.\r\nSee \"docs\" for <p>details</p>."
+    }
+  },
+  "shapes": {
+    "DeprecatedOperationInput": {
+      "type": "structure",
+      "members": {
+        "OldField": {
+          "shape": "OldFieldShape",
+          "deprecated": true,
+          "deprecatedMessage": "This field is deprecated.\nUse <code>NewField</code> instead.\r\nSee \"docs\" for <p>details</p>."
+        }
+      }
+    },
+    "DeprecatedOperationOutput": {
+      "type": "structure",
+      "members": {}
+    },
+    "OldFieldShape": { "type": "string" },
+    "DeprecatedShape": {
+      "type": "structure",
+      "members": {},
+      "deprecated": true,
+      "deprecatedMessage": "This shape is deprecated.\nUse <code>NewShape</code> instead.\r\nSee \"docs\" for <p>details</p>."
+    }
+  }
+}

--- a/generator/ServiceClientGeneratorTests/UnitTests.cs
+++ b/generator/ServiceClientGeneratorTests/UnitTests.cs
@@ -103,5 +103,75 @@ namespace ServiceClientGeneratorTests
             var printedText = sb.ToString();
             Assert.Equal(expectedText, printedText);
         }
+
+        #region Deprecation Message Sanitization Tests
+
+        private const string _deprecatedModelsPath = "../../Content/TestModelDeprecated.json";
+
+        // The expected sanitized message after removing \r, \n, replacing " with ',
+        // removing <p></p>, and replacing <code></code> with <c></c>.
+        private const string _expectedSanitizedMessage = "This operation is deprecated.Use <c>NewOperation</c> instead.See 'docs' for details.";
+        private const string _expectedSanitizedMemberMessage = "This field is deprecated.Use <c>NewField</c> instead.See 'docs' for details.";
+        private const string _expectedSanitizedShapeMessage = "This shape is deprecated.Use <c>NewShape</c> instead.See 'docs' for details.";
+
+        [Fact]
+        public void OperationDeprecationMessageIsSanitized()
+        {
+            var model = new ServiceModel(_deprecatedModelsPath, null);
+            var operation = model.Operations.Single(x => x.Name.Equals("DeprecatedOperation"));
+
+            Assert.True(operation.IsDeprecated);
+            var message = operation.DeprecationMessage;
+
+            Assert.DoesNotContain("\n", message);
+            Assert.DoesNotContain("\r", message);
+            Assert.DoesNotContain("\"", message);
+            Assert.DoesNotContain("<p>", message);
+            Assert.DoesNotContain("</p>", message);
+            Assert.DoesNotContain("<code>", message);
+            Assert.DoesNotContain("</code>", message);
+            Assert.Equal(_expectedSanitizedMessage, message);
+        }
+
+        [Fact]
+        public void ShapeDeprecationMessageIsSanitized()
+        {
+            var model = new ServiceModel(_deprecatedModelsPath, null);
+            var shape = model.Shapes.Single(x => x.Name.Equals("DeprecatedShape"));
+
+            Assert.True(shape.IsDeprecated);
+            var message = shape.DeprecationMessage;
+
+            Assert.DoesNotContain("\n", message);
+            Assert.DoesNotContain("\r", message);
+            Assert.DoesNotContain("\"", message);
+            Assert.DoesNotContain("<p>", message);
+            Assert.DoesNotContain("</p>", message);
+            Assert.DoesNotContain("<code>", message);
+            Assert.DoesNotContain("</code>", message);
+            Assert.Equal(_expectedSanitizedShapeMessage, message);
+        }
+
+        [Fact]
+        public void MemberDeprecationMessageIsSanitized()
+        {
+            var model = new ServiceModel(_deprecatedModelsPath, null);
+            var shape = model.Shapes.Single(x => x.Name.Equals("DeprecatedOperationInput"));
+            var member = shape.Members.Single(x => x.ModeledName.Equals("OldField"));
+
+            Assert.True(member.IsDeprecated);
+            var message = member.DeprecationMessage;
+
+            Assert.DoesNotContain("\n", message);
+            Assert.DoesNotContain("\r", message);
+            Assert.DoesNotContain("\"", message);
+            Assert.DoesNotContain("<p>", message);
+            Assert.DoesNotContain("</p>", message);
+            Assert.DoesNotContain("<code>", message);
+            Assert.DoesNotContain("</code>", message);
+            Assert.Equal(_expectedSanitizedMemberMessage, message);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Description

Added input sanitization for `deprecatedMessage` values from service models before they are emitted into generated C# code. The `deprecatedMessage` field was being used raw in `[Obsolete("...")]` attributes, which could produce broken generated code if the message contained newlines (`\r`, `\n`), double quotes (`"`), or HTML tags (`<p>`, `</p>`, `<code>`, `</code>`).

A new `SanitizeDeprecationMessage()` extension method was added to the `StringExtensions` class in `GeneratorHelpers.cs` and is now called from the `DeprecationMessage` property getters in `Member.cs`, `Operation.cs`, and `Shape.cs`.

## Motivation and Context

Other fields in the generator (e.g., documentation strings) are sanitized via `Replace("\n", string.Empty)` and similar transformations before being emitted into generated code. However, `deprecatedMessage` was not receiving any sanitization. Since deprecation messages are placed directly into `[Obsolete("...")]` string literals in generated C# code, unsanitized content such as newlines or quotes could break compilation of the generated SDK code.

## Testing

- Added 3 new unit tests in `ServiceClientGeneratorTests/UnitTests.cs` that verify sanitization of deprecation messages for operations, shapes, and members.
- Created a test model (`TestModelDeprecated.json`) containing deprecated items with newlines, `\r`, HTML tags (`<p>`, `</p>`, `<code>`, `</code>`), and double quotes in their `deprecatedMessage` values.
- All 3 new tests pass, and all existing tests continue to pass.

### Dry-run
- **Dry-run ID:** b87882a7-07cc-4fb6-9f71-88c01f4fdb2b
- **Status:**
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **Failed bypass reason:**

## Breaking Changes Assessment

No breaking changes. This is a strictly additive sanitization step applied to generated code output. The sanitization only removes/replaces characters that would have caused issues in generated code (`\r`, `\n`, `"`, HTML tags). Existing valid deprecation messages that don't contain these characters are unaffected.

## Screenshots (if appropriate)

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
