### PR TITLE
Allow configuring of HttpClientFactory through DI factories

### DIFF
--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
@@ -39,14 +39,17 @@ namespace Amazon.Extensions.NETCore.Setup
         private static readonly object[] EMPTY_PARAMETERS = Array.Empty<object>();
 
         private AWSOptions _awsOptions;
+        private Action<ClientConfig, IServiceProvider> _configAction;
 
         /// <summary>
         /// Constructs an instance of the ClientFactory
         /// </summary>
         /// <param name="awsOptions">The AWS options used for creating service clients.</param>
-        internal ClientFactory(AWSOptions awsOptions)
+        /// <param name="configAction">An optional action to configure the ClientConfig using services from the IServiceProvider.</param>
+        internal ClientFactory(AWSOptions awsOptions, Action<ClientConfig, IServiceProvider> configAction = null)
         {
             _awsOptions = awsOptions;
+            _configAction = configAction;
         }
 
         /// <summary>
@@ -72,7 +75,30 @@ namespace Amazon.Extensions.NETCore.Setup
                 }
             }
 
-            return CreateServiceClient(logger, options);
+            if (_configAction == null)
+            {
+                return CreateServiceClient(logger, options);
+            }
+
+            PerformGlobalConfig(logger, options);
+            var credentials = CreateCredentials(logger, options);
+
+            if (!string.IsNullOrEmpty(options?.SessionRoleArn))
+            {
+                if (string.IsNullOrEmpty(options?.ExternalId))
+                {
+                    credentials = new AssumeRoleAWSCredentials(credentials, options.SessionRoleArn, options.SessionName);
+                }
+                else
+                {
+                    credentials = new AssumeRoleAWSCredentials(credentials, options.SessionRoleArn, options.SessionName, new AssumeRoleAWSCredentialsOptions() { ExternalId = options.ExternalId });
+                }
+            }
+
+            var config = CreateConfig(options);
+            _configAction(config, provider);
+            var client = CreateClient(credentials, config);
+            return client as IAmazonService;
         }
 
         /// <summary>

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ClientFactory.cs
@@ -75,30 +75,7 @@ namespace Amazon.Extensions.NETCore.Setup
                 }
             }
 
-            if (_configAction == null)
-            {
-                return CreateServiceClient(logger, options);
-            }
-
-            PerformGlobalConfig(logger, options);
-            var credentials = CreateCredentials(logger, options);
-
-            if (!string.IsNullOrEmpty(options?.SessionRoleArn))
-            {
-                if (string.IsNullOrEmpty(options?.ExternalId))
-                {
-                    credentials = new AssumeRoleAWSCredentials(credentials, options.SessionRoleArn, options.SessionName);
-                }
-                else
-                {
-                    credentials = new AssumeRoleAWSCredentials(credentials, options.SessionRoleArn, options.SessionName, new AssumeRoleAWSCredentialsOptions() { ExternalId = options.ExternalId });
-                }
-            }
-
-            var config = CreateConfig(options);
-            _configAction(config, provider);
-            var client = CreateClient(credentials, config);
-            return client as IAmazonService;
+            return CreateServiceClient(logger, options, provider);
         }
 
         /// <summary>
@@ -107,8 +84,9 @@ namespace Amazon.Extensions.NETCore.Setup
         /// </summary>
         /// <param name="logger">Logger instance for writing diagnostic logs.</param>
         /// <param name="options">The AWS options used for creating the service client.</param>
+        /// <param name="provider">Optional service provider for resolving dependencies in the config action.</param>
         /// <returns>The AWS service client</returns>
-        internal IAmazonService CreateServiceClient(ILogger logger, AWSOptions options)
+        internal IAmazonService CreateServiceClient(ILogger logger, AWSOptions options, IServiceProvider provider = null)
         {
             PerformGlobalConfig(logger, options);
             var credentials = CreateCredentials(logger, options);
@@ -126,6 +104,10 @@ namespace Amazon.Extensions.NETCore.Setup
             }
 
             var config = CreateConfig(options);
+            if (_configAction != null && provider != null)
+            {
+                _configAction(config, provider);
+            }
             var client = CreateClient(credentials, config);
             return client as IAmazonService;
         }

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection AddAWSService<T>(this IServiceCollection collection, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
-            return AddAWSService<T>(collection, null, lifetime);
+            return AddAWSService<T>(collection, (AWSOptions)null, lifetime);
         }
 
         /// <summary>
@@ -130,6 +130,42 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework. The Amazon service client is not
+        /// created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="configAction">An action to configure the ClientConfig using services from the IServiceProvider.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection AddAWSService<T>(this IServiceCollection collection, Action<ClientConfig, IServiceProvider> configAction, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
+        {
+            return AddAWSService<T>(collection, null, configAction, lifetime);
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework. The Amazon service client is not
+        /// created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
+        /// <param name="configAction">An action to configure the ClientConfig using services from the IServiceProvider.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection AddAWSService<T>(this IServiceCollection collection, AWSOptions options, Action<ClientConfig, IServiceProvider> configAction, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
+        {
+            Func<IServiceProvider, object> factory =
+                new ClientFactory<T>(options, configAction).CreateServiceClient;
+
+            var descriptor = new ServiceDescriptor(typeof(T), factory, lifetime);
+            collection.Add(descriptor);
+            return collection;
+        }
+
+        /// <summary>
         /// Adds the Amazon service client to the dependency injection framework if the service type hasn't already been registered.
         /// The Amazon service client is not created until it is requested. If the ServiceLifetime property is set to Singleton,
         /// the default, then the same instance will be reused for the lifetime of the process and the object should not be disposed.
@@ -140,7 +176,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection TryAddAWSService<T>(this IServiceCollection collection, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
-            return TryAddAWSService<T>(collection, null, lifetime);
+            return TryAddAWSService<T>(collection, (AWSOptions)null, lifetime);
         }
 
         /// <summary>
@@ -162,6 +198,42 @@ namespace Microsoft.Extensions.DependencyInjection
             collection.TryAdd(descriptor);
             return collection;
         }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework if the service type hasn't already been registered.
+        /// The Amazon service client is not created until it is requested. If the ServiceLifetime property is set to Singleton,
+        /// the default, then the same instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="configAction">An action to configure the ClientConfig using services from the IServiceProvider.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection TryAddAWSService<T>(this IServiceCollection collection, Action<ClientConfig, IServiceProvider> configAction, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
+        {
+            return TryAddAWSService<T>(collection, null, configAction, lifetime);
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework if the service type hasn't already been registered.
+        /// The Amazon service client is not created until it is requested. If the ServiceLifetime property is set to Singleton,
+        /// the default, then the same instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3.</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
+        /// <param name="configAction">An action to configure the ClientConfig using services from the IServiceProvider.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection TryAddAWSService<T>(this IServiceCollection collection, AWSOptions options, Action<ClientConfig, IServiceProvider> configAction, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
+        {
+            Func<IServiceProvider, object> factory =
+                new ClientFactory<T>(options, configAction).CreateServiceClient;
+
+            var descriptor = new ServiceDescriptor(typeof(T), factory, lifetime);
+            collection.TryAdd(descriptor);
+            return collection;
+        }
         
 #if NET8_0_OR_GREATER
 
@@ -177,7 +249,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection AddKeyedAWSService<T>(this IServiceCollection collection, object serviceKey, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
-            return AddKeyedAWSService<T>(collection, serviceKey, null, lifetime);
+            return AddKeyedAWSService<T>(collection, serviceKey, (AWSOptions)null, lifetime);
         }
         
         /// <summary>
@@ -199,6 +271,43 @@ namespace Microsoft.Extensions.DependencyInjection
             collection.Add(descriptor);
             return collection;
         }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework with a key. The Amazon service client is not
