### PR TITLE
SDK V3 - Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws/aws-sdk-dotnet-reviewers @aws/aws-sdk-dotnet-team


### PR DESCRIPTION
Adds a [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file per OSPO GitHub permissions guidance.

This assigns `@aws/aws-sdk-dotnet-team` as the default code owner for all files, enabling automatic review assignment on PRs.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners