### PR TITLE
Fix Credential resolution storm caused by high parallelization

### DIFF
--- a/generator/.DevConfigs/60e32337-c0b9-457f-8b6c-b4e018ce73d0.json
+++ b/generator/.DevConfigs/60e32337-c0b9-457f-8b6c-b4e018ce73d0.json
@@ -3,7 +3,8 @@
     "updateMinimum": true,
     "type": "patch",
     "changeLogMessages": [
-      "Fix credential resolution issue under high concurrency where multiple threads simultaneously walked the credential chain causing initial service calls to fail."
+      "Fix credential resolution issue under high concurrency where multiple threads simultaneously walked the credential chain causing initial service calls to fail.",
+      "[Breaking Change] DefaultAWSCredentialsIdentityResolver implements IDisposable now. Most users will be unaffected since the static GetCredentials() or GetCredentialsAsync() methods are being called."
     ]
   }
 }

--- a/generator/.DevConfigs/60e32337-c0b9-457f-8b6c-b4e018ce73d0.json
+++ b/generator/.DevConfigs/60e32337-c0b9-457f-8b6c-b4e018ce73d0.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fix credential resolution issue under high concurrency where multiple threads simultaneously walked the credential chain causing initial service calls to fail."
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -390,9 +390,9 @@ namespace Amazon.Runtime.Credentials
             if (_disposed) return;
             if (disposing)
             {
-                _disposed = true;
                 _credentialResolutionLock.Dispose();
             }
+            _disposed = true;
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -32,31 +32,20 @@ namespace Amazon.Runtime.Credentials
     /// The default search order used is described in the <a href="https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/creds-assign.html">
     /// developer guide</a>, but it can be overwritten by setting the <see cref="AWSConfigs.AWSCredentialsGenerators"/> property.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1001:Types that own disposable fields should be disposable",
-        Justification = "This resolver is designed to be long-lived (singleton via DefaultIdentityResolverConfiguration). Disposing the semaphore would break concurrent callers.")]
-    public class DefaultAWSCredentialsIdentityResolver : IIdentityResolver<AWSCredentials>
+    public class DefaultAWSCredentialsIdentityResolver : IIdentityResolver<AWSCredentials>, IDisposable
     {
         private const string AWS_PROFILE_ENVIRONMENT_VARIABLE = "AWS_PROFILE";
         private const string DEFAULT_PROFILE_NAME = "default";
 
-        /// <summary>
-        /// A method that should either return valid <see cref="AWSCredentials"/> or throw an exception (so
-        /// that the SDK can move on and attempt the next generator in the credential chain).
-        /// </summary>
         public delegate AWSCredentials CredentialsGenerator();
 
-        /// <summary>
-        /// SemaphoreSlim supports both synchronous Wait() and asynchronous WaitAsync(), preventing
-        /// thread pool starvation when many concurrent async requests need to resolve credentials
-        /// simultaneously. Only one caller walks the credential chain; all others wait and reuse
-        /// the cached result.
-        /// </summary>
         private readonly SemaphoreSlim _credentialResolutionLock = new SemaphoreSlim(1, 1);
         private volatile AWSCredentials _cachedCredentials;
         private readonly List<CredentialsGenerator> _credentialsGenerators;
         private readonly CredentialProfileStoreChain _credentialProfileChain = new();
         private readonly EnvironmentState _lastKnownEnvironmentState = new();
         private static readonly Lazy<DefaultAWSCredentialsIdentityResolver> _defaultInstance = new();
+        private bool _disposed;
 
         public DefaultAWSCredentialsIdentityResolver()
         {
@@ -387,6 +376,22 @@ namespace Amazon.Runtime.Credentials
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
                     "Failed to connect to EC2 instance metadata to retrieve credentials: {0}.",
                     e.Message), e);
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            if (disposing)
+            {
+                _disposed = true;
+                _credentialResolutionLock.Dispose();
             }
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -218,11 +218,11 @@ namespace Amazon.Runtime.Credentials
 
             if (resolvedCredentials != null)
             {
-                // Update the environment snapshot before publishing the credentials via the
-                // volatile write. This avoids a race where a concurrent reader in
-                // TryGetCachedCredentials sees non-null _cachedCredentials but stale
-                // environment state, causing a false "environment changed" detection and
-                // an unnecessary re-resolution attempt.
+                // Clear the cache first so that any concurrent lock-free reader in
+                // TryGetCachedCredentials sees a cache miss and waits for the lock
+                // rather than returning stale credentials while the environment
+                // snapshot is being updated.
+                _cachedCredentials = null;
                 _lastKnownEnvironmentState.UpdateEnvironment();
                 _cachedCredentials = resolvedCredentials;
                 return resolvedCredentials;

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -32,6 +32,8 @@ namespace Amazon.Runtime.Credentials
     /// The default search order used is described in the <a href="https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/creds-assign.html">
     /// developer guide</a>, but it can be overwritten by setting the <see cref="AWSConfigs.AWSCredentialsGenerators"/> property.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1001:Types that own disposable fields should be disposable",
+        Justification = "This resolver is designed to be long-lived (singleton via DefaultIdentityResolverConfiguration). Disposing the semaphore would break concurrent callers.")]
     public class DefaultAWSCredentialsIdentityResolver : IIdentityResolver<AWSCredentials>
     {
         private const string AWS_PROFILE_ENVIRONMENT_VARIABLE = "AWS_PROFILE";
@@ -43,8 +45,14 @@ namespace Amazon.Runtime.Credentials
         /// </summary>
         public delegate AWSCredentials CredentialsGenerator();
 
-        private static readonly ReaderWriterLockSlim _cachedCredentialsLock = new();
-        private AWSCredentials _cachedCredentials;
+        /// <summary>
+        /// SemaphoreSlim supports both synchronous Wait() and asynchronous WaitAsync(), preventing
+        /// thread pool starvation when many concurrent async requests need to resolve credentials
+        /// simultaneously. Only one caller walks the credential chain; all others wait and reuse
+        /// the cached result.
+        /// </summary>
+        private readonly SemaphoreSlim _credentialResolutionLock = new SemaphoreSlim(1, 1);
+        private volatile AWSCredentials _cachedCredentials;
         private readonly List<CredentialsGenerator> _credentialsGenerators;
         private readonly CredentialProfileStoreChain _credentialProfileChain = new();
         private readonly EnvironmentState _lastKnownEnvironmentState = new();
@@ -116,108 +124,183 @@ namespace Amazon.Runtime.Credentials
         }
 
         Task<BaseIdentity> IIdentityResolver.ResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken) =>
-            Task.FromResult<BaseIdentity>(ResolveIdentity(clientConfig));
+            InternalResolveIdentityAsync(clientConfig, cancellationToken);
 
-        public Task<AWSCredentials> ResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken = default) =>
-            Task.FromResult(ResolveIdentity(clientConfig));
-
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We need to catch all exceptions to be able to move the the next generator.")]
-        private AWSCredentials InternalGetCredentials()
+        public async Task<AWSCredentials> ResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken = default)
         {
-            var hasEnvironmentChanged = false;
-
-            try
+            var profile = clientConfig?.Profile;
+            if (!string.IsNullOrEmpty(profile?.Name))
             {
-                _cachedCredentialsLock.EnterReadLock();
-                if (_cachedCredentials != null)
+                var source = new CredentialProfileStoreChain(profile.Location);
+                if (source.TryGetProfile(profile.Name, out CredentialProfile storedProfile))
                 {
-                    hasEnvironmentChanged = _lastKnownEnvironmentState.HasEnvironmentChanged();
-                    if (!hasEnvironmentChanged)
-                    {
-                        return _cachedCredentials;
-                    }
+                    return storedProfile.GetAWSCredentials(source, true);
+                }
+
+                throw new AmazonClientException($"Unable to find the \"{profile.Name}\" profile specified in the client configuration.");
+            }
+
+            return await InternalGetCredentialsAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<BaseIdentity> InternalResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken)
+        {
+            return await ResolveIdentityAsync(clientConfig, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Checks whether valid cached credentials are available without acquiring the lock.
+        /// Returns the cached credentials if they exist and the environment hasn't changed,
+        /// otherwise returns null to indicate that credentials need to be resolved.
+        /// </summary>
+        private AWSCredentials TryGetCachedCredentials(out bool hasEnvironmentChanged)
+        {
+            hasEnvironmentChanged = false;
+            var cached = _cachedCredentials;
+            if (cached != null)
+            {
+                hasEnvironmentChanged = _lastKnownEnvironmentState.HasEnvironmentChanged();
+                if (!hasEnvironmentChanged)
+                {
+                    return cached;
                 }
             }
-            finally
+            return null;
+        }
+
+        /// <summary>
+        /// Walks the credential chain and resolves credentials. This method must only be
+        /// called while holding the <see cref="_credentialResolutionLock"/>.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We need to catch all exceptions to be able to move to the next generator.")]
+        private AWSCredentials ResolveCredentialChain()
+        {
+            List<CredentialsGenerator> providersToUse;
+            if (AWSConfigs.AWSCredentialsGenerators != null)
             {
-                _cachedCredentialsLock.ExitReadLock();
+                Logger.GetLogger(typeof(DefaultAWSCredentialsIdentityResolver)).DebugFormat("Using custom credential search order defined in {0}", nameof(AWSConfigs));
+                providersToUse = AWSConfigs.AWSCredentialsGenerators;
+            }
+            else
+            {
+                providersToUse = _credentialsGenerators;
             }
 
+            AWSCredentials resolvedCredentials = null;
+            List<Exception> errors = new List<Exception>();
+            foreach (CredentialsGenerator generator in providersToUse)
+            {
+                try
+                {
+                    resolvedCredentials = generator();
+                }
+                // Breaking the chain in case a ProcessAWSCredentialException exception 
+                // is encountered. ProcessAWSCredentialException is thrown by the ProcessAWSCredential provider
+                // when an exception is encountered when running a user provided process to obtain Basic/Session 
+                // credentials. The motivation behind this is that, if the user has provided a process to be run
+                // he expects to use the credentials obtained by running the process. Therefore the exception is
+                // surfaced to the user.
+                catch (ProcessAWSCredentialException)
+                {
+                    throw;
+                }
+                // Also breaking the chain in case a custom profile name was specified and the profile does not exist.
+                // This differs from the FallbackCredentialsFactory, which would default to the IMDS provider (and throw
+                // an error that may not be applicable when running outside of an EC2 environment).
+                catch (ProfileNotFoundException)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    resolvedCredentials = null;
+                    errors.Add(e);
+                }
+
+                if (resolvedCredentials != null)
+                {
+                    break;
+                }
+            }
+
+            if (resolvedCredentials != null)
+            {
+                _cachedCredentials = resolvedCredentials;
+                _lastKnownEnvironmentState.UpdateEnvironment();
+                return resolvedCredentials;
+            }
+
+            using var writer = new StringWriter(CultureInfo.InvariantCulture);
+            writer.WriteLine("Failed to resolve AWS credentials. The credential providers used to search for credentials returned the following errors:");
+            writer.WriteLine();
+            for (int i = 0; i < errors.Count; i++)
+            {
+                Exception e = errors[i];
+                writer.WriteLine("Exception {0} of {1}: {2}", i + 1, errors.Count, e.Message);
+            }
+
+            throw new AmazonClientException(writer.ToString());
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We need to catch all exceptions to be able to move to the next generator.")]
+        private AWSCredentials InternalGetCredentials()
+        {
+            // Fast path: return cached credentials without acquiring the lock.
+            var cached = TryGetCachedCredentials(out var hasEnvironmentChanged);
+            if (cached != null)
+            {
+                return cached;
+            }
+
+            // Slow path: acquire the lock synchronously so only one thread walks the credential chain.
+            _credentialResolutionLock.Wait();
             try
             {
-                _cachedCredentialsLock.EnterWriteLock();
+                // Double-check: another thread may have resolved credentials while we waited.
                 if (_cachedCredentials != null && !hasEnvironmentChanged)
                 {
                     return _cachedCredentials;
                 }
 
-                List<CredentialsGenerator> providersToUse;
-                if (AWSConfigs.AWSCredentialsGenerators != null)
-                {
-                    Logger.GetLogger(typeof(DefaultAWSCredentialsIdentityResolver)).DebugFormat("Using custom credential search order defined in {0}", nameof(AWSConfigs));
-                    providersToUse = AWSConfigs.AWSCredentialsGenerators;
-                }
-                else 
-                {
-                    providersToUse = _credentialsGenerators;
-                }
-
-                List<Exception> errors = new List<Exception>();
-                foreach (CredentialsGenerator generator in providersToUse)
-                {
-                    try
-                    {
-                        _cachedCredentials = generator();
-                    }
-                    // Breaking the chain in case a ProcessAWSCredentialException exception 
-                    // is encountered. ProcessAWSCredentialException is thrown by the ProcessAWSCredential provider
-                    // when an exception is encountered when running a user provided process to obtain Basic/Session 
-                    // credentials. The motivation behind this is that, if the user has provided a process to be run
-                    // he expects to use the credentials obtained by running the process. Therefore the exception is
-                    // surfaced to the user.
-                    catch (ProcessAWSCredentialException)
-                    {
-                        throw;
-                    }
-                    // Also breaking the chain in case a custom profile name was specified and the profile does not exist.
-                    // This differs from the FallbackCredentialsFactory, which would default to the IMDS provider (and throw
-                    // an error that may not be applicable when running outside of an EC2 environment).
-                    catch (ProfileNotFoundException)
-                    {
-                        throw;
-                    }
-                    catch (Exception e)
-                    {
-                        _cachedCredentials = null;
-                        errors.Add(e);
-                    }
-
-                    if (_cachedCredentials != null)
-                    {
-                        break;
-                    }
-                }
-
-                if (_cachedCredentials != null)
-                {
-                    _lastKnownEnvironmentState.UpdateEnvironment();
-                    return _cachedCredentials;
-                }
-
-                using var writer = new StringWriter(CultureInfo.InvariantCulture);
-                writer.WriteLine("Failed to resolve AWS credentials. The credential providers used to search for credentials returned the following errors:");
-                writer.WriteLine();
-                for (int i = 0; i < errors.Count; i++)
-                {
-                    Exception e = errors[i];
-                    writer.WriteLine("Exception {0} of {1}: {2}", i + 1, errors.Count, e.Message);
-                }
-
-                throw new AmazonClientException(writer.ToString());
+                return ResolveCredentialChain();
             }
             finally
             {
-                _cachedCredentialsLock.ExitWriteLock();
+                _credentialResolutionLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously resolves credentials using a single-flight pattern.
+        /// Only one task walks the credential chain; all other concurrent tasks
+        /// asynchronously wait on the semaphore (yielding their thread back to
+        /// the thread pool) and then reuse the cached result.  This prevents
+        /// thread pool starvation under high concurrency.
+        /// </summary>
+        private async Task<AWSCredentials> InternalGetCredentialsAsync(CancellationToken cancellationToken)
+        {
+            // Fast path: return cached credentials without acquiring the lock.
+            var cached = TryGetCachedCredentials(out var hasEnvironmentChanged);
+            if (cached != null)
+            {
+                return cached;
+            }
+
+            // Slow path: asynchronously wait for the lock so we don't block thread pool threads.
+            await _credentialResolutionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // Double-check: another task may have resolved credentials while we waited.
+                if (_cachedCredentials != null && !hasEnvironmentChanged)
+                {
+                    return _cachedCredentials;
+                }
+
+                return ResolveCredentialChain();
+            }
+            finally
+            {
+                _credentialResolutionLock.Release();
             }
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -108,44 +108,39 @@ namespace Amazon.Runtime.Credentials
 
         public AWSCredentials ResolveIdentity(IClientConfig clientConfig)
         {
-            var profile = clientConfig?.Profile;
-            if (!string.IsNullOrEmpty(profile?.Name))
-            {
-                var source = new CredentialProfileStoreChain(profile.Location);
-                if (source.TryGetProfile(profile.Name, out CredentialProfile storedProfile))
-                {
-                    return storedProfile.GetAWSCredentials(source, true);
-                }
-
-                throw new AmazonClientException($"Unable to find the \"{profile.Name}\" profile specified in the client configuration.");
-            }
+            var profileCredentials = TryGetProfileCredentials(clientConfig);
+            if (profileCredentials != null) return profileCredentials;
 
             return InternalGetCredentials();
         }
 
-        Task<BaseIdentity> IIdentityResolver.ResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken) =>
-            InternalResolveIdentityAsync(clientConfig, cancellationToken);
+        async Task<BaseIdentity> IIdentityResolver.ResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken) =>
+            await ResolveIdentityAsync(clientConfig, cancellationToken).ConfigureAwait(false);
 
         public async Task<AWSCredentials> ResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken = default)
         {
-            var profile = clientConfig?.Profile;
-            if (!string.IsNullOrEmpty(profile?.Name))
-            {
-                var source = new CredentialProfileStoreChain(profile.Location);
-                if (source.TryGetProfile(profile.Name, out CredentialProfile storedProfile))
-                {
-                    return storedProfile.GetAWSCredentials(source, true);
-                }
-
-                throw new AmazonClientException($"Unable to find the \"{profile.Name}\" profile specified in the client configuration.");
-            }
+            var profileCredentials = TryGetProfileCredentials(clientConfig);
+            if (profileCredentials != null) return profileCredentials;
 
             return await InternalGetCredentialsAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<BaseIdentity> InternalResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken)
+        /// <summary>
+        /// Resolves credentials from the profile specified in <paramref name="clientConfig"/>, if any.
+        /// Returns null if no profile name is configured, allowing the caller to fall back to the credential chain.
+        /// </summary>
+        private static AWSCredentials TryGetProfileCredentials(IClientConfig clientConfig)
         {
-            return await ResolveIdentityAsync(clientConfig, cancellationToken).ConfigureAwait(false);
+            var profile = clientConfig?.Profile;
+            if (string.IsNullOrEmpty(profile?.Name)) return null;
+
+            var source = new CredentialProfileStoreChain(profile.Location);
+            if (source.TryGetProfile(profile.Name, out CredentialProfile storedProfile))
+            {
+                return storedProfile.GetAWSCredentials(source, true);
+            }
+
+            throw new AmazonClientException($"Unable to find the \"{profile.Name}\" profile specified in the client configuration.");
         }
 
         /// <summary>
@@ -153,14 +148,12 @@ namespace Amazon.Runtime.Credentials
         /// Returns the cached credentials if they exist and the environment hasn't changed,
         /// otherwise returns null to indicate that credentials need to be resolved.
         /// </summary>
-        private AWSCredentials TryGetCachedCredentials(out bool hasEnvironmentChanged)
+        private AWSCredentials TryGetCachedCredentials()
         {
-            hasEnvironmentChanged = false;
             var cached = _cachedCredentials;
             if (cached != null)
             {
-                hasEnvironmentChanged = _lastKnownEnvironmentState.HasEnvironmentChanged();
-                if (!hasEnvironmentChanged)
+                if (!_lastKnownEnvironmentState.HasEnvironmentChanged())
                 {
                     return cached;
                 }
@@ -251,7 +244,7 @@ namespace Amazon.Runtime.Credentials
         private AWSCredentials InternalGetCredentials()
         {
             // Fast path: return cached credentials without acquiring the lock.
-            var cached = TryGetCachedCredentials(out _);
+            var cached = TryGetCachedCredentials();
             if (cached != null)
             {
                 return cached;
@@ -262,9 +255,7 @@ namespace Amazon.Runtime.Credentials
             try
             {
                 // Re-check with fresh environment state after acquiring the lock.
-                // We discard the pre-lock hasEnvironmentChanged because the environment
-                // may have changed while we were waiting on the semaphore.
-                cached = TryGetCachedCredentials(out _);
+                cached = TryGetCachedCredentials();
                 if (cached != null)
                 {
                     return cached;
@@ -288,7 +279,7 @@ namespace Amazon.Runtime.Credentials
         private async Task<AWSCredentials> InternalGetCredentialsAsync(CancellationToken cancellationToken)
         {
             // Fast path: return cached credentials without acquiring the lock.
-            var cached = TryGetCachedCredentials(out _);
+            var cached = TryGetCachedCredentials();
             if (cached != null)
             {
                 return cached;
@@ -299,9 +290,7 @@ namespace Amazon.Runtime.Credentials
             try
             {
                 // Re-check with fresh environment state after acquiring the lock.
-                // We discard the pre-lock hasEnvironmentChanged because the environment
-                // may have changed while we were waiting on the semaphore.
-                cached = TryGetCachedCredentials(out _);
+                cached = TryGetCachedCredentials();
                 if (cached != null)
                 {
                     return cached;

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -96,13 +96,17 @@ namespace Amazon.Runtime.Credentials
             => ResolveIdentity(clientConfig);
 
         /// <summary>
-        /// Resolves the identity using no cancellation token. If a network call is made during credential
-        /// resolution (e.g. EC2 instance metadata) and hangs, this overload will block indefinitely.
-        /// Use <see cref="ResolveIdentity(IClientConfig, CancellationToken)"/> with a timeout-bound
-        /// cancellation token to avoid this.
+        /// Resolves the identity using a cancellation token with a default of 35 seconds. 
+        /// 35 seconds is calculated as the worst case scenario for DefaultInstanceProfileAWSCredentials and its
+        /// retry mechanism during resolution.
+        /// To pass in your own cancellation token call <see cref="ResolveIdentity(IClientConfig, CancellationToken)"/>.
         /// </summary>
         public AWSCredentials ResolveIdentity(IClientConfig clientConfig)
-            => ResolveIdentity(clientConfig, CancellationToken.None);
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(35));
+            return ResolveIdentity(clientConfig, cts.Token);
+        }
+            
 
         /// <summary>
         /// Resolves the identity using the provided <paramref name="cancellationToken"/>. Pass a token

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -225,8 +225,13 @@ namespace Amazon.Runtime.Credentials
 
             if (resolvedCredentials != null)
             {
-                _cachedCredentials = resolvedCredentials;
+                // Update the environment snapshot before publishing the credentials via the
+                // volatile write. This avoids a race where a concurrent reader in
+                // TryGetCachedCredentials sees non-null _cachedCredentials but stale
+                // environment state, causing a false "environment changed" detection and
+                // an unnecessary re-resolution attempt.
                 _lastKnownEnvironmentState.UpdateEnvironment();
+                _cachedCredentials = resolvedCredentials;
                 return resolvedCredentials;
             }
 
@@ -246,7 +251,7 @@ namespace Amazon.Runtime.Credentials
         private AWSCredentials InternalGetCredentials()
         {
             // Fast path: return cached credentials without acquiring the lock.
-            var cached = TryGetCachedCredentials(out var hasEnvironmentChanged);
+            var cached = TryGetCachedCredentials(out _);
             if (cached != null)
             {
                 return cached;
@@ -256,10 +261,13 @@ namespace Amazon.Runtime.Credentials
             _credentialResolutionLock.Wait();
             try
             {
-                // Double-check: another thread may have resolved credentials while we waited.
-                if (_cachedCredentials != null && !hasEnvironmentChanged)
+                // Re-check with fresh environment state after acquiring the lock.
+                // We discard the pre-lock hasEnvironmentChanged because the environment
+                // may have changed while we were waiting on the semaphore.
+                cached = TryGetCachedCredentials(out _);
+                if (cached != null)
                 {
-                    return _cachedCredentials;
+                    return cached;
                 }
 
                 return ResolveCredentialChain();
@@ -280,7 +288,7 @@ namespace Amazon.Runtime.Credentials
         private async Task<AWSCredentials> InternalGetCredentialsAsync(CancellationToken cancellationToken)
         {
             // Fast path: return cached credentials without acquiring the lock.
-            var cached = TryGetCachedCredentials(out var hasEnvironmentChanged);
+            var cached = TryGetCachedCredentials(out _);
             if (cached != null)
             {
                 return cached;
@@ -290,10 +298,13 @@ namespace Amazon.Runtime.Credentials
             await _credentialResolutionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                // Double-check: another task may have resolved credentials while we waited.
-                if (_cachedCredentials != null && !hasEnvironmentChanged)
+                // Re-check with fresh environment state after acquiring the lock.
+                // We discard the pre-lock hasEnvironmentChanged because the environment
+                // may have changed while we were waiting on the semaphore.
+                cached = TryGetCachedCredentials(out _);
+                if (cached != null)
                 {
-                    return _cachedCredentials;
+                    return cached;
                 }
 
                 return ResolveCredentialChain();

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -106,12 +106,25 @@ namespace Amazon.Runtime.Credentials
         BaseIdentity IIdentityResolver.ResolveIdentity(IClientConfig clientConfig) 
             => ResolveIdentity(clientConfig);
 
+        /// <summary>
+        /// Resolves the identity using no cancellation token. If a network call is made during credential
+        /// resolution (e.g. EC2 instance metadata) and hangs, this overload will block indefinitely.
+        /// Use <see cref="ResolveIdentity(IClientConfig, CancellationToken)"/> with a timeout-bound
+        /// cancellation token to avoid this.
+        /// </summary>
         public AWSCredentials ResolveIdentity(IClientConfig clientConfig)
+            => ResolveIdentity(clientConfig, CancellationToken.None);
+
+        /// <summary>
+        /// Resolves the identity using the provided <paramref name="cancellationToken"/>. Pass a token
+        /// with a timeout to avoid blocking indefinitely if a network call during credential resolution hangs.
+        /// </summary>
+        public AWSCredentials ResolveIdentity(IClientConfig clientConfig, CancellationToken cancellationToken)
         {
             var profileCredentials = TryGetProfileCredentials(clientConfig);
             if (profileCredentials != null) return profileCredentials;
 
-            return InternalGetCredentials();
+            return InternalGetCredentials(cancellationToken);
         }
 
         async Task<BaseIdentity> IIdentityResolver.ResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken) =>
@@ -241,7 +254,7 @@ namespace Amazon.Runtime.Credentials
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We need to catch all exceptions to be able to move to the next generator.")]
-        private AWSCredentials InternalGetCredentials()
+        private AWSCredentials InternalGetCredentials(CancellationToken cancellationToken)
         {
             // Fast path: return cached credentials without acquiring the lock.
             var cached = TryGetCachedCredentials();
@@ -251,10 +264,9 @@ namespace Amazon.Runtime.Credentials
             }
 
             // Slow path: acquire the lock synchronously so only one thread walks the credential chain.
-            _credentialResolutionLock.Wait();
+            _credentialResolutionLock.Wait(cancellationToken);
             try
             {
-                // Re-check with fresh environment state after acquiring the lock.
                 cached = TryGetCachedCredentials();
                 if (cached != null)
                 {
@@ -289,7 +301,6 @@ namespace Amazon.Runtime.Credentials
             await _credentialResolutionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                // Re-check with fresh environment state after acquiring the lock.
                 cached = TryGetCachedCredentials();
                 if (cached != null)
                 {

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/CancellationTokenCredentialResolutionTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/CancellationTokenCredentialResolutionTests.cs
@@ -84,11 +84,13 @@ namespace AWSSDK.UnitTests
             {
                 cts.Cancel();
 
-                var resolver = new DefaultAWSCredentialsIdentityResolver();
-                Assert.ThrowsException<OperationCanceledException>(
-                    () => resolver.ResolveIdentity(clientConfig: null, cts.Token));
+                using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+                {
+                    Assert.ThrowsException<OperationCanceledException>(
+                        () => resolver.ResolveIdentity(clientConfig: null, cts.Token));
 
-                Assert.AreEqual(0, generatorCallCount, "Generator should not be called when token is already cancelled.");
+                    Assert.AreEqual(0, generatorCallCount, "Generator should not be called when token is already cancelled.");
+                }
             }
         }
 
@@ -113,12 +115,14 @@ namespace AWSSDK.UnitTests
             {
                 cts.Cancel();
 
-                var resolver = new DefaultAWSCredentialsIdentityResolver();
-                var ex = await Assert.ThrowsExceptionAsync<TaskCanceledException>(
-                    () => resolver.ResolveIdentityAsync(clientConfig: null, cts.Token));
-                Assert.IsInstanceOfType(ex, typeof(OperationCanceledException));
+                using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+                {
+                    var ex = await Assert.ThrowsExceptionAsync<TaskCanceledException>(
+                        () => resolver.ResolveIdentityAsync(clientConfig: null, cts.Token));
+                    Assert.IsInstanceOfType(ex, typeof(OperationCanceledException));
 
-                Assert.AreEqual(0, generatorCallCount, "Generator should not be called when token is already cancelled.");
+                    Assert.AreEqual(0, generatorCallCount, "Generator should not be called when token is already cancelled."); 
+                }
             }
         }
 
@@ -144,22 +148,23 @@ namespace AWSSDK.UnitTests
                 }
             };
 
-            var resolver = new DefaultAWSCredentialsIdentityResolver();
-
-            // First thread acquires the lock and hangs inside the generator.
-            var firstThread = Task.Run(() => resolver.ResolveIdentity(clientConfig: null));
-            generatorStarted.Wait(); // Ensure the first thread holds the lock.
-
-            // Second thread tries to resolve with a short timeout — should be cancelled.
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
             {
-                Assert.ThrowsException<OperationCanceledException>(
-                    () => resolver.ResolveIdentity(clientConfig: null, cts.Token));
-            }
+                // First thread acquires the lock and hangs inside the generator.
+                var firstThread = Task.Run(() => resolver.ResolveIdentity(clientConfig: null));
+                generatorStarted.Wait(); // Ensure the first thread holds the lock.
 
-            // Unblock the first thread so the test can clean up.
-            generatorCanProceed.Set();
-            firstThread.Wait();
+                // Second thread tries to resolve with a short timeout — should be cancelled.
+                using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
+                {
+                    Assert.ThrowsException<OperationCanceledException>(
+                        () => resolver.ResolveIdentity(clientConfig: null, cts.Token));
+                }
+
+                // Unblock the first thread so the test can clean up.
+                generatorCanProceed.Set();
+                firstThread.Wait();
+            }
         }
 
         /// <summary>
@@ -181,27 +186,28 @@ namespace AWSSDK.UnitTests
                 }
             };
 
-            var resolver = new DefaultAWSCredentialsIdentityResolver();
-
-            var firstTask = Task.Run(() => resolver.ResolveIdentityAsync(clientConfig: null));
-            generatorStarted.Wait();
-
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
             {
-                Exception caughtEx = null;
-                try
-                {
-                    await resolver.ResolveIdentityAsync(clientConfig: null, cts.Token);
-                }
-                catch (OperationCanceledException ex)
-                {
-                    caughtEx = ex;
-                }
-                Assert.IsNotNull(caughtEx, "Expected OperationCanceledException or TaskCanceledException to be thrown.");
-            }
+                var firstTask = Task.Run(() => resolver.ResolveIdentityAsync(clientConfig: null));
+                generatorStarted.Wait();
 
-            generatorCanProceed.Set();
-            await firstTask;
+                using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
+                {
+                    Exception caughtEx = null;
+                    try
+                    {
+                        await resolver.ResolveIdentityAsync(clientConfig: null, cts.Token);
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        caughtEx = ex;
+                    }
+                    Assert.IsNotNull(caughtEx, "Expected OperationCanceledException or TaskCanceledException to be thrown.");
+                }
+
+                generatorCanProceed.Set();
+                await firstTask;
+            }
         }
 
         /// <summary>
@@ -217,9 +223,8 @@ namespace AWSSDK.UnitTests
             };
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
             {
-                var resolver = new DefaultAWSCredentialsIdentityResolver();
-
                 var credentials = resolver.ResolveIdentity(clientConfig: null, cts.Token);
 
                 Assert.IsNotNull(credentials);
@@ -240,9 +245,8 @@ namespace AWSSDK.UnitTests
             };
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
             {
-                var resolver = new DefaultAWSCredentialsIdentityResolver();
-
                 var credentials = await resolver.ResolveIdentityAsync(clientConfig: null, cts.Token);
 
                 Assert.IsNotNull(credentials);
@@ -261,21 +265,21 @@ namespace AWSSDK.UnitTests
             {
                 () => new BasicAWSCredentials("key", "secret")
             };
-
-            var resolver = new DefaultAWSCredentialsIdentityResolver();
-
-            // Warm the cache.
-            resolver.ResolveIdentity(clientConfig: null);
-
-            // A pre-cancelled token should still return cached credentials since the fast
-            // path returns before ever touching the semaphore.
-            using (var cts = new CancellationTokenSource())
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
             {
-                cts.Cancel();
+                // Warm the cache.
+                resolver.ResolveIdentity(clientConfig: null);
 
-                var credentials = resolver.ResolveIdentity(clientConfig: null, cts.Token);
-                Assert.IsNotNull(credentials);
-                Assert.IsInstanceOfType(credentials, typeof(BasicAWSCredentials));
+                // A pre-cancelled token should still return cached credentials since the fast
+                // path returns before ever touching the semaphore.
+                using (var cts = new CancellationTokenSource())
+                {
+                    cts.Cancel();
+
+                    var credentials = resolver.ResolveIdentity(clientConfig: null, cts.Token);
+                    Assert.IsNotNull(credentials);
+                    Assert.IsInstanceOfType(credentials, typeof(BasicAWSCredentials));
+                }
             }
         }
     }

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/CancellationTokenCredentialResolutionTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/CancellationTokenCredentialResolutionTests.cs
@@ -1,0 +1,282 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.Credentials;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AWSSDK.UnitTests
+{
+    /// <summary>
+    /// Tests that verify cancellation token behaviour in <see cref="DefaultAWSCredentialsIdentityResolver"/>.
+    /// Covers: pre-cancelled tokens, timeout-bound tokens, and ensuring a hanging credential
+    /// provider does not block indefinitely when a token is supplied.
+    /// </summary>
+    [TestClass]
+    public class CancellationTokenCredentialResolutionTests
+    {
+        private List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator> _cachedGenerators;
+        private string _cachedContainersUriVariable;
+        private string _cachedAccessKeyVariable;
+        private string _cachedSecretKeyVariable;
+        private string _cachedSessionTokenVariable;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _cachedGenerators = AWSConfigs.AWSCredentialsGenerators;
+            _cachedContainersUriVariable = Environment.GetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable);
+            _cachedAccessKeyVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY);
+            _cachedSecretKeyVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY);
+            _cachedSessionTokenVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN);
+
+            Environment.SetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN, null);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            AWSConfigs.AWSCredentialsGenerators = _cachedGenerators;
+            Environment.SetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable, _cachedContainersUriVariable);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, _cachedAccessKeyVariable);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, _cachedSecretKeyVariable);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN, _cachedSessionTokenVariable);
+        }
+
+        /// <summary>
+        /// A pre-cancelled token should cause ResolveIdentity to throw OperationCanceledException
+        /// immediately without invoking the credential generator at all.
+        /// </summary>
+        [TestMethod]
+        public void ResolveIdentity_PreCancelledToken_ThrowsOperationCanceledException()
+        {
+            int generatorCallCount = 0;
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () =>
+                {
+                    Interlocked.Increment(ref generatorCallCount);
+                    return new BasicAWSCredentials("key", "secret");
+                }
+            };
+
+            using (var cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                var resolver = new DefaultAWSCredentialsIdentityResolver();
+                Assert.ThrowsException<OperationCanceledException>(
+                    () => resolver.ResolveIdentity(clientConfig: null, cts.Token));
+
+                Assert.AreEqual(0, generatorCallCount, "Generator should not be called when token is already cancelled.");
+            }
+        }
+
+        /// <summary>
+        /// A pre-cancelled token should cause ResolveIdentityAsync to throw OperationCanceledException
+        /// immediately without invoking the credential generator at all.
+        /// </summary>
+        [TestMethod]
+        public async Task ResolveIdentityAsync_PreCancelledToken_ThrowsOperationCanceledException()
+        {
+            int generatorCallCount = 0;
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () =>
+                {
+                    Interlocked.Increment(ref generatorCallCount);
+                    return new BasicAWSCredentials("key", "secret");
+                }
+            };
+
+            using (var cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                var resolver = new DefaultAWSCredentialsIdentityResolver();
+                var ex = await Assert.ThrowsExceptionAsync<TaskCanceledException>(
+                    () => resolver.ResolveIdentityAsync(clientConfig: null, cts.Token));
+                Assert.IsInstanceOfType(ex, typeof(OperationCanceledException));
+
+                Assert.AreEqual(0, generatorCallCount, "Generator should not be called when token is already cancelled.");
+            }
+        }
+
+        /// <summary>
+        /// Simulates a hanging credential provider (e.g. IMDS with no timeout). A second thread
+        /// holds the semaphore while a slow generator runs. The waiting thread should be unblocked
+        /// by the cancellation token rather than hanging forever.
+        /// </summary>
+        [TestMethod]
+        public void ResolveIdentity_HangingProvider_CancelledWhileWaitingForLock_ThrowsOperationCanceledException()
+        {
+            var generatorStarted = new ManualResetEventSlim(false);
+            var generatorCanProceed = new ManualResetEventSlim(false);
+
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () =>
+                {
+                    generatorStarted.Set();
+                    // Simulate a hanging network call — only unblocks when the test signals it.
+                    generatorCanProceed.Wait();
+                    return new BasicAWSCredentials("key", "secret");
+                }
+            };
+
+            var resolver = new DefaultAWSCredentialsIdentityResolver();
+
+            // First thread acquires the lock and hangs inside the generator.
+            var firstThread = Task.Run(() => resolver.ResolveIdentity(clientConfig: null));
+            generatorStarted.Wait(); // Ensure the first thread holds the lock.
+
+            // Second thread tries to resolve with a short timeout — should be cancelled.
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
+            {
+                Assert.ThrowsException<OperationCanceledException>(
+                    () => resolver.ResolveIdentity(clientConfig: null, cts.Token));
+            }
+
+            // Unblock the first thread so the test can clean up.
+            generatorCanProceed.Set();
+            firstThread.Wait();
+        }
+
+        /// <summary>
+        /// Same as the sync hanging test but exercises the async path.
+        /// </summary>
+        [TestMethod]
+        public async Task ResolveIdentityAsync_HangingProvider_CancelledWhileWaitingForLock_ThrowsOperationCanceledException()
+        {
+            var generatorStarted = new ManualResetEventSlim(false);
+            var generatorCanProceed = new ManualResetEventSlim(false);
+
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () =>
+                {
+                    generatorStarted.Set();
+                    generatorCanProceed.Wait();
+                    return new BasicAWSCredentials("key", "secret");
+                }
+            };
+
+            var resolver = new DefaultAWSCredentialsIdentityResolver();
+
+            var firstTask = Task.Run(() => resolver.ResolveIdentityAsync(clientConfig: null));
+            generatorStarted.Wait();
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
+            {
+                Exception caughtEx = null;
+                try
+                {
+                    await resolver.ResolveIdentityAsync(clientConfig: null, cts.Token);
+                }
+                catch (OperationCanceledException ex)
+                {
+                    caughtEx = ex;
+                }
+                Assert.IsNotNull(caughtEx, "Expected OperationCanceledException or TaskCanceledException to be thrown.");
+            }
+
+            generatorCanProceed.Set();
+            await firstTask;
+        }
+
+        /// <summary>
+        /// Verifies that when a valid token is supplied and the generator completes before the
+        /// timeout, credentials are returned successfully.
+        /// </summary>
+        [TestMethod]
+        public void ResolveIdentity_WithNonExpiredToken_ReturnsCredentials()
+        {
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () => new BasicAWSCredentials("key", "secret")
+            };
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+            {
+                var resolver = new DefaultAWSCredentialsIdentityResolver();
+
+                var credentials = resolver.ResolveIdentity(clientConfig: null, cts.Token);
+
+                Assert.IsNotNull(credentials);
+                Assert.IsInstanceOfType(credentials, typeof(BasicAWSCredentials));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when a valid token is supplied and the generator completes before the
+        /// timeout, credentials are returned successfully via the async path.
+        /// </summary>
+        [TestMethod]
+        public async Task ResolveIdentityAsync_WithNonExpiredToken_ReturnsCredentials()
+        {
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () => new BasicAWSCredentials("key", "secret")
+            };
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+            {
+                var resolver = new DefaultAWSCredentialsIdentityResolver();
+
+                var credentials = await resolver.ResolveIdentityAsync(clientConfig: null, cts.Token);
+
+                Assert.IsNotNull(credentials);
+                Assert.IsInstanceOfType(credentials, typeof(BasicAWSCredentials));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that cached credentials are returned immediately even when a pre-cancelled
+        /// token is passed, since the fast path does not touch the semaphore.
+        /// </summary>
+        [TestMethod]
+        public void ResolveIdentity_CachedCredentials_PreCancelledToken_ReturnsCachedCredentials()
+        {
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () => new BasicAWSCredentials("key", "secret")
+            };
+
+            var resolver = new DefaultAWSCredentialsIdentityResolver();
+
+            // Warm the cache.
+            resolver.ResolveIdentity(clientConfig: null);
+
+            // A pre-cancelled token should still return cached credentials since the fast
+            // path returns before ever touching the semaphore.
+            using (var cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                var credentials = resolver.ResolveIdentity(clientConfig: null, cts.Token);
+                Assert.IsNotNull(credentials);
+                Assert.IsInstanceOfType(credentials, typeof(BasicAWSCredentials));
+            }
+        }
+    }
+}

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/ConcurrentCredentialResolutionTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/ConcurrentCredentialResolutionTests.cs
@@ -1,0 +1,223 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.Credentials;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AWSSDK.UnitTests
+{
+    /// <summary>
+    /// Tests that verify credential resolution under high concurrency
+    /// does not fail due to multiple threads simultaneously walking the
+    /// credential chain. This specifically tests the single-flight pattern
+    /// in <see cref="DefaultAWSCredentialsIdentityResolver"/> where only
+    /// one thread resolves credentials while others wait and reuse the result.
+    /// </summary>
+    [TestClass]
+    public class ConcurrentCredentialResolutionTests
+    {
+        private const string AWS_PROFILE_ENVIRONMENT_VARIABLE = "AWS_PROFILE";
+
+        private string _cachedContainersUriVariable;
+        private string _cachedProfileVariable;
+        private string _cachedAccessTokenVariable;
+        private string _cachedSecretKeyVariable;
+        private string _cachedSessionTokenVariable;
+        private List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator> _cachedGenerators;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _cachedContainersUriVariable = Environment.GetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable);
+            Environment.SetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable, null);
+
+            _cachedProfileVariable = Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
+            _cachedAccessTokenVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY);
+            _cachedSecretKeyVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY);
+            _cachedSessionTokenVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN);
+
+            _cachedGenerators = AWSConfigs.AWSCredentialsGenerators;
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Environment.SetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable, _cachedContainersUriVariable);
+            Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, _cachedProfileVariable);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, _cachedAccessTokenVariable);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, _cachedSecretKeyVariable);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN, _cachedSessionTokenVariable);
+
+            AWSConfigs.AWSCredentialsGenerators = _cachedGenerators;
+        }
+
+        /// <summary>
+        /// Simulates 64 concurrent credential resolution requests against a
+        /// slow credential provider (e.g., IMDS on EC2). Verifies that all
+        /// concurrent callers succeed and only one actually walks the chain.
+        /// This tests the fix for the issue where high concurrency on first use
+        /// would overwhelm the IMDS endpoint.
+        /// </summary>
+        [TestMethod]
+        public void ConcurrentSyncResolution_AllTasksSucceed_OnlyOneChainWalk()
+        {
+            const int concurrency = 64;
+            int generatorCallCount = 0;
+
+            // Simulate a slow credential provider (like IMDS) that takes some time
+            // to return. Only one invocation should go through; others should
+            // get the cached result.
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () =>
+                {
+                    Interlocked.Increment(ref generatorCallCount);
+                    // Simulate network latency of IMDS
+                    Thread.Sleep(100);
+                    return new BasicAWSCredentials("test-access-key", "test-secret-key");
+                }
+            };
+
+            var resolver = new DefaultAWSCredentialsIdentityResolver();
+            var tasks = new Task<AWSCredentials>[concurrency];
+            var barrier = new ManualResetEventSlim(false);
+
+            // Launch all tasks, have them wait at a barrier, then release simultaneously
+            for (int i = 0; i < concurrency; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    barrier.Wait();
+                    return resolver.ResolveIdentity(clientConfig: null);
+                });
+            }
+
+            // Release all threads simultaneously to maximize contention
+            barrier.Set();
+
+            Task.WaitAll(tasks);
+
+            // All tasks should have succeeded
+            for (int i = 0; i < concurrency; i++)
+            {
+                Assert.IsNotNull(tasks[i].Result, $"Task {i} returned null credentials");
+                Assert.IsInstanceOfType(tasks[i].Result, typeof(BasicAWSCredentials));
+            }
+
+            // The generator should have been called exactly once due to single-flight pattern
+            Assert.AreEqual(1, generatorCallCount,
+                $"Expected generator to be called exactly once, but it was called {generatorCallCount} times. " +
+                "This indicates the single-flight pattern is not working correctly.");
+        }
+
+        /// <summary>
+        /// Same as the sync test but exercises the async path via ResolveIdentityAsync,
+        /// which uses SemaphoreSlim.WaitAsync to avoid blocking thread pool threads.
+        /// </summary>
+        [TestMethod]
+        public async Task ConcurrentAsyncResolution_AllTasksSucceed_OnlyOneChainWalk()
+        {
+            const int concurrency = 64;
+            int generatorCallCount = 0;
+
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () =>
+                {
+                    Interlocked.Increment(ref generatorCallCount);
+                    Thread.Sleep(100);
+                    return new BasicAWSCredentials("test-access-key", "test-secret-key");
+                }
+            };
+
+            var resolver = new DefaultAWSCredentialsIdentityResolver();
+            var tasks = new Task<AWSCredentials>[concurrency];
+            var barrier = new TaskCompletionSource<bool>();
+
+            for (int i = 0; i < concurrency; i++)
+            {
+                tasks[i] = Task.Run(async () =>
+                {
+                    await barrier.Task.ConfigureAwait(false);
+                    return await resolver.ResolveIdentityAsync(clientConfig: null).ConfigureAwait(false);
+                });
+            }
+
+            // Release all tasks simultaneously
+            barrier.SetResult(true);
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            for (int i = 0; i < concurrency; i++)
+            {
+                Assert.IsNotNull(tasks[i].Result, $"Task {i} returned null credentials");
+                Assert.IsInstanceOfType(tasks[i].Result, typeof(BasicAWSCredentials));
+            }
+
+            Assert.AreEqual(1, generatorCallCount,
+                $"Expected generator to be called exactly once, but it was called {generatorCallCount} times.");
+        }
+
+        /// <summary>
+        /// Verifies that when the first concurrent credential resolution fails,
+        /// each subsequent caller that enters the lock also attempts resolution
+        /// (i.e. a failure is not cached). Then verifies that once credentials
+        /// succeed, the result is cached and the generator is not called again.
+        /// </summary>
+        [TestMethod]
+        public void ConcurrentResolution_FailureThenSuccess_RetriesCorrectly()
+        {
+            int generatorCallCount = 0;
+            bool shouldFail = true;
+
+            AWSConfigs.AWSCredentialsGenerators = new List<DefaultAWSCredentialsIdentityResolver.CredentialsGenerator>
+            {
+                () =>
+                {
+                    int count = Interlocked.Increment(ref generatorCallCount);
+                    if (shouldFail)
+                    {
+                        throw new InvalidOperationException("Simulated IMDS failure");
+                    }
+                    return new BasicAWSCredentials("test-access-key", "test-secret-key");
+                }
+            };
+
+            var resolver = new DefaultAWSCredentialsIdentityResolver();
+
+            // First resolution attempt should fail
+            Assert.ThrowsException<AmazonClientException>(() => resolver.ResolveIdentity(clientConfig: null));
+
+            // Fix the provider and try again - should succeed
+            shouldFail = false;
+            var credentials = resolver.ResolveIdentity(clientConfig: null);
+            Assert.IsNotNull(credentials);
+            Assert.IsInstanceOfType(credentials, typeof(BasicAWSCredentials));
+
+            // Third call should use cached credentials without calling the generator again
+            int callsBeforeThirdAttempt = generatorCallCount;
+            var cachedCredentials = resolver.ResolveIdentity(clientConfig: null);
+            Assert.IsNotNull(cachedCredentials);
+            Assert.AreEqual(callsBeforeThirdAttempt, generatorCallCount,
+                "Generator should not be called again when credentials are cached");
+        }
+    }
+}

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/ConcurrentCredentialResolutionTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/ConcurrentCredentialResolutionTests.cs
@@ -101,37 +101,38 @@ namespace AWSSDK.UnitTests
                     return new BasicAWSCredentials("test-access-key", "test-secret-key");
                 }
             };
