### PR TITLE
Cache compiled Regex instances in Partition and RegionEndpoint for en…

### DIFF
--- a/generator/.DevConfigs/1b22ae51-b2c9-40ca-bb2b-d16a341993fe.json
+++ b/generator/.DevConfigs/1b22ae51-b2c9-40ca-bb2b-d16a341993fe.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "changeLogMessages": [
+            "Cache compiled Regex instances in Partition and RegionEndpoint for endpoint resolution performance"
+        ],
+        "type": "patch",
+        "updateMinimum": true
+    }
+}

--- a/generator/ServiceClientGeneratorLib/Generators/Endpoints/PartitionsTemplate.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Endpoints/PartitionsTemplate.cs
@@ -16,7 +16,7 @@ namespace ServiceClientGenerator.Generators.Endpoints
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+    #line 1 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "17.0.0.0")]
     public partial class PartitionsTemplate : PartitionsTemplateBase
     {
@@ -46,6 +46,8 @@ namespace ServiceClientGenerator.Generators.Endpoints
  *  AWS SDK for .NET
  *
  */
+using System.Text.RegularExpressions;
+
 namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
 {
     /// <summary>
@@ -58,105 +60,105 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
         {
 ");
             
-            #line 33 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 35 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
  foreach(var partition in Partitions.partitions) { 
             
             #line default
             #line hidden
             this.Write("            var ");
             
-            #line 34 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 36 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.id.ToVariableName()));
             
             #line default
             #line hidden
             this.Write(" = new PartitionAttributesShape\r\n            {\r\n                name = \"");
             
-            #line 36 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 38 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.outputs.name));
             
             #line default
             #line hidden
             this.Write("\",\r\n                dnsSuffix = \"");
             
-            #line 37 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 39 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.outputs.dnsSuffix));
             
             #line default
             #line hidden
             this.Write("\",\r\n                dualStackDnsSuffix = \"");
             
-            #line 38 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 40 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.outputs.dualStackDnsSuffix));
             
             #line default
             #line hidden
             this.Write("\",\r\n                supportsFIPS = ");
             
-            #line 39 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 41 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.outputs.supportsFIPS.ToString().ToLower()));
             
             #line default
             #line hidden
             this.Write(",\r\n                supportsDualStack = ");
             
-            #line 40 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 42 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.outputs.supportsDualStack.ToString().ToLower()));
             
             #line default
             #line hidden
             this.Write(",\r\n                implicitGlobalRegion = \"");
             
-            #line 41 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 43 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.outputs.implicitGlobalRegion));
             
             #line default
             #line hidden
-            this.Write("\"\r\n            };\r\n            _partitionsByRegex.Add(@\"");
+            this.Write("\"\r\n            };\r\n            _partitionsByRegex.Add((new Regex(@\"");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 45 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.regionRegex));
             
             #line default
             #line hidden
-            this.Write("\", ");
+            this.Write("\", RegexOptions.Compiled), ");
             
-            #line 43 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 45 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.id.ToVariableName()));
             
             #line default
             #line hidden
-            this.Write(");\r\n");
+            this.Write("));\r\n");
             
-            #line 44 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 46 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
      foreach(var region in partition.regions.Keys) { 
             
             #line default
             #line hidden
             this.Write("            _partitionsByRegionName.Add(\"");
             
-            #line 45 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 47 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(region));
             
             #line default
             #line hidden
             this.Write("\", ");
             
-            #line 45 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 47 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(partition.id.ToVariableName()));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 46 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 48 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
      } 
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 48 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+            #line 50 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
  } 
             
             #line default
@@ -165,7 +167,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 54 "C:\codebase\v3\AWSDotNetPublic\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
+        #line 56 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Endpoints\PartitionsTemplate.tt"
 
 public ServiceClientGenerator.Endpoints.Partitions.Partitions Partitions { get; set; }
 

--- a/generator/ServiceClientGeneratorLib/Generators/Endpoints/PartitionsTemplate.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Endpoints/PartitionsTemplate.tt
@@ -20,6 +20,8 @@
  *  AWS SDK for .NET
  *
  */
+using System.Text.RegularExpressions;
+
 namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
 {
     /// <summary>
@@ -40,7 +42,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 supportsDualStack = <#=partition.outputs.supportsDualStack.ToString().ToLower()#>,
                 implicitGlobalRegion = "<#=partition.outputs.implicitGlobalRegion#>"
             };
-            _partitionsByRegex.Add(@"<#=partition.regionRegex#>", <#=partition.id.ToVariableName()#>);
+            _partitionsByRegex.Add((new Regex(@"<#=partition.regionRegex#>", RegexOptions.Compiled), <#=partition.id.ToVariableName()#>));
 <#     foreach(var region in partition.regions.Keys) { #>
             _partitionsByRegionName.Add("<#=region#>", <#=partition.id.ToVariableName()#>);
 <#     } #>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Partition.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Partition.cs
@@ -99,7 +99,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
 
         private static readonly ReaderWriterLockSlim _locker = new ReaderWriterLockSlim();
         private static Dictionary<string, PartitionAttributesShape> _partitionsByRegionName = new Dictionary<string, PartitionAttributesShape>();
-        private static Dictionary<string, PartitionAttributesShape> _partitionsByRegex = new Dictionary<string, PartitionAttributesShape>();
+        private static List<(Regex Regex, PartitionAttributesShape Partition)> _partitionsByRegex = new List<(Regex, PartitionAttributesShape)>();
         private static PartitionAttributesShape _defaultPartition;
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                     {
                         _defaultPartition = partition.outputs;
                     }
-                    _partitionsByRegex.Add(partition.regionRegex, partition.outputs);
+                    _partitionsByRegex.Add((new Regex(partition.regionRegex, RegexOptions.Compiled), partition.outputs));
                     foreach (var region in partition.regions.Keys)
                     {
                         _partitionsByRegionName.Add(region, partition.outputs);
@@ -149,12 +149,12 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 {
                     return FromPartitionData(partition);
                 }
-                // regex match
-                foreach (var regex in _partitionsByRegex.Keys)
+                // regex match using cached compiled Regex instances
+                foreach (var entry in _partitionsByRegex)
                 {
-                    if (Regex.IsMatch(region, regex))
+                    if (entry.Regex.IsMatch(region))
                     {
-                        return FromPartitionData(_partitionsByRegex[regex]);
+                        return FromPartitionData(entry.Partition);
                     }
                 }
                 return FromPartitionData(_defaultPartition);

--- a/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Partition.generated.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Partition.generated.cs
@@ -18,6 +18,8 @@
  *  AWS SDK for .NET
  *
  */
+using System.Text.RegularExpressions;
+
 namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
 {
     /// <summary>
@@ -37,7 +39,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 supportsDualStack = true,
                 implicitGlobalRegion = "us-east-1"
             };
-            _partitionsByRegex.Add(@"^(us|eu|ap|sa|ca|me|af|il|mx)\-\w+\-\d+$", aws);
+            _partitionsByRegex.Add((new Regex(@"^(us|eu|ap|sa|ca|me|af|il|mx)\-\w+\-\d+$", RegexOptions.Compiled), aws));
             _partitionsByRegionName.Add("af-south-1", aws);
             _partitionsByRegionName.Add("ap-east-1", aws);
             _partitionsByRegionName.Add("ap-east-2", aws);
@@ -83,7 +85,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 supportsDualStack = true,
                 implicitGlobalRegion = "cn-northwest-1"
             };
-            _partitionsByRegex.Add(@"^cn\-\w+\-\d+$", aws_cn);
+            _partitionsByRegex.Add((new Regex(@"^cn\-\w+\-\d+$", RegexOptions.Compiled), aws_cn));
             _partitionsByRegionName.Add("aws-cn-global", aws_cn);
             _partitionsByRegionName.Add("cn-north-1", aws_cn);
             _partitionsByRegionName.Add("cn-northwest-1", aws_cn);
@@ -97,7 +99,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 supportsDualStack = true,
                 implicitGlobalRegion = "eusc-de-east-1"
             };
-            _partitionsByRegex.Add(@"^eusc\-(de)\-\w+\-\d+$", aws_eusc);
+            _partitionsByRegex.Add((new Regex(@"^eusc\-(de)\-\w+\-\d+$", RegexOptions.Compiled), aws_eusc));
             _partitionsByRegionName.Add("eusc-de-east-1", aws_eusc);
 
             var aws_iso = new PartitionAttributesShape
@@ -109,7 +111,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 supportsDualStack = true,
                 implicitGlobalRegion = "us-iso-east-1"
             };
-            _partitionsByRegex.Add(@"^us\-iso\-\w+\-\d+$", aws_iso);
+            _partitionsByRegex.Add((new Regex(@"^us\-iso\-\w+\-\d+$", RegexOptions.Compiled), aws_iso));
             _partitionsByRegionName.Add("aws-iso-global", aws_iso);
             _partitionsByRegionName.Add("us-iso-east-1", aws_iso);
             _partitionsByRegionName.Add("us-iso-west-1", aws_iso);
@@ -123,7 +125,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 supportsDualStack = true,
                 implicitGlobalRegion = "us-isob-east-1"
             };
-            _partitionsByRegex.Add(@"^us\-isob\-\w+\-\d+$", aws_iso_b);
+            _partitionsByRegex.Add((new Regex(@"^us\-isob\-\w+\-\d+$", RegexOptions.Compiled), aws_iso_b));
             _partitionsByRegionName.Add("aws-iso-b-global", aws_iso_b);
             _partitionsByRegionName.Add("us-isob-east-1", aws_iso_b);
             _partitionsByRegionName.Add("us-isob-west-1", aws_iso_b);
@@ -137,7 +139,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 supportsDualStack = true,
                 implicitGlobalRegion = "eu-isoe-west-1"
             };
-            _partitionsByRegex.Add(@"^eu\-isoe\-\w+\-\d+$", aws_iso_e);
+            _partitionsByRegex.Add((new Regex(@"^eu\-isoe\-\w+\-\d+$", RegexOptions.Compiled), aws_iso_e));
             _partitionsByRegionName.Add("aws-iso-e-global", aws_iso_e);
             _partitionsByRegionName.Add("eu-isoe-west-1", aws_iso_e);
 
@@ -150,7 +152,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 supportsDualStack = true,
                 implicitGlobalRegion = "us-isof-south-1"
             };
-            _partitionsByRegex.Add(@"^us\-isof\-\w+\-\d+$", aws_iso_f);
+            _partitionsByRegex.Add((new Regex(@"^us\-isof\-\w+\-\d+$", RegexOptions.Compiled), aws_iso_f));
             _partitionsByRegionName.Add("aws-iso-f-global", aws_iso_f);
             _partitionsByRegionName.Add("us-isof-east-1", aws_iso_f);
             _partitionsByRegionName.Add("us-isof-south-1", aws_iso_f);
@@ -164,7 +166,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 supportsDualStack = true,
                 implicitGlobalRegion = "us-gov-west-1"
             };
-            _partitionsByRegex.Add(@"^us\-gov\-\w+\-\d+$", aws_us_gov);
+            _partitionsByRegex.Add((new Regex(@"^us\-gov\-\w+\-\d+$", RegexOptions.Compiled), aws_us_gov));
             _partitionsByRegionName.Add("aws-us-gov-global", aws_us_gov);
             _partitionsByRegionName.Add("us-gov-east-1", aws_us_gov);
             _partitionsByRegionName.Add("us-gov-west-1", aws_us_gov);

--- a/sdk/src/Core/RegionEndpoint/RegionEndpoint.cs
+++ b/sdk/src/Core/RegionEndpoint/RegionEndpoint.cs
@@ -38,7 +38,11 @@ namespace Amazon
         private static Dictionary<string, RegionEndpoint> _hashBySystemName = new Dictionary<string, RegionEndpoint>(StringComparer.OrdinalIgnoreCase);
         private static ReaderWriterLockSlim _readerWriterLock = new ReaderWriterLockSlim();
 
-        private static HashSet<string> _allPartitionRegionRegex = new HashSet<string>();
+        /// <summary>
+        /// Maps partition region regex patterns to their compiled Regex instances.
+        /// Serves as both the set of known patterns and the compiled regex cache.
+        /// </summary>
+        private static Dictionary<string, Regex> _partitionRegionRegexMap = new Dictionary<string, Regex>();
 
         public static IEnumerable<RegionEndpoint> EnumerableAllRegions
         {
@@ -63,7 +67,7 @@ namespace Amazon
                 try
                 {
                     _readerWriterLock.EnterReadLock();
-                    return _allPartitionRegionRegex.ToList();
+                    return _partitionRegionRegexMap.Keys.ToList();
                 }
                 finally
                 {
@@ -93,7 +97,10 @@ namespace Amazon
 
                 regionEndpoint = new RegionEndpoint(systemName, displayName, partitionName, partitionDnsSuffix, partitionRegionRegex, hostnameTemplate);
                 _hashBySystemName.Add(systemName, regionEndpoint);
-                _allPartitionRegionRegex.Add(partitionRegionRegex);
+                if (!_partitionRegionRegexMap.ContainsKey(partitionRegionRegex))
+                {
+                    _partitionRegionRegexMap[partitionRegionRegex] = new Regex(partitionRegionRegex, RegexOptions.Compiled);
+                }
 
                 return regionEndpoint;
             }
@@ -158,7 +165,10 @@ namespace Amazon
 
             // no region key in the entry, but it matches the pattern in this partition.
             // we can try to construct an endpoint based on the heuristics.
-            else if (new Regex(partitionRegionPattern).Match(regionName).Success)
+            // Use cached compiled Regex to avoid per-call Regex instantiation.
+            else if (_partitionRegionRegexMap.TryGetValue(partitionRegionPattern, out var cachedRegex)
+                ? cachedRegex.IsMatch(regionName)
+                : new Regex(partitionRegionPattern).IsMatch(regionName))
             {
                 description = GetUnknownRegionDescription(regionName);
                 return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Changed `_partitionsByRegex` dictionary key from `string` to `Regex`. The compiled `Regex` instances are now the keys themselves — no separate cache needed. This is thread-safe because the dictionary is already guarded by `ReaderWriterLockSlim`.
- Updated `PartitionsTemplate.tt` to generate `new Regex(@"pattern", RegexOptions.Compiled)` keys so future regeneration produces the correct code.

- Merged `_allPartitionRegionRegex` (HashSet) and added a compiled Regex cache into a single `_partitionRegionRegexMap` (`Dictionary<string, Regex>`). Also changed from `.Match().Success` to `.IsMatch()` to avoid unnecessary `Match` object allocation.
<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-8584`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing

Created a BenchmarkDotNet tests and got these results for Fn.Partition()

| Method | Before | After | 
|--------|--------|-------|
| Known region (us-east-1) | 241 ns | 208 ns | 
| Regex match (us-west-99) | 308 ns | 297 ns | 
| **Regex match (cn-south-1)** | **537 ns** | **260 ns** | 
| **Regex match (us-gov-east-99)** | **1,282 ns** | **534 ns** | 
| **No match (unknown-1)** | **759 ns** | **412 ns** |

**RegionEndpoint.GetBySystemName:** Shows no benchmark difference because it self-caches resolved regions in `_hashBySystemName` — subsequent calls hit the dictionary directly. The regex caching improvement applies only to the first resolution of an unknown region.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 88936fb2-0de8-4dac-baf1-9d358809e919
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** d9576ae0-8a36-40cb-ad18-90074dfdef94
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed


## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
