### PR TITLE
Cache credentials sourced from profile if set on client config.

### DIFF
--- a/generator/.DevConfigs/395227c9-ff5d-4d11-9e9c-817dbdb78eb6.json
+++ b/generator/.DevConfigs/395227c9-ff5d-4d11-9e9c-817dbdb78eb6.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Cache credentials sourced from profiles when calling ResodentityAsync rather than doing a full file read every time a profile is specified on the config."
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -44,6 +45,7 @@ namespace Amazon.Runtime.Credentials
         private readonly List<CredentialsGenerator> _credentialsGenerators;
         private readonly CredentialProfileStoreChain _credentialProfileChain = new();
         private readonly EnvironmentState _lastKnownEnvironmentState = new();
+        private readonly ConcurrentDictionary<(string ProfileName, string Location), ProfileCredentialEntry> _profileCredentialCache = new();
         private static readonly Lazy<DefaultAWSCredentialsIdentityResolver> _defaultInstance = new();
         private bool _disposed;
 
@@ -114,7 +116,7 @@ namespace Amazon.Runtime.Credentials
         /// </summary>
         public AWSCredentials ResolveIdentity(IClientConfig clientConfig, CancellationToken cancellationToken)
         {
-            var profileCredentials = TryGetProfileCredentials(clientConfig);
+            var profileCredentials = TryGetProfileCredentials(clientConfig, cancellationToken);
             if (profileCredentials != null) return profileCredentials;
 
             return InternalGetCredentials(cancellationToken);
@@ -125,28 +127,120 @@ namespace Amazon.Runtime.Credentials
 
         public async Task<AWSCredentials> ResolveIdentityAsync(IClientConfig clientConfig, CancellationToken cancellationToken = default)
         {
-            var profileCredentials = TryGetProfileCredentials(clientConfig);
+            var profileCredentials = await TryGetProfileCredentialsAsync(clientConfig, cancellationToken).ConfigureAwait(false);
             if (profileCredentials != null) return profileCredentials;
 
             return await InternalGetCredentialsAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Resolves credentials from the profile specified in <paramref name="clientConfig"/>, if any.
-        /// Returns null if no profile name is configured, allowing the caller to fall back to the credential chain.
+        /// Returns the <see cref="ProfileCredentialEntry"/> for the given key, creating it if absent.
+        /// The entry owns the per-key <see cref="SemaphoreSlim"/> and the volatile cached snapshot.
         /// </summary>
-        private static AWSCredentials TryGetProfileCredentials(IClientConfig clientConfig)
+        private ProfileCredentialEntry GetOrCreateEntry((string ProfileName, string Location) key) 
+        => _profileCredentialCache.GetOrAdd(key, _ => new ProfileCredentialEntry());
+
+        /// <summary>
+        /// Resolves credentials from the profile specified in <paramref name="clientConfig"/> synchronously,
+        /// using a per-key double-checked lock pattern to avoid redundant disk reads under concurrency.
+        /// Returns null if no profile is configured.
+        /// </summary>
+        private AWSCredentials TryGetProfileCredentials(IClientConfig clientConfig, CancellationToken cancellationToken)
         {
             var profile = clientConfig?.Profile;
             if (string.IsNullOrEmpty(profile?.Name)) return null;
 
-            var source = new CredentialProfileStoreChain(profile.Location);
-            if (source.TryGetProfile(profile.Name, out CredentialProfile storedProfile))
-            {
-                return storedProfile.GetAWSCredentials(source, true);
-            }
+            var key = (profile.Name, profile.Location ?? string.Empty);
+            var entry = GetOrCreateEntry(key);
 
-            throw new AmazonClientException($"Unable to find the \"{profile.Name}\" profile specified in the client configuration.");
+            // Fast path: valid cached credentials, no lock needed.
+            var cached = entry.GetIfValid();
+            if (cached != null) return cached;
+
+            entry.ResolutionLock.Wait(cancellationToken);
+            // this flag is to track whether or not the entry will be removed later if the given profile
+            // hasn't been found. This is to prevent disposing a lock of an already disposed object.
+            bool entryRemoved = false;
+            try
+            {
+                cached = entry.GetIfValid();
+                if (cached != null) return cached;
+
+                return ResolveAndCacheProfileCredentials(profile, entry);
+            }
+            // if we go here that means we were unable to find a profile with that name
+            // we must clean up the zombie entry that was added in GetOrCreateEntry above
+            // so that we don't add semaphore overhead to every future call
+            catch (AmazonClientException)
+            {
+                entryRemoved = _profileCredentialCache.TryRemove(key, out _);
+                entry.Dispose();
+                throw;
+            }
+            finally
+            {
+                if (entryRemoved)
+                    entry.ResolutionLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Resolves credentials from the profile specified in <paramref name="clientConfig"/> asynchronously,
+        /// using a per-key double-checked lock pattern to avoid redundant disk reads under concurrency.
+        /// Returns null if no profile is configured.
+        /// </summary>
+        private async Task<AWSCredentials> TryGetProfileCredentialsAsync(IClientConfig clientConfig, CancellationToken cancellationToken)
+        {
+            var profile = clientConfig?.Profile;
+            if (string.IsNullOrEmpty(profile?.Name)) return null;
+
+            var key = (profile.Name, profile.Location ?? string.Empty);
+            var entry = GetOrCreateEntry(key);
+
+            // Fast path: valid cached credentials, no lock needed.
+            var cached = entry.GetIfValid();
+            if (cached != null) return cached;
+
+            await entry.ResolutionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            // this flag is to track whether or not the entry will be removed later if the given profile
+            // hasn't been found. This is to prevent disposing a lock of an already disposed object.
+            bool entryRemoved = false;
+            try
+            {
+                cached = entry.GetIfValid();
+                if (cached != null) return cached;
+
+                return ResolveAndCacheProfileCredentials(profile, entry);
+            }
+            // if we go here that means we were unable to find a profile with that name
+            // we must clean up the zombie entry that was added in GetOrCreateEntry above
+            // so that we don't add semaphore overhead to every future call
+            catch (AmazonClientException)
+            {
+                entryRemoved = _profileCredentialCache.TryRemove(key, out _);
+                entry.Dispose();
+                throw;
+            }
+            finally
+            {
+                if (entryRemoved)
+                    entry.ResolutionLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Performs the actual disk read and updates the entry's cached snapshot.
+        /// Must only be called while holding <paramref name="entry"/>.ResolutionLock.
+        /// </summary>
+        private static AWSCredentials ResolveAndCacheProfileCredentials(Profile profile, ProfileCredentialEntry entry)
+        {
+            var source = new CredentialProfileStoreChain(profile.Location);
+            if (!source.TryGetProfile(profile.Name, out CredentialProfile storedProfile))
+                throw new AmazonClientException($"Unable to find the \"{profile.Name}\" profile specified in the client configuration.");
+
+            var credentials = storedProfile.GetAWSCredentials(source, true);
+            entry.Update(credentials, source.ProfilesLocation);
+            return credentials;
         }
 
         /// <summary>
@@ -395,6 +489,8 @@ namespace Amazon.Runtime.Credentials
             if (disposing)
             {
                 _credentialResolutionLock.Dispose();
+                foreach (var entry in _profileCredentialCache.Values)
+                    entry.Dispose();
             }
             _disposed = true;
         }
@@ -440,6 +536,64 @@ namespace Amazon.Runtime.Credentials
                 SessionToken = Environment.GetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN);
                 ProfileName = Environment.GetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE);
             }
+        }
+
+        /// <summary>
+        /// Holds the per-profile resolution lock and the volatile cached credential snapshot.
+        /// The lock serialises re-resolution; the volatile field allows a lock-free fast path read.
+        /// </summary>
+        private sealed class ProfileCredentialEntry : IDisposable
+        {
+            public readonly SemaphoreSlim ResolutionLock = new SemaphoreSlim(1, 1);
+
+            // Written only while holding ResolutionLock; read lock-free on the fast path.
+            private volatile ProfileCredentialSnapshot _snapshot;
+
+            /// <summary>Returns cached credentials if the backing files have not changed, otherwise null.</summary>
+            public AWSCredentials GetIfValid()
+            {
+                var s = _snapshot;
+                return s != null && !s.HasFileChanged() ? s.Credentials : null;
+            }
+
+            /// <summary>Replaces the cached snapshot. Must be called while holding <see cref="ResolutionLock"/>.</summary>
+            public void Update(AWSCredentials credentials, string profilesLocation)
+            {
+                _snapshot = new ProfileCredentialSnapshot(credentials, profilesLocation);
+            }
+
+            public void Dispose() => ResolutionLock.Dispose();
+        }
+
+        /// <summary>
+        /// Immutable snapshot of resolved credentials and the file timestamps captured at resolution time.
+        /// </summary>
+        private sealed class ProfileCredentialSnapshot
+        {
+            private readonly string _credentialsFilePath;
+            private readonly string _configFilePath;
+            private readonly DateTime _credentialsFileWriteTime;
+            private readonly DateTime _configFileWriteTime;
+
+            public AWSCredentials Credentials { get; }
+
+            public ProfileCredentialSnapshot(AWSCredentials credentials, string profilesLocation)
+            {
+                Credentials = credentials;
+                _credentialsFilePath = string.IsNullOrEmpty(profilesLocation)
+                    ? SharedCredentialsFile.DefaultFilePath
+                    : profilesLocation;
+                _configFilePath = SharedCredentialsFile.DefaultConfigFilePath;
+                _credentialsFileWriteTime = GetLastWriteTime(_credentialsFilePath);
+                _configFileWriteTime = GetLastWriteTime(_configFilePath);
+            }
+
+            public bool HasFileChanged() =>
+                GetLastWriteTime(_credentialsFilePath) != _credentialsFileWriteTime ||
+                GetLastWriteTime(_configFilePath) != _configFileWriteTime;
+
+            private static DateTime GetLastWriteTime(string path) =>
+                string.IsNullOrEmpty(path) ? default : File.GetLastWriteTimeUtc(path);
         }
     }
 }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -158,9 +158,6 @@ namespace Amazon.Runtime.Credentials
             if (cached != null) return cached;
 
             entry.ResolutionLock.Wait(cancellationToken);
-            // this flag is to track whether or not the entry will be removed later if the given profile
-            // hasn't been found. This is to prevent disposing a lock of an already disposed object.
-            bool entryRemoved = false;
             try
             {
                 cached = entry.GetIfValid();
@@ -173,14 +170,19 @@ namespace Amazon.Runtime.Credentials
             // so that we don't add semaphore overhead to every future call
             catch (AmazonClientException)
             {
-                entryRemoved = _profileCredentialCache.TryRemove(key, out _);
+                _profileCredentialCache.TryRemove(key, out _);
                 entry.Dispose();
                 throw;
             }
             finally
             {
-                if (entryRemoved)
+                try
+                {
                     entry.ResolutionLock.Release();
+                }
+                // in multithreaded scenarios where a zombie entry was removed, releasing the lock
+                // will throw an object disposed exception since the entry has been disposed.
+                catch (ObjectDisposedException) { }
             }
         }
 
@@ -202,9 +204,6 @@ namespace Amazon.Runtime.Credentials
             if (cached != null) return cached;
 
             await entry.ResolutionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            // this flag is to track whether or not the entry will be removed later if the given profile
-            // hasn't been found. This is to prevent disposing a lock of an already disposed object.
-            bool entryRemoved = false;
             try
             {
                 cached = entry.GetIfValid();
@@ -217,14 +216,19 @@ namespace Amazon.Runtime.Credentials
             // so that we don't add semaphore overhead to every future call
             catch (AmazonClientException)
             {
-                entryRemoved = _profileCredentialCache.TryRemove(key, out _);
+                _profileCredentialCache.TryRemove(key, out _);
                 entry.Dispose();
                 throw;
             }
             finally
             {
-                if (entryRemoved)
+                try
+                {
                     entry.ResolutionLock.Release();
+                }
+                // in multithreaded scenarios where a zombie entry was removed, releasing the lock
+                // will throw an object disposed exception since the entry has been disposed.
+                catch (ObjectDisposedException) { }
             }
         }
 

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
@@ -20,6 +20,9 @@ using Amazon.Runtime.Credentials;
 using Amazon.S3;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace AWSSDK.UnitTests
 {
@@ -120,5 +123,457 @@ namespace AWSSDK.UnitTests
                 Assert.IsTrue(resolvedIdentity is EnvironmentVariablesAWSCredentials);
             }
         }
+
+        #region Profile Credential Caching Tests
+
+        private static string BasicProfileText(string profileName, string accessKey, string secretKey) =>
+            $"[{profileName}]\naws_access_key_id = {accessKey}\naws_secret_access_key = {secretKey}\n";
+
+        /// <summary>
+        /// Verifies that a second synchronous call to ResolveIdentity with the same profile
+        /// returns the cached credentials (same object reference) without re-reading the disk.
+        /// </summary>
+        [TestMethod]
+        public void ProfileCredentials_SecondSyncCall_ReturnsCachedInstance()
+        {
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("test-profile", "AKID_FIRST", "SECRET_FIRST")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("test-profile", fixture.CredentialsFilePath)
+                };
+
+                var first = resolver.ResolveIdentity(config);
+                var second = resolver.ResolveIdentity(config);
+
+                Assert.IsNotNull(first);
+                Assert.IsNotNull(second);
+                // The exact same cached object should be returned on the second call.
+                Assert.AreSame(first, second, "Expected the second call to return the same cached credentials object.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a second asynchronous call to ResolveIdentityAsync with the same profile
+        /// returns the cached credentials (same object reference) without re-reading the disk.
+        /// </summary>
+        [TestMethod]
+        public async Task ProfileCredentials_SecondAsyncCall_ReturnsCachedInstance()
+        {
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("test-profile", "AKID_FIRST", "SECRET_FIRST")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("test-profile", fixture.CredentialsFilePath)
+                };
+
+                var first = await resolver.ResolveIdentityAsync(config);
+                var second = await resolver.ResolveIdentityAsync(config);
+
+                Assert.IsNotNull(first);
+                Assert.IsNotNull(second);
+                Assert.AreSame(first, second, "Expected the second async call to return the same cached credentials object.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the cached credentials are shared across the sync and async paths
+        /// when they use the same resolver instance and profile key.
+        /// </summary>
+        [TestMethod]
+        public async Task ProfileCredentials_MixedSyncAndAsyncCalls_ShareCache()
+        {
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("test-profile", "AKID_MIXED", "SECRET_MIXED")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("test-profile", fixture.CredentialsFilePath)
+                };
+
+                var syncResult = resolver.ResolveIdentity(config);
+                var asyncResult = await resolver.ResolveIdentityAsync(config);
+
+                Assert.AreSame(syncResult, asyncResult, "Sync and async paths should share the same cached credentials.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that different profile names result in independent cache entries.
+        /// </summary>
+        [TestMethod]
+        public void ProfileCredentials_DifferentProfiles_AreCachedIndependently()
+        {
+            var contents = BasicProfileText("profile-a", "AKID_A", "SECRET_A") +
+                           BasicProfileText("profile-b", "AKID_B", "SECRET_B");
+
+            using (var fixture = new SharedCredentialsFileTestFixture(contents))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var configA = new AmazonS3Config { Profile = new Profile("profile-a", fixture.CredentialsFilePath) };
+                var configB = new AmazonS3Config { Profile = new Profile("profile-b", fixture.CredentialsFilePath) };
+
+                var credsA = resolver.ResolveIdentity(configA);
+                var credsB = resolver.ResolveIdentity(configB);
+
+                Assert.IsNotNull(credsA);
+                Assert.IsNotNull(credsB);
+                Assert.AreNotSame(credsA, credsB, "Different profiles should produce different credential objects.");
+
+                // Both should still be individually cached.
+                var credsA2 = resolver.ResolveIdentity(configA);
+                var credsB2 = resolver.ResolveIdentity(configB);
+                Assert.AreSame(credsA, credsA2);
+                Assert.AreSame(credsB, credsB2);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when the backing credentials file is modified between
+        /// ResolveIdentity calls, the cache detects the change and returns fresh credentials.
+        /// </summary>
+        [TestMethod]
+        public void ProfileCredentials_FileModified_ReturnsNewCredentials()
+        {
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("test-profile", "AKID_ORIGINAL", "SECRET_ORIGINAL")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("test-profile", fixture.CredentialsFilePath)
+                };
+
+                var original = resolver.ResolveIdentity(config);
+                Assert.IsNotNull(original);
+
+                // Mutate the credentials file.
+                File.WriteAllText(fixture.CredentialsFilePath, BasicProfileText("test-profile", "AKID_UPDATED", "SECRET_UPDATED"));
+
+                var updated = resolver.ResolveIdentity(config);
+                Assert.IsNotNull(updated);
+                Assert.AreNotSame(original, updated,
+                    "After modifying the credentials file the resolver should return a new credentials object.");
+                Assert.AreEqual<string>("AKID_UPDATED", updated.GetCredentials().AccessKey);
+            }
+        }
+
+        /// <summary>
+        /// Same as the sync test but exercises the async path.
+        /// </summary>
+        [TestMethod]
+        public async Task ProfileCredentials_FileModifiedAsync_ReturnsNewCredentials()
+        {
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("test-profile", "AKID_ORIGINAL", "SECRET_ORIGINAL")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("test-profile", fixture.CredentialsFilePath)
+                };
+
+                var original = await resolver.ResolveIdentityAsync(config).ConfigureAwait(false);
+                Assert.IsNotNull(original);
+
+                // Mutate the credentials file.
+                File.WriteAllText(fixture.CredentialsFilePath, BasicProfileText("test-profile", "AKID_UPDATED", "SECRET_UPDATED"));
+
+                var updated = resolver.ResolveIdentity(config);
+                Assert.IsNotNull(updated);
+                Assert.AreNotSame(original, updated,
+                    "After modifying the credentials file the resolver should return a new credentials object.");
+                Assert.AreEqual<string>("AKID_UPDATED", updated.GetCredentials().AccessKey);
+            }
+        }
+        /// <summary>
+        /// Verifies that when the file has NOT changed between calls, the cache
+        /// continues to return the original cached object even after the file was
+        /// previously updated. This ensures the snapshot timestamp is refreshed correctly.
+        /// </summary>
+        [TestMethod]
+        public void ProfileCredentials_FileModifiedThenStable_CachesAfterRefresh()
+        {
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("test-profile", "AKID_V1", "SECRET_V1")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("test-profile", fixture.CredentialsFilePath)
+                };
+
+                // First resolution – populates cache.
+                var v1 = resolver.ResolveIdentity(config);
+
+                // Modify file → cache invalidated.
+                File.WriteAllText(fixture.CredentialsFilePath, BasicProfileText("test-profile", "AKID_V2", "SECRET_V2"));
+
+                var v2 = resolver.ResolveIdentity(config);
+                Assert.AreNotSame(v1, v2, "Should have re-resolved after file change.");
+
+                // Now the file is stable – subsequent calls should hit cache.
+                var v2Again = resolver.ResolveIdentity(config);
+                Assert.AreSame(v2, v2Again, "Credentials should be cached again after re-resolution.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when a non-existent profile is requested, the resolver throws
+        /// <see cref="AmazonClientException"/> and subsequent calls with the same bad
+        /// profile also throw (i.e. zombie entries are cleaned up from the cache).
+        /// </summary>
+        [TestMethod]
+        public void ProfileCredentials_NonExistentProfile_ThrowsAndCleansUpEntry()
+        {
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("real-profile", "AKID", "SECRET")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("non-existent-profile", fixture.CredentialsFilePath)
+                };
+
+                Assert.ThrowsException<AmazonClientException>(() => resolver.ResolveIdentity(config));
+
+                // The zombie entry should have been removed, so calling again should
+                // still throw (not hang on a disposed semaphore).
+                Assert.ThrowsException<AmazonClientException>(() => resolver.ResolveIdentity(config));
+            }
+        }
+
+        #endregion
+
+        #region Threading / Concurrency Tests for Profile Credential Cache
+
+        /// <summary>
+        /// Launches many concurrent synchronous threads that all call ResolveIdentity with the
+        /// same profile. Verifies that all threads receive the same cached credentials object,
+        /// proving that only one thread performed the actual resolution and stored the result.
+        /// </summary>
+        [TestMethod]
+        public void ProfileCredentials_ConcurrentSyncCalls_OnlyOneWritesToCache()
+        {
+            const int threadCount = 32;
+
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("concurrent-profile", "AKID_CONCURRENT", "SECRET_CONCURRENT")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("concurrent-profile", fixture.CredentialsFilePath)
+                };
+
+                var barrier = new ManualResetEventSlim(false);
+                var results = new AWSCredentials[threadCount];
+                var tasks = new Task[threadCount];
+
+                for (int i = 0; i < threadCount; i++)
+                {
+                    int index = i;
+                    tasks[index] = Task.Run(() =>
+                    {
+                        barrier.Wait();
+                        results[index] = resolver.ResolveIdentity(config);
+                    });
+                }
+
+                // Release all threads simultaneously to maximise contention.
+                barrier.Set();
+                Task.WaitAll(tasks);
+
+                // Every thread should have received a non-null result.
+                for (int i = 0; i < threadCount; i++)
+                {
+                    Assert.IsNotNull(results[i], $"Thread {i} returned null credentials.");
+                }
+
+                // All results should be the exact same object reference,
+                // proving the cache was written once and read by all others.
+                var expected = results[0];
+                for (int i = 1; i < threadCount; i++)
+                {
+                    Assert.AreSame(expected, results[i],
+                        $"Thread {i} received a different credentials object than thread 0. " +
+                        "This suggests the cache was written more than once.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Same as the synchronous variant, but exercises the async code path
+        /// (SemaphoreSlim.WaitAsync) which avoids blocking thread pool threads.
+        /// </summary>
+        [TestMethod]
+        public async Task ProfileCredentials_ConcurrentAsyncCalls_OnlyOneWritesToCache()
+        {
+            const int concurrency = 32;
+
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("async-concurrent-profile", "AKID_ASYNC", "SECRET_ASYNC")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("async-concurrent-profile", fixture.CredentialsFilePath)
+                };
+
+                var barrier = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tasks = new Task<AWSCredentials>[concurrency];
+
+                for (int i = 0; i < concurrency; i++)
+                {
+                    tasks[i] = Task.Run(async () =>
+                    {
+                        await barrier.Task.ConfigureAwait(false);
+                        return await resolver.ResolveIdentityAsync(config).ConfigureAwait(false);
+                    });
+                }
+
+                // Release all tasks simultaneously.
+                barrier.SetResult(true);
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                for (int i = 0; i < concurrency; i++)
+                {
+                    Assert.IsNotNull(tasks[i].Result, $"Task {i} returned null credentials.");
+                }
+
+                var expected = tasks[0].Result;
+                for (int i = 1; i < concurrency; i++)
+                {
+                    Assert.AreSame(expected, tasks[i].Result,
+                        $"Task {i} received a different credentials object than task 0.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that concurrent callers targeting different profiles resolve
+        /// independently and do not interfere with each other's cache entries.
+        /// </summary>
+        [TestMethod]
+        public void ProfileCredentials_ConcurrentDifferentProfiles_ResolveIndependently()
+        {
+            const int profileCount = 8;
+            const int callsPerProfile = 8;
+
+            // Build a single credentials file containing all profiles.
+            var sb = new System.Text.StringBuilder();
+            for (int p = 0; p < profileCount; p++)
+            {
+                sb.Append(BasicProfileText($"profile-{p}", $"AKID_{p}", $"SECRET_{p}"));
+            }
+
+            using (var fixture = new SharedCredentialsFileTestFixture(sb.ToString()))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var totalTasks = profileCount * callsPerProfile;
+                var barrier = new ManualResetEventSlim(false);
+                var results = new AWSCredentials[totalTasks];
+                var tasks = new Task[totalTasks];
+
+                for (int p = 0; p < profileCount; p++)
+                {
+                    for (int c = 0; c < callsPerProfile; c++)
+                    {
+                        int taskIndex = p * callsPerProfile + c;
+                        int profileIndex = p;
+                        tasks[taskIndex] = Task.Run(() =>
+                        {
+                            var cfg = new AmazonS3Config
+                            {
+                                Profile = new Profile($"profile-{profileIndex}", fixture.CredentialsFilePath)
+                            };
+                            barrier.Wait();
+                            results[taskIndex] = resolver.ResolveIdentity(cfg);
+                        });
+                    }
+                }
+
+                barrier.Set();
+                Task.WaitAll(tasks);
+
+                // For each profile, all calls should return the same cached object.
+                for (int p = 0; p < profileCount; p++)
+                {
+                    var firstForProfile = results[p * callsPerProfile];
+                    Assert.IsNotNull(firstForProfile, $"Profile {p} returned null credentials.");
+                    for (int c = 1; c < callsPerProfile; c++)
+                    {
+                        Assert.AreSame(firstForProfile, results[p * callsPerProfile + c],
+                            $"Profile {p}, call {c} returned a different credentials object.");
+                    }
+                }
+
+                // Different profiles should have different credentials objects.
+                for (int p = 1; p < profileCount; p++)
+                {
+                    Assert.AreNotSame(results[0], results[p * callsPerProfile],
+                        $"Profile 0 and profile {p} should have different credentials objects.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that under concurrent access, when the file changes mid-flight,
+        /// all threads that observe the file change converge on a single new credentials
+        /// object (i.e. only one re-resolution occurs per invalidation).
+        /// </summary>
+        [TestMethod]
+        public void ProfileCredentials_ConcurrentCallsAfterFileChange_AllGetSameNewObject()
+        {
+            const int threadCount = 32;
+
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("refresh-profile", "AKID_OLD", "SECRET_OLD")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var config = new AmazonS3Config
+                {
+                    Profile = new Profile("refresh-profile", fixture.CredentialsFilePath)
+                };
+
+                // Populate the cache with the original credentials.
+                var original = resolver.ResolveIdentity(config);
+                Assert.IsNotNull(original);
+
+                // Modify the file so the cache is invalidated on next read.
+                File.WriteAllText(fixture.CredentialsFilePath, BasicProfileText("refresh-profile", "AKID_NEW", "SECRET_NEW"));
+
+                // Now launch many threads that all compete to re-resolve.
+                var barrier = new ManualResetEventSlim(false);
+                var results = new AWSCredentials[threadCount];
+                var tasks = new Task[threadCount];
+
+                for (int i = 0; i < threadCount; i++)
+                {
+                    int index = i;
+                    tasks[index] = Task.Run(() =>
+                    {
+                        barrier.Wait();
+                        results[index] = resolver.ResolveIdentity(config);
+                    });
+                }
+
+                barrier.Set();
+                Task.WaitAll(tasks);
+
+                // Every result should be non-null and different from the original.
+                for (int i = 0; i < threadCount; i++)
+                {
+                    Assert.IsNotNull(results[i], $"Thread {i} returned null.");
+                    Assert.AreNotSame(original, results[i],
+                        $"Thread {i} still returned the stale cached credentials.");
+                }
+
+                // All threads should have converged on the same new object.
+                var expected = results[0];
+                for (int i = 1; i < threadCount; i++)
+                {
+                    Assert.AreSame(expected, results[i],
+                        $"Thread {i} resolved a different new credentials object than thread 0.");
+                }
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, if a profile was specified on the client config on `DefaultAWSCredentialsIdentityResolver.ResolveIdentity`, the resolver would create a new `CredentialProfileStoreChain` then call `TryGetProfile()` which creates a new `SharedCredentialsFile`. `SharedCredentialsFile`'s constructor calls `Refresh()` which reads the entire credentials file and config file, to find the given profile and return the appropriate credentials, resulting in an expensive disk read every operation.

This PR updates the DefaultResolver to cache the credentials. The key to cache on is the ProfileName, and location, and the value is the ProfileCredentialEntry, which contains information about the profile. We determine if the profile has been updated, since the last read, by checking the file's last write time. Although this is still a disk read, it is a much less expensive operation than reading a full file as it just reads the file's metadata. 

Here are the benchmarks results on my machine
```
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26100.8037/24H2/2024Update/HudsonValley)
12th Gen Intel Core i9-12900HK 2.50GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 9.0.312
  [Host]     : .NET 8.0.25 (8.0.25, 8.0.2526.11203), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 8.0.25 (8.0.25, 8.0.2526.11203), X64 RyuJIT x86-64-v3
**BEFORE CACHING**

| Method               | Mean     | Error    | StdDev   | Gen0   | Allocated |
|--------------------- |---------:|---------:|---------:|-------:|----------:|
| ResolveIdentity      | 436.8 us | 17.15 us | 50.30 us | 1.9531 |   24.1 KB |
| ResolveIdentityAsync | 446.3 us | 20.12 us | 58.70 us | 1.9531 |   24.1 KB |

// * Hints *
Outliers
  ResolveIdentityBenchmarks.ResolveIdentity: Default      -> 1 outlier  was  removed (678.97 us)
  ResolveIdentityBenchmarks.ResolveIdentityAsync: Default -> 2 outliers were removed (635.24 us, 770.09 us)
** AFTER CACHING ** 

| Method               | Mean     | Error    | StdDev   | Allocated |
|--------------------- |---------:|---------:|---------:|----------:|
| ResolveIdentity      | 46.84 us | 2.126 us | 6.236 us |     144 B |
| ResolveIdentityAsync | 41.20 us | 1.223 us | 3.567 us |     216 B |

// * Hints *
Outliers
  ResolveIdentityBenchmarks.ResolveIdentity: Default      -> 1 outlier  was  removed (68.19 us)
  ResolveIdentityBenchmarks.ResolveIdentityAsync: Default -> 2 outliers were removed (64.54 us, 70.63 us)
```


`ResolveIdentity` is about a 9.32x increase in speed
`ResolveIdentityAsync` is about a 10.83x increase in speed

`ResolveIdentity` allocates 99.4% less memory
`ResolveIdentityAsync` allocates 99.1% less memory

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Performance benefit for users who use profiles
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
extensive unit tests added.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**cfa65a5f-857c-4213-a3af-b4fa8fea9d5b
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**8f4fd6be-92e4-4698-ac5e-017a4cd2fc48
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment
NONE
1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement