### PR TITLE
Implements the updated Retry Behavior behind a feature flag

### DIFF
--- a/generator/.DevConfigs/94c889f3-af3a-4d8f-940a-0205846afe42.json
+++ b/generator/.DevConfigs/94c889f3-af3a-4d8f-940a-0205846afe42.json
@@ -1,0 +1,26 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Implements the updated Retry Behavior behind a feature flag (AWS_NEW_RETRIES_2026)."
+    ],
+    "type": "minor",
+    "updateMinimum": true,
+    "backwardIncompatibilitiesToIgnore": []
+  },
+  "services": [
+    {
+      "serviceName": "DynamoDBv2",
+      "type": "patch",
+      "changeLogMessages": [
+        "Remove max-retries from DynamoDB service and depend on values applied in the `AWSSDK.Core` package."
+      ]
+    },
+    {
+      "serviceName": "DynamoDBStreams",
+      "type": "patch",
+      "changeLogMessages": [
+        "Remove max-retries from DynamoDB Streams service and depend on values applied in the `AWSSDK.Core` package."
+      ]
+    }
+  ]
+}

--- a/generator/ServiceModels/dynamodb/metadata.json
+++ b/generator/ServiceModels/dynamodb/metadata.json
@@ -1,6 +1,5 @@
 {
   "active": true,
-  "max-retries": 10,
   "namespace": "Amazon.DynamoDBv2",
   "synopsis": "Amazon DynamoDB is a fast and flexible NoSQL database service for all applications that need consistent, single-digit millisecond latency at any scale.",
   "legacy-service-id": "DynamoDB"

--- a/generator/ServiceModels/streams.dynamodb/metadata.json
+++ b/generator/ServiceModels/streams.dynamodb/metadata.json
@@ -1,6 +1,5 @@
 {
   "active": true,
-  "max-retries": 10,
   "legacy-service-id": "DynamoDB Streams",
   "generate-client-constructors": true,
   "synopsis": "Amazon DynamoDB Streams captures a time-ordered sequence of item-level modifications in any DynamoDB table and stores this information in a log for up to 24 hours."

--- a/sdk/src/Core/Amazon.Runtime/CapacityManager.cs
+++ b/sdk/src/Core/Amazon.Runtime/CapacityManager.cs
@@ -41,7 +41,12 @@ namespace Amazon.Runtime.Internal
             /// <summary>
             /// The timeout capacity type uses the timeout capacity amount.
             /// </summary>
-            Timeout
+            Timeout,
+            /// <summary>
+            /// The throttling capacity type uses the throttling retry cost amount.
+            /// Used when the new retry behavior (SEP 2.1) is enabled.
+            /// </summary>
+            Throttling
         }
 
 
@@ -63,17 +68,46 @@ namespace Amazon.Runtime.Internal
             }
         }
 
-        public CapacityManager(int throttleRetryCount, int throttleRetryCost, int throttleCost) 
-            : this(throttleRetryCount, throttleRetryCost, throttleCost, throttleRetryCost)
-        {    
+        /// <summary>
+        /// Constructor for CapacityManager.
+        /// </summary>
+        /// <param name="throttleRetryCount">The initial and maximum number of retry tokens.</param>
+        /// <param name="throttleRetryCost">The cost of a retry.</param>
+        /// <param name="throttleCost">The capacity to add on a successful non-retry request.</param>
+        [Obsolete("Use the constructor with explicit parameter names (initialRetryTokens, retryCost, noRetryIncrement, timeoutRetryCost, throttlingRetryCost) instead.")]
+        public CapacityManager(int throttleRetryCount, int throttleRetryCost, int throttleCost)
+            : this(throttleRetryCount, throttleRetryCost, throttleCost, throttleRetryCost, 0)
+        {
         }
 
+        /// <summary>
+        /// Constructor for CapacityManager.
+        /// </summary>
+        /// <param name="throttleRetryCount">The initial and maximum number of retry tokens.</param>
+        /// <param name="throttleRetryCost">The cost of a retry.</param>
+        /// <param name="throttleCost">The capacity to add on a successful non-retry request.</param>
+        /// <param name="timeoutRetryCost">The cost of a timeout retry.</param>
+        [Obsolete("Use the constructor with explicit parameter names (initialRetryTokens, retryCost, noRetryIncrement, timeoutRetryCost, throttlingRetryCost) instead.")]
         public CapacityManager(int throttleRetryCount, int throttleRetryCost, int throttleCost, int timeoutRetryCost)
+            : this(throttleRetryCount, throttleRetryCost, throttleCost, timeoutRetryCost, 0)
         {
-            retryCost = throttleRetryCost;
-            initialRetryTokens = throttleRetryCount;
-            noRetryIncrement = throttleCost;
+        }
+
+        /// <summary>
+        /// Constructor for CapacityManager.
+        /// </summary>
+        /// <param name="initialRetryTokens">The initial and maximum number of retry tokens.</param>
+        /// <param name="retryCost">The cost of a non-throttling retry.</param>
+        /// <param name="noRetryIncrement">The capacity to add on a successful non-retry request.</param>
+        /// <param name="timeoutRetryCost">The cost of a timeout retry.</param>
+        /// <param name="throttlingRetryCost">The cost of a throttling retry (0 if not applicable).</param>
+        public CapacityManager(int initialRetryTokens, int retryCost, int noRetryIncrement, int timeoutRetryCost, int throttlingRetryCost)
+        {
+            this.retryCost = retryCost;
+            this.initialRetryTokens = initialRetryTokens;
+            this.noRetryIncrement = noRetryIncrement;
             this.timeoutRetryCost = timeoutRetryCost;
+            this.throttlingRetryCost = throttlingRetryCost;
         }
 
         /// <summary>
@@ -92,7 +126,19 @@ namespace Amazon.Runtime.Internal
         /// <param name="capacityType">Specifies what capacity type cost to use for obtaining capacity</param>
         public bool TryAcquireCapacity(RetryCapacity retryCapacity, CapacityType capacityType)
         {
-            var capacityCost = capacityType == CapacityType.Timeout ? timeoutRetryCost : retryCost;
+            int capacityCost;
+            switch (capacityType)
+            {
+                case CapacityType.Timeout:
+                    capacityCost = timeoutRetryCost;
+                    break;
+                case CapacityType.Throttling:
+                    capacityCost = throttlingRetryCost;
+                    break;
+                default:
+                    capacityCost = retryCost;
+                    break;
+            }
             if (capacityCost < 0)
             {
                 return false;
@@ -126,6 +172,9 @@ namespace Amazon.Runtime.Internal
                     break;
                 case CapacityType.Timeout:
                     ReleaseCapacity(timeoutRetryCost, retryCapacity);
+                    break;
+                case CapacityType.Throttling:
+                    ReleaseCapacity(throttlingRetryCost, retryCapacity);
                     break;
                 case CapacityType.Increment:
                     ReleaseCapacity(noRetryIncrement, retryCapacity);
@@ -163,6 +212,10 @@ namespace Amazon.Runtime.Internal
         // legacy retry modes and 10 for all other retry modes.
         private readonly int timeoutRetryCost;
 
+        // This parameter sets the cost of making a retry call when the error is a throttling error.
+        // Used when the new retry behavior (SEP 2.1) is enabled. The default value is 5.
+        private readonly int throttlingRetryCost;
+
         // Maximum capacity in a bucket set to 100 for legacy retry mode and 500 for all other retry modes.
         private readonly int initialRetryTokens;
 
@@ -199,7 +252,7 @@ namespace Amazon.Runtime.Internal
                     _rwlock.EnterWriteLock();
                     try
                     {
-                        retryCapacity = new RetryCapacity(retryCost * initialRetryTokens);
+                        retryCapacity = new RetryCapacity(initialRetryTokens);
                         _serviceUrlToCapacityMap.Add(serviceURL, retryCapacity);
                         return retryCapacity;
                     }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/DefaultRetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/DefaultRetryPolicy.cs
@@ -31,7 +31,7 @@ namespace Amazon.Runtime.Internal
         //The status code returned from a service request when an invalid endpoint is used.
         private const int INVALID_ENDPOINT_EXCEPTION_STATUSCODE = 421;
         //Holds on to the singleton instance.
-        private static readonly CapacityManager _capacityManagerInstance = new CapacityManager(throttleRetryCount: 100, throttleRetryCost: 5, throttleCost: 1);
+        private static readonly CapacityManager _capacityManagerInstance = new CapacityManager(initialRetryTokens: 500, retryCost: 5, noRetryIncrement: 1, timeoutRetryCost: 5, throttlingRetryCost: 0);
 
         private static readonly HashSet<string> _netStandardRetryErrorMessages = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryHandler.cs
@@ -121,6 +121,21 @@ namespace Amazon.Runtime.Internal
                     shouldRetry = this.RetryPolicy.Retry(executionContext, exception);
                     if (!shouldRetry)
                     {
+                        // SEP 2.1: Long-polling operations must always back off when the error is
+                        // retryable and retry quota is exhausted (but NOT when max attempts is reached).
+                        // The RetryLimitReached check distinguishes quota exhaustion from max attempts.
+                        if (IsLongPollingOperation(executionContext)
+                            && requestContext.IsLastExceptionRetryable
+                            && !this.RetryPolicy.RetryLimitReached(executionContext))
+                        {
+                            // Temporarily increment Retries so the backoff formula computes the
+                            // delay for the correct attempt index (i=1 for first failure), then
+                            // restore the original value so LogForError reports accurately.
+                            requestContext.Retries++;
+                            this.RetryPolicy.WaitBeforeRetry(executionContext);
+                            requestContext.Retries--;
+                        }
+
                         LogForError(requestContext, exception);
                         throw;
                     }
@@ -215,6 +230,21 @@ namespace Amazon.Runtime.Internal
                     shouldRetry = await this.RetryPolicy.RetryAsync(executionContext, capturedException.SourceException).ConfigureAwait(false);
                     if (!shouldRetry)
                     {
+                        // SEP 2.1: Long-polling operations must always back off when the error is
+                        // retryable and retry quota is exhausted (but NOT when max attempts is reached).
+                        // The RetryLimitReached check distinguishes quota exhaustion from max attempts.
+                        if (IsLongPollingOperation(executionContext)
+                            && requestContext.IsLastExceptionRetryable
+                            && !this.RetryPolicy.RetryLimitReached(executionContext))
+                        {
+                            // Temporarily increment Retries so the backoff formula computes the
+                            // delay for the correct attempt index (i=1 for first failure), then
+                            // restore the original value so LogForError reports accurately.
+                            requestContext.Retries++;
+                            await RetryPolicy.WaitBeforeRetryAsync(executionContext).ConfigureAwait(false);
+                            requestContext.Retries--;
+                        }
+
                         LogForError(requestContext, capturedException.SourceException);
                         capturedException.Throw();
                     }
@@ -346,6 +376,35 @@ namespace Amazon.Runtime.Internal
                 return true;
             }
             
+            return false;
+        }
+
+        /// <summary>
+        /// Determines if the current operation is a long-polling operation that should always back off
+        /// when retryable, even if retry quota is exhausted.
+        /// </summary>
+        private static bool IsLongPollingOperation(IExecutionContext executionContext)
+        {
+            if (!RetryPolicy.UseNewRetries2026) return false;
+
+            // TODO: Check longPoll trait from model when available in C2J models.
+            // Until the trait is available, use hard-coded service/operation combinations.
+            var serviceId = executionContext.RequestContext.ClientConfig?.ServiceId;
+            var operationName = AWSSDKUtils.ExtractOperationName(executionContext.RequestContext.RequestName);
+
+            if (string.Equals(serviceId, "SQS", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(operationName, "ReceiveMessage", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (string.Equals(serviceId, "SFN", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(operationName, "GetActivityTask", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (string.Equals(serviceId, "SWF", StringComparison.OrdinalIgnoreCase) &&
+                (string.Equals(operationName, "PollForActivityTask", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(operationName, "PollForDecisionTask", StringComparison.OrdinalIgnoreCase)))
+                return true;
+
             return false;
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
@@ -35,6 +35,16 @@ namespace Amazon.Runtime
     public abstract partial class RetryPolicy
     {
         /// <summary>
+        /// Temporary feature flag for updated retry behavior improvements including
+        /// revised backoff timing, updated retry quota costs, and other enhancements.
+        /// Enabled by setting the AWS_NEW_RETRIES_2026 environment variable to "true".
+        /// Defaults to false. This flag will be removed at end of 2026 when the new
+        /// behavior becomes the default.
+        /// </summary>
+        internal static bool UseNewRetries2026 { get; set; } =
+            string.Equals(Environment.GetEnvironmentVariable("AWS_NEW_RETRIES_2026"), "true", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
         /// Maximum number of retries to be performed.
         /// This does not count the initial request.
         /// </summary>
@@ -146,8 +156,17 @@ namespace Amazon.Runtime
                         return false;
                     }
 
-                    executionContext.RequestContext.LastCapacityType = IsServiceTimeoutError(exception) ? 
-                        CapacityManager.CapacityType.Timeout : CapacityManager.CapacityType.Retry;
+                    if (UseNewRetries2026)
+                    {
+                        executionContext.RequestContext.LastCapacityType = IsThrottlingError(exception) ?
+                            CapacityManager.CapacityType.Throttling : CapacityManager.CapacityType.Retry;
+                        StoreRetryAfterHeader(executionContext, exception);
+                    }
+                    else
+                    {
+                        executionContext.RequestContext.LastCapacityType = IsServiceTimeoutError(exception) ?
+                            CapacityManager.CapacityType.Timeout : CapacityManager.CapacityType.Retry;
+                    }
                     return OnRetry(executionContext, isClockSkewError,  IsThrottlingError(exception));
                 }
             }
@@ -622,6 +641,39 @@ namespace Amazon.Runtime
         }
 
         #endregion
+
+        /// <summary>
+        /// Context attribute key for storing the x-amz-retry-after header value (in milliseconds).
+        /// </summary>
+        protected const string RetryAfterContextKey = "RetryAfterMs";
+
+        /// <summary>
+        /// Extracts the x-amz-retry-after header from the error response and stores it in ContextAttributes.
+        /// The header value is an integer representing milliseconds.
+        /// </summary>
+        private void StoreRetryAfterHeader(IExecutionContext executionContext, Exception exception)
+        {
+            // Remove any previously stored value
+            executionContext.RequestContext.ContextAttributes.Remove(RetryAfterContextKey);
+
+            var serviceException = exception as AmazonServiceException;
+            var webData = GetWebData(serviceException);
+            if (webData == null)
+                return;
+
+            var retryAfterValue = webData.GetHeaderValue("x-amz-retry-after");
+            if (string.IsNullOrEmpty(retryAfterValue))
+                return;
+
+            if (int.TryParse(retryAfterValue, out var retryAfterMs) && retryAfterMs >= 0)
+            {
+                executionContext.RequestContext.ContextAttributes[RetryAfterContextKey] = retryAfterMs;
+            }
+            else
+            {
+                Logger?.DebugFormat("Invalid x-amz-retry-after header value '{0}', falling back to exponential backoff.", retryAfterValue);
+            }
+        }
 
         private static IWebResponseData GetWebData(AmazonServiceException ase)
         {

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/StandardRetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/StandardRetryPolicy.cs
@@ -33,7 +33,9 @@ namespace Amazon.Runtime.Internal
         //The status code returned from a service request when an invalid endpoint is used.
         private const int INVALID_ENDPOINT_EXCEPTION_STATUSCODE = 421;        
         
-        protected static CapacityManager CapacityManagerInstance { get; set; } = new CapacityManager(throttleRetryCount: 100, throttleRetryCost: 5, throttleCost: 1, timeoutRetryCost: 10);
+        protected static CapacityManager CapacityManagerInstance { get; set; } = UseNewRetries2026
+            ? new CapacityManager(initialRetryTokens: 500, retryCost: 14, noRetryIncrement: 1, timeoutRetryCost: 10, throttlingRetryCost: 5)
+            : new CapacityManager(initialRetryTokens: 500, retryCost: 5, noRetryIncrement: 1, timeoutRetryCost: 10, throttlingRetryCost: 0);
 
         /// <summary>
         /// The maximum value of exponential backoff in milliseconds, which will be used to wait
@@ -62,6 +64,19 @@ namespace Amazon.Runtime.Internal
         public StandardRetryPolicy(IClientConfig config)
         {
             this.MaxRetries = config.MaxErrorRetry;
+
+            // DynamoDB and DynamoDB Streams retry count handling:
+            // Previously, MaxErrorRetry was set to 10 in the generated AmazonDynamoDBConfig/AmazonDynamoDBStreamsConfig.
+            // This was moved here to the retry policy so we can apply the correct default based on the
+            // UseNewRetries2026 flag. When UseNewRetries2026 is enabled, DynamoDB uses 3 retries (4 attempts)
+            // per SEP 2.1. When disabled, it preserves the legacy default of 10 retries.
+            // TODO: After the UseNewRetries2026 flag is removed (end of 2026), update the generated
+            // DynamoDB/DynamoDB Streams configs to set MaxErrorRetry to 3 directly and remove this block.
+            if (!config.IsMaxErrorRetrySet && IsDynamoDBService(config))
+            {
+                this.MaxRetries = UseNewRetries2026 ? 3 : 10;
+            }
+
             if (config.ThrottleRetries)
             {
                 RetryCapacity = CapacityManagerInstance.GetRetryCapacity(GetRetryCapacityKey(config));
@@ -91,7 +106,7 @@ namespace Amazon.Runtime.Internal
 
         /// <summary>
         /// Virtual method that gets called when a retry request is initiated. If retry throttling is
-        /// enabled, the value returned is true if the required capacity is retured, false otherwise. 
+        /// enabled, the value returned is true if the required capacity is returned, false otherwise. 
         /// If retry throttling is disabled, true is returned.
         /// </summary>
         /// <param name="executionContext">The execution context which contains both the
@@ -103,7 +118,7 @@ namespace Amazon.Runtime.Internal
 
         /// <summary>
         /// Virtual method that gets called when a retry request is initiated. If retry throttling is
-        /// enabled, the value returned is true if the required capacity is retured, false otherwise. 
+        /// enabled, the value returned is true if the required capacity is returned, false otherwise. 
         /// If retry throttling is disabled, true is returned.
         /// </summary>
         /// <param name="executionContext">The execution context which contains both the
@@ -116,13 +131,13 @@ namespace Amazon.Runtime.Internal
 
         /// <summary>
         /// Virtual method that gets called when a retry request is initiated. If retry throttling is
-        /// enabled, the value returned is true if the required capacity is retured, false otherwise. 
+        /// enabled, the value returned is true if the required capacity is returned, false otherwise. 
         /// If retry throttling is disabled, true is returned.
         /// </summary>
         /// <param name="executionContext">The execution context which contains both the
         /// requests and response context.</param>
         /// <param name="bypassAcquireCapacity">true to bypass any attempt to acquire capacity on a retry</param>
-        /// <param name="isThrottlingError">true if the error that will be retried is a throtting error</param>        
+        /// <param name="isThrottlingError">true if the error that will be retried is a throttling error</param>        
         public override bool OnRetry(IExecutionContext executionContext, bool bypassAcquireCapacity, bool isThrottlingError)
         {
             if (!bypassAcquireCapacity && executionContext.RequestContext.ClientConfig.ThrottleRetries && RetryCapacity != null)
@@ -218,33 +233,115 @@ namespace Amazon.Runtime.Internal
         }
 
         /// <summary>
-        /// Waits before retrying a request. The default policy implements a exponential backoff with 
-        /// jitter algorithm.
+        /// Determines if the service associated with the given client config is DynamoDB or DynamoDB Streams.
+        /// Used for service-specific retry behavior such as adjusted backoff timing and increased retry counts.
         /// </summary>
-        /// <param name="executionContext">Request context containing the state of the request.</param>
-        public override void WaitBeforeRetry(IExecutionContext executionContext)
+        internal static bool IsDynamoDBService(IClientConfig config)
         {
-            StandardRetryPolicy.WaitBeforeRetry(executionContext.RequestContext.Retries, this.MaxBackoffInMilliseconds);
+            var serviceId = config?.ServiceId;
+            return string.Equals(serviceId, "DynamoDB", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(serviceId, "DynamoDB Streams", StringComparison.OrdinalIgnoreCase);
         }
-        
+
         /// <summary>
         /// Waits for an amount of time using an exponential backoff with jitter algorithm.
         /// </summary>
         /// <param name="retries">The request retry index. The first request is expected to be 0 while 
         /// the first retry will be 1.</param>
         /// <param name="maxBackoffInMilliseconds">The max number of milliseconds to wait</param>
+        [Obsolete("Use WaitBeforeRetry(IExecutionContext) instead.")]
         public static void WaitBeforeRetry(int retries, int maxBackoffInMilliseconds)
         {
             AWSSDKUtils.Sleep(CalculateRetryDelay(retries, maxBackoffInMilliseconds));
-        }        
+        }
 
+        /// <summary>
+        /// Calculates the retry delay using exponential backoff with jitter.
+        /// </summary>
+        /// <param name="retries">The retry index (0-based).</param>
+        /// <param name="maxBackoffInMilliseconds">The maximum backoff in milliseconds.</param>
+        /// <returns>The delay in milliseconds.</returns>
+        [Obsolete("Use CalculateRetryDelay(IExecutionContext, int) instead.")]
         protected static int CalculateRetryDelay(int retries, int maxBackoffInMilliseconds)
         {
             double jitter;
-            lock (_randomJitter) {        
+            lock (_randomJitter)
+            {
                 jitter = _randomJitter.NextDouble();
             }
             return Convert.ToInt32(Math.Min(jitter * Math.Pow(2, retries - 1) * 1000.0, maxBackoffInMilliseconds));
         }
+
+        /// <summary>
+        /// Waits before retrying a request. The default policy implements a exponential backoff with 
+        /// jitter algorithm.
+        /// </summary>
+        /// <param name="executionContext">Request context containing the state of the request.</param>
+        public override void WaitBeforeRetry(IExecutionContext executionContext)
+        {
+            AWSSDKUtils.Sleep(CalculateRetryDelay(executionContext, this.MaxBackoffInMilliseconds));
+        }
+
+        /// <summary>
+        /// Calculates the retry delay in milliseconds. When UseNewRetries2026 is enabled, uses the
+        /// SEP 2.1 formula with service-aware base delay, MAX_BACKOFF applied before jitter, and
+        /// x-amz-retry-after header clamping. Otherwise uses the legacy 2.0 formula.
+        /// </summary>
+        /// <param name="executionContext">The execution context for the current request.</param>
+        /// <param name="maxBackoffInMilliseconds">The maximum backoff in milliseconds.</param>
+        /// <returns>The delay in milliseconds before the next retry.</returns>
+        internal static int CalculateRetryDelay(IExecutionContext executionContext, int maxBackoffInMilliseconds)
+        {
+            var retries = executionContext.RequestContext.Retries;
+            double jitter;
+            lock (_randomJitter) {        
+                jitter = _randomJitter.NextDouble();
+            }
+
+            if (!UseNewRetries2026)
+            {
+                return Convert.ToInt32(Math.Min(jitter * Math.Pow(2, retries - 1) * 1000.0, maxBackoffInMilliseconds));
+            }
+
+            // SEP 2.1: Determine the base delay multiplier (x) based on error type and service.
+            //   - 1.0 (1000ms) for throttling errors
+            //   - 0.05 (50ms) for non-throttling errors on most services
+            //   - 0.025 (25ms) for non-throttling errors on DynamoDB/DynamoDB Streams
+            var isThrottlingError = executionContext.RequestContext.LastCapacityType == CapacityManager.CapacityType.Throttling;
+            double baseDelayMs;
+            if (isThrottlingError)
+            {
+                baseDelayMs = 1000.0;
+            }
+            else if (IsDynamoDBService(executionContext.RequestContext.ClientConfig))
+            {
+                baseDelayMs = 25.0;
+            }
+            else
+            {
+                baseDelayMs = 50.0;
+            }
+
+            // SEP 2.1: MAX_BACKOFF is applied before jitter.
+            // Formula: jitter * Min(baseDelayMs * 2^(retries-1), MAX_BACKOFF)
+            // where baseDelayMs is 1000, 50, or 25 depending on the service.
+            double rawDelay = baseDelayMs * Math.Pow(2, retries - 1);
+            double cappedDelay = Math.Min(rawDelay, maxBackoffInMilliseconds);
+            var backoffDelayMs = Convert.ToInt32(jitter * cappedDelay);
+
+            // SEP 2.1: x-amz-retry-after header clamping.
+            // The header value (ms) is clamped to [backoffDelay, 5000 + backoffDelay]. MAX_BACKOFF is NOT applied.
+            if (executionContext.RequestContext.ContextAttributes.TryGetValue(RetryAfterContextKey, out var retryAfterObj)
+                && retryAfterObj is int retryAfterMs)
+            {
+                var clampedMs = retryAfterMs;
+                if (clampedMs < backoffDelayMs) clampedMs = backoffDelayMs;
+                if (clampedMs > 5000 + backoffDelayMs) clampedMs = 5000 + backoffDelayMs;
+                return clampedMs;
+            }
+
+            return backoffDelayMs;
+        }
+
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/_async/AdaptiveRetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/_async/AdaptiveRetryPolicy.cs
@@ -42,7 +42,7 @@ namespace Amazon.Runtime.Internal
         /// requests and response context.</param>
         public override Task WaitBeforeRetryAsync(IExecutionContext executionContext)
         {
-            var delay = CalculateRetryDelay(executionContext.RequestContext.Retries, this.MaxBackoffInMilliseconds);
+            var delay = CalculateRetryDelay(executionContext, this.MaxBackoffInMilliseconds);
             return Task.Delay(delay, executionContext.RequestContext.CancellationToken);
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/_async/RetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/_async/RetryPolicy.cs
@@ -50,6 +50,12 @@ namespace Amazon.Runtime
                     {
                         return false;
                     }
+                    if (UseNewRetries2026)
+                    {
+                        executionContext.RequestContext.LastCapacityType = IsThrottlingError(exception) ?
+                            CapacityManager.CapacityType.Throttling : CapacityManager.CapacityType.Retry;
+                        StoreRetryAfterHeader(executionContext, exception);
+                    }
                     return OnRetry(executionContext, isClockSkewError, IsThrottlingError(exception));
                 }
             }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/_async/StandardRetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/_async/StandardRetryPolicy.cs
@@ -42,7 +42,7 @@ namespace Amazon.Runtime.Internal
         /// requests and response context.</param>
         public override Task WaitBeforeRetryAsync(IExecutionContext executionContext)
         {
-            var delay = CalculateRetryDelay(executionContext.RequestContext.Retries, this.MaxBackoffInMilliseconds);
+            var delay = CalculateRetryDelay(executionContext, this.MaxBackoffInMilliseconds);
             return Task.Delay(delay, executionContext.RequestContext.CancellationToken);
         }
     }

--- a/sdk/src/Services/DynamoDBStreams/Generated/AmazonDynamoDBStreamsConfig.cs
+++ b/sdk/src/Services/DynamoDBStreams/Generated/AmazonDynamoDBStreamsConfig.cs
@@ -57,7 +57,6 @@ namespace Amazon.DynamoDBStreams
         {
             base.ServiceId = "DynamoDB Streams";
             this.AuthenticationServiceName = "dynamodb";
-            this.MaxErrorRetry = 10;
             this.EndpointProvider = new AmazonDynamoDBStreamsEndpointProvider();
         }
 

--- a/sdk/src/Services/DynamoDBv2/Generated/AmazonDynamoDBConfig.cs
+++ b/sdk/src/Services/DynamoDBv2/Generated/AmazonDynamoDBConfig.cs
@@ -57,7 +57,6 @@ namespace Amazon.DynamoDBv2
         {
             base.ServiceId = "DynamoDB";
             this.AuthenticationServiceName = "dynamodb";
-            this.MaxErrorRetry = 10;
             this.EndpointProvider = new AmazonDynamoDBEndpointProvider();
         }
 

--- a/sdk/test/UnitTests/Custom/CapacityManagerTests.cs
+++ b/sdk/test/UnitTests/Custom/CapacityManagerTests.cs
@@ -39,7 +39,10 @@ namespace AWSSDK_DotNet.UnitTests
             int throttleRetryCount = 5; 
             int throttleRetryCost = 5; 
             int throttleCost = 1;
-            CapacityManager capacityManagerInstance = new CapacityManager(throttleRetryCount, throttleRetryCost, throttleCost);
+            CapacityManager capacityManagerInstance = new CapacityManager(
+                initialRetryTokens: throttleRetryCost * throttleRetryCount, 
+                retryCost: throttleRetryCost, noRetryIncrement: throttleCost, 
+                timeoutRetryCost: throttleRetryCost, throttlingRetryCost: 0);
             retryCapacity = capacityManagerInstance.GetRetryCapacity("AcquireCapacityUnitTest");
             Assert.IsNotNull(retryCapacity);
             Assert.IsTrue(capacityManagerInstance.TryAcquireCapacity(retryCapacity));
@@ -61,7 +64,10 @@ namespace AWSSDK_DotNet.UnitTests
             int throttleRetryCount = 0;
             int throttleRetryCost = 5;
             int throttleCost = 1;
-            CapacityManager capacityManagerInstance = new CapacityManager(throttleRetryCount, throttleRetryCost, throttleCost);
+            CapacityManager capacityManagerInstance = new CapacityManager(
+                initialRetryTokens: throttleRetryCost * throttleRetryCount, 
+                retryCost: throttleRetryCost, noRetryIncrement: throttleCost, 
+                timeoutRetryCost: throttleRetryCost, throttlingRetryCost: 0);
             retryCapacity = capacityManagerInstance.GetRetryCapacity("AcquireCapacityInvalidUnitTest");
             Assert.IsNotNull(retryCapacity);
             Assert.IsFalse(capacityManagerInstance.TryAcquireCapacity(retryCapacity));
@@ -83,7 +89,10 @@ namespace AWSSDK_DotNet.UnitTests
             int throttleRetryCount = 5;
             int throttleRetryCost = 5;
             int throttleCost = 1;
-            CapacityManager capacityManagerInstance = new CapacityManager(throttleRetryCount, throttleRetryCost, throttleCost);
+            CapacityManager capacityManagerInstance = new CapacityManager(
+                initialRetryTokens: throttleRetryCost * throttleRetryCount, 
+                retryCost: throttleRetryCost, noRetryIncrement: throttleCost, 
+                timeoutRetryCost: throttleRetryCost, throttlingRetryCost: 0);
             retryCapacity = capacityManagerInstance.GetRetryCapacity("ReleaseCapacityUnitTest");
             Assert.IsNotNull(retryCapacity);
             Assert.IsTrue(capacityManagerInstance.TryAcquireCapacity(retryCapacity));
@@ -112,7 +121,10 @@ namespace AWSSDK_DotNet.UnitTests
             int throttleRetryCount = 5;
             int throttleRetryCost = 5;
             int throttleCost = 1;
-            CapacityManager capacityManagerInstance = new CapacityManager(throttleRetryCount, throttleRetryCost, throttleCost);
+            CapacityManager capacityManagerInstance = new CapacityManager(
+                initialRetryTokens: throttleRetryCost * throttleRetryCount, 
+                retryCost: throttleRetryCost, noRetryIncrement: throttleCost, 
+                timeoutRetryCost: throttleRetryCost, throttlingRetryCost: 0);
             retryCapacity = capacityManagerInstance.GetRetryCapacity("ReleaseCapacityInvalidUnitTest");
             Assert.IsNotNull(retryCapacity);
 

--- a/sdk/test/UnitTests/Custom/Runtime/RetryHandlerAdaptiveModeTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RetryHandlerAdaptiveModeTests.cs
@@ -134,7 +134,7 @@ namespace AWSSDK.UnitTests
         public void RetryQuotaReachedAfterASingleRetry()
         {
             var config = CreateConfig();
-            var capacityManager = new CapacityManager(throttleRetryCount: 1, throttleRetryCost: 5, throttleCost: 1, timeoutRetryCost: 10);
+            var capacityManager = new CapacityManager(initialRetryTokens: 5, retryCost: 5, noRetryIncrement: 1, timeoutRetryCost: 10, throttlingRetryCost: 0);
             RunRetryTest((executionContext, retryPolicy) =>
             {
                 Tester.Reset();
@@ -173,7 +173,7 @@ namespace AWSSDK.UnitTests
         public void NoRetriesAtAllIfRetryQuotaIs0()
         {
             var config = CreateConfig();
-            var capacityManager = new CapacityManager(throttleRetryCount: 0, throttleRetryCost: 5, throttleCost: 1, timeoutRetryCost: 10);
+            var capacityManager = new CapacityManager(initialRetryTokens: 0, retryCost: 5, noRetryIncrement: 1, timeoutRetryCost: 10, throttlingRetryCost: 0);
             RunRetryTest((executionContext, retryPolicy) =>
             {
                 Tester.Reset();

--- a/sdk/test/UnitTests/Custom/Runtime/RetryHandlerStandardMode21Tests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RetryHandlerStandardMode21Tests.cs
@@ -1,0 +1,1140 @@
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Auth;
+using Amazon.Runtime.Internal.Transform;
+using Amazon.S3;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Amazon.SQS.Model.Internal.MarshallTransformations;
+using Amazon.DynamoDBv2;
+using AWSSDK_DotNet.UnitTests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+
+namespace AWSSDK.UnitTests
+{
+    /// <summary>
+    /// Tests for the SEP 2.1 retry behavior, gated behind UseNewRetries2026.
+    /// These test cases correspond to the standard mode test cases defined in the
+    /// Retry Behavior 2.1 SEP specification.
+    /// </summary>
+    [TestClass]
+    public class RetryHandlerStandardMode21Tests : RuntimePipelineTestBase<RetryHandler>
+    {
+        private bool _originalUseNewRetries2026;
+
+        [TestInitialize]
+        public void TestSetup()
+        {
+            _originalUseNewRetries2026 = RetryPolicy.UseNewRetries2026;
+            RetryPolicy.UseNewRetries2026 = true;
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            RetryPolicy.UseNewRetries2026 = _originalUseNewRetries2026;
+            Mock21StandardRetryPolicy.Restore();
+        }
+
+        private AmazonS3Config CreateS3Config()
+        {
+            return new AmazonS3Config
+            {
+                ServiceURL = $"https://s3-{Guid.NewGuid()}.amazonaws.com",
+                RetryMode = RequestRetryMode.Standard
+            };
+        }
+
+        private AmazonDynamoDBConfig CreateDynamoDBConfig()
+        {
+            return new AmazonDynamoDBConfig
+            {
+                ServiceURL = $"https://dynamodb-{Guid.NewGuid()}.amazonaws.com",
+                RetryMode = RequestRetryMode.Standard
+            };
+        }
+
+        /// <summary>
+        /// Default SEP 2.1 capacity manager with the spec-defined values.
+        /// </summary>
+        private static CapacityManager CreateDefault21CapacityManager() =>
+            new CapacityManager(initialRetryTokens: 500, retryCost: 14, noRetryIncrement: 1,
+                timeoutRetryCost: 10, throttlingRetryCost: 5);
+
+        private void RunRetryTest(Action<IExecutionContext, Mock21StandardRetryPolicy> doAction, 
+            ClientConfig config, CapacityManager capacityManager = null)
+        {
+            try
+            {
+                // Always set a 2.1 capacity manager because the static CapacityManagerInstance
+                // is initialized at class load time (before UseNewRetries2026 = true in TestSetup).
+                Mock21StandardRetryPolicy.SetCapacityManagerInstance(capacityManager ?? CreateDefault21CapacityManager());
+
+                var retryPolicy = new Mock21StandardRetryPolicy(config);
+                Handler = new RetryHandler(retryPolicy);
+                if (RuntimePipeline.Handlers.Find(h => h is RetryHandler) != null)
+                {
+                    RuntimePipeline.ReplaceHandler<RetryHandler>(Handler);
+                }
+                else
+                {
+                    RuntimePipeline.AddHandler(Handler);
+                }
+
+                var executionContext = CreateTestContext(null, null, config);
+                doAction(executionContext, retryPolicy);
+            }
+            finally
+            {
+                Mock21StandardRetryPolicy.Restore();
+            }
+        }
+
+        /// <summary>
+        /// Creates an SQS ReceiveMessage execution context for testing long-polling behavior.
+        /// </summary>
+        private IExecutionContext CreateSqsReceiveMessageContext(AmazonSQSConfig config)
+        {
+            var receiveMessageRequest = new ReceiveMessageRequest
+            {
+                QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/test-queue"
+            };
+
+            var requestContext = new RequestContext(true, new NullSigner())
+            {
+                OriginalRequest = receiveMessageRequest,
+                Request = new ReceiveMessageRequestMarshaller().Marshall(receiveMessageRequest),
+                Unmarshaller = ReceiveMessageResponseUnmarshaller.Instance,
+                ClientConfig = config
+            };
+
+            var serviceMetaData = Assembly.GetAssembly(requestContext.GetType())
+                .CreateInstance("Amazon.Runtime.Internal.ServiceMetadata");
+            requestContext.GetType().GetProperty("ServiceMetaData").SetValue(requestContext, serviceMetaData);
+
+            requestContext.Request.Endpoint = new Uri("https://sqs.us-east-1.amazonaws.com");
+
+            // Uses PutObjectResponse.txt as a dummy HTTP response — same as RuntimePipelineTestBase.
+            // The actual response content is irrelevant; retry tests only need a non-null HttpResponse.
+            var dummyResponse = MockWebResponse.CreateFromResource("PutObjectResponse.txt") as HttpWebResponse;
+            return new Amazon.Runtime.Internal.ExecutionContext(requestContext,
+                new ResponseContext
+                {
+                    HttpResponse = new HttpWebRequestResponseData(dummyResponse)
+                });
+        }
+
+        private AmazonSQSConfig CreateSQSConfig()
+        {
+            return new AmazonSQSConfig
+            {
+                ServiceURL = $"https://sqs-{Guid.NewGuid()}.amazonaws.com",
+                RetryMode = RequestRetryMode.Standard
+            };
+        }
+
+        #region SEP 2.1 Standard Mode Test Cases
+
+        /// <summary>
+        /// SEP Test: Retry eventually succeeds.
+        /// exponential_base: 1, delays: [0.05, 0.1], quota: 486→472→486
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void RetryEventuallySucceeds()
+        {
+            var config = CreateS3Config();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                        case 2:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 3:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(2, executionContext.RequestContext.Retries);
+                Assert.AreEqual(3, Tester.CallCount);
+                Assert.AreEqual(486, capacity.AvailableCapacity); // 500 - 14 = 486, then restored to 486
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50, 100 });
+            }, config);
+        }
+
+        /// <summary>
+        /// SEP Test: Fail due to max attempts reached.
+        /// exponential_base: 1, delays: [0.05, 0.1], quota: 486→472
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void FailDueToMaxAttemptsReached()
+        {
+            var config = CreateS3Config();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    throw new AmazonServiceException($"Mocked service error ({callCount})",
+                        new WebException(), HttpStatusCode.BadGateway);
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked service error (3)", exception.Message);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(2, executionContext.RequestContext.Retries);
+                Assert.AreEqual(3, Tester.CallCount);
+                Assert.AreEqual(472, capacity.AvailableCapacity); // 500 - 14 - 14 = 472
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50, 100 });
+            }, config);
+        }
+
+        /// <summary>
+        /// SEP Test: Retry Quota reached after a single retry.
+        /// initial_retry_tokens: 14, delays: [0.05], quota: 0
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void RetryQuotaReachedAfterASingleRetry()
+        {
+            var config = CreateS3Config();
+            var capacityManager = new CapacityManager(
+                initialRetryTokens: 14, retryCost: 14, noRetryIncrement: 1, 
+                timeoutRetryCost: 10, throttlingRetryCost: 5);
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked service error (2)", exception.Message);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(1, executionContext.RequestContext.Retries);
+                Assert.AreEqual(2, Tester.CallCount);
+                Assert.AreEqual(0, capacity.AvailableCapacity);
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50 });
+            }, config, capacityManager);
+        }
+
+        /// <summary>
+        /// SEP Test: No retries at all if retry quota is 0.
+        /// initial_retry_tokens: 0
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void NoRetriesAtAllIfRetryQuotaIs0()
+        {
+            var config = CreateS3Config();
+            var capacityManager = new CapacityManager(
+                initialRetryTokens: 0, retryCost: 14, noRetryIncrement: 1, 
+                timeoutRetryCost: 10, throttlingRetryCost: 5);
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked service error (1)", exception.Message);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(0, executionContext.RequestContext.Retries);
+                Assert.AreEqual(1, Tester.CallCount);
+                Assert.AreEqual(0, capacity.AvailableCapacity);
+            }, config, capacityManager);
+        }
+
+        /// <summary>
+        /// SEP Test: Verifying exponential backoff timing.
+        /// max_attempts: 5, exponential_base: 1, delays: [0.05, 0.1, 0.2, 0.4]
+        /// quota: 486→472→458→444
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void VerifyExponentialBackoffTiming()
+        {
+            var config = CreateS3Config();
+            config.MaxErrorRetry = 4;
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    throw new AmazonServiceException($"Mocked service error ({callCount})",
+                        new WebException(), HttpStatusCode.InternalServerError);
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked service error (5)", exception.Message);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(4, executionContext.RequestContext.Retries);
+                Assert.AreEqual(5, Tester.CallCount);
+                Assert.AreEqual(444, capacity.AvailableCapacity); // 500 - 4*14 = 444
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50, 100, 200, 400 });
+            }, config);
+        }
+
+        /// <summary>
+        /// SEP Test: Verify max backoff time.
+        /// max_attempts: 5, exponential_base: 1, max_backoff_time: 0.2 (200ms)
+        /// delays: [0.05, 0.1, 0.2, 0.2]
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void VerifyMaxBackoffTime()
+        {
+            var config = CreateS3Config();
+            config.MaxErrorRetry = 4;
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                retryPolicy.MaxBackoffInMilliseconds = 200;
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    throw new AmazonServiceException($"Mocked service error ({callCount})",
+                        new WebException(), HttpStatusCode.InternalServerError);
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked service error (5)", exception.Message);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(4, executionContext.RequestContext.Retries);
+                Assert.AreEqual(5, Tester.CallCount);
+                Assert.AreEqual(444, capacity.AvailableCapacity);
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50, 100, 200, 200 });
+            }, config);
+        }
+
+        /// <summary>
+        /// SEP Test: Retry Stops After Retry Quota Exhaustion.
+        /// max_attempts: 5, initial_retry_tokens: 20, delays: [0.05]
+        /// After 1st retry: quota=6, 2nd retry denied (6 is less than 14)
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void RetryStopsAfterRetryQuotaExhaustion()
+        {
+            var config = CreateS3Config();
+            config.MaxErrorRetry = 4;
+            var capacityManager = new CapacityManager(
+                initialRetryTokens: 20, retryCost: 14, noRetryIncrement: 1,
+                timeoutRetryCost: 10, throttlingRetryCost: 5);
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    throw new AmazonServiceException($"Mocked service error ({callCount})",
+                        new WebException(), HttpStatusCode.InternalServerError);
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked service error (2)", exception.Message);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(1, executionContext.RequestContext.Retries);
+                Assert.AreEqual(2, Tester.CallCount);
+                Assert.AreEqual(6, capacity.AvailableCapacity); // 20 - 14 = 6
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50 });
+            }, config, capacityManager);
+        }
+
+        /// <summary>
+        /// SEP Test: Retry quota Recovery After Successful Responses.
+        /// max_attempts: 5, initial_retry_tokens: 30
+        /// quota: 30→16→2→16→2→16
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void RetryQuotaRecoveryAfterSuccessfulResponses()
+        {
+            var config = CreateS3Config();
+            config.MaxErrorRetry = 4;
+            var capacityManager = new CapacityManager(
+                initialRetryTokens: 30, retryCost: 14, noRetryIncrement: 1,
+                timeoutRetryCost: 10, throttlingRetryCost: 5);
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.BadGateway);
+                        case 3:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(16, capacity.AvailableCapacity); // 30 - 14 - 14 + 14 = 16
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50, 100 });
+
+                // Second SDK operation invocation
+                retryPolicy.RecordedDelays.Clear();
+                var executionContext2 = CreateTestContext(null, null, config);
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext2);
+
+                capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(16, capacity.AvailableCapacity); // 16 - 14 + 14 = 16
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50 });
+            }, config, capacityManager);
+        }
+
+        /// <summary>
+        /// SEP Test: Throttling Error Token Bucket Drain (5 tokens) and Backoff Duration (1000ms).
+        /// error_code: "Throttling", quota: 495→500, delay: 1000ms
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void ThrottlingErrorTokenBucketDrainAndBackoff()
+        {
+            var config = CreateS3Config();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            // Throttling error - costs 5 tokens, uses 1000ms base delay
+                            throw new AmazonServiceException("Mocked throttling", new WebException(),
+                                ErrorType.Receiver, "Throttling", "TestRequestId", HttpStatusCode.BadRequest);
+                        case 2:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(1, executionContext.RequestContext.Retries);
+                Assert.AreEqual(2, Tester.CallCount);
+                Assert.AreEqual(500, capacity.AvailableCapacity); // 500 - 5 + 5 = 500
+
+                retryPolicy.AssertDelaysMatch(new int[] { 1000 });
+            }, config);
+        }
+
+        /// <summary>
+        /// SEP Test: DynamoDB Base Backoff (25ms) and Increased Retries.
+        /// service: dynamodb, delays: [25, 50, 100], max_attempts: 4 (3 retries)
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void DynamoDBBaseBackoffAndIncreasedRetries()
+        {
+            var config = CreateDynamoDBConfig();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    throw new AmazonServiceException($"Mocked service error ({callCount})",
+                        new WebException(), HttpStatusCode.InternalServerError);
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                // DynamoDB gets 4 max attempts (3 retries) per SEP 2.1
+                Assert.AreEqual("Mocked service error (4)", exception.Message);
+                Assert.AreEqual(3, executionContext.RequestContext.Retries);
+                Assert.AreEqual(4, Tester.CallCount);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(458, capacity.AvailableCapacity); // 500 - 3*14 = 458
+
+                retryPolicy.AssertDelaysMatch(new int[] { 25, 50, 100 });
+            }, config);
+        }
+
+        /// <summary>
+        /// Helper to run a long-polling (SQS ReceiveMessage) retry test.
+        /// Sets up the SQS execution context and capacity manager.
+        /// </summary>
+        private void RunLongPollingRetryTest(Action<IExecutionContext, Mock21StandardRetryPolicy> doAction,
+            CapacityManager capacityManager = null, int? maxRetries = null)
+        {
+            var config = CreateSQSConfig();
+            if (maxRetries.HasValue) config.MaxErrorRetry = maxRetries.Value;
+            try
+            {
+                Mock21StandardRetryPolicy.SetCapacityManagerInstance(capacityManager ?? CreateDefault21CapacityManager());
+
+                var retryPolicy = new Mock21StandardRetryPolicy(config);
+                Handler = new RetryHandler(retryPolicy);
+                if (RuntimePipeline.Handlers.Find(h => h is RetryHandler) != null)
+                    RuntimePipeline.ReplaceHandler<RetryHandler>(Handler);
+                else
+                    RuntimePipeline.AddHandler(Handler);
+
+                var executionContext = CreateSqsReceiveMessageContext(config);
+                doAction(executionContext, retryPolicy);
+            }
+            finally
+            {
+                Mock21StandardRetryPolicy.Restore();
+            }
+        }
+
+        /// <summary>
+        /// SEP Test: Long-Polling Backoff After Transient Error When Token Bucket Empty.
+        /// service: sqs, long_polling: true, initial_retry_tokens: 0
+        /// Even though retry quota is exhausted, a long-polling operation should still back off.
+        /// outcome: retry_quota_exceeded, delay: 0.05
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void LongPollingBackoffAfterTransientErrorWhenTokenBucketEmpty()
+        {
+            var capacityManager = new CapacityManager(
+                initialRetryTokens: 0, retryCost: 14, noRetryIncrement: 1,
+                timeoutRetryCost: 10, throttlingRetryCost: 5);
+            RunLongPollingRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked service error (1)", exception.Message);
+                Assert.AreEqual(0, executionContext.RequestContext.Retries);
+                Assert.AreEqual(1, Tester.CallCount);
+                Assert.AreEqual(0, Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(executionContext.RequestContext.ClientConfig.ServiceURL).AvailableCapacity);
+
+                // Even though we didn't retry (quota exhausted), the long-polling operation
+                // should still have delayed (backoff on quota exhaustion per SEP 2.1)
+                retryPolicy.AssertDelaysMatch(new int[] { 50 });
+            }, capacityManager);
+        }
+
+        /// <summary>
+        /// SEP Test: Long-Polling Backoff After Throttling Error When Token Bucket Empty.
+        /// service: sqs, long_polling: true, initial_retry_tokens: 0
+        /// Throttling error with empty quota should still back off using the throttling base delay
+        /// (1000ms), because the SEP ExponentialBackoff formula uses x=1 for throttling errors.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void LongPollingBackoffAfterThrottlingErrorWhenTokenBucketEmpty()
+        {
+            var capacityManager = new CapacityManager(
+                initialRetryTokens: 0, retryCost: 14, noRetryIncrement: 1,
+                timeoutRetryCost: 10, throttlingRetryCost: 5);
+            RunLongPollingRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException("Mocked throttling", new WebException(),
+                                ErrorType.Receiver, "Throttling", "TestRequestId", HttpStatusCode.BadRequest);
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked throttling", exception.Message);
+                Assert.AreEqual(0, executionContext.RequestContext.Retries);
+                Assert.AreEqual(1, Tester.CallCount);
+
+                // Should still back off even with empty quota — uses 1000ms throttling base
+                retryPolicy.AssertDelaysMatch(new int[] { 1000 });
+            }, capacityManager);
+        }
+
+        /// <summary>
+        /// SEP Test: Long-Polling Max Attempts Exceeded Must NOT Delay.
+        /// service: sqs, long_polling: true, max_attempts: 2
+        /// When max attempts is reached, the exception should be thrown immediately with no backoff.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void LongPollingMaxAttemptsExceededMustNotDelay()
+        {
+            RunLongPollingRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    throw new AmazonServiceException($"Mocked service error ({callCount})",
+                        new WebException(), HttpStatusCode.InternalServerError);
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked service error (2)", exception.Message);
+                Assert.AreEqual(1, executionContext.RequestContext.Retries);
+                Assert.AreEqual(2, Tester.CallCount);
+
+                // Only one delay for the actual retry, NO delay on max-attempts-exceeded
+                retryPolicy.AssertDelaysMatch(new int[] { 50 });
+            }, maxRetries: 1);
+        }
+
+        /// <summary>
+        /// SEP Test: Long-Polling Success Must NOT Delay.
+        /// service: sqs, long_polling: true, max_attempts: 2
+        /// A successful response after a retry should return immediately with no extra backoff.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void LongPollingSuccessMustNotDelay()
+        {
+            RunLongPollingRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                Assert.AreEqual(1, executionContext.RequestContext.Retries);
+                Assert.AreEqual(2, Tester.CallCount);
+
+                // Only one delay for the retry backoff, no extra delay on success
+                retryPolicy.AssertDelaysMatch(new int[] { 50 });
+            }, maxRetries: 1);
+        }
+
+        /// <summary>
+        /// SEP Test: Long-Polling Non-Retryable Errors Must NOT Delay.
+        /// service: sqs, long_polling: true
+        /// A non-retryable error (e.g., 404) should fail immediately with no backoff.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void LongPollingNonRetryableErrorMustNotDelay()
+        {
+            RunLongPollingRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked not found ({callCount})",
+                                new WebException(), HttpStatusCode.NotFound);
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                var exception = Utils.AssertExceptionExpected<AmazonServiceException>(() =>
+                {
+                    RuntimePipeline.InvokeSync(executionContext);
+                });
+
+                Assert.AreEqual("Mocked not found (1)", exception.Message);
+                Assert.AreEqual(0, executionContext.RequestContext.Retries);
+                Assert.AreEqual(1, Tester.CallCount);
+
+                // No delays at all — non-retryable error returns immediately
+                retryPolicy.AssertDelaysMatch(new int[] { });
+            });
+        }
+
+        /// <summary>
+        /// SEP Test: Honor x-amz-retry-after Header.
+        /// header: "1500", delay: 1.5s (1500ms)
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void HonorXAmzRetryAfterHeader()
+        {
+            var config = CreateS3Config();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                retryPolicy.RetryAfterValue = 1500;
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                Assert.AreEqual(1, executionContext.RequestContext.Retries);
+                Assert.AreEqual(2, Tester.CallCount);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                Assert.AreEqual(500, capacity.AvailableCapacity); // 500 - 14 + 14 = 500
+
+                retryPolicy.AssertDelaysMatch(new int[] { 1500 });
+            }, config);
+        }
+
+        /// <summary>
+        /// SEP Test: x-amz-retry-after minimum is exponential backoff duration.
+        /// header: "0", delay: 0.05s (50ms) — falls back to backoffDelayMs
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void XAmzRetryAfterMinimumIsExponentialBackoff()
+        {
+            var config = CreateS3Config();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                retryPolicy.RetryAfterValue = 0;
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50 }); // Clamped to backoffDelayMs = 50ms
+            }, config);
+        }
+
+        /// <summary>
+        /// SEP Test: x-amz-retry-after maximum is 5+exponential backoff duration.
+        /// header: "10000" (10s), delay: 5.05s (5050ms) = 5000 + backoffDelayMs(50)
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void XAmzRetryAfterMaximumIs5PlusExponentialBackoff()
+        {
+            var config = CreateS3Config();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                retryPolicy.RetryAfterValue = 10000;
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                retryPolicy.AssertDelaysMatch(new int[] { 5050 }); // Clamped to 5000 + backoffDelayMs(50)
+            }, config);
+        }
+
+        /// <summary>
+        /// SEP Test: Invalid x-amz-retry-after Falls Back to Exponential Backoff.
+        /// When a non-integer value is present in the retry-after context attribute,
+        /// CalculateRetryDelay ignores it and falls back to standard exponential backoff.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void InvalidXAmzRetryAfterFallsBackToExponentialBackoff()
+        {
+            var config = CreateS3Config();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                retryPolicy.RetryAfterValue = "invalid";
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                retryPolicy.AssertDelaysMatch(new int[] { 50 }); // Falls back to exponential backoff
+            }, config);
+        }
+
+        /// <summary>
+        /// Verify that when UseNewRetries2026 is false, legacy behavior is preserved
+        /// (1000ms base delay, jitter applied after MAX_BACKOFF).
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void FeatureFlagOff_PreservesLegacyBehavior()
+        {
+            RetryPolicy.UseNewRetries2026 = false;
+            var config = CreateS3Config();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            break; // Success
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                // Legacy formula with jitter=1.0: Min(1 * 2^0 * 1000, 20000) = 1000ms
+                retryPolicy.AssertDelaysMatch(new int[] { 1000 });
+            }, config);
+        }
+
+        /// <summary>
+        /// Verify NO_RETRY_INCREMENT: a successful request after a retry restores
+        /// the retry cost, while a first-time success adds NO_RETRY_INCREMENT (1 token).
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void NoRetryIncrementOnSuccessAfterRetry()
+        {
+            var config = CreateS3Config();
+            var capacityManager = new CapacityManager(
+                initialRetryTokens: 490, retryCost: 14, noRetryIncrement: 1,
+                timeoutRetryCost: 10, throttlingRetryCost: 5);
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) =>
+                {
+                    switch (callCount)
+                    {
+                        case 1:
+                            throw new AmazonServiceException($"Mocked service error ({callCount})",
+                                new WebException(), HttpStatusCode.InternalServerError);
+                        case 2:
+                            break; // Success after retry
+                        default:
+                            throw new Exception($"Invalid number of calls ({callCount})");
+                    }
+                };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                // 490 - 14 (retry cost) + 14 (restored on success) = 490
+                Assert.AreEqual(490, capacity.AvailableCapacity);
+            }, config, capacityManager);
+        }
+
+        /// <summary>
+        /// Verify capacity never exceeds INITIAL_RETRY_TOKENS after success.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CapacityNeverExceedsInitialRetryTokens()
+        {
+            var config = CreateS3Config();
+            RunRetryTest((executionContext, retryPolicy) =>
+            {
+                Tester.Reset();
+                Tester.Action = (int callCount) => { /* Success on first try */ };
+
+                RuntimePipeline.InvokeSync(executionContext);
+
+                var capacity = Mock21StandardRetryPolicy.CurrentCapacityManagerInstance
+                    .GetRetryCapacity(config.ServiceURL);
+                // Should be capped at 500 (INITIAL_RETRY_TOKENS), not 501
+                Assert.AreEqual(500, capacity.AvailableCapacity);
+            }, config);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// A Random implementation that always returns a fixed value.
+    /// Used to eliminate jitter in tests.
+    /// </summary>
+    internal class FixedRandom : Random
+    {
+        private readonly double _value;
+        public FixedRandom(double value) { _value = value; }
+        public override double NextDouble() => _value;
+    }
+
+    public class Mock21StandardRetryPolicy : StandardRetryPolicy
+    {
+        private static CapacityManager _originalCapacityManager;
+        private static Random _originalRandomJitter;
+
+        private static readonly FieldInfo RandomJitterField = typeof(StandardRetryPolicy)
+            .GetField("_randomJitter", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "Could not find private static field '_randomJitter' on StandardRetryPolicy. " +
+                "The field may have been renamed or removed.");
+
+        public Mock21StandardRetryPolicy(IClientConfig config) : base(config)
+        {
+            // Replace random jitter with fixed value of 1.0 (no jitter, per SEP tests)
+            // Uses reflection since _randomJitter is private.
+            _originalRandomJitter = (Random)RandomJitterField.GetValue(null);
+            RandomJitterField.SetValue(null, new FixedRandom(1.0));
+        }
+
+        public static void SetCapacityManagerInstance(CapacityManager capacityManager)
+        {
+            _originalCapacityManager = CapacityManagerInstance;
+            CapacityManagerInstance = capacityManager;
+        }
+
+        public static void Restore()
+        {
+            if (_originalCapacityManager != null)
+            {
+                CapacityManagerInstance = _originalCapacityManager;
+                _originalCapacityManager = null;
+            }
+            if (_originalRandomJitter != null)
+            {
+                RandomJitterField.SetValue(null, _originalRandomJitter);
+                _originalRandomJitter = null;
+            }
+        }
+
+        public static CapacityManager CurrentCapacityManagerInstance => CapacityManagerInstance;
+
+        public object RetryAfterValue { get; set; }
+
+        public List<int> RecordedDelays { get; set; } = new List<int>();
+
+        public void AssertDelaysMatch(int[] expectedDelays)
+        {
+            if (RecordedDelays.Count != expectedDelays.Length)
+            {
+                throw new AssertFailedException(
+                    $"Recorded {RecordedDelays.Count} delays [{string.Join(", ", RecordedDelays)}] " +
+                    $"but expected {expectedDelays.Length} delays [{string.Join(", ", expectedDelays)}].");
+            }
+
+            for (var i = 0; i < expectedDelays.Length; i++)
+            {
+                if (RecordedDelays[i] != expectedDelays[i])
+                {
+                    throw new AssertFailedException(
+                        $"Delay index {i} has recorded value of {RecordedDelays[i]} " +
+                        $"but expected {expectedDelays[i]}. " +
+                        $"All recorded: [{string.Join(", ", RecordedDelays)}], " +
+                        $"All expected: [{string.Join(", ", expectedDelays)}].");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Overrides WaitBeforeRetry to record the delay calculated by the real
+        /// CalculateRetryDelay method instead of actually sleeping. Jitter is set to 1.0
+        /// (no randomness) by replacing the Random instance in the constructor.
+        /// </summary>
+        public override void WaitBeforeRetry(IExecutionContext executionContext)
+        {
+            if (RetryAfterValue != null)
+            {
+                executionContext.RequestContext.ContextAttributes["RetryAfterMs"] = RetryAfterValue;
+            }
+
+            var delay = CalculateRetryDelay(executionContext, this.MaxBackoffInMilliseconds);
+            RecordedDelays.Add(delay);
+        }
+    }
+}

--- a/sdk/test/UnitTests/Custom/Runtime/RetryHandlerStandardModeTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RetryHandlerStandardModeTests.cs
@@ -141,7 +141,7 @@ namespace AWSSDK.UnitTests
         public void RetryQuotaReachedAfterASingleRetry()
         {
             var config = CreateConfig();
-            var capacityManager = new CapacityManager(throttleRetryCount: 1, throttleRetryCost: 5, throttleCost: 1, timeoutRetryCost: 10);
+            var capacityManager = new CapacityManager(initialRetryTokens: 5, retryCost: 5, noRetryIncrement: 1, timeoutRetryCost: 10, throttlingRetryCost: 0);
             RunRetryTest((executionContext, retryPolicy) =>
             {
                 Tester.Reset();
@@ -180,7 +180,7 @@ namespace AWSSDK.UnitTests
         public void NoRetriesAtAllIfRetryQuotaIs0()
         {
             var config = CreateConfig();
-            var capacityManager = new CapacityManager(throttleRetryCount: 0, throttleRetryCost: 5, throttleCost: 1, timeoutRetryCost: 10);
+            var capacityManager = new CapacityManager(initialRetryTokens: 0, retryCost: 5, noRetryIncrement: 1, timeoutRetryCost: 10, throttlingRetryCost: 0);
             RunRetryTest((executionContext, retryPolicy) =>
             {
                 Tester.Reset();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR implements the Retry Behavior 2.1 SEP specification updates for the AWS SDK for .NET, gated behind a feature flag (`AWS_NEW_RETRIES_2026` environment variable). When enabled, the SDK uses updated retry parameters including revised backoff timing, updated retry quota costs, service-specific configurations, long-polling backoff behavior, and `x-amz-retry-after` header support.

All changes are backward-compatible, the feature flag defaults to `false`, preserving existing behavior. When the flag is removed at end of 2026, the new behavior will become the default.

## Motivation and Context
`DOTNET-8570`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
- Added `RetryHandlerStandardMode21Tests.cs` with 18 test cases covering all SEP 2.1 standard mode scenarios.
- All existing retry tests (standard mode, adaptive mode, capacity manager) continue to pass.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 1666b78d-9279-4431-9ead-6214171098c8
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** c559ee8d-4c35-49d6-a66e-43a1424d3bc6
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed


## Breaking Changes Assessment

### 1. Identify all breaking changes

This PR modifies several APIs in the `Amazon.Runtime.Internal` namespace. While technically public (due to C# accessibility), these are internal SDK implementation details not intended for external consumption.

#### Change 1: `CapacityManager` — Old constructors removed

* **What functionality was changed?** The 3-parameter `CapacityManager(throttleRetryCount, throttleRetryCost, throttleCost)` and 4-parameter `CapacityManager(..., timeoutRetryCost)` constructors were replaced with a single 5-parameter constructor `CapacityManager(initialRetryTokens, retryCost, noRetryIncrement, timeoutRetryCost, throttlingRetryCost)`.
* **How will this impact customers?** No impact. `CapacityManager` is in the `Amazon.Runtime.Internal` namespace. No service DLL or external code constructs `CapacityManager` directly, it is only instantiated by `StandardRetryPolicy` and `DefaultRetryPolicy` within the Core assembly.
* **Why does this need to be a breaking change?** The old constructors computed `initialRetryTokens` from `throttleRetryCount * throttleRetryCost`, which was confusing and hid the actual token count. The new constructor takes the total token count directly, matching the SEP 2.1 specification terminology.
* **Are best practices being followed?** Yes. The `Internal` namespace convention signals these are not part of the public API contract.
* **How have you tested this?** 
  - All 47 unit tests pass (18 SEP 2.1 + 13 standard + 12 adaptive + 4 capacity manager)
  - All service DLLs (EC2, S3, DynamoDB, STS) compile successfully against the new Core
  - **Binary compatibility test**: Built old S3/STS service DLLs from `main` branch, then ran them with the new Core DLL, real AWS calls (S3 ListBuckets, STS GetCallerIdentity) succeeded without any `MissingMethodException` or `TypeLoadException`

#### Change 2: `StandardRetryPolicy.CalculateRetryDelay` — Signature changed

* **What functionality was changed?** `CalculateRetryDelay(int retries, int maxBackoffInMilliseconds)` (protected static) was replaced with `CalculateRetryDelay(IExecutionContext, int maxBackoffInMilliseconds)` (internal static) to support service-aware backoff and x-amz-retry-after header.
* **How will this impact customers?** No impact. No service DLL or known external code calls this method. DynamoDB has its own private `CalculateRetryDelay(int)` with a different signature.
* **Why does this need to be a breaking change?** The new formula requires `IExecutionContext` to determine the service type (DynamoDB vs others), error type (throttling vs transient), and x-amz-retry-after header value.
* **How have you tested this?** Same as above, binary compatibility test confirmed no runtime errors.

#### Change 3: `StandardRetryPolicy.WaitBeforeRetry(int, int)` — Removed

* **What functionality was changed?** The public static helper `WaitBeforeRetry(int retries, int maxBackoffInMilliseconds)` was removed. The virtual `WaitBeforeRetry(IExecutionContext)` override remains unchanged.
* **How will this impact customers?** No impact. All service retry policies use the virtual `WaitBeforeRetry(IExecutionContext)` method, not the static helper.
* **How have you tested this?** Binary compatibility test with old service DLLs confirmed no `MissingMethodException`.

#### Change 4: DynamoDB/DynamoDB Streams `MaxErrorRetry` default

* **What functionality was changed?** The `MaxErrorRetry = 10` assignment was removed from the generated `AmazonDynamoDBConfig`/`AmazonDynamoDBStreamsConfig` constructors. The retry policy now sets the default internally: 3 retries when `UseNewRetries2026` is enabled, 10 retries when disabled.
* **How will this impact customers?** When `UseNewRetries2026` is disabled (default), DynamoDB still defaults to 10 retries, no behavioral change. When enabled, it uses 3 retries per SEP 2.1.
* **How have you tested this?** Unit test `DynamoDBBaseBackoffAndIncreasedRetries` verifies 4 max attempts (3 retries) under the new flag.

2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement