### PR TITLE
Fix issue with credentials incorrectly rotating for H2 operations

### DIFF
--- a/generator/.DevConfigs/07725a05-7af8-4a36-8bf8-3876b711325b.json
+++ b/generator/.DevConfigs/07725a05-7af8-4a36-8bf8-3876b711325b.json
@@ -4,6 +4,13 @@
     "type": "patch",
     "changeLogMessages": [
       "Fix issue with credentials incorrectly rotating during H2 request stream operations triggering a signature mismatch exception"
-    ]
+    ],
+    "backwardIncompatibilitiesToIgnore": [ 
+      "Amazon.Runtime.Internal.Auth.AbstractAWSSigner/MethodRemoved",
+      "Amazon.Runtime.Internal.Auth.AWS4SigningResult/MethodRemoved",
+      "Amazon.Runtime.Internal.Auth.ISigner/MethodRemoved",
+      "Amazon.Runtime.Internal.Auth.AWS4EventSigner/MethodRemoved",
+      "Amazon.Runtime.Internal.Auth.AWS4Signer/MethodRemoved"
+    ]	
   }
 }

--- a/generator/.DevConfigs/07725a05-7af8-4a36-8bf8-3876b711325b.json
+++ b/generator/.DevConfigs/07725a05-7af8-4a36-8bf8-3876b711325b.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fix issue with credentials incorrectly rotating during H2 request stream operations triggering a signature mismatch exception"
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4EventSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4EventSigner.cs
@@ -60,7 +60,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// </summary>
         /// <param name="eventBytes">The bytes of the event that must be signed.</param>
         /// <returns>The signed events that can be sent to the AWS service.</returns>
-        public async Task<byte[]> SignEventAsync(byte[] eventBytes)
+        public Task<byte[]> SignEventAsync(byte[] eventBytes)
         {
             var timestamp = AWSSDKUtils.CorrectedUtcNow;
 
@@ -104,7 +104,7 @@ namespace Amazon.Runtime.Internal.Auth
 
             _previousSignature = AWSSDKUtils.ToHex(signature, true);
 
-            return signedMessageBytes;
+            return Task.FromResult(signedMessageBytes);
         }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4EventSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4EventSigner.cs
@@ -14,9 +14,7 @@
  */
 
 using Amazon.Runtime.EventStreams;
-using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
-using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -32,7 +30,7 @@ namespace Amazon.Runtime.Internal.Auth
         private const string HeaderDate = ":date";
         private const string HeaderChunkSignature = ":chunk-signature";
 
-        private readonly AWSCredentials _credentials;
+        private readonly string _secretKey;
         private readonly string _region;
         private readonly string _service;
 
@@ -41,13 +39,13 @@ namespace Amazon.Runtime.Internal.Auth
         /// <summary>
         /// Constructe an isntance of the event signer.
         /// </summary>
-        /// <param name="credentials">AWS Credentials used to sign the request.</param>
+        /// <param name="secretKey">The AWS secret key used to sign the initial request. All events must be signed with the same secret key.</param>
         /// <param name="region">The region to authenticate for.</param>
         /// <param name="service">The service to authenticate for.</param>
         /// <param name="requestSignature">The signature computed for the original request.</param>
-        public AWS4EventSigner(AWSCredentials credentials, string region, string service, string requestSignature)
+        public AWS4EventSigner(string secretKey, string region, string service, string requestSignature)
         {
-            _credentials = credentials;
+            _secretKey = secretKey;
             _region = region;
             _service = service;
             _previousSignature = requestSignature;
@@ -64,8 +62,6 @@ namespace Amazon.Runtime.Internal.Auth
         /// <returns>The signed events that can be sent to the AWS service.</returns>
         public async Task<byte[]> SignEventAsync(byte[] eventBytes)
         {
-            var secretKey = (await _credentials.GetCredentialsAsync().ConfigureAwait(false)).SecretKey;
-
             var timestamp = AWSSDKUtils.CorrectedUtcNow;
 
             var signedHeaders = new List<IEventStreamHeader>();
@@ -97,7 +93,7 @@ namespace Amazon.Runtime.Internal.Auth
             stringToSign.Append("\n");
             stringToSign.Append(AWSSDKUtils.ToHex(CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(eventBytes), true));
 
-            var signature = AWS4Signer.ComputeKeyedHash(AWS4Signer.SignerAlgorithm, AWS4Signer.ComposeSigningKey(secretKey, _region, timestamp.ToString(AWSSDKUtils.ISO8601BasicDateFormat), _service), UTF8Encoding.UTF8.GetBytes(stringToSign.ToString()));
+            var signature = AWS4Signer.ComputeKeyedHash(AWS4Signer.SignerAlgorithm, AWS4Signer.ComposeSigningKey(_secretKey, _region, timestamp.ToString(AWSSDKUtils.ISO8601BasicDateFormat), _service), UTF8Encoding.UTF8.GetBytes(stringToSign.ToString()));
 
             var signedSignatureHeader = new EventStreamHeader(HeaderChunkSignature) { HeaderType = EventStreamHeaderType.String };
             signedSignatureHeader.SetByteBuf(signature);

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -136,14 +136,9 @@ namespace Amazon.Runtime.Internal.Auth
         }
 
         /// <inheritdoc/>
-        public override IEventSigner CreateEventSigner(BaseIdentity identity, string region, string service, string requestSignature)
+        public override IEventSigner CreateEventSigner(string awsSecretKey, string region, string service, string requestSignature)
         {
-            if (identity is not AWSCredentials credentials)
-            {
-                throw new AmazonClientException($"The identity parameter must be of type AWSCredentials for the signer {nameof(AWS4Signer)}.");
-            }
-
-            return new AWS4EventSigner(credentials, region, service, requestSignature);
+            return new AWS4EventSigner(awsSecretKey, region, service, requestSignature);
         }
 
         /// <summary>
@@ -405,7 +400,7 @@ namespace Amazon.Runtime.Internal.Auth
 
             var stringToSign = stringToSignBuilder.ToString();
             var signature = ComputeKeyedHash(SignerAlgorithm, key, stringToSign);
-            return new AWS4SigningResult(awsAccessKey, signedAt, signedHeaders, scope, key, signature);
+            return new AWS4SigningResult(awsAccessKey, awsSecretAccessKey, signedAt, signedHeaders, scope, key, signature);
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4SigningResult.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4SigningResult.cs
@@ -28,6 +28,7 @@ namespace Amazon.Runtime.Internal.Auth
     /// </summary>
     public class AWS4SigningResult : AWSSigningResultBase
     {
+        private readonly string _awsSecretAccessKey;
         private readonly byte[] _signingKey;
         private readonly byte[] _signature;
 
@@ -35,12 +36,14 @@ namespace Amazon.Runtime.Internal.Auth
         /// Constructs a new signing result instance for a computed signature
         /// </summary>
         /// <param name="awsAccessKeyId">The access key that was included in the signature</param>
+        /// <param name="awsSecretAccessKey">The secret key that was used to compute the signature</param>
         /// <param name="signedAt">Date/time (UTC) that the signature was computed</param>
         /// <param name="signedHeaders">The collection of headers names that were included in the signature</param>
         /// <param name="scope">Formatted 'scope' value for signing (YYYYMMDD/region/service/aws4_request)</param>
         /// <param name="signingKey">Returns the key that was used to compute the signature</param>
         /// <param name="signature">Computed signature</param>
         public AWS4SigningResult(string awsAccessKeyId,
+                                 string  awsSecretAccessKey,
                                  DateTime signedAt,
                                  string signedHeaders,
                                  string scope,
@@ -48,6 +51,7 @@ namespace Amazon.Runtime.Internal.Auth
                                  byte[] signature) :
             base(awsAccessKeyId, signedAt, signedHeaders, scope)
         {
+            _awsSecretAccessKey = awsSecretAccessKey;
             _signingKey = signingKey;
             _signature = signature;
         }
@@ -68,6 +72,14 @@ namespace Amazon.Runtime.Internal.Auth
         public override string Signature
         {
             get { return AWSSDKUtils.ToHex(_signature, true); }
+        }
+
+        /// <summary>
+        /// The secret key that was used to compute the signature
+        /// </summary>
+        public string SecretKey
+        {
+            get { return _awsSecretAccessKey; }
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AbstractAWSSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AbstractAWSSigner.cs
@@ -179,7 +179,7 @@ namespace Amazon.Runtime.Internal.Auth
         }
 
         /// <inheritdoc/>
-        public virtual IEventSigner CreateEventSigner(BaseIdentity identity, string region, string service, string requestSignature)
+        public virtual IEventSigner CreateEventSigner(string awsSecretKey, string region, string service, string requestSignature)
         {
             throw new NotImplementedException();
         }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/ISigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/ISigner.cs
@@ -29,6 +29,7 @@ namespace Amazon.Runtime.Internal.Auth
     /// the service to authenticate the SDK customer's identity.
     /// </para>
     /// </summary>
+    [AWSIsBackwardsCompatible]
     public interface ISigner
     {
         /// <summary> 
@@ -73,11 +74,11 @@ namespace Amazon.Runtime.Internal.Auth
         /// <summary>
         /// Creates an event signer based on the signer used to sign the request.
         /// </summary>
-        /// <param name="identity">The identity to sign the request with.</param>
+        /// <param name="awsSecretKey">The AWS secret key used to sign the initial request. All events must be signed with the same secret key.</param>
         /// <param name="region">The region to authenticate for.</param>
         /// <param name="service">The service to authenticate for.</param>
         /// <param name="requestSignature">The signature computed for the original request.</param>
         /// <returns></returns>
-        IEventSigner CreateEventSigner(BaseIdentity identity, string region, string service, string requestSignature);
+        IEventSigner CreateEventSigner(string awsSecretKey, string region, string service, string requestSignature);
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/Signer.cs
@@ -150,7 +150,7 @@ namespace Amazon.Runtime.Internal
                 if (requestContext.Request.EventStreamPublisher != null)
                 {
                     var eventSigner = requestContext.Signer.CreateEventSigner(
-                                            requestContext.Identity, 
+                                            awsSecretKey: requestContext.Request.AWS4SignerResult.SecretKey, 
                                             region: requestContext.Request.DeterminedSigningRegion, 
                                             service: requestContext.ClientConfig.AuthenticationServiceName, 
                                             requestSignature: requestContext.Request.AWS4SignerResult.Signature);
@@ -220,7 +220,7 @@ namespace Amazon.Runtime.Internal
                 if (requestContext.Request.EventStreamPublisher != null)
                 {
                     var eventSigner = requestContext.Signer.CreateEventSigner(
-                                            requestContext.Identity,
+                                            awsSecretKey: requestContext.Request.AWS4SignerResult.SecretKey,
                                             region: requestContext.Request.DeterminedSigningRegion,
                                             service: requestContext.ClientConfig.AuthenticationServiceName,
                                             requestSignature: requestContext.Request.AWS4SignerResult.Signature);

--- a/sdk/test/NetStandard/UnitTests/Core/RequestEventStreamTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/RequestEventStreamTests.cs
@@ -110,7 +110,7 @@ namespace UnitTests.NetStandard.Core
             var identity = new BasicAWSCredentials("access-dummy", "secret-dummy");
             var aws4Signer = new AWS4Signer();
 
-            var eventSigner = aws4Signer.CreateEventSigner(identity, "us-east-1", "the-service", signature);
+            var eventSigner = aws4Signer.CreateEventSigner("secret-dummy", "us-east-1", "the-service", signature);
 
             var eventType = "Foo1";
             var contentType = "application/json";

--- a/sdk/test/NetStandard/UnitTests/Core/RequestEventStreamTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/RequestEventStreamTests.cs
@@ -107,7 +107,6 @@ namespace UnitTests.NetStandard.Core
         public async Task SignInputEvents()
         {
             var signature = "initial-signature";
-            var identity = new BasicAWSCredentials("access-dummy", "secret-dummy");
             var aws4Signer = new AWS4Signer();
 
             var eventSigner = aws4Signer.CreateEventSigner("secret-dummy", "us-east-1", "the-service", signature);

--- a/sdk/test/UnitTests/Custom/Runtime/ChunkedUploadWrapperStreamTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/ChunkedUploadWrapperStreamTests.cs
@@ -32,6 +32,7 @@ namespace AWSSDK.UnitTests
     {
         private static DateTime _fixedSigningTimestamp = new DateTime(2015, 8, 30, 12, 36, 0, DateTimeKind.Utc);
         private static string _accessKey = "accesskey";
+        private static string _secretKey = "secretkey";
         private static byte[] _signingKey = new byte[32];
         private static byte[] _headerSignature = new byte[64];
 
@@ -88,7 +89,7 @@ namespace AWSSDK.UnitTests
                 {checksumKey, "" }  // checksum will be calculated as the stream is read then replaced at the end
             };
 
-            var headerSigningResult = new AWS4SigningResult(_accessKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
+            var headerSigningResult = new AWS4SigningResult(_accessKey, _secretKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
             var cachedChecksum = new CachedChecksum
             {
                 Value = null,
@@ -116,7 +117,7 @@ namespace AWSSDK.UnitTests
             {
                 {"x-amz-checksum-sha256", "" }  // checksum will be calculated as the stream is read then replaced at the end
             };
-            var headerSigningResult = new AWS4SigningResult(_accessKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
+            var headerSigningResult = new AWS4SigningResult(_accessKey, _secretKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
             var cachedChecksum = new CachedChecksum
             {
                 Value = null,
@@ -154,7 +155,7 @@ namespace AWSSDK.UnitTests
             {
                 {"x-amz-checksum-sha256", "" }  // checksum will be calculated as the stream is read then replaced at the end
             };
-            var headerSigningResult = new AWS4SigningResult(_accessKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
+            var headerSigningResult = new AWS4SigningResult(_accessKey, _secretKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
 
             var expectedContent =
                 "14000;chunk-signature=dd6818ebe851d9f6006431fac25c71960881bf8d86501344f19a43c1a2c2a9a7\r\n" +
@@ -194,7 +195,7 @@ namespace AWSSDK.UnitTests
                 {"header-a", "value-a" },
                 {"header-b", "value-b" }
             };
-            var headerSigningResult = new AWS4SigningResult(_accessKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
+            var headerSigningResult = new AWS4SigningResult(_accessKey, _secretKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
 
             var expectedContent =
                 "B;chunk-signature=6a4d50a3307c001ad83900a73442136a0a0f203520fd8c0e966f655cc830bbe8\r\n" +
@@ -237,7 +238,7 @@ namespace AWSSDK.UnitTests
                 {"header-b", "value-b" },
                 {"x-amz-checksum-sha256", "" }  // checksum will be calculated as the stream is read then replaced at the end
             };
-            var headerSigningResult = new AWS4SigningResult(_accessKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
+            var headerSigningResult = new AWS4SigningResult(_accessKey, _secretKey, _fixedSigningTimestamp, "", "", _signingKey, _headerSignature);
 
             var expectedContent =
                 "B;chunk-signature=6a4d50a3307c001ad83900a73442136a0a0f203520fd8c0e966f655cc830bbe8\r\n" +


### PR DESCRIPTION
Draft mode till testing and dry runs are complete

## Description
For H2 request stream operations all the events must be signed with the same secret key that was used during the initial request. Since the event signer was taking in the `AWSCredentials` object the underlying credentials could get refreshed depending on what was the underlying credential provider. To avoid this happen I reworked the signatures creating the event signer to take in the secret key instead of the `AWSCredentials`.

If the credentials do expire that essentially ends the request streaming. With this PR the user will an expired credentials error instead of a signature mismatch error. Also the credentials will be used to very last minute instead of being preemptively rotated.

Given users usually can't tell how long to the environment's credentials rotate the recommendation before starting a streaming API is to use STS and assume a role for the duration they expect to be streaming. This would allow valid credentials for up to 12 hours.


## Testing
Running endurance tests now with an assume role credential provider refreshing credentials every 15 minutes.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement