### PR TITLE
Fix issue where region was being overriden if AWS_ENDPOINT_URL (or service specific variants) were set.

### DIFF
--- a/generator/.DevConfigs/718e7bc9-3f12-49d2-abf1-dd20051661c4.json
+++ b/generator/.DevConfigs/718e7bc9-3f12-49d2-abf1-dd20051661c4.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fix: Fix an issue where AWS_REGION and AWS_ENDPOINT_URL both being set would cause the region to be nullified."
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -339,22 +339,22 @@ namespace Amazon.Runtime
         /// </summary>
         public string ServiceURL
         {
-            get 
+            get
             {
                 if (!didProcessServiceURL && this.serviceURL == null && IgnoreConfiguredEndpointUrls == false && ServiceId != null)
                 {
-                    
+
                     string serviceSpecificTransformedEnvironmentVariable = TransformServiceId.TransformServiceIdToEnvVariable(ServiceId);
                     string transformedConfigServiceId = TransformServiceId.TransformServiceIdToConfigVariable(ServiceId);
 
                     if (Environment.GetEnvironmentVariable(serviceSpecificTransformedEnvironmentVariable) != null)
                     {
                         Logger.GetLogger(GetType()).InfoFormat($"ServiceURL configured from service specific environment variable: {serviceSpecificTransformedEnvironmentVariable}.");
-                        this.ServiceURL = Environment.GetEnvironmentVariable(serviceSpecificTransformedEnvironmentVariable);                    
+                        this.serviceURL = NormalizeServiceURL(Environment.GetEnvironmentVariable(serviceSpecificTransformedEnvironmentVariable));
                     }
                     else if (Environment.GetEnvironmentVariable(EnvironmentVariables.GLOBAL_ENDPOINT_ENVIRONMENT_VARIABLE) != null)
                     {
-                        this.ServiceURL = Environment.GetEnvironmentVariable(EnvironmentVariables.GLOBAL_ENDPOINT_ENVIRONMENT_VARIABLE);
+                        this.serviceURL = NormalizeServiceURL(Environment.GetEnvironmentVariable(EnvironmentVariables.GLOBAL_ENDPOINT_ENVIRONMENT_VARIABLE));
                         Logger.GetLogger(GetType()).InfoFormat($"ServiceURL configured from global environment variable: {EnvironmentVariables.GLOBAL_ENDPOINT_ENVIRONMENT_VARIABLE}.");
                     }
                     else
@@ -378,7 +378,7 @@ namespace Amazon.Runtime
                                 {
                                     Logger.GetLogger(GetType()).InfoFormat($"ServiceURL configured from service specific endpoint url in " +
                                     $"profile {profile.Name} from key {transformedConfigServiceId}.");
-                                    this.ServiceURL = endpointUrlValue;
+                                    this.serviceURL = NormalizeServiceURL(endpointUrlValue);
                                 }
 
                             }
@@ -386,7 +386,7 @@ namespace Amazon.Runtime
                             {
                                 Logger.GetLogger(GetType()).InfoFormat($"ServiceURL configured from global endpoint url" +
                                     $"in profile {profile.Name} from key {SettingsConstants.EndpointUrl}.");
-                                this.ServiceURL = profile.EndpointUrl;
+                                this.serviceURL = NormalizeServiceURL(profile.EndpointUrl);
                             }
                         }
 
@@ -403,32 +403,33 @@ namespace Amazon.Runtime
                         $"ServiceUrl was set last, ServiceUrl: {value} will be used to make the request and RegionEndpoint: {this.regionEndpoint} has been set to null.");
                 this.regionEndpoint = null;
                 this.probeForRegionEndpoint = false;
-                
-                if(!string.IsNullOrEmpty(value))
+
+                this.serviceURL = NormalizeServiceURL(value);
+            }
+        }
+
+        private static string NormalizeServiceURL(string value)
+        {
+            if(!string.IsNullOrEmpty(value))
+            {
+                try
                 {
-                    // If the URL passed in only has a host name make sure there is an ending "/" to avoid signature mismatch issues.
-                    // If there is a resource path do not add a "/" because the marshallers are relying on the URL to be in format without the "/".
-                    // API Gateway Management API is an example of a service that vends its own URL that users have to set which has a resource path.
-                    // The marshallers add new segments to the resource path with the "/".
-                    try
+                    var path = new Uri(value).PathAndQuery;
+                    if (string.IsNullOrEmpty(path) || path == "/")
                     {
-                        var path = new Uri(value).PathAndQuery;
-                        if (string.IsNullOrEmpty(path) || path == "/")
+                        if (!value.EndsWith("/"))
                         {
-                            if (!string.IsNullOrEmpty(value) && !value.EndsWith("/"))
-                            {
-                                value += "/";
-                            }
+                            value += "/";
                         }
                     }
-                    catch(UriFormatException)
-                    {
-                        throw new AmazonClientException("Value for ServiceURL is not a valid URL: " + value);
-                    }
                 }
-
-                this.serviceURL = value;
+                catch(UriFormatException)
+                {
+                    throw new AmazonClientException("Value for ServiceURL is not a valid URL: " + value);
+                }
             }
+
+            return value;
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -345,7 +345,7 @@ namespace Amazon.Runtime
                 {
                     string serviceSpecificTransformedEnvironmentVariable = TransformServiceId.TransformServiceIdToEnvVariable(ServiceId);
                     string transformedConfigServiceId = TransformServiceId.TransformServiceIdToConfigVariable(ServiceId);
-
+                    // the backing field this.serviceURL is used on purpose here to avoid calling the setter which would nullify the region.
                     if (Environment.GetEnvironmentVariable(serviceSpecificTransformedEnvironmentVariable) != null)
                     {
                         Logger.GetLogger(GetType()).InfoFormat($"ServiceURL configured from service specific environment variable: {serviceSpecificTransformedEnvironmentVariable}.");

--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -409,8 +409,12 @@ namespace Amazon.Runtime
 
         private static string NormalizeServiceURL(string value)
         {
-            if(!string.IsNullOrEmpty(value))
+            if (!string.IsNullOrEmpty(value))
             {
+                // If the URL passed in only has a host name make sure there is an ending "/" to avoid signature mismatch issues.
+                // If there is a resource path do not add a "/" because the marshallers are relying on the URL to be in format without the "/".
+                // API Gateway Management API is an example of a service that vends its own URL that users have to set which has a resource path.
+                // The marshallers add new segments to the resource path with the "/".
                 try
                 {
                     var path = new Uri(value).PathAndQuery;

--- a/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
+++ b/sdk/src/Core/Amazon.Runtime/ClientConfig.cs
@@ -343,7 +343,6 @@ namespace Amazon.Runtime
             {
                 if (!didProcessServiceURL && this.serviceURL == null && IgnoreConfiguredEndpointUrls == false && ServiceId != null)
                 {
-
                     string serviceSpecificTransformedEnvironmentVariable = TransformServiceId.TransformServiceIdToEnvVariable(ServiceId);
                     string transformedConfigServiceId = TransformServiceId.TransformServiceIdToConfigVariable(ServiceId);
 

--- a/sdk/test/UnitTests/Custom/Runtime/ClientConfigTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/ClientConfigTests.cs
@@ -114,6 +114,72 @@ namespace AWSSDK.UnitTests
             Assert.IsNotNull(config.AuthenticationRegion);
             Assert.IsNotNull(config.ServiceURL);
         }
+
+        [TestMethod]
+        public void RegionEndpointPreservedWhenServiceURLResolvedFromGlobalEnvVar()
+        {
+            var savedRegion = Environment.GetEnvironmentVariable("AWS_REGION");
+            var savedEndpoint = Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL");
+            try
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", "us-east-2");
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", "http://localhost:4566");
+                FallbackRegionFactory.Reset();
+
+                var config = new TestClientConfig();
+                config.ServiceId = "S3";
+
+                Assert.AreEqual("http://localhost:4566/", config.ServiceURL);
+                Assert.AreEqual("us-east-2", config.RegionEndpoint.SystemName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", savedRegion);
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", savedEndpoint);
+                FallbackRegionFactory.Reset();
+            }
+        }
+
+        [TestMethod]
+        public void RegionEndpointPreservedWhenServiceURLResolvedFromServiceSpecificEnvVar()
+        {
+            var savedRegion = Environment.GetEnvironmentVariable("AWS_REGION");
+            var savedEndpoint = Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL_S3");
+            try
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", "eu-west-1");
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL_S3", "http://localhost:9000");
+                FallbackRegionFactory.Reset();
+
+                var config = new TestClientConfig();
+                config.ServiceId = "S3";
+
+                Assert.AreEqual("http://localhost:9000/", config.ServiceURL);
+                Assert.AreEqual("eu-west-1", config.RegionEndpoint.SystemName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", savedRegion);
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL_S3", savedEndpoint);
+                FallbackRegionFactory.Reset();
+            }
+        }
+
+        [TestMethod]
+        public void ExplicitServiceURLSetterStillClearsRegionEndpoint()
+        {
+            var config = new TestClientConfig
+            {
+                RegionEndpoint = RegionEndpoint.USWest2,
+            };
+
+            Assert.AreEqual("us-west-2", config.RegionEndpoint.SystemName);
+
+            config.ServiceURL = "http://localhost:4566";
+
+            Assert.IsNull(config.RegionEndpoint);
+            Assert.AreEqual("http://localhost:4566/", config.ServiceURL);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
While working on something else I realized that when `AWS_ENDPOINT_URL` is set and `AWS_REGION` is also set, the `AWS_REGION` is set to null by the getter in `ServiceURL`. This is because the `serviceURL `getter was incorrectly writing to `this.ServiceUrl` instead of the backing field `this.serviceURL`, which was triggering the logic to nullify the regionEndpoint. 

The setter's behavior is unchanged, explicitly setting `config.ServiceURL` will still nullify the regionEndpoint. However, we should consider if we want to change this "mutually exclusive" behavior and be smarter about the behavior when both are set. 

The null region means it was just using the default value of us-east-1.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
The `ServiceURL` property getter auto-resolves from environment variables (`AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_{SERVICE}`) and profile configuration. When it finds a value, it previously called `this.ServiceURL = value` (the property setter), which unconditionally sets `regionEndpoint = null` and `probeForRegionEndpoint = false` due to the "mutually exclusive" design between RegionEndpoint and ServiceURL.

This meant that any code path reading `config.ServiceURL` after the region was already resolved (e.g.,
EndpointDiscoveryResolver constructor, signers, endpoint resolvers) would permanently destroy the region — even though
the user explicitly configured both via environment variables.

The fix is to write to the backing field and create a new `NormalizeServiceURL` static helper which bypasses the setter altogether while preserving the previous behavior.


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** e72953ee-befa-40ef-b1dd-a2beacfc35ce
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** e55ceb36-f326-46c4-9900-300b0e625bc8
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement