### PR TITLE
Update xml docs on GetCredentials / GetCredentialsAsync on RefreshingAWSCredentials

### DIFF
--- a/generator/.DevConfigs/1afdb220-9b45-4bab-a1bb-54599ac3a1fe.json
+++ b/generator/.DevConfigs/1afdb220-9b45-4bab-a1bb-54599ac3a1fe.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Update docs on RefreshingAWSCredentials."
+    ]
+  }
+}

--- a/generator/.DevConfigs/1afdb220-9b45-4bab-a1bb-54599ac3a1fe.json
+++ b/generator/.DevConfigs/1afdb220-9b45-4bab-a1bb-54599ac3a1fe.json
@@ -1,6 +1,6 @@
 {
   "core": {
-    "updateMinimum": true,
+    "updateMinimum": false,
     "type": "patch",
     "changeLogMessages": [
       "Update docs on GetCredentials and GetCredentialsAsync to clarify background refresh behavior"

--- a/generator/.DevConfigs/1afdb220-9b45-4bab-a1bb-54599ac3a1fe.json
+++ b/generator/.DevConfigs/1afdb220-9b45-4bab-a1bb-54599ac3a1fe.json
@@ -3,7 +3,7 @@
     "updateMinimum": true,
     "type": "patch",
     "changeLogMessages": [
-      "Update docs on RefreshingAWSCredentials."
+      "Update docs on GetCredentials and GetCredentialsAsync to clarify background refresh behavior"
     ]
   }
 }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -35,7 +35,12 @@ namespace Amazon.Runtime
         protected RefreshingAWSCredentials(ITimeProvider timeProvider) 
             => _timeProvider = timeProvider ?? DefaultTimeProvider.Instance;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Expiration may be updated if credentials are updated during a background credential refresh. 
+        /// A background credential refresh can happen if the credentials are in the preempt expiry window.
+        /// Always call <see cref="GetCredentialsAsync"/> before reading Expiration to ensure the updated 
+        /// Expiration value is read.
+        /// </summary>
         public override DateTime? Expiration
         {
             get

--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -35,12 +35,7 @@ namespace Amazon.Runtime
         protected RefreshingAWSCredentials(ITimeProvider timeProvider) 
             => _timeProvider = timeProvider ?? DefaultTimeProvider.Instance;
 
-        /// <summary>
-        /// Expiration may be updated if credentials are updated during a background credential refresh. 
-        /// A background credential refresh can happen if the credentials are in the preempt expiry window.
-        /// Always call <see cref="GetCredentialsAsync"/> before reading Expiration to ensure the updated 
-        /// Expiration value is read.
-        /// </summary>
+        /// <inheritdoc/>
         public override DateTime? Expiration
         {
             get
@@ -165,9 +160,12 @@ namespace Amazon.Runtime
         #region Override methods
 
         /// <summary>
-        /// Returns an instance of ImmutableCredentials for this instance
+        /// GetCredentials may refresh credentials if the credentials are in the pre-empt expiration window. This will trigger
+        /// a background refresh of the credentials and could force an update to the credentials and to the expiration. Users should
+        /// not rely on the <see cref="Expiration"/> property before calling <see cref="GetCredentials"/> because the <see cref="Expiration"/>
+        /// could be updated.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>An instance of ImmutableCredentials</returns>
         public override sealed ImmutableCredentials GetCredentials()
         {
             // We save the currentState as it might be modified or cleared.
@@ -233,6 +231,13 @@ namespace Amazon.Runtime
             return tempState.Credentials;
         }
 
+        /// <summary>
+        /// GetCredentialsAsync may refresh credentials if the credentials are in the pre-empt expiration window. This will trigger
+        /// a background refresh of the credentials and could force an update to the credentials and to the expiration. Users should
+        /// not rely on the <see cref="Expiration"/> property before calling <see cref="GetCredentialsAsync"/> because the <see cref="Expiration"/>
+        /// could be updated.
+        /// </summary>
+        /// <returns>A task whose result is an ImmutableCredentials instance.</returns>
         public override sealed async Task<ImmutableCredentials> GetCredentialsAsync()
         {
             // NOTICE: Before modifying any of the logic read the comments in the synchronous GetCredentials method to 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates the Expiration property to call out that `GetCredentialsAsync()` should be called before reading this property since a background credential refresh may happen
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**cd532743-b51a-4f28-a105-db956fd41396
  - [] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**c74ca0c6-ce07-47fa-8f6b-2e6853b23e7d
  - [] Pending
  - [x] Completed successfully
  - [ ] Failed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement