### PR TITLE
Replace AttributesToGet usage with ProjectionExpression for batch get requests

### DIFF
--- a/generator/.DevConfigs/9f2f30a2-1c7a-421e-b329-5b27715518d7.json
+++ b/generator/.DevConfigs/9f2f30a2-1c7a-421e-b329-5b27715518d7.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "DynamoDBv2",
+      "type": "minor",
+      "changeLogMessages": [
+        "Replace AttributesToGet usage with ProjectionExpression for batch get requests"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGet.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/BatchGet.cs
@@ -193,7 +193,7 @@ namespace Amazon.DynamoDBv2.DataModel
 
             DocumentBatchGet docBatch = new DocumentBatchGet(table)
             {
-                AttributesToGet = _itemStorageConfig.AttributesToGet,
+                ProjectionExpression = _itemStorageConfig.ProjectionExpression,
                 ConsistentRead = ConsistentRead
             };
             docBatch.Keys.AddRange(_keys);
@@ -205,6 +205,7 @@ namespace Amazon.DynamoDBv2.DataModel
         {
             UntypedResults.Clear();
             Results.Clear();
+
             foreach (var doc in items)
             {
                 var item = _context.FromDocumentHelper<T>(doc, _config);

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -506,6 +506,8 @@ namespace Amazon.DynamoDBv2.DataModel
         // properties to get
         public List<string> AttributesToGet { get; private set; }
 
+        public Expression ProjectionExpression { get; private set; }
+
         // version
         public string VersionPropertyName { get; private set; }
         public bool HasVersion { get { return !string.IsNullOrEmpty(VersionPropertyName); } }
@@ -678,6 +680,23 @@ namespace Amazon.DynamoDBv2.DataModel
             this.PolymorphicConfig.Add(derivedType, typeDiscriminator);
         }
 
+        private void AddAttributeNameToProjectionExpression(string derivedTypeAttributeName)
+        {
+            var projectionExpressionBuilder = new StringBuilder();
+            var expressionAttributeName = "#P" + ProjectionExpression.ExpressionAttributeNames.Count.ToString(CultureInfo.InvariantCulture);
+            if (projectionExpressionBuilder.Length == 0 && !string.IsNullOrEmpty(ProjectionExpression.ExpressionStatement))
+            {
+                projectionExpressionBuilder.Append(ProjectionExpression.ExpressionStatement);
+            }
+            if (ProjectionExpression.ExpressionAttributeNames.Count > 0)
+            {
+                projectionExpressionBuilder.Append(", ");
+            }
+            projectionExpressionBuilder.Append(expressionAttributeName);
+            ProjectionExpression.ExpressionStatement = projectionExpressionBuilder.ToString();
+            ProjectionExpression.ExpressionAttributeNames.Add(expressionAttributeName, derivedTypeAttributeName);
+        }
+
         private void AddPropertyStorage(PropertyStorage value, StorageConfig config)
         {
             string propertyName = value.PropertyName;
@@ -687,6 +706,10 @@ namespace Amazon.DynamoDBv2.DataModel
 
             if (!AttributesToGet.Contains(attributeName))
                 AttributesToGet.Add(attributeName);
+
+            if (!ProjectionExpression.ExpressionAttributeNames.ContainsValue(attributeName))
+                AddAttributeNameToProjectionExpression(attributeName);
+
             if (value.StoreAsEpoch)
                 AttributesToStoreAsEpoch.Add(attributeName);
             if (value.StoreAsEpochLong)
@@ -776,6 +799,7 @@ namespace Amazon.DynamoDBv2.DataModel
             IndexNameToLSIRangePropertiesMapping = new Dictionary<string, List<string>>(StringComparer.Ordinal);
             IndexNameToGSIMapping = new Dictionary<string, GSIConfig>(StringComparer.Ordinal);
             AttributesToGet = new List<string>();
+            ProjectionExpression = new Expression();
             HashKeyPropertyNames = new List<string>();
             RangeKeyPropertyNames = new List<string>();
             AttributesToStoreAsEpoch = new HashSet<string>();

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -683,18 +683,21 @@ namespace Amazon.DynamoDBv2.DataModel
 
         private void AddAttributeNameToProjectionExpression(string derivedTypeAttributeName)
         {
-            var projectionExpressionBuilder = new StringBuilder();
-            var expressionAttributeName = "#P" + ProjectionExpression.ExpressionAttributeNames.Count.ToString(CultureInfo.InvariantCulture);
-            if (projectionExpressionBuilder.Length == 0 && !string.IsNullOrEmpty(ProjectionExpression.ExpressionStatement))
+            var expressionAttributeCount = ProjectionExpression.ExpressionAttributeNames.Count;
+            var expressionAttributeName = "#P" + expressionAttributeCount.ToString(CultureInfo.InvariantCulture);
+
+            var currentExpressionStatement = ProjectionExpression.ExpressionStatement;
+            if (string.IsNullOrEmpty(currentExpressionStatement))
             {
-                projectionExpressionBuilder.Append(ProjectionExpression.ExpressionStatement);
+                ProjectionExpression.ExpressionStatement = expressionAttributeName;
             }
-            if (ProjectionExpression.ExpressionAttributeNames.Count > 0)
+            else
             {
-                projectionExpressionBuilder.Append(", ");
+                ProjectionExpression.ExpressionStatement = expressionAttributeCount > 0
+                    ? string.Concat(currentExpressionStatement, ", ", expressionAttributeName)
+                    : string.Concat(currentExpressionStatement, expressionAttributeName);
             }
-            projectionExpressionBuilder.Append(expressionAttributeName);
-            ProjectionExpression.ExpressionStatement = projectionExpressionBuilder.ToString();
+
             ProjectionExpression.ExpressionAttributeNames.Add(expressionAttributeName, derivedTypeAttributeName);
         }
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DataModel/InternalModel.cs
@@ -624,6 +624,7 @@ namespace Amazon.DynamoDBv2.DataModel
             if (StorePolymorphicTypes)
             {
                 AttributesToGet.Add(derivedTypeAttributeName);
+                AddAttributeNameToProjectionExpression(derivedTypeAttributeName);
             }
 
             if (this.BaseTypeStorageConfig.Properties.Count == 0)

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentBatchGet.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentBatchGet.cs
@@ -40,6 +40,11 @@ namespace Amazon.DynamoDBv2.DocumentModel
         public List<string> AttributesToGet { get; set; }
 
         /// <summary>
+        /// Expression to specify the attributes to retrieve.
+        /// </summary>
+        public Expression ProjectionExpression { get; set; }
+
+        /// <summary>
         /// Returns the total number of keys associated with this Batch request.
         /// </summary>
         public int TotalKeys { get; }
@@ -103,6 +108,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
         public List<string> AttributesToGet { get; set; }
 
         /// <inheritdoc/>
+        public Expression ProjectionExpression { get; set; }
+
+        /// <inheritdoc/>
         public int TotalKeys => Keys.Count;
 
         /// <inheritdoc/>
@@ -163,40 +171,26 @@ namespace Amazon.DynamoDBv2.DocumentModel
         {
             MultiBatchGet resultsObject = new MultiBatchGet
             {
-                Batches = new List<DocumentBatchGet> { this }
+                Batches = new List<DocumentBatchGet>(1) { this }
             };
 
             var results = resultsObject.GetItemsHelper();
 
             List<Document> batchResults;
-            if (results.TryGetValue(TargetTable.TableName, out batchResults))
-            {
-                Results = batchResults;
-            }
-            else
-            {
-                Results = new List<Document>();
-            }
+            Results = results.TryGetValue(TargetTable.TableName, out batchResults) ? batchResults : new List<Document>();
         }
 
         internal async Task ExecuteHelperAsync(CancellationToken cancellationToken)
         {
             MultiBatchGet resultsObject = new MultiBatchGet
             {
-                Batches = new List<DocumentBatchGet> { this }
+                Batches = new List<DocumentBatchGet>(1) { this }
             };
 
             var results = await resultsObject.GetItemsHelperAsync(cancellationToken).ConfigureAwait(false);
 
             List<Document> batchResults;
-            if (results.TryGetValue(TargetTable.TableName, out batchResults))
-            {
-                Results = batchResults;
-            }
-            else
-            {
-                Results = new List<Document>();
-            }
+            Results = results.TryGetValue(TargetTable.TableName, out batchResults) ? batchResults : new List<Document>();
         }
 
         internal void AddKey(Document document)
@@ -398,13 +392,13 @@ namespace Amazon.DynamoDBv2.DocumentModel
         {
             var results = await GetAttributeItemsAsync(cancellationToken).ConfigureAwait(false);
 
-            var itemsAsDocuments = new Dictionary<string, List<Document>>(StringComparer.Ordinal);
+            var itemsAsDocuments = new Dictionary<string, List<Document>>(results.RetrievedItems.Count, StringComparer.Ordinal);
             foreach (var kvp in results.RetrievedItems)
             {
                 var tableName = kvp.Key;
                 var table = results.TargetTables[tableName];
 
-                List<Document> documents = new List<Document>();
+                List<Document> documents = new List<Document>(kvp.Value.Count);
                 foreach (var dictionary in kvp.Value)
                 {
                     documents.Add(table.FromAttributeMap(dictionary));
@@ -419,13 +413,13 @@ namespace Amazon.DynamoDBv2.DocumentModel
         {
             var results = GetAttributeItems();
 
-            var itemsAsDocuments = new Dictionary<string, List<Document>>(StringComparer.Ordinal);
+            var itemsAsDocuments = new Dictionary<string, List<Document>>(results.RetrievedItems.Count, StringComparer.Ordinal);
             foreach (var kvp in results.RetrievedItems)
             {
                 var tableName = kvp.Key;
                 var table = results.TargetTables[tableName];
 
-                List<Document> documents = new List<Document>();
+                List<Document> documents = new List<Document>(kvp.Value.Count);
                 foreach (var dictionary in kvp.Value)
                 {
                     documents.Add(table.FromAttributeMap(dictionary));
@@ -450,7 +444,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
             var convertedBatches = ConvertBatches();
             while (true)
             {
-                var nextSet = GetNextRequestItems(ref convertedBatches, MaxItemsPerCall);
+                var nextSet = GetNextRequestItems(convertedBatches, MaxItemsPerCall);
                 if (nextSet.Count == 0)
                     break;
 
@@ -477,7 +471,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
             var convertedBatches = ConvertBatches();
             while (true)
             {
-                var nextSet = GetNextRequestItems(ref convertedBatches, MaxItemsPerCall);
+                var nextSet = GetNextRequestItems(convertedBatches, MaxItemsPerCall);
                 if (nextSet.Count == 0)
                     break;
 
@@ -539,18 +533,33 @@ namespace Amazon.DynamoDBv2.DocumentModel
         {
             BatchGetItemRequest request = new BatchGetItemRequest();
 
-            var requestItems = new Dictionary<string, KeysAndAttributes>();
+            var requestItems = new Dictionary<string, KeysAndAttributes>(set.Count);
             foreach (var kvp in set)
             {
                 var tableName = kvp.Key;
                 var requestSet = kvp.Value;
 
+                if (requestSet.Batch.ProjectionExpression is { IsSet: true } &&
+                    requestSet.Batch.AttributesToGet is { Count: > 0 }) 
+                {
+                    throw new  InvalidOperationException($"BatchGetItem request for table {tableName} contains both ProjectionExpression and AttributesToGet, which is not allowed. Please specify only one of these properties.");
+                }
+
                 var keys = new KeysAndAttributes
                 {
                     Keys = requestSet.GetItems(),
-                    ConsistentRead = requestSet.Batch.ConsistentRead,
-                    AttributesToGet = requestSet.Batch.AttributesToGet
+                    ConsistentRead = requestSet.Batch.ConsistentRead
                 };
+
+                if (requestSet.Batch.ProjectionExpression is { IsSet: true })
+                {
+                    keys.ProjectionExpression = requestSet.Batch.ProjectionExpression.ExpressionStatement;
+                    keys.ExpressionAttributeNames = requestSet.Batch.ProjectionExpression.ExpressionAttributeNames;
+                }
+                else
+                {
+                    keys.AttributesToGet = requestSet.Batch.AttributesToGet;
+                }
 
                 requestItems.Add(tableName, keys);
             }
@@ -561,7 +570,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         private Dictionary<string, RequestSet> ConvertBatches()
         {
-            var allItems = new Dictionary<string, RequestSet>();
+            var allItems = new Dictionary<string, RequestSet>(Batches?.Count ?? 0);
             if (Batches == null || Batches.Count == 0)
                 return allItems;
 
@@ -584,17 +593,17 @@ namespace Amazon.DynamoDBv2.DocumentModel
             return allItems;
         }
 
-        private static Dictionary<string, RequestSet> GetNextRequestItems(ref Dictionary<string, RequestSet> getRequestsMap, int maxNumberOfItems)
+        private static Dictionary<string, RequestSet> GetNextRequestItems(Dictionary<string, RequestSet> getRequestsMap, int maxNumberOfItems)
         {
             int numberOfItems = 0;
-            var nextItems = new Dictionary<string, RequestSet>();
-            List<string> keys = new List<string>(getRequestsMap.Keys);
-            foreach (string tableName in keys)
+            var nextItems = new Dictionary<string, RequestSet>(getRequestsMap.Count);
+            foreach (var kvp in getRequestsMap)
             {
                 if (numberOfItems >= maxNumberOfItems)
                     break;
 
-                var getRequests = getRequestsMap[tableName];
+                var tableName = kvp.Key;
+                var getRequests = kvp.Value;
                 if (getRequests.Count == 0)
                     continue;
 

--- a/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModel/DataModelNestedTableTests.cs
+++ b/sdk/test/Services/DynamoDBv2/IntegrationTests/DataModel/DataModelNestedTableTests.cs
@@ -121,6 +121,47 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.DynamoDB
         }
 
         [Fact]
+        public async Task TestContext_SaveAndBatchGet_WithDerivedTypeItems_ByHashKey()
+        {
+            var model1 = CreateNestedTypeItem(out var id1);
+            var model2 = new ModelA2
+            {
+                Id = Guid.NewGuid(),
+                MyType = new A { Name = "A1", MyPropA = 1 },
+                MyInterface = new InterfaceB
+                {
+                    S2 = 2,
+                    S1 = "s1",
+                    S4 = "s4"
+                },
+                DictionaryClasses = new Dictionary<string, A>
+                {
+                    { "A", new A { Name = "A1", MyPropA = 1 } },
+                    { "B", new B { Name = "A1", MyPropA = 1, MyPropB = 2 } }
+                }
+            };
+
+            var transactWrite = _context.CreateTransactWrite<ModelA>();
+            transactWrite.AddSaveItems(new[] { model1, model2 });
+            await transactWrite.ExecuteAsync();
+
+            var batchGet = _context.CreateBatchGet<ModelA>();
+            batchGet.AddKey(id1);
+            batchGet.AddKey(model2.Id);
+            await batchGet.ExecuteAsync();
+
+            Assert.Equal(2, batchGet.Results.Count);
+
+            var storedModel1 = batchGet.Results.FirstOrDefault(m => m.Id == id1);
+            var storedModel2 = batchGet.Results.FirstOrDefault(m => m.Id == model2.Id);
+
+            Assert.NotNull(storedModel1);
+            Assert.NotNull(storedModel2);
+            Assert.IsType<ModelA1>(storedModel1);
+            Assert.IsType<ModelA2>(storedModel2);
+        }
+
+        [Fact]
         public async Task TestContext_TransactWriteAndLoad_WithLocalSecondaryIndexRangeKey()
         {
             var model = new ModelA2

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModel/ItemStorageConfigTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModel/ItemStorageConfigTests.cs
@@ -112,6 +112,36 @@ namespace AWSSDK_DotNet.UnitTests
         }
 
         [TestMethod]
+        public void Denormalize_DerivedTypeAttribute_MustBeInProjectionExpression()
+        {
+            var mockClient = new Mock<IAmazonDynamoDB>();
+            var context = new DummyContext(mockClient.Object);
+            var config = CreatePopulatedConfig(mockClient);
+
+            var polyStorage = new StorageConfig(typeof(DerivedType));
+            var extraProp = new PropertyStorage(typeof(DerivedType).GetProperty(nameof(DerivedType.Extra)))
+            { AttributeName = "Extra" };
+            extraProp.IndexNames ??= new List<string>();
+            extraProp.FlattenProperties ??= new List<PropertyStorage>();
+            polyStorage.Properties.Add(extraProp);
+
+            config.AddPolymorphicPropertyStorageConfiguration("DT1", typeof(DerivedType), polyStorage);
+
+            var polyPropOnBase = new PropertyStorage(typeof(TestClass).GetProperty(nameof(TestClass.Poly)))
+            { AttributeName = "Poly", PolymorphicProperty = true };
+            polyPropOnBase.IndexNames ??= new List<string>();
+            polyPropOnBase.FlattenProperties ??= new List<PropertyStorage>();
+            config.BaseTypeStorageConfig.Properties.Add(polyPropOnBase);
+
+            config.Denormalize(context, derivedTypeAttributeName: "dtype");
+
+            Assert.IsTrue(config.AttributesToGet.Contains("dtype"));
+            Assert.IsTrue(
+                config.ProjectionExpression.ExpressionAttributeNames.ContainsValue("dtype"),
+                "ProjectionExpression must include the derived type attribute so polymorphic batch gets return the $type column");
+        }
+
+        [TestMethod]
         public void Denormalize_PopulatesKeys_AttributesAndIndexMappings()
         {
             var mockClient = new Mock<IAmazonDynamoDB>();
@@ -144,6 +174,8 @@ namespace AWSSDK_DotNet.UnitTests
             CollectionAssert.Contains(config.IndexNameToLSIRangePropertiesMapping["LSI_A"], nameof(TestClass.LsiRange));
 
             Assert.IsFalse(config.AttributesToGet.Contains("dtype"));
+            Assert.IsFalse(config.ProjectionExpression.ExpressionAttributeNames.ContainsValue("dtype"));
+
         }
 
         [TestMethod]

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModel/PropertyStorageTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModel/PropertyStorageTests.cs
@@ -1,10 +1,11 @@
-﻿using Amazon.DynamoDBv2.DataModel;
+﻿using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
-using Amazon.DynamoDBv2;
+using System.IO;
 
 namespace AWSSDK_DotNet.UnitTests
 {

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DocumentModel/DocumentBatchGetTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DocumentModel/DocumentBatchGetTests.cs
@@ -1,0 +1,239 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DocumentModel;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AWSSDK_DotNet.UnitTests
+{
+    [TestClass]
+    public class DocumentBatchGetTests
+    {
+        private Mock<IAmazonDynamoDB> ddbClientMock;
+        private Table addressTable;
+        private Table personTable;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            ddbClientMock = new Mock<IAmazonDynamoDB>(MockBehavior.Strict);
+
+            var clientConfigMock = new Mock<IClientConfig>();
+            clientConfigMock.SetupGet(c => c.RegionEndpoint).Returns((Amazon.RegionEndpoint)null);
+            clientConfigMock.SetupGet(c => c.ServiceURL).Returns((string)null);
+            ddbClientMock.SetupGet(c => c.Config).Returns(clientConfigMock.Object);
+
+            addressTable = CreateTable(ddbClientMock.Object, "AddressTable");
+            personTable = CreateTable(ddbClientMock.Object, "PersonTable");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_MultiTableBatch_MapsRetrievedItemsToDocuments()
+        {
+            ddbClientMock
+                .Setup(c => c.BatchGetItemAsync(It.IsAny<BatchGetItemRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(CreateBatchGetItemResponse());
+
+            var (addressBatch, personBatch) = CreateBatches(addressTable, personTable);
+
+            var multiBatch = new MultiTableDocumentBatchGet(addressBatch, personBatch);
+
+            await multiBatch.ExecuteAsync();
+
+            AssertBatchResults(addressBatch, "A1", "A2");
+            AssertBatchResults(personBatch, "P1", "P2");
+
+            ddbClientMock.Verify(
+                c => c.BatchGetItemAsync(It.IsAny<BatchGetItemRequest>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public void Execute_MultiTableBatch_MapsRetrievedItemsToDocuments()
+        {
+            ddbClientMock
+                .Setup(c => c.BatchGetItem(It.IsAny<BatchGetItemRequest>()))
+                .Returns(CreateBatchGetItemResponse());
+
+            var (addressBatch, personBatch) = CreateBatches(addressTable, personTable);
+
+            var multiBatch = new MultiTableDocumentBatchGet(addressBatch, personBatch);
+
+            multiBatch.Execute();
+
+            AssertBatchResults(addressBatch, "A1", "A2");
+            AssertBatchResults(personBatch, "P1", "P2");
+
+            ddbClientMock.Verify(
+                c => c.BatchGetItem(It.IsAny<BatchGetItemRequest>()),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public async Task GetItemsAsync_WhenBatchesIsNull_ReturnsEmptyResults()
+        {
+            var multiBatchGet = new MultiBatchGet
+            {
+                Batches = null
+            };
+
+            var results = await multiBatchGet.GetItemsAsync();
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [TestMethod]
+        public async Task GetItemsAsync_WhenMultipleBatchesTargetSameTable_ThrowsException()
+        {
+            var firstBatch = (DocumentBatchGet)addressTable.CreateBatchGet();
+            firstBatch.AddKey(new Primitive("A1"));
+
+            var secondBatch = (DocumentBatchGet)addressTable.CreateBatchGet();
+            secondBatch.AddKey(new Primitive("A2"));
+
+            var multiBatchGet = new MultiBatchGet
+            {
+                Batches = new List<DocumentBatchGet> { firstBatch, secondBatch }
+            };
+
+            await Assert.ThrowsExceptionAsync<AmazonDynamoDBException>(() => multiBatchGet.GetItemsAsync());
+        }
+
+        [TestMethod]
+        public async Task GetItemsAsync_WhenRequestHitsMaxItems_ProcessesOneTablePerCall()
+        {
+            var requestTableNamesPerCall = new List<List<string>>();
+            var requestKeyCountPerCall = new List<int>();
+
+            ddbClientMock
+                .Setup(c => c.BatchGetItemAsync(It.IsAny<BatchGetItemRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((BatchGetItemRequest request, CancellationToken _) =>
+                {
+                    requestTableNamesPerCall.Add(request.RequestItems.Keys.ToList());
+                    requestKeyCountPerCall.Add(request.RequestItems.Values.Sum(v => v.Keys.Count));
+
+                    return new BatchGetItemResponse
+                    {
+                        Responses = new Dictionary<string, List<Dictionary<string, AttributeValue>>>(),
+                        UnprocessedKeys = new Dictionary<string, KeysAndAttributes>()
+                    };
+                });
+
+            var addressBatch = CreateBatchWithKeys(addressTable, "A", MultiBatchGet.MaxItemsPerCall);
+
+            var multiBatchGet = new MultiBatchGet
+            {
+                Batches = new List<DocumentBatchGet> { addressBatch }
+            };
+
+            var results = await multiBatchGet.GetItemsAsync();
+
+            Assert.AreEqual(0, results.Count);
+            Assert.AreEqual(1, requestTableNamesPerCall.Count);
+            Assert.IsTrue(requestTableNamesPerCall.All(tables => tables.Count == 1));
+            Assert.IsTrue(requestKeyCountPerCall.All(count => count == MultiBatchGet.MaxItemsPerCall));
+
+            var allRequestedTables = requestTableNamesPerCall.SelectMany(t => t).ToList();
+            CollectionAssert.AreEquivalent(new List<string> { "AddressTable" }, allRequestedTables);
+        }
+
+        [TestMethod]
+        public async Task GetItemsAsync_WhenBatchesIsEmpty_ReturnsEmptyResults()
+        {
+            var multiBatchGet = new MultiBatchGet
+            {
+                Batches = new List<DocumentBatchGet>()
+            };
+
+            var results = await multiBatchGet.GetItemsAsync();
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(0, results.Count);
+        }
+
+        private static (IDocumentBatchGet AddressBatch, IDocumentBatchGet PersonBatch) CreateBatches(Table addressTable, Table personTable)
+        {
+            var addressBatch = addressTable.CreateBatchGet();
+            addressBatch.AddKey(new Primitive("A1"));
+            addressBatch.AddKey(new Primitive("A2"));
+
+            var personBatch = personTable.CreateBatchGet();
+            personBatch.AddKey(new Primitive("P1"));
+            personBatch.AddKey(new Primitive("P2"));
+
+            return (addressBatch, personBatch);
+        }
+
+        private static DocumentBatchGet CreateBatchWithKeys(Table table, string keyPrefix, int count)
+        {
+            var batch = (DocumentBatchGet)table.CreateBatchGet();
+            for (var i = 1; i <= count; i++)
+            {
+                batch.AddKey(new Primitive($"{keyPrefix}{i}"));
+            }
+
+            return batch;
+        }
+
+        private static BatchGetItemResponse CreateBatchGetItemResponse()
+        {
+            return new BatchGetItemResponse
+            {
+                Responses = new Dictionary<string, List<Dictionary<string, AttributeValue>>>
+                {
+                    ["AddressTable"] = new List<Dictionary<string, AttributeValue>>
+                    {
+                        new Dictionary<string, AttributeValue>
+                        {
+                            ["Id"] = new AttributeValue { S = "A1" },
+                            ["Zip"] = new AttributeValue { S = "12345" }
+                        },
+                        new Dictionary<string, AttributeValue>
+                        {
+                            ["Id"] = new AttributeValue { S = "A2" },
+                            ["Zip"] = new AttributeValue { S = "67890" }
+                        }
+                    },
+                    ["PersonTable"] = new List<Dictionary<string, AttributeValue>>
+                    {
+                        new Dictionary<string, AttributeValue>
+                        {
+                            ["Id"] = new AttributeValue { S = "P1" },
+                            ["Name"] = new AttributeValue { S = "Ada" }
+                        },
+                        new Dictionary<string, AttributeValue>
+                        {
+                            ["Id"] = new AttributeValue { S = "P2" },
+                            ["Name"] = new AttributeValue { S = "Grace" }
+                        }
+                    }
+                },
+                UnprocessedKeys = new Dictionary<string, KeysAndAttributes>()
+            };
+        }
+
+        private static void AssertBatchResults(IDocumentBatchGet batch, params string[] expectedIds)
+        {
+            Assert.AreEqual(expectedIds.Length, batch.Results.Count);
+            CollectionAssert.AreEquivalent(expectedIds, batch.Results.Select(d => d["Id"].AsString()).ToList());
+        }
+
+        private static Table CreateTable(IAmazonDynamoDB client, string tableName)
+        {
+            var config = new TableConfig(tableName);
+            var table = new Table(client, config);
+
+            table.ClearTableData();
+            table.Keys.Add("Id", new KeyDescription { IsHash = true, Type = DynamoDBEntryType.String });
+            table.HashKeys.Add("Id");
+
+            return table;
+        }
+    }
+}


### PR DESCRIPTION
Replace `AttributesToGet` usage with `ProjectionExpression` for batch get requests created from the DynamoDB data model layer, and add tests around `DocumentBatchGet` behavior. 

## Description

* pass `ProjectionExpression` from `ItemStorageConfig` into `DocumentBatchGet`
* build projection expressions and expression attribute names as properties are added to storage config, (AttributesToGet internal property can be removed after PR#4343 is also merged)
* update request creation to use either `ProjectionExpression` or `AttributesToGet`, and throws if both are set,
* add unit tests for multi-batch execution and edge cases in `DocumentBatchGet`. 

## Motivation and Context
Replace legacy params usage in HLL

## Testing
Unit tests added, all existing integration tests passing

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement