### PR TITLE
Use MD5.HashData() on .NET 8+ to reduce allocations in CryptoUtil.ComputeMD5Hash

### DIFF
--- a/generator/.DevConfigs/2ae3bf1c-c2cd-40f5-a173-b7a1dc417c70.json
+++ b/generator/.DevConfigs/2ae3bf1c-c2cd-40f5-a173-b7a1dc417c70.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Use MD5.HashData() on .NET 8+ to reduce allocations in CryptoUtil.ComputeMD5Hash."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Util/CryptoUtil.cs
+++ b/sdk/src/Core/Amazon.Util/CryptoUtil.cs
@@ -169,8 +169,12 @@ namespace Amazon.Util
             /// <returns>Computed hash code</returns>
             public byte[] ComputeMD5Hash(byte[] data)
             {
+#if NET8_0_OR_GREATER
+                return MD5.HashData(data);
+#else
                 var hashed = new MD5Managed().ComputeHash(data);
                 return hashed;
+#endif
             }
 
             /// <summary>
@@ -180,8 +184,12 @@ namespace Amazon.Util
             /// <returns>Computed hash code</returns>
             public byte[] ComputeMD5Hash(Stream steam)
             {
+#if NET8_0_OR_GREATER
+                return MD5.HashData(steam);
+#else
                 var hashed = new MD5Managed().ComputeHash(steam);
                 return hashed;
+#endif
             }
 
             /// <summary>

--- a/sdk/test/NetStandard/UnitTests/Core/CryptoUtilTests.cs
+++ b/sdk/test/NetStandard/UnitTests/Core/CryptoUtilTests.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Runtime;
+﻿using System;
+using System.IO;
+using System.Text;
+using Amazon.Runtime;
 using Amazon.Util;
 using Xunit;
 
@@ -13,6 +16,39 @@ namespace UnitTests.NetStandard.Core
             var actual = CryptoUtilFactory.CryptoInstance.HMACSign("HELLOWORLD", "HELLOKEY", SigningAlgorithm.HmacSHA256);
 
             Assert.Equal("LH+6qR+N6WU91evFKfjq/6NqiVES5BD6z6EHYsDwOUE=", actual);
+        }
+
+        [Fact]
+        [Trait("Category", "Core")]
+        public void ComputeMD5Hash_ByteArray_ReturnsCorrectHash()
+        {
+            var data = Encoding.UTF8.GetBytes("hello");
+            var hash = CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(data);
+            var hex = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+
+            Assert.Equal("5d41402abc4b2a76b9719d911017c592", hex);
+        }
+
+        [Fact]
+        [Trait("Category", "Core")]
+        public void ComputeMD5Hash_Stream_ReturnsCorrectHash()
+        {
+            var data = Encoding.UTF8.GetBytes("hello");
+            using var stream = new MemoryStream(data);
+            var hash = CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(stream);
+            var hex = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+
+            Assert.Equal("5d41402abc4b2a76b9719d911017c592", hex);
+        }
+
+        [Fact]
+        [Trait("Category", "Core")]
+        public void ComputeMD5Hash_EmptyInput_ReturnsCorrectHash()
+        {
+            var hash = CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(Array.Empty<byte>());
+            var hex = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+
+            Assert.Equal("d41d8cd98f00b204e9800998ecf8427e", hex);
         }
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
`CryptoUtil.ComputeMD5Hash()` instantiates a new `MD5Managed()` object on every call, which allocates internal buffers proportional to the input size.

On .NET 8+, use the static `MD5.HashData()` API instead of `new MD5Managed().ComputeHash()`. The existing `MD5Managed` fallback is retained for older target frameworks via `#if NET8_0_OR_GREATER` / `#else`.

<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-8583`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
- Tested via BenchmarkDotNet and got these results:

|                                  Method |           Mean |        Error |        StdDev |         Median |     Gen0 | Allocated |
|---------------------------------------- |---------------:|-------------:|--------------:|---------------:|---------:|----------:|
|                      &#39;MD5Managed  256B&#39; |       933.7 ns |     39.37 ns |     116.10 ns |       915.1 ns |   0.0801 |    1024 B |
|                    &#39;MD5.HashData  256B&#39; |       781.5 ns |     25.00 ns |      73.72 ns |       771.3 ns |   0.0029 |      40 B |
|                       &#39;MD5Managed  8KB&#39; |    18,566.0 ns |    542.86 ns |   1,583.55 ns |    17,972.2 ns |   0.9460 |   11936 B |
|                     &#39;MD5.HashData  8KB&#39; |    13,930.3 ns |    233.08 ns |     395.79 ns |    13,712.0 ns |        - |      40 B |
|                       &#39;MD5Managed  1MB&#39; | 2,208,101.6 ns | 47,608.26 ns | 132,712.79 ns | 2,169,982.6 ns | 113.2813 | 1442466 B |
|                     &#39;MD5.HashData  1MB&#39; | 1,827,672.8 ns | 36,416.11 ns |  48,614.45 ns | 1,821,326.6 ns |        - |      41 B |
|       &#39;CryptoUtil.ComputeMD5Hash  256B&#39; |       731.6 ns |     17.24 ns |      49.46 ns |       723.5 ns |   0.0029 |      40 B |
|        &#39;CryptoUtil.ComputeMD5Hash  8KB&#39; |    14,605.5 ns |    295.54 ns |     833.57 ns |    14,451.6 ns |        - |      40 B |
|        &#39;CryptoUtil.ComputeMD5Hash  1MB&#39; | 1,786,034.0 ns | 35,547.24 ns |  52,104.68 ns | 1,783,583.6 ns |        - |      41 B |
- Add new unit tests to verify the results against known MD5 test vectors: MD5("hello"), MD5(""), byte/stream parity.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** e5fae745-7882-4750-b132-15e35c4e2780
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 54fa5b87-ff84-4bcf-9d5d-a6d0326a8cf6
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed


## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement