### PR TITLE
Fix issue with unexpected exceptions when disposing event stream responses

### DIFF
--- a/generator/.DevConfigs/4e632d80-3442-433f-9ffd-6d506095bfdb.json
+++ b/generator/.DevConfigs/4e632d80-3442-433f-9ffd-6d506095bfdb.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fix issue with unexpected exceptions when disposing event stream responses"
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EnumerableEventOutputStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EnumerableEventOutputStream.cs
@@ -194,6 +194,9 @@ namespace Amazon.Runtime.EventStreams.Internal
                     catch (Exception ex)
                     {
                         IsProcessing = false;
+                        if (IsDisposed) 
+                            yield break;
+
                         Dispose();
 
                         // Wrap exceptions as needed to match event-driven behavior.

--- a/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EnumerableEventOutputStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EnumerableEventOutputStream.cs
@@ -133,6 +133,9 @@ namespace Amazon.Runtime.EventStreams.Internal
                     catch (Exception ex)
                     {
                         IsProcessing = false;
+                        if (IsDisposed)
+                            yield break;
+
                         Dispose();
 
                         // Wrap exceptions as needed to match event-driven behavior.

--- a/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EventOutputStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EventOutputStream.cs
@@ -272,6 +272,9 @@ namespace Amazon.Runtime.EventStreams.Internal
             // These exceptions are raised on the background thread. They are fired as events for visibility.
             catch (Exception ex)
             {
+                if (IsDisposed)
+                    return;
+
                 IsProcessing = false;
 
                 // surfaceException means what is surfaced to the user. For example, in S3Select, that would be a S3EventStreamException.
@@ -317,19 +320,30 @@ namespace Amazon.Runtime.EventStreams.Internal
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         protected async Task ReadFromStreamAsync(byte[] buffer, CancellationToken cancellationToken)
         {
-#if NETCOREAPP
-            var bytesRead = await NetworkStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-#else
-            var bytesRead = await NetworkStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
-#endif
-            if (bytesRead > 0)
+            try
             {
-                // Decoder raises MessageReceived for every message it encounters.
-                Decoder.ProcessData(buffer, 0, bytesRead);
+#if NETCOREAPP
+                var bytesRead = await NetworkStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+#else
+                var bytesRead = await NetworkStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+#endif
+                if (bytesRead > 0)
+                {
+                    // Decoder raises MessageReceived for every message it encounters.
+                    Decoder.ProcessData(buffer, 0, bytesRead);
+                }
+                else
+                {
+                    IsProcessing = false;
+                }
             }
-            else
+            catch
             {
                 IsProcessing = false;
+                if (IsDisposed)
+                    return;
+
+                throw;
             }
         }
 
@@ -384,7 +398,9 @@ namespace Amazon.Runtime.EventStreams.Internal
         }
 
         #region Dispose Pattern
-        private bool _disposed;
+        private volatile bool _disposed;
+
+        protected bool IsDisposed => _disposed;
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EventOutputStream.cs
+++ b/sdk/src/Core/Amazon.Runtime/EventStreams/Internal/EventOutputStream.cs
@@ -417,16 +417,18 @@ namespace Amazon.Runtime.EventStreams.Internal
         /// <param name="disposing">Should dispose of unmanged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (_disposed) return;
+            if (_disposed) 
+                return;
+
             if (disposing)
             {
+                _disposed = true;
+
                 IsProcessing = false;
 
                 NetworkStream?.Dispose();
                 Decoder?.Dispose();
             }
-
-            _disposed = true;
         }
 
         #endregion


### PR DESCRIPTION
## Description
When you have an event stream response object the way to stop the event stream is to dispose of the stream. The trouble is there are background process for the events that can trigger exceptions when the HTTP connection is shutdown as part of the dispose. This PR adds check in the processing loops whether callback or async enumerable and will ignore any exceptions that are triggered if it finds out the stream is disposed so the caller won't be expected to handle them.

## Testing
Ran test app to confirm no unexpected exceptions were thrown.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

