### PR TITLE
fix: Render <list>, <item>, <term>, and <description> XML doc tags as…

### DIFF
--- a/docgenerator/SDKDocGenerator.UnitTests/NDocUtilitiesHtmlTests.cs
+++ b/docgenerator/SDKDocGenerator.UnitTests/NDocUtilitiesHtmlTests.cs
@@ -72,5 +72,45 @@ namespace SDKDocGenerator.UnitTests
                 "<p><div class=\"noteblock\" type=\"caution\"><p>Be careful.</p></div></p>",
                 result);
         }
+
+        [Fact]
+        public void BulletList_RendersAsUnorderedList()
+        {
+            var result = TransformSummary("<list type=\"bullet\"><item><description>text</description></item></list>");
+
+            Assert.Equal(
+                "<p><ul><li><span>text</span></li></ul></p>",
+                result);
+        }
+
+        [Fact]
+        public void NumberedList_RendersAsOrderedList()
+        {
+            var result = TransformSummary("<list type=\"number\"><item><description>first</description></item></list>");
+
+            Assert.Equal(
+                "<p><ol><li><span>first</span></li></ol></p>",
+                result);
+        }
+
+        [Fact]
+        public void ListWithTermAndDescription_RendersBoth()
+        {
+            var result = TransformSummary("<list type=\"bullet\"><item><term>T</term><description>D</description></item></list>");
+
+            Assert.Equal(
+                "<p><ul><li><span>T</span><span>D</span></li></ul></p>",
+                result);
+        }
+
+        [Fact]
+        public void ListDefaultsToUnorderedList()
+        {
+            var result = TransformSummary("<list><item><description>text</description></item></list>");
+
+            Assert.Equal(
+                "<p><ul><li><span>text</span></li></ul></p>",
+                result);
+        }
     }
 }

--- a/docgenerator/SDKDocGeneratorLib/NDocUtilities.cs
+++ b/docgenerator/SDKDocGeneratorLib/NDocUtilities.cs
@@ -43,7 +43,10 @@ namespace SDKDocGenerator
             { "see", "a" },
             { "paramref", "code" },
             { "important", "div" },
-            { "note", "div" }
+            { "note", "div" },
+            { "item", "li" },
+            { "term", "span" },
+            { "description", "span" }
         };
 
         private static readonly Dictionary<string, string> NdocToHtmlClassMapping = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -616,7 +619,14 @@ namespace SDKDocGenerator
 
                                 // element name substitution, if necessary
                                 string elementName;
-                                if (!NdocToHtmlElementMapping.TryGetValue(originalLocalName, out elementName))
+                                var isList = originalLocalName == "list";
+                                if (isList)
+                                {
+                                    // <list type="bullet"> → <ul>, <list type="number"> → <ol>
+                                    var listType = reader.GetAttribute("type");
+                                    elementName = (listType == "number") ? "ol" : "ul";
+                                }
+                                else if (!NdocToHtmlElementMapping.TryGetValue(originalLocalName, out elementName))
                                     elementName = originalLocalName;
 
                                 // some elements can't be empty, use this variable for that
@@ -632,8 +642,8 @@ namespace SDKDocGenerator
                                     writer.WriteAttributeString("class", cssClass);
                                 }
 
-                                // copy over attributes
-                                if (reader.HasAttributes)
+                                // copy over attributes (skip for list elements — type attribute already consumed)
+                                if (reader.HasAttributes && !isList)
                                 {
                                     var isAbsoluteLink = false;
                                     var hasTarget = false;

--- a/generator/.DevConfigs/f7e26ea2-528f-4ab3-a20f-a25f707fec41.json
+++ b/generator/.DevConfigs/f7e26ea2-528f-4ab3-a20f-a25f707fec41.json
@@ -1,0 +1,8 @@
+{
+  "services": [],
+  "core": {
+    "updateSinceLastRelease": false,
+    "type": "enhancement",
+    "changeLogMessage": "Fix rendering of <list>, <item>, <term>, and <description> XML doc tags in generated API reference documentation."
+  }
+}

--- a/generator/.DevConfigs/f7e26ea2-528f-4ab3-a20f-a25f707fec41.json
+++ b/generator/.DevConfigs/f7e26ea2-528f-4ab3-a20f-a25f707fec41.json
@@ -1,8 +1,9 @@
 {
-  "services": [],
   "core": {
-    "updateSinceLastRelease": false,
-    "type": "enhancement",
-    "changeLogMessage": "Fix rendering of <list>, <item>, <term>, and <description> XML doc tags in generated API reference documentation."
+    "changeLogMessages": [
+      "Fix rendering of <list>, <item>, <term>, and <description> XML doc tags in generated API reference documentation."
+    ],
+    "type": "patch",
+    "updateMinimum": true
   }
 }


### PR DESCRIPTION
## Description

The doc generator's `DocBlobToHTML` method now converts XML doc `<list>` elements to proper HTML lists instead of passing them through as raw XML:

- `<list type="bullet">` / `<list>` -> `<ul>`
- `<list type="number">` -> `<ol>`
- `<item>` -> `<li>`
- `<term>` / `<description>` -> `<span>`

## Motivation and Context

XML doc comments use `<list type="bullet">` for bulleted lists (e.g., documenting possible events, conditions, or examples). These were not being converted to HTML, so the raw XML tags appeared in the rendered API reference. This is a follow-up to #4353 which fixed the same issue for `<important>` and `<note>` tags.

## Testing

4 unit tests added covering bullet lists, numbered lists, term+description items, and default (no type attribute) lists. All 25 tests in `SDKDocGenerator.UnitTests` pass.

### Dry-runs
- **DotNet Dry-run ID:** e27f71cc-ddd8-4cbd-b76f-e9eba3861bc1
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** e25d2ab1-1b8c-48ac-a1e3-1e271e728212
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

None. This is a rendering-only fix in the doc generator.

Screenshots:

Before:
<img width="612" height="178" alt="image" src="https://github.com/user-attachments/assets/d47d45d8-f644-47dd-9c39-0429ad0c4f1d" />

After fix:
<img width="685" height="319" alt="image" src="https://github.com/user-attachments/assets/46991755-f7c4-468c-bd94-564bc47e5a46" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
