### PR TITLE
Fix: Throw NoSuchLifecycleConfiguration when GetLifecycleConfiguration returns empty response

### DIFF
--- a/generator/.DevConfigs/b033c7b4-3e39-47c3-8560-47a30e54ec12.json
+++ b/generator/.DevConfigs/b033c7b4-3e39-47c3-8560-47a30e54ec12.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "serviceName": "S3",
+            "type": "patch",
+            "changeLogMessages": [
+                "Fixed GetLifecycleConfiguration to throw AmazonS3Exception with NoSuchLifecycleConfiguration error code when the bucket has no lifecycle configuration. In V4, S3 returns HTTP 200 with an empty body (due to region-specific endpoints) instead of HTTP 404, causing the SDK to silently return an empty response. The fix detects the empty response and throws the documented error to match the S3 API contract."
+            ]
+        }
+    ]
+}

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetLifecycleConfigurationResponseUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetLifecycleConfigurationResponseUnmarshaller.cs
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using System.Net;
+using Amazon.Runtime.Internal.Transform;
+using Amazon.S3.Util;
+
+namespace Amazon.S3.Model.Internal.MarshallTransformations
+{
+    /// <summary>
+    /// Custom response unmarshaller for GetLifecycleConfiguration operation.
+    /// Handles the case where S3 returns an HTTP 200 with an empty body when
+    /// no lifecycle configuration exists on the bucket. In this case, we throw
+    /// an AmazonS3Exception with the NoSuchLifecycleConfiguration error code
+    /// to match the documented S3 API behavior.
+    /// See: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html
+    /// </summary>
+    public partial class GetLifecycleConfigurationResponseUnmarshaller
+    {
+        partial void PostUnmarshallCustomization(XmlUnmarshallerContext context, GetLifecycleConfigurationResponse response)
+        {
+            // When S3 returns an HTTP 200 with an empty body (no lifecycle configuration),
+            // the Configuration property will not have been set by the unmarshaller.
+            // The S3 API documentation states that NoSuchLifecycleConfiguration (HTTP 404)
+            // should be returned when no lifecycle configuration exists:
+            // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html
+            if (context.IsEmptyResponse && !response.IsSetConfiguration())
+            {
+                throw new AmazonS3Exception("The lifecycle configuration does not exist")
+                {
+                    ErrorCode = S3Constants.NoSuchLifecycleConfiguration,
+                    StatusCode = HttpStatusCode.NotFound
+                };
+            }
+        }
+    }
+}

--- a/sdk/test/Services/S3/UnitTests/Custom/LifecycleConfigurationTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/LifecycleConfigurationTests.cs
@@ -32,6 +32,8 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using AWSSDK.UnitTests.TestTools;
+using System.Net;
+
 namespace AWSSDK.UnitTests
 {
     /// <summary>
@@ -126,6 +128,76 @@ namespace AWSSDK.UnitTests
                 return context;
             }
         }
+        /// <summary>
+        /// When S3 returns an HTTP 200 with an empty body  (no lifecycle configuration exists), the 
+        // SDK should throw an AmazonS3Exception with NoSuchLifecycleConfiguration error code, matching 
+        // V3 behavior.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("S3")]
+        public void GetLifecycleConfiguration_EmptyResponse_ThrowsNoSuchLifecycleConfiguration()
+        {
+            // Simulate an HTTP 200 response with empty body (Content-Length: 0)
+            // This is what S3 returns in V4 when no lifecycle configuration exists
+            var responseData = new WebResponseData
+            {
+                StatusCode = HttpStatusCode.OK,
+                IsSuccessStatusCode = true,
+                Headers = new Dictionary<string, string>
+                {
+                    { "x-amzn-RequestId", "test-request-id" },
+                    { "Content-Length", "0" }
+                },
+                ContentLength = 0
+            };
+
+            var context = new S3UnmarshallerContext(new MemoryStream(), false, responseData, false);
+            var exception = Assert.ThrowsException<AmazonS3Exception>(() =>
+            {
+                GetLifecycleConfigurationResponseUnmarshaller.Instance.Unmarshall(context);
+            });
+
+            Assert.AreEqual("NoSuchLifecycleConfiguration", exception.ErrorCode);
+            Assert.AreEqual(HttpStatusCode.NotFound, exception.StatusCode);
+        }
+
+        /// <summary>
+        /// Verifies that a valid lifecycle configuration response is still unmarshalled correctly.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("S3")]
+        public void GetLifecycleConfiguration_ValidResponse_ReturnsConfiguration()
+        {
+            var xmlContent = @"<LifecycleConfiguration>
+                <Rule>
+                    <ID>test-rule</ID>
+                    <Filter><Prefix>logs/</Prefix></Filter>
+                    <Expiration><Days>30</Days></Expiration>
+                </Rule>
+            </LifecycleConfiguration>";
+
+            var buffer = Encoding.UTF8.GetBytes(xmlContent);
+            var responseData = new WebResponseData
+            {
+                StatusCode = HttpStatusCode.OK,
+                IsSuccessStatusCode = true,
+                Headers = new Dictionary<string, string>
+                {
+                    { "x-amzn-RequestId", "test-request-id" },
+                    { "Content-Length", buffer.Length.ToString() }
+                },
+                ContentLength = buffer.Length
+            };
+
+            var context = new S3UnmarshallerContext(new MemoryStream(buffer), false, responseData, false);
+            var response = (GetLifecycleConfigurationResponse)GetLifecycleConfigurationResponseUnmarshaller.Instance.Unmarshall(context);
+
+            Assert.IsNotNull(response.Configuration);
+            Assert.IsNotNull(response.Configuration.Rules);
+            Assert.AreEqual(1, response.Configuration.Rules.Count);
+            Assert.AreEqual("test-rule", response.Configuration.Rules[0].Id);
+        }
+
         [TestMethod]
         public void TestPutLifecycleConfiguration()
         {


### PR DESCRIPTION
## Description

Added a `PostUnmarshallCustomization` implementation for `GetLifecycleConfigurationResponseUnmarshaller` that detects when S3 returns an HTTP 200 with an empty body (indicating no lifecycle configuration exists on the bucket) and throws an `AmazonS3Exception` with error code `NoSuchLifecycleConfiguration` and HTTP status 404.

In V4, S3 returns HTTP 200 OK with an empty body when using region-specific endpoints (`s3.us-east-1.amazonaws.com`) for buckets with no lifecycle configuration. Previously in V3, S3 returned HTTP 404 for the same scenario (using the global endpoint `s3.amazonaws.com`). This change in S3 service behavior caused the SDK's existing `Suppress404Exceptions` mechanism to never trigger, silently returning an empty response instead of signaling the missing configuration.

The fix checks `context.IsEmptyResponse` and `!response.IsSetConfiguration()` in the `PostUnmarshallCustomization` hook. When both conditions are true, it throws `AmazonS3Exception` with `NoSuchLifecycleConfiguration`, matching the [documented S3 API behavior](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html).

### Files Changed
- **NEW**: `sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/GetLifecycleConfigurationResponseUnmarshaller.cs`
- **MODIFIED**: `sdk/test/Services/S3/UnitTests/Custom/LifecycleConfigurationTests.cs` (2 new tests added)

## Motivation and Context

Fixes https://github.com/aws/aws-sdk-net/issues/4329

When customers upgrade from V3 to V4, calling `GetLifecycleConfiguration` on a bucket with no lifecycle rules no longer signals the absence of configuration. In V4:
- `HttpStatusCode` is `OK` (200) instead of `NotFound` (404)
- `Configuration.Rules` is `null` instead of an empty list (due to `InitializeCollections` defaulting to `false`)
- No exception is thrown

This breaks customer code that relied on checking `HttpStatusCode == NotFound`, accessing `Rules.Count` (now throws `NullReferenceException`), or catching `AmazonS3Exception`.

The S3 API documentation explicitly states that `NoSuchLifecycleConfiguration` (HTTP 404) should be returned when no lifecycle configuration exists.

### Behavior Comparison

| Aspect | V3 (3.7.510.4) | V4 Bug (4.0.17.2) | V4 Fixed |
|--------|----------------|-------------------|----------|
| S3 HTTP Response | 404 | 200 (empty body) | 200 (empty body) |
| Exception thrown? | No (suppressed) | No | **Yes** (`AmazonS3Exception`) |
| ErrorCode | N/A | N/A | `NoSuchLifecycleConfiguration` |
| HttpStatusCode | NotFound (404) | OK (200) | NotFound (404) |
| Configuration.Rules | Empty list `[]` | `null` | N/A (exception) |
| User code breaks? | No | **Yes** | No |

## Testing

### Unit Tests
Added 2 new unit tests to `LifecycleConfigurationTests.cs`:

1. **`GetLifecycleConfiguration_EmptyResponse_ThrowsNoSuchLifecycleConfiguration`**: Simulates HTTP 200 with empty body (Content-Length: 0). Verifies `AmazonS3Exception` is thrown with `ErrorCode = "NoSuchLifecycleConfiguration"` and `StatusCode = HttpStatusCode.NotFound`.

2. **`GetLifecycleConfiguration_ValidResponse_ReturnsConfiguration`**: Simulates HTTP 200 with valid lifecycle XML. Verifies the response is correctly unmarshalled with `Configuration.Rules.Count == 1`.

### Test Results
All 12 lifecycle-related tests pass (2 new + 10 existing):
```
Passed GetLifecycleConfiguration_EmptyResponse_ThrowsNoSuchLifecycleConfiguration [16 ms]
Passed GetLifecycleConfiguration_ValidResponse_ReturnsConfiguration [113 ms]
Passed TestPutLifecycleConfiguration [49 ms]
Passed MarshallRequestNullPredicate [< 1 ms]
Passed MarshallRequestNullPrefix [< 1 ms]
Passed MarshallRequestEmptyPrefix [< 1 ms]
Passed MarshallRequestNullTag [< 1 ms]
Passed MarshallRequestNullTagKeyAndValue [< 1 ms]
Passed MarshallRequestEmptyTagKeyAndValue [< 1 ms]
Passed MarshallRequestNullAndOperands [< 1 ms]
Passed MarshallRequestEmptyAndOperands [< 1 ms]
Passed MarshallRequestNullAndOperand [< 1 ms]

Test Run Successful. Total tests: 12, Passed: 12
```

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. **What functionality was changed?**
    `GetLifecycleConfiguration` now throws `AmazonS3Exception` with `NoSuchLifecycleConfiguration` error code when the bucket has no lifecycle configuration, instead of silently returning an empty response.

    **How will this impact customers?**
    * Customers who were catching `AmazonS3Exception` will now correctly receive the exception (positive impact)
    * Customers who were checking `response.Configuration.Rules == null` or `response.HttpStatusCode == OK` to detect missing lifecycle config will need to add a try/catch instead
    * Note: V3 also did not throw (it suppressed the 404), so this is technically a new behavior that matches the documented S3 API contract

    **Why does this need to be a breaking change?**
    The current V4 behavior is broken — `Configuration.Rules` is `null`, causing `NullReferenceException` for customers accessing `Rules.Count`. The fix aligns with the [documented S3 API behavior](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html) which specifies `NoSuchLifecycleConfiguration` as a special error for this operation.

    Non-breaking alternative: Return a response with `HttpStatusCode = NotFound` and empty `Configuration` (matching V3 behavior). However, this would not match the documented API contract.

2. Has a senior/+ engineer been assigned to review this PR?

    - [ ] Yes

## Screenshots (if appropriate)

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