-
-            var resolver = new DefaultAWSCredentialsIdentityResolver();
-            var tasks = new Task<AWSCredentials>[concurrency];
-            var barrier = new ManualResetEventSlim(false);
-
-            // Launch all tasks, have them wait at a barrier, then release simultaneously
-            for (int i = 0; i < concurrency; i++)
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
             {
-                tasks[i] = Task.Run(() =>
+                var tasks = new Task<AWSCredentials>[concurrency];
+                var barrier = new ManualResetEventSlim(false);
+
+                // Launch all tasks, have them wait at a barrier, then release simultaneously
+                for (int i = 0; i < concurrency; i++)
                 {
-                    barrier.Wait();
-                    return resolver.ResolveIdentity(clientConfig: null);
-                });
+                    tasks[i] = Task.Run(() =>
+                    {
+                        barrier.Wait();
+                        return resolver.ResolveIdentity(clientConfig: null);
+                    });
+                }
+
+                // Release all threads simultaneously to maximize contention
+                barrier.Set();
+
+                Task.WaitAll(tasks);
+
+                // All tasks should have succeeded
+                for (int i = 0; i < concurrency; i++)
+                {
+                    Assert.IsNotNull(tasks[i].Result, $"Task {i} returned null credentials");
+                    Assert.IsInstanceOfType(tasks[i].Result, typeof(BasicAWSCredentials));
+                }
+
+                // The generator should have been called exactly once due to single-flight pattern
+                Assert.AreEqual(1, generatorCallCount,
+                    $"Expected generator to be called exactly once, but it was called {generatorCallCount} times. " +
+                    "This indicates the single-flight pattern is not working correctly.");
             }
-
-            // Release all threads simultaneously to maximize contention
-            barrier.Set();
-
-            Task.WaitAll(tasks);
-
-            // All tasks should have succeeded
-            for (int i = 0; i < concurrency; i++)
-            {
-                Assert.IsNotNull(tasks[i].Result, $"Task {i} returned null credentials");
-                Assert.IsInstanceOfType(tasks[i].Result, typeof(BasicAWSCredentials));
-            }
-
-            // The generator should have been called exactly once due to single-flight pattern
-            Assert.AreEqual(1, generatorCallCount,
-                $"Expected generator to be called exactly once, but it was called {generatorCallCount} times. " +
-                "This indicates the single-flight pattern is not working correctly.");
         }
 
         /// <summary>
@@ -154,32 +155,34 @@ namespace AWSSDK.UnitTests
                 }
             };
 
-            var resolver = new DefaultAWSCredentialsIdentityResolver();
-            var tasks = new Task<AWSCredentials>[concurrency];
-            var barrier = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            for (int i = 0; i < concurrency; i++)
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
             {
-                tasks[i] = Task.Run(async () =>
+                var tasks = new Task<AWSCredentials>[concurrency];
+                var barrier = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                for (int i = 0; i < concurrency; i++)
                 {
-                    await barrier.Task.ConfigureAwait(false);
-                    return await resolver.ResolveIdentityAsync(clientConfig: null).ConfigureAwait(false);
-                });
+                    tasks[i] = Task.Run(async () =>
+                    {
+                        await barrier.Task.ConfigureAwait(false);
+                        return await resolver.ResolveIdentityAsync(clientConfig: null).ConfigureAwait(false);
+                    });
+                }
+
+                // Release all tasks simultaneously
+                barrier.SetResult(true);
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                for (int i = 0; i < concurrency; i++)
+                {
+                    Assert.IsNotNull(tasks[i].Result, $"Task {i} returned null credentials");
+                    Assert.IsInstanceOfType(tasks[i].Result, typeof(BasicAWSCredentials));
+                }
+
+                Assert.AreEqual(1, generatorCallCount,
+                    $"Expected generator to be called exactly once, but it was called {generatorCallCount} times."); 
             }
-
-            // Release all tasks simultaneously
-            barrier.SetResult(true);
-
-            await Task.WhenAll(tasks).ConfigureAwait(false);
-
-            for (int i = 0; i < concurrency; i++)
-            {
-                Assert.IsNotNull(tasks[i].Result, $"Task {i} returned null credentials");
-                Assert.IsInstanceOfType(tasks[i].Result, typeof(BasicAWSCredentials));
-            }
-
-            Assert.AreEqual(1, generatorCallCount,
-                $"Expected generator to be called exactly once, but it was called {generatorCallCount} times.");
         }
 
         /// <summary>
@@ -207,23 +210,24 @@ namespace AWSSDK.UnitTests
                 }
             };
 
-            var resolver = new DefaultAWSCredentialsIdentityResolver();
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                // First resolution attempt should fail
+                Assert.ThrowsException<AmazonClientException>(() => resolver.ResolveIdentity(clientConfig: null));
 
-            // First resolution attempt should fail
-            Assert.ThrowsException<AmazonClientException>(() => resolver.ResolveIdentity(clientConfig: null));
+                // Fix the provider and try again - should succeed
+                shouldFail = false;
+                var credentials = resolver.ResolveIdentity(clientConfig: null);
+                Assert.IsNotNull(credentials);
+                Assert.IsInstanceOfType(credentials, typeof(BasicAWSCredentials));
 
-            // Fix the provider and try again - should succeed
-            shouldFail = false;
-            var credentials = resolver.ResolveIdentity(clientConfig: null);
-            Assert.IsNotNull(credentials);
-            Assert.IsInstanceOfType(credentials, typeof(BasicAWSCredentials));
-
-            // Third call should use cached credentials without calling the generator again
-            int callsBeforeThirdAttempt = generatorCallCount;
-            var cachedCredentials = resolver.ResolveIdentity(clientConfig: null);
-            Assert.IsNotNull(cachedCredentials);
-            Assert.AreEqual(callsBeforeThirdAttempt, generatorCallCount,
-                "Generator should not be called again when credentials are cached");
+                // Third call should use cached credentials without calling the generator again
+                int callsBeforeThirdAttempt = generatorCallCount;
+                var cachedCredentials = resolver.ResolveIdentity(clientConfig: null);
+                Assert.IsNotNull(cachedCredentials);
+                Assert.AreEqual(callsBeforeThirdAttempt, generatorCallCount,
+                    "Generator should not be called again when credentials are cached"); 
+            }
         }
     }
 }

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/ConcurrentCredentialResolutionTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/ConcurrentCredentialResolutionTests.cs
@@ -46,15 +46,21 @@ namespace AWSSDK.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
+            // Cache the current values so they can be restored in TestCleanup.
             _cachedContainersUriVariable = Environment.GetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable);
-            Environment.SetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable, null);
-
             _cachedProfileVariable = Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
             _cachedAccessTokenVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY);
             _cachedSecretKeyVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY);
             _cachedSessionTokenVariable = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN);
-
             _cachedGenerators = AWSConfigs.AWSCredentialsGenerators;
+
+            // Clear all credential-related env vars so the resolver only uses the
+            // custom generator set via AWSConfigs.AWSCredentialsGenerators.
+            Environment.SetEnvironmentVariable(GenericContainerCredentials.RelativeURIEnvVariable, null);
+            Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN, null);
         }
 
         [TestCleanup]
@@ -150,7 +156,7 @@ namespace AWSSDK.UnitTests
 
             var resolver = new DefaultAWSCredentialsIdentityResolver();
             var tasks = new Task<AWSCredentials>[concurrency];
-            var barrier = new TaskCompletionSource<bool>();
+            var barrier = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             for (int i = 0; i < concurrency; i++)
             {
@@ -192,7 +198,7 @@ namespace AWSSDK.UnitTests
             {
                 () =>
                 {
-                    int count = Interlocked.Increment(ref generatorCallCount);
+                    Interlocked.Increment(ref generatorCallCount);
                     if (shouldFail)
                     {
                         throw new InvalidOperationException("Simulated IMDS failure");

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
@@ -82,13 +82,15 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         public void CredentialsAreReevaluatedWhenProfileChanges()
         {
-            var identityResolver = new DefaultAWSCredentialsIdentityResolver();
-            var initialIdentity = identityResolver.ResolveIdentity(clientConfig: null);
-            Assert.IsFalse(initialIdentity is DefaultInstanceProfileAWSCredentials);
+            using (var identityResolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var initialIdentity = identityResolver.ResolveIdentity(clientConfig: null);
+                Assert.IsFalse(initialIdentity is DefaultInstanceProfileAWSCredentials);
 
-            // Since the specified profile does not exist, the identity resolver will throw an exception.
-            Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "non-existent-profile");
-            Assert.ThrowsException<ProfileNotFoundException>(() => identityResolver.ResolveIdentity(clientConfig: null));
+                // Since the specified profile does not exist, the identity resolver will throw an exception.
+                Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, "non-existent-profile");
+                Assert.ThrowsException<ProfileNotFoundException>(() => identityResolver.ResolveIdentity(clientConfig: null));
+            }
         }
 
         /// <summary>
@@ -107,14 +109,16 @@ namespace AWSSDK.UnitTests
             Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, "foo");
             Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, "bar");
 
-            var identityResolver = new DefaultAWSCredentialsIdentityResolver();
-            var resolvedIdentity = identityResolver.ResolveIdentity(new AmazonS3Config
+            using (var identityResolver = new DefaultAWSCredentialsIdentityResolver())
             {
-                Profile = new Profile(profileName)
-            });
+                var resolvedIdentity = identityResolver.ResolveIdentity(new AmazonS3Config
+                {
+                    Profile = new Profile(profileName)
+                });
 
-            Assert.IsNotNull(resolvedIdentity);
-            Assert.IsTrue(resolvedIdentity is EnvironmentVariablesAWSCredentials);
+                Assert.IsNotNull(resolvedIdentity);
+                Assert.IsTrue(resolvedIdentity is EnvironmentVariablesAWSCredentials);
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed concurrent credential resolution failure in `DefaultAWSCredentialsIdentityResolver` by replacing the `ReaderWriterLockSlim` with a `SemaphoreSlim(1,1)` single-flight pattern. The key changes in `DefaultAWSCredentialsIdentityResolver.cs`:

1. **Replaced `ReaderWriterLockSlim` with `SemaphoreSlim(1,1)`** — `SemaphoreSlim` supports both synchronous `Wait()` and asynchronous `WaitAsync()`, preventing thread pool starvation when 64+ async tasks contend simultaneously.

2. **Made `_cachedCredentials` volatile** (this is key) — enables a lock-free fast path where concurrent callers can read cached credentials without acquiring the semaphore. This allows the _cachedCredentials to be updated by any thread and then when read by all other threads it forces the new cached credentials to be read.

3. **Added truly async `ResolveIdentityAsync`/`InternalGetCredentialsAsync`** — the previous implementation wrapped the sync method with `Task.FromResult`, causing all concurrent async callers to block thread pool threads. The new async path uses `SemaphoreSlim.WaitAsync()` so waiting tasks yield their threads back to the pool.

4. **Extracted `ResolveCredentialChain()` and `TryGetCachedCredentials()`** — shared logic between sync and async paths with a double-check pattern: first check cache without lock, then acquire semaphore and re-check before walking the chain.

5. **Added `ConcurrentCredentialResolutionTests.cs`** with 3 tests: sync 64-concurrency (verifies single chain walk), async 64-concurrency (verifies async path), and failure-then-retry (verifies failures aren't cached). All 3 new tests plus all 5 existing `DefaultCredentialsResolverTests` pass.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

**Root cause:** The credential resolution in `DefaultAWSCredentialsIdentityResolver` (`sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs`) is invoked per-request in the pipeline via `BaseAuthResolverHandler.PreInvokeAsync()` (`sdk/src/Core/Amazon.Runtime/Pipeline/Handlers/BaseAuthResolverHandler.cs`). When many concurrent requests are made before credentials have been cached, each request independently walks the credential chain and attempts to call `DefaultInstanceProfileAWSCredentials.Instance.GetCredentials()` (`sdk/src/Core/Amazon.Runtime/Credentials/DefaultInstanceProfileAWSCredentials.cs`).

While `DefaultInstanceProfileAWSCredentials` uses a `SemaphoreSlim(1,1)` to serialize IMDS access, the issue is that `DefaultAWSCredentialsIdentityResolver.InternalGetCredentials()` (line ~216) wraps the IMDS call in a try/catch and converts failures to `InvalidOperationException("Failed to connect to EC2 instance metadata to retrieve credentials")`. Under high concurrency, the IMDS endpoint (169.254.169.254) becomes overwhelmed with simultaneous HTTP requests from the credential chain probing (environment variables → web identity → profile → IMDS), causing timeouts that propagate as credential resolution failures.
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added Unit Tests
### Dry-runs

<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 2797b819-c62a-457a-9abe-113ec4cbf2bd
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**8ed357ee-c4af-492a-98ab-08aefec2f1d0
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed

NEW REVISION

<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 12f8fb02-e7a3-4c2f-8cef-95121759f82
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**f0310498-2077-4630-8e4c-a0ce2807a16f
  - [] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

DefaultAWSCredentialsIdentityResolver.cs implements IDisposable now, because it utilizes a semaphoreslim, which must be disposed of. This is an acceptable breaking change because most users are just using the static `GetCredentials / GetCredentialsAsync`

1. Identify all breaking changes including the following details:
    * What functionality was changed? Now only one thread will walk the credential chain while the other threads wait. Once credentials are resolved, the other threads can read the cached credentials. This will eliminate the possibility of overwhelming IMDS on the initial call with 64+ threads.
    * How will this impact customers? Allows for higher concurrency and less threadpool starvation in multi-threaded environments.
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * 
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
