### PR TITLE
Support passing attributes when creating tracers

### DIFF
--- a/generator/.DevConfigs/2d9c0ac9-66b3-457b-a93e-62b7cc5c9a90.json
+++ b/generator/.DevConfigs/2d9c0ac9-66b3-457b-a93e-62b7cc5c9a90.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "minor",
+    "changeLogMessages": [
+      "Add TracerProvider.GetTracer() method overload that accepts Attributes to use to create the Tracer."
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Telemetry/Tracing/TracerProvider.cs
+++ b/sdk/src/Core/Amazon.Runtime/Telemetry/Tracing/TracerProvider.cs
@@ -28,5 +28,15 @@ namespace Amazon.Runtime.Telemetry.Tracing
         /// <param name="scope">The name of the instrumentation scope that uniquely identifies the tracer.</param>
         /// <returns>A <see cref="Tracer"/> instance for the specified scope.</returns>
         public abstract Tracer GetTracer(string scope);
+
+        /// <summary>
+        /// Creates a new <see cref="Tracer"/> instance for a given scope.
+        /// Tracers are used as an entry point for creating spans.
+        /// </summary>
+        /// <param name="scope">The name of the instrumentation scope that uniquely identifies the tracer.</param>
+        /// <param name="attributes">Optional attributes associated with the tracer.</param> 
+        /// <returns>A <see cref="Tracer"/> instance for the specified scope.</returns>
+        /// <remarks>The implementation of this method ignores the attributes and simply calls the <see cref="GetTracer(string)"/> method. Derived classes can override this method to provide custom behavior based on the attributes.</remarks
+        public virtual Tracer GetTracer(string scope, Attributes attributes) => GetTracer(scope);
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Telemetry/Tracing/TracerProvider.cs
+++ b/sdk/src/Core/Amazon.Runtime/Telemetry/Tracing/TracerProvider.cs
@@ -36,7 +36,7 @@ namespace Amazon.Runtime.Telemetry.Tracing
         /// <param name="scope">The name of the instrumentation scope that uniquely identifies the tracer.</param>
         /// <param name="attributes">Optional attributes associated with the tracer.</param> 
         /// <returns>A <see cref="Tracer"/> instance for the specified scope.</returns>
-        /// <remarks>The implementation of this method ignores the attributes and simply calls the <see cref="GetTracer(string)"/> method. Derived classes can override this method to provide custom behavior based on the attributes.</remarks
+        /// <remarks>The implementation of this method ignores the attributes and simply calls the <see cref="GetTracer(string)"/> method. Derived classes can override this method to provide custom behavior based on the attributes.</remarks>
         public virtual Tracer GetTracer(string scope, Attributes attributes) => GetTracer(scope);
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Telemetry/Tracing/TracerProvider.cs
+++ b/sdk/src/Core/Amazon.Runtime/Telemetry/Tracing/TracerProvider.cs
@@ -34,7 +34,7 @@ namespace Amazon.Runtime.Telemetry.Tracing
         /// Tracers are used as an entry point for creating spans.
         /// </summary>
         /// <param name="scope">The name of the instrumentation scope that uniquely identifies the tracer.</param>
-        /// <param name="attributes">Optional attributes associated with the tracer.</param> 
+        /// <param name="attributes">Attributes associated with the tracer.</param>
         /// <returns>A <see cref="Tracer"/> instance for the specified scope.</returns>
         /// <remarks>The implementation of this method ignores the attributes and simply calls the <see cref="GetTracer(string)"/> method. Derived classes can override this method to provide custom behavior based on the attributes.</remarks>
         public virtual Tracer GetTracer(string scope, Attributes attributes) => GetTracer(scope);


### PR DESCRIPTION
## Description

Support passing attributes to `TracerProvider.GetTracer()` via a new virtual overload as described in #4393.

## Motivation and Context

See #4393. The intention is to be able to consume the changes in the AWS instrumentation in [open-telemetry/opentelemetry-dotnet-contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib).

## Testing

Code-inspection only. Existing code doesn't yet use the new method and I didn't see any specific tests for the `TracerProvider` as an abstract concept.

I can add tests if required - just let me know what/where you'd like adding.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 326604a6-b03d-4a4c-9215-100b8cea6d95
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 15ffa639-b208-46ec-a553-f6901f312f7e
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
