### PR TITLE
Fix adaptive retry to adjust client send rate when retries are disabled.

### DIFF
--- a/generator/.DevConfigs/3a8fe54f-c1c4-4ec8-951e-e7297583134e.json
+++ b/generator/.DevConfigs/3a8fe54f-c1c4-4ec8-951e-e7297583134e.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Fixed adaptive retry mode to adjust client send rate when retries are disabled."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/AdaptiveRetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/AdaptiveRetryPolicy.cs
@@ -59,9 +59,20 @@ namespace Amazon.Runtime.Internal
         /// <returns>True if retry throttling is disabled or retry throttling is enabled and capacity can be obtained.</returns>
         public override bool OnRetry(IExecutionContext executionContext, bool bypassAcquireCapacity, bool isThrottlingError)        
         {
-            TokenBucket.UpdateClientSendingRate(isThrottlingError);
-
             return base.OnRetry(executionContext, bypassAcquireCapacity, isThrottlingError);
+        }
+
+        /// <summary>
+        /// Called for every error response, regardless of whether the request will be retried.
+        /// Updates the client sending rate based on whether the error was a throttling error,
+        /// ensuring the token bucket rate is adjusted even when retries are disabled.
+        /// </summary>
+        /// <param name="executionContext">The execution context which contains both the
+        /// requests and response context.</param>
+        /// <param name="exception">The exception from the failed request.</param>
+        public override void NotifyError(IExecutionContext executionContext, Exception exception)
+        {
+            TokenBucket.UpdateClientSendingRate(IsThrottlingError(exception));
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryHandler.cs
@@ -111,6 +111,12 @@ namespace Amazon.Runtime.Internal
                         continue;
                     }
                     
+                    // Notify the retry policy of the error so it can update its rate limiting
+                    // state (e.g. adaptive retry token bucket). This must be called for every
+                    // error, regardless of whether the request will be retried, to ensure the
+                    // client send rate is adjusted even when retries are disabled.
+                    this.RetryPolicy.NotifyError(executionContext, exception);
+
                     // Standard retry logic
                     shouldRetry = this.RetryPolicy.Retry(executionContext, exception);
                     if (!shouldRetry)
@@ -199,6 +205,12 @@ namespace Amazon.Runtime.Internal
                         continue;
                     }
                     
+                    // Notify the retry policy of the error so it can update its rate limiting
+                    // state (e.g. adaptive retry token bucket). This must be called for every
+                    // error, regardless of whether the request will be retried, to ensure the
+                    // client send rate is adjusted even when retries are disabled.
+                    this.RetryPolicy.NotifyError(executionContext, capturedException.SourceException);
+
                     // Standard retry logic
                     shouldRetry = await this.RetryPolicy.RetryAsync(executionContext, capturedException.SourceException).ConfigureAwait(false);
                     if (!shouldRetry)

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
@@ -194,6 +194,17 @@ namespace Amazon.Runtime
         public virtual void NotifySuccess(IExecutionContext executionContext)
         {    
         }
+
+        /// <summary>
+        /// Virtual method that gets called when a request results in an error.
+        /// This is called for every error, regardless of whether the request will be retried.
+        /// </summary>
+        /// <param name="executionContext">The execution context which contains both the
+        /// requests and response context.</param>
+        /// <param name="exception">The exception from the failed request.</param>
+        public virtual void NotifyError(IExecutionContext executionContext, Exception exception)
+        {
+        }
         
         /// <summary>
          /// Virtual method that gets called before a retry request is initiated. The value 

--- a/sdk/test/UnitTests/Custom/Runtime/RetryHandlerAdaptiveModeTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RetryHandlerAdaptiveModeTests.cs
@@ -351,6 +351,45 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         [TestCategory("UnitTest")]
         [TestCategory("Runtime")]
+        public void VerifyClientSendRateAdjustedWhenRetriesDisabled()
+        {
+            var config = CreateConfig();
+            config.MaxErrorRetry = 0;
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            // Throw a throttling error - even with no retries, the token bucket 
+                            // should still have its rate updated.
+                            throw new AmazonServiceException("Mocked throttling exception", new WebException(), ErrorType.Receiver, "TooManyRequestsException", "TestRequestId", (HttpStatusCode)429);
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked throttling exception", exception.Message);
+
+                // Verify no retries were made
+                Assert.AreEqual(0, executionContext.RequestContext.Retries);
+                Assert.AreEqual(1, Tester.CallCount);
+
+                // Even though retries are disabled, the token bucket should have been enabled by the throttling error.
+                Assert.IsTrue(retryPolicy.TokenBucketInstance.IsTokenBucketEnabled);
+            }, config);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
         public void VerifyCUBICCalculations()
         {
             var expectedRates = new double[] { 7.0, 9.64893600966, 10.000030849917364, 
@@ -431,6 +470,7 @@ namespace AWSSDK.UnitTests
         {
             _exponentialBase = 1;
             _exponentialPower = 2;
+            TokenBucket = new MockedTokenBucket();
         }
 
         public static void SetCapacityManagerInstance(CapacityManager capacityManager)
@@ -551,5 +591,11 @@ namespace AWSSDK.UnitTests
         {
             CurrentCapacity = 0;
         }
+
+        /// <summary>
+        /// Exposes the protected Enabled property so tests can verify 
+        /// token bucket state after throttling errors.
+        /// </summary>
+        public bool IsTokenBucketEnabled => Enabled;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using adaptive retry mode with retries disabled, the SDK was not updating the token bucket's client send rate upon receiving throttling errors. This was because `UpdateClientSendingRate` was only called inside `AdaptiveRetryPolicy.OnRetry()`, which is only invoked when a retry is actually attempted. When `MaxRetries=0`, the retry path is never reached, so the rate limiting algorithm never received throttling error signals.

Added a `NotifyError` method to `RetryPolicy` (overridden in `AdaptiveRetryPolicy`) that calls `TokenBucket.UpdateClientSendingRate` for every error. The `RetryHandler` now invokes this in both sync and async paths before the retry decision. 
Previously, `UpdateClientSendingRate` was only called inside OnRetry, which is never reached when retries were disabled.

## Motivation and Context
`DOTNET-8580`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
- All 12 existing `RetryHandlerAdaptiveModeTests` pass.
- Added `VerifyClientSendRateAdjustedWhenRetriesDisabled` test which configures MaxErrorRetry=0, triggers a throttling error, and asserts the token bucket is enabled despite no retries occurring.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** f1f4fc8e-bb96-4144-9c78-e61de4c63280
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 3a968968-17a9-41c5-afc4-30f72e422368
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