+        /// created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="serviceKey">The key with which the service will be added in the dependency injection framework.</param>
+        /// <param name="configAction">An action to configure the ClientConfig using services from the IServiceProvider.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection AddKeyedAWSService<T>(this IServiceCollection collection, object serviceKey, Action<ClientConfig, IServiceProvider> configAction, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
+        {
+            return AddKeyedAWSService<T>(collection, serviceKey, null, configAction, lifetime);
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework with a key. The Amazon service client is not
+        /// created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="serviceKey">The key with which the service will be added in the dependency injection framework.</param>
+        /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
+        /// <param name="configAction">An action to configure the ClientConfig using services from the IServiceProvider.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection AddKeyedAWSService<T>(this IServiceCollection collection, object serviceKey, AWSOptions options, Action<ClientConfig, IServiceProvider> configAction, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
+        {
+            object Factory(IServiceProvider sp, object key) => new ClientFactory<T>(options, configAction).CreateServiceClient(sp);
+
+            var descriptor = new ServiceDescriptor(typeof(T), serviceKey, Factory, lifetime);
+            collection.Add(descriptor);
+            return collection;
+        }
         
         /// <summary>
         /// Adds the Amazon service client to the dependency injection framework with a key if the service type hasn't already been registered with the same key.
@@ -212,7 +321,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection TryAddKeyedAWSService<T>(this IServiceCollection collection, object serviceKey, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         { 
-            return TryAddKeyedAWSService<T>(collection, serviceKey, null, lifetime);
+            return TryAddKeyedAWSService<T>(collection, serviceKey, (AWSOptions)null, lifetime);
         }
         
         /// <summary>
@@ -229,6 +338,43 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection TryAddKeyedAWSService<T>(this IServiceCollection collection, object serviceKey, AWSOptions options, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
             object Factory(IServiceProvider sp, object key) => new ClientFactory<T>(options).CreateServiceClient(sp);
+
+            var descriptor = new ServiceDescriptor(typeof(T), serviceKey, Factory, lifetime);
+            collection.TryAdd(descriptor);
+            return collection;
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework with a key if the service type hasn't already been registered with the same key.
+        /// The Amazon service client is not created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="serviceKey">The key with which the service will be added in the dependency injection framework.</param>
+        /// <param name="configAction">An action to configure the ClientConfig using services from the IServiceProvider.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection TryAddKeyedAWSService<T>(this IServiceCollection collection, object serviceKey, Action<ClientConfig, IServiceProvider> configAction, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
+        {
+            return TryAddKeyedAWSService<T>(collection, serviceKey, null, configAction, lifetime);
+        }
+
+        /// <summary>
+        /// Adds the Amazon service client to the dependency injection framework with a key if the service type hasn't already been registered with the same key.
+        /// The Amazon service client is not created until it is requested. If the ServiceLifetime property is set to Singleton, the default, then the same
+        /// instance will be reused for the lifetime of the process and the object should not be disposed.
+        /// </summary>
+        /// <typeparam name="T">The AWS service interface, like IAmazonS3</typeparam>
+        /// <param name="collection"></param>
+        /// <param name="serviceKey">The key with which the service will be added in the dependency injection framework.</param>
+        /// <param name="options">The AWS options used to create the service client overriding the default AWS options added using AddDefaultAWSOptions.</param>
+        /// <param name="configAction">An action to configure the ClientConfig using services from the IServiceProvider.</param>
+        /// <param name="lifetime">The lifetime of the service client created. The default is Singleton.</param>
+        /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
+        public static IServiceCollection TryAddKeyedAWSService<T>(this IServiceCollection collection, object serviceKey, AWSOptions options, Action<ClientConfig, IServiceProvider> configAction, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
+        {
+            object Factory(IServiceProvider sp, object key) => new ClientFactory<T>(options, configAction).CreateServiceClient(sp);
 
             var descriptor = new ServiceDescriptor(typeof(T), serviceKey, Factory, lifetime);
             collection.TryAdd(descriptor);

--- a/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.NETCore.Setup/ServiceCollectionExtensions.cs
@@ -121,12 +121,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection AddAWSService<T>(this IServiceCollection collection, AWSOptions options, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
-            Func<IServiceProvider, object> factory =
-                new ClientFactory<T>(options).CreateServiceClient;
-
-            var descriptor = new ServiceDescriptor(typeof(T), factory, lifetime);
-            collection.Add(descriptor);
-            return collection;
+            return AddAWSService<T>(collection, options, null, lifetime);
         }
 
         /// <summary>
@@ -191,12 +186,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection TryAddAWSService<T>(this IServiceCollection collection, AWSOptions options, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
-            Func<IServiceProvider, object> factory =
-                new ClientFactory<T>(options).CreateServiceClient;
-
-            var descriptor = new ServiceDescriptor(typeof(T), factory, lifetime);
-            collection.TryAdd(descriptor);
-            return collection;
+            return TryAddAWSService<T>(collection, options, null, lifetime);
         }
 
         /// <summary>
@@ -265,11 +255,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection AddKeyedAWSService<T>(this IServiceCollection collection, object serviceKey, AWSOptions options, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
-            object Factory(IServiceProvider sp, object key) => new ClientFactory<T>(options).CreateServiceClient(sp);
-
-            var descriptor = new ServiceDescriptor(typeof(T), serviceKey, Factory, lifetime);
-            collection.Add(descriptor);
-            return collection;
+            return AddKeyedAWSService<T>(collection, serviceKey, options, null, lifetime);
         }
 
         /// <summary>
@@ -337,11 +323,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>Returns back the IServiceCollection to continue the fluent system of IServiceCollection.</returns>
         public static IServiceCollection TryAddKeyedAWSService<T>(this IServiceCollection collection, object serviceKey, AWSOptions options, ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
         {
-            object Factory(IServiceProvider sp, object key) => new ClientFactory<T>(options).CreateServiceClient(sp);
-
-            var descriptor = new ServiceDescriptor(typeof(T), serviceKey, Factory, lifetime);
-            collection.TryAdd(descriptor);
-            return collection;
+            return TryAddKeyedAWSService<T>(collection, serviceKey, options, null, lifetime);
         }
 
         /// <summary>

--- a/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
+++ b/extensions/test/NETCore.SetupTests/DependencyInjectionTests.cs
@@ -342,6 +342,90 @@ namespace DependencyInjectionTests
         }
 #endif
 
+        [Fact]
+        public void AddAWSService_WithConfigAction_AppliesConfig()
+        {
+            var services = new ServiceCollection();
+            services.AddDefaultAWSOptions(new AWSOptions { Region = RegionEndpoint.USEast1, Credentials = new Amazon.Runtime.BasicAWSCredentials("test", "test") });
+            services.AddAWSService<IAmazonS3>((config, sp) =>
+            {
+                config.BufferSize = 1234;
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var s3 = serviceProvider.GetRequiredService<IAmazonS3>();
+
+            Assert.Equal(1234, s3.Config.BufferSize);
+        }
+
+        [Fact]
+        public void AddAWSService_WithOptionsAndConfigAction_AppliesBoth()
+        {
+            var services = new ServiceCollection();
+            services.AddAWSService<IAmazonS3>(new AWSOptions { Region = RegionEndpoint.EUWest1, Credentials = new Amazon.Runtime.BasicAWSCredentials("test", "test") }, (config, sp) =>
+            {
+                config.BufferSize = 5678;
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var s3 = serviceProvider.GetRequiredService<IAmazonS3>();
+
+            Assert.Equal(RegionEndpoint.EUWest1, s3.Config.RegionEndpoint);
+            Assert.Equal(5678, s3.Config.BufferSize);
+        }
+
+        [Fact]
+        public void TryAddAWSService_WithConfigAction_AppliesConfig()
+        {
+            var services = new ServiceCollection();
+            services.AddDefaultAWSOptions(new AWSOptions { Region = RegionEndpoint.USEast1, Credentials = new Amazon.Runtime.BasicAWSCredentials("test", "test") });
+            services.TryAddAWSService<IAmazonS3>((config, sp) =>
+            {
+                config.BufferSize = 9999;
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var s3 = serviceProvider.GetRequiredService<IAmazonS3>();
+
+            Assert.Equal(9999, s3.Config.BufferSize);
+        }
+
+        [Fact]
+        public void AddAWSService_ConfigActionReceivesWorkingServiceProvider()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AWSSetting { Region = RegionEndpoint.APSouth1, Profile = "TestProfile" });
+            services.AddDefaultAWSOptions(new AWSOptions { Region = RegionEndpoint.USEast1, Credentials = new Amazon.Runtime.BasicAWSCredentials("test", "test") });
+            services.AddAWSService<IAmazonS3>((config, sp) =>
+            {
+                var setting = sp.GetRequiredService<AWSSetting>();
+                config.BufferSize = setting.Profile.Length;
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var s3 = serviceProvider.GetRequiredService<IAmazonS3>();
+
+            Assert.Equal("TestProfile".Length, s3.Config.BufferSize);
+        }
+
+#if NET8_0_OR_GREATER
+        [Fact]
+        public void AddKeyedAWSService_WithConfigAction_AppliesConfig()
+        {
+            var services = new ServiceCollection();
+            services.AddDefaultAWSOptions(new AWSOptions { Region = RegionEndpoint.USEast1, Credentials = new Amazon.Runtime.BasicAWSCredentials("test", "test") });
+            services.AddKeyedAWSService<IAmazonS3>(TestControllerKeyed.Key, (config, sp) =>
+            {
+                config.BufferSize = 4321;
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var controller = ActivatorUtilities.CreateInstance<TestControllerKeyed>(serviceProvider);
+
+            Assert.Equal(4321, controller.S3Client.Config.BufferSize);
+        }
+#endif
+
         public class TestController
         {
             public IAmazonS3 S3Client { get; private set; }

--- a/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
+++ b/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
@@ -1,0 +1,11 @@
+{
+  "extensions": [
+    {
+      "extensionName": "Extensions.NETCore.Setup",
+      "type": "patch",
+      "changeLogMessages": [
+        "Add Action\u003CClientConfig, IServiceProvider\u003E overloads to service registration methods, prng a way to configure clientConfig.HttpClientFactory directly at the point of registration."
+      ]
+    }
+  ]
+}

--- a/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
+++ b/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
@@ -5,7 +5,8 @@
       "type": "patch",
       "changeLogMessages": [
         "Allow users to configure HttpClientFactory through DI Factories, by providing an overload of AddAWSService.",
-        "This allows users to use the `IHttpClientFactory` provided by microsoft which is only available through DI, with AWS Services."
+        "This allows users to use the `IHttpClientFactory` provided by microsoft which is only available through DI, with AWS Services.",
+        "Note: Callers passing a literal null as the second argument to AddAWSService or AddKeyedAWSService may need to cast (e.g., (AWSOptions)null) to resolve overload ambiguity."
       ]
     }
   ]

--- a/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
+++ b/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
@@ -4,7 +4,8 @@
       "extensionName": "Extensions.NETCore.Setup",
       "type": "patch",
       "changeLogMessages": [
-        "Add Action\u003CClientConfig, IServiceProvider\u003E overloads to service registration methods, prng a way to configure clientConfig.HttpClientFactory directly at the point of registration."
+        "Allow users to configure HttpClientFactory through DI Factories, by providing an overload of AddAWSService.",
+        "This allows users to use the `IHttpClientFactory` provided by microsoft which is only available through DI, with AWS Services."
       ]
     }
   ]

--- a/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
+++ b/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
@@ -4,7 +4,7 @@
       "extensionName": "Extensions.NETCore.Setup",
       "type": "minor",
       "changeLogMessages": [
-        "Added new callback for the `AddAWSService` and similar methods allowing customization of the service client config before being used to create the service client. For example the callback can be used to configure the `HttpClientFactory` with an implementation coming from the DI using the `IHttpClientFactory` provided by microsoft.",
+        "Added new callback for the `AddAWSService` and similar methods allowing customization of the service client config before being used to create the service client. For example the callback can be used to configure the `HttpClientFactory` with an implementation coming from the DI using the `IHttpClientFactory` provided by Microsoft.",
         "Note: Callers passing a literal null as the second argument to AddAWSService or AddKeyedAWSService may need to cast (e.g., (AWSOptions)null) to resolve overload ambiguity."
       ]
     }

--- a/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
+++ b/generator/.DevConfigs/37c0ad85-9929-448a-aaeb-7732bcf8ec27.json
@@ -2,10 +2,9 @@
   "extensions": [
     {
       "extensionName": "Extensions.NETCore.Setup",
-      "type": "patch",
+      "type": "minor",
       "changeLogMessages": [
-        "Allow users to configure HttpClientFactory through DI Factories, by providing an overload of AddAWSService.",
-        "This allows users to use the `IHttpClientFactory` provided by microsoft which is only available through DI, with AWS Services.",
+        "Added new callback for the `AddAWSService` and similar methods allowing customization of the service client config before being used to create the service client. For example the callback can be used to configure the `HttpClientFactory` with an implementation coming from the DI using the `IHttpClientFactory` provided by microsoft.",
         "Note: Callers passing a literal null as the second argument to AddAWSService or AddKeyedAWSService may need to cast (e.g., (AWSOptions)null) to resolve overload ambiguity."
       ]
     }

--- a/generator/.DevConfigs/ea4cc558-15b5-426c-8b2e-7c674e39f145.json
+++ b/generator/.DevConfigs/ea4cc558-15b5-426c-8b2e-7c674e39f145.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "Remove outdated xamarin links on httpClientFactory docs."
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/_netstandard/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/_netstandard/ClientConfig.cs
@@ -115,10 +115,6 @@ namespace Amazon.Runtime
         /// If null, an HttpClient will be created by the SDK.
         /// Note that IClientConfig members such as ProxyHost, ProxyPort, GetWebProxy, and AllowAutoRedirect
         /// will have no effect unless they're used explicitly by the HttpClientFactory implementation.
-        ///
-        /// See https://docs.microsoft.com/en-us/xamarin/cross-platform/macios/http-stack?context=xamarin/ios and
-        /// https://learn.microsoft.com/en-us/xamarin/android/app-fundamentals/http-stack?context=xamarin%2Fcross-platform
-        /// for guidance on creating HttpClients for your platform.
         /// </summary>
         public HttpClientFactory HttpClientFactory { get; set; } = AWSConfigs.HttpClientFactory;
         


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds an overload to `AddAWSService` to provide a way to configure `clientConfig.HttpClientFactory` directly at the point of registration. This allows users to use the `IHttpClientFactory` provided by microsoft which is ONLY available through DI (or any custom factory), with an AWS service.

Allows something like:
```
  services.AddHttpClient("aws-s3");

  services.AddAWSService<IAmazonS3>((config, sp) =>
  {
      var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
      config.HttpClientFactory = new AwsHttpClientFactory(httpFactory, "aws-s3");
  });
```

The user still has to create a class that bridges the `IHttpClientFactory` with the SDK's HttpClientFactory like so (just an example):
```
  public class AwsHttpClientFactory : Amazon.Runtime.HttpClientFactory
  {
      private readonly IHttpClientFactory _httpClientFactory;
      private readonly string _name;

      public AwsHttpClientFactory(IHttpClientFactory httpClientFactory, string name)
      {
          _httpClientFactory = httpClientFactory;
          _name = name;
      }

      public override HttpClient CreateHttpClient(IClientConfig clientConfig)
      {
          return _httpClientFactory.CreateClient(_name);
      }

      public override bool UseSDKHttpClientCaching(IClientConfig clientConfig)
      {
          // Microsoft's IHttpClientFactory manages the handler lifecycle,
          // so don't let the SDK cache on top of it.
          return false;
      }

      public override bool DisposeHttpClientsAfterUse(IClientConfig clientConfig)
      {
          // IHttpClientFactory-created clients are safe to dispose (it only
          // disposes the HttpClient wrapper, not the underlying handler).
          return true;
      }
  }
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Fixes #4092 
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
UnitTests added, dry run passed
### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** ea61611a-8e2c-4872-8bbd-f5c3664228fa
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 8f291e19-3267-4b79-8231-2c31c9d4ad5c
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement