### PR TITLE
fix: fix bug in BedrockChatClient when used in NativeAOT

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockJsonContext.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockJsonContext.cs
@@ -72,6 +72,24 @@ internal partial class BedrockJsonContext : JsonSerializerContext
             return options;
         }
 
-        return Default.Options;
+        // When reflection is disabled (NativeAOT / trimming), we cannot access the static
+        // "Default" singleton here because it is also a static member of this class.
+        // Accessing Default.Options during the static field initializer for DefaultOptions
+        // causes a circular dependency: the static constructor is already running to
+        // initialize DefaultOptions, so Default is still null, producing a
+        // NullReferenceException that permanently breaks the type.
+        //
+        // Instead, create a fresh JsonSerializerOptions and attach a new instance of this
+        // source-generated context as the TypeInfoResolver. This gives us the same
+        // source-generated metadata without the circular static initialization issue.
+        var aotOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            TypeInfoResolver = new BedrockJsonContext(),
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = true,
+        };
+
+        aotOptions.MakeReadOnly();
+        return aotOptions;
     }
 }

--- a/generator/.DevConfigs/b3c1875e-46be-4f02-8b6a-5d07ac9bb7a1.json
+++ b/generator/.DevConfigs/b3c1875e-46be-4f02-8b6a-5d07ac9bb7a1.json
@@ -1,0 +1,11 @@
+{
+  "extensions": [
+    {
+      "extensionName": "Extensions.Bedrock.MEAI",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fixed TypeInitializationException crash in BedrockChatClient tool calling under NativeAOT caused by circular static initialization in BedrockJsonContext"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Under NativeAOT, `BedrockJsonContext.CreateDefaultToolJsonOptions()` accessed `Default.Options` during its own static field initialization, causing a `NullReferenceException` wrapped in `TypeInitializationException`. This crashed `BedrockChatClient` whenever it processed tool call responses via `DocumentToDictionary`.

The fix replaces `return Default.Options` with a new `JsonSerializerOptions` that uses `new BedrockJsonContext()` as its `TypeInfoResolver`, breaking the circular dependency while preserving the same source-generated type metadata. Non-AOT behavior is unchanged.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran a NativeAOT agent without this fix and it failed. After the fix, the agent worked fine.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** f27f1f98-6727-474d-a4c6-d1103656200e
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** f7bb05aa-49e3-42ff-9bcc-58ee149b76ab
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement