### PR TITLE
Fix credential_process failing when executable path contains spaces on Windows.

### DIFF
--- a/generator/.DevConfigs/a2e30a7f-6345-4090-95b9-4f8f09819413.json
+++ b/generator/.DevConfigs/a2e30a7f-6345-4090-95b9-4f8f09819413.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Fix credential_process failing when executable path contains spaces on Windows."
+    ],
+    "type": "patch",
+    "updateMinimum": false
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/ProcessAWSCredentials.cs
@@ -74,19 +74,24 @@ namespace Amazon.Runtime
         public ProcessAWSCredentials(string processCredentialInfo, string accountId)
         {
             processCredentialInfo = processCredentialInfo.Trim();
-
-            //Default to cmd on Windows since that is the only thing BCL runs on.
-            var fileName = "cmd.exe";
-            var arguments = $@"/c {processCredentialInfo}";
             _accountId = accountId;
+
+            string fileName;
+            string arguments;
+
 #if NETSTANDARD
-            //If it is netstandard and not running on Windows use sh.
-            if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))            
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 fileName = "sh";
-                var escapedArgs = processCredentialInfo.Replace("\\", "\\\\").Replace("\"", "\\\"");    
+                var escapedArgs = processCredentialInfo.Replace("\\", "\\\\").Replace("\"", "\\\"");
                 arguments = $"-c \"{escapedArgs}\"";
             }
+            else
+            {
+                (fileName, arguments) = ParseCredentialProcessCommand(processCredentialInfo);
+            }
+#else
+            (fileName, arguments) = ParseCredentialProcessCommand(processCredentialInfo);
 #endif
             _processStartInfo = new ProcessStartInfo
             {
@@ -164,6 +169,57 @@ namespace Amazon.Runtime
         #endregion
 
         #region Private methods
+
+        /// <summary>
+        /// Parses the credential_process command string into an executable path and arguments,
+        /// correctly handling double-quoted paths that contain spaces per the AWS SDK specification
+        /// (https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html).
+        /// This avoids using cmd.exe, which has issues with quoted paths
+        /// and hangs when cmd.exe is disabled via Group Policy.
+        /// </summary>
+        private static (string FileName, string Arguments) ParseCredentialProcessCommand(string command)
+        {
+            if (string.IsNullOrEmpty(command))
+            {
+                return (string.Empty, string.Empty);
+            }
+
+            string fileName;
+            string arguments;
+
+            if (command[0] == '"')
+            {
+                var closingQuote = command.IndexOf('"', 1);
+                if (closingQuote == -1)
+                {
+                    // Fail fast on malformed input, consistent with botocore's _windows_shell_split().
+                    throw new ProcessAWSCredentialException(
+                        "No closing quotation mark found in credential_process command.");
+                }
+
+                fileName = command.Substring(1, closingQuote - 1);
+                arguments = closingQuote + 1 < command.Length
+                    ? command.Substring(closingQuote + 1).TrimStart()
+                    : string.Empty;
+            }
+            else
+            {
+                var spaceIndex = command.IndexOfAny(new[] { ' ', '\t' });
+                if (spaceIndex == -1)
+                {
+                    fileName = command;
+                    arguments = string.Empty;
+                }
+                else
+                {
+                    fileName = command.Substring(0, spaceIndex);
+                    arguments = command.Substring(spaceIndex + 1).TrimStart();
+                }
+            }
+
+            return (fileName, arguments);
+        }
+
         [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         private CredentialsRefreshState SetCredentialsRefreshState(ProcessExecutionResult processInfo)
         {    

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/ProcessAWSCredentialsTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/ProcessAWSCredentialsTest.cs
@@ -149,5 +149,81 @@ namespace AWSSDK.UnitTests
             }
         }
 #endif
+
+        [TestMethod]
+        public void QuotedExecutablePathWithSpaces()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var dirWithSpace = Path.Combine(Path.GetTempPath(), $"aws sdk test {Guid.NewGuid():N}");
+            Directory.CreateDirectory(dirWithSpace);
+
+            try
+            {
+                var scriptCopy = Path.Combine(dirWithSpace, "windows-credentials-script.bat");
+                File.Copy(Executable, scriptCopy, overwrite: true);
+
+                var processCredential = new ProcessAWSCredentials(
+                    $"\"{scriptCopy}\" {ArgumentsBasic} {ValidVersionNumber}");
+                var credentialsRefreshState = processCredential.DetermineProcessCredential();
+                Assert.AreEqual(ActualAccessKey, credentialsRefreshState.Credentials.AccessKey);
+                Assert.AreEqual(ActualSecretKey, credentialsRefreshState.Credentials.SecretKey);
+            }
+            finally
+            {
+                Directory.Delete(dirWithSpace, recursive: true);
+            }
+        }
+
+        [TestMethod]
+        public void UnquotedExecutablePathWithoutSpaces()
+        {
+            var processCredential = new ProcessAWSCredentials(
+                $"{Executable} {ArgumentsBasic} {ValidVersionNumber}");
+            var credentialsRefreshState = processCredential.DetermineProcessCredential();
+            Assert.AreEqual(ActualAccessKey, credentialsRefreshState.Credentials.AccessKey);
+            Assert.AreEqual(ActualSecretKey, credentialsRefreshState.Credentials.SecretKey);
+        }
+
+
+        [TestMethod]
+        public void QuotedExecutablePathWithMultipleArguments()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var dirWithSpace = Path.Combine(Path.GetTempPath(), $"aws sdk test {Guid.NewGuid():N}");
+            Directory.CreateDirectory(dirWithSpace);
+
+            try
+            {
+                var scriptCopy = Path.Combine(dirWithSpace, "windows-credentials-script.bat");
+                File.Copy(Executable, scriptCopy, overwrite: true);
+
+                var processCredential = new ProcessAWSCredentials(
+                    $"\"{scriptCopy}\" {ArgumentsSession} {ValidVersionNumber}");
+                var credentialsRefreshState = processCredential.DetermineProcessCredential();
+                Assert.AreEqual(ActualAccessKey, credentialsRefreshState.Credentials.AccessKey);
+                Assert.AreEqual(ActualSecretKey, credentialsRefreshState.Credentials.SecretKey);
+                Assert.IsNotNull(credentialsRefreshState.Credentials.Token);
+            }
+            finally
+            {
+                Directory.Delete(dirWithSpace, recursive: true);
+            }
+        }
+
+        [TestMethod]
+        public void UnmatchedDoubleQuoteThrows()
+        {
+            Assert.ThrowsExactly<ProcessAWSCredentialException>(() =>
+                new ProcessAWSCredentials("\"C:\\Program Files\\foo.exe").DetermineProcessCredential());
+        }
+
     }
 }


### PR DESCRIPTION
## Description
`ProcessAWSCredentials` previously delegated to `cmd.exe /c` to run the `credential_process` command. This caused two issues:

1. Quoted paths with spaces (e.g., "C:\Program Files\foo.exe") were broken because cmd.exe strips quotes when arguments follow, causing it to interpret "C:\Program" as the executable (GitHub [#393](https://github.com/aws/aws-tools-for-powershell/issues/393)).

2. On systems where cmd.exe is disabled via Group Policy, the SDK hung indefinitely waiting for cmd.exe to exit (GitHub [#1845](https://github.com/aws/aws-sdk-net/issues/1845)).

The fix removes the `cmd.exe` intermediary on Windows and instead parses the `credential_process` value directly — extracting the double-quoted executable path and arguments per the AWS SDK specification — then launches the process via `ProcessStartInfo.FileName`. This is consistent with how `botocore` handles `credential_process` on Windows.

Refer https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html for some guidance around using double-quotes.

## Motivation and Context
Issues:
- https://github.com/aws/aws-tools-for-powershell/issues/393
- https://github.com/aws/aws-sdk-net/issues/1845

## Testing
- Added test cases.
- Tested locally:
  - File Path with spaces
  - File Path with spaces enclosed in double-quotes
  - File Path enclosed in double quotes and arguments also in double-quotes

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** [DRY_RUN-067d8422-41ff-4140-bb7d-dcc8a5be2671](https://tiny.amazon.com/y1xmjhfq/IsenLink)
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** [DRY_RUN-481b41ae-043d-4fb2-b8fb-28821e782d6e](https://tiny.amazon.com/y8tlq2ue/IsenLink)
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement