### PR TITLE
Add E2E serde benchmarks with mocked HTTP for CI performance testing

### DIFF
--- a/sdk/test/Performance/SerdeBenchmarks/README.md
+++ b/sdk/test/Performance/SerdeBenchmarks/README.md
@@ -2,6 +2,24 @@
 
 Benchmarks for measuring serialization and deserialization performance across AWS protocol types using standardized mock service models from the [AwsSdkPerformanceBenchmarkModels](https://code.amazon.com/packages/AwsSdkPerformanceBenchmarkModels) package.
 
+## Test Suites
+
+### `e2e` — Full Client Pipeline Benchmarks (default)
+
+Tests the complete SDK client pipeline with a mocked HTTP handler:
+- Credential resolution
+- Request signing (SigV4)
+- Request marshalling
+- HTTP dispatch (mocked — no network I/O)
+- Response unmarshalling
+- Response object construction
+
+This measures the true end-to-end cost of an SDK call without network latency. BenchmarkDotNet auto-determines warmup count, iteration count, and invocation count for statistically stable results.
+
+### `serde` — Isolated Marshal/Unmarshal Benchmarks
+
+Tests only the marshaller and unmarshaller components in isolation. Faster runtime (~12-18 min) using a constrained BDN configuration (5 warmup iterations, 5-20 measurement iterations).
+
 ## Protocols Tested
 
 | Protocol | Service Client | Operations |
@@ -20,23 +38,43 @@ Each operation is tested with different payload sizes:
 - **M** (Medium) — Medium payload
 - **L** (Large) — Large payload
 
-## Measurement
-
-- Each test case runs at least 1,000 iterations (up to 10,000 or 30 seconds)
-- Warmup iterations are discarded (up to 50% of earliest data)
-- Results reported in nanoseconds: mean, p50, p90, p95, p99, standard deviation
-- Output in JSON format per the AwsSdkPerformanceBenchmarkModels specification
-
 ## Running
 
 ```bash
-# From the repository root
-dotnet run --configuration Release --project sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/SerdeBenchmarksRunner.csproj
+# Run E2E benchmarks (default)
+dotnet run -c Release --project sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/SerdeBenchmarksRunner.csproj -- --filter '*'
 
-# With instance type and output path
-dotnet run --configuration Release --project sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/SerdeBenchmarksRunner.csproj -- --instance m7i.xlarge --output serde-results.json
+# Run E2E benchmarks (explicit)
+dotnet run -c Release --project sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/SerdeBenchmarksRunner.csproj -- --suite e2e --filter '*'
+
+# Run serde-only (marshal/unmarshal) benchmarks
+dotnet run -c Release --project sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/SerdeBenchmarksRunner.csproj -- --suite serde --filter '*'
+
+# Filter to a specific protocol
+dotnet run -c Release --project sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/SerdeBenchmarksRunner.csproj -- --filter '*RestJson1*'
+
+# Filter to a specific protocol (serde only)
+dotnet run -c Release --project sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/SerdeBenchmarksRunner.csproj -- --suite serde --filter '*AwsQuery*'
 ```
+
+## Measurement
+
+### E2E suite (default)
+- BenchmarkDotNet Throughput mode with **auto-pilot** — BDN determines warmup count, iteration count, and invocation count automatically for statistically stable results
+- Results reported in nanoseconds: mean, p50, p90, p95, max
+- Memory allocation tracked via `[MemoryDiagnoser]`
+
+### Serde suite
+- BenchmarkDotNet Throughput mode with **constrained configuration**: 5 warmup iterations, 5-20 measurement iterations
+- BDN automatically determines invocation counts for accurate measurement of fast micro-benchmarks (µs-scale serde operations)
+- Results reported in nanoseconds: mean, p50, p90, p95, max
+- Memory allocation tracked via `[MemoryDiagnoser]`
 
 ## Output
 
-Results are written to `serde-results.json` in the working directory, in the format specified by the AwsSdkPerformanceBenchmarkModels package README.
+Results are written to `BenchmarkDotNet.Artifacts/results/` in CSV, GitHub Markdown, and HTML formats.
+
+## CI/CD Integration
+
+For CI/CD, the `--suite` argument is used by the `test.sh`/`test.ps1` scripts:
+- **RELEASE / DRY_RUN builds** → `--suite e2e` (full pipeline regression detection)

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/AwsJson10E2EBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/AwsJson10E2EBenchmarks.cs
@@ -1,0 +1,107 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Text;
+using Amazon.JsonRpc10DataPlane;
+using Amazon.JsonRpc10DataPlane.Model;
+using Amazon.Runtime;
+using BenchmarkDotNet.Attributes;
+
+namespace AWSSDK.Benchmarks.Serde;
+
+/// <summary>
+/// E2E benchmarks for AWS JSON 1.0 protocol (DynamoDB-like operations).
+/// Full SDK client pipeline with mocked HTTP.
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(E2EBenchmarkConfig))]
+public class AwsJson10E2EBenchmarks
+{
+    private AmazonJsonRpc10DataPlaneClient _healthcheckClient = null!;
+    private AmazonJsonRpc10DataPlaneClient _putClient = null!;
+    private AmazonJsonRpc10DataPlaneClient _getClientS = null!;
+    private AmazonJsonRpc10DataPlaneClient _getClientM = null!;
+    private AmazonJsonRpc10DataPlaneClient _getClientL = null!;
+
+    private PutItemRequest _putItemS = null!;
+    private PutItemRequest _putItemM = null!;
+    private PutItemRequest _putItemL = null!;
+    private GetItemRequest _getItemRequest = null!;
+    private HealthcheckRequest _healthcheckRequest = null!;
+
+    private static readonly byte[] EmptyJson = Encoding.UTF8.GetBytes("{}");
+    private static readonly byte[] GetItemResponseS = Encoding.UTF8.GetBytes(BuildGetItemJson(5));
+    private static readonly byte[] GetItemResponseM = Encoding.UTF8.GetBytes(BuildGetItemJson(20));
+    private static readonly byte[] GetItemResponseL = Encoding.UTF8.GetBytes(BuildGetItemJson(50));
+
+    private static string BuildGetItemJson(int attrCount)
+    {
+        var sb = new StringBuilder("{\"Item\":{");
+        for (int i = 0; i < attrCount; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append($"\"attr_{i}\":{{\"S\":\"value-{i}-{new string('x', 20)}\"}}");
+        }
+        sb.Append("}}");
+        return sb.ToString();
+    }
+
+    private AmazonJsonRpc10DataPlaneClient CreateClient(byte[] responseBody)
+    {
+        var handler = new MockHttpHandler(responseBody, "application/x-amz-json-1.0");
+        var config = new AmazonJsonRpc10DataPlaneConfig
+        {
+            RegionEndpoint = Amazon.RegionEndpoint.USWest2,
+            HttpClientFactory = new MockHttpClientFactory(handler)
+        };
+        return new AmazonJsonRpc10DataPlaneClient(new BasicAWSCredentials("AKID", "SECRET"), config);
+    }
+
+    private static AttributeValue S(string v) => new AttributeValue { S = v };
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _healthcheckClient = CreateClient(EmptyJson);
+        _putClient = CreateClient(EmptyJson);
+        _getClientS = CreateClient(GetItemResponseS);
+        _getClientM = CreateClient(GetItemResponseM);
+        _getClientL = CreateClient(GetItemResponseL);
+
+        _healthcheckRequest = new HealthcheckRequest();
+        _putItemS = new PutItemRequest { TableName = "T", Item = TestDataHelpers.CreateSmallItem<AttributeValue>(S, n => new AttributeValue { N = n.ToString() }, b => new AttributeValue { BOOL = b }) };
+        _putItemM = new PutItemRequest { TableName = "T", Item = TestDataHelpers.CreateMediumItem<AttributeValue>(S, n => new AttributeValue { N = n.ToString() }, b => new AttributeValue { BOOL = b }, l => new AttributeValue { L = l }, m => new AttributeValue { M = m }) };
+        _putItemL = new PutItemRequest { TableName = "T", Item = TestDataHelpers.CreateLargeItem<AttributeValue>(S, n => new AttributeValue { N = n.ToString() }, b => new AttributeValue { BOOL = b }, l => new AttributeValue { L = l }, m => new AttributeValue { M = m }) };
+        _getItemRequest = new GetItemRequest { TableName = "T", Key = TestDataHelpers.CreateBaselineItem<AttributeValue>(S) };
+    }
+
+    [Benchmark] public async Task awsJson10_e2e_Healthcheck() => await _healthcheckClient.HealthcheckAsync(_healthcheckRequest);
+    [Benchmark] public async Task awsJson10_e2e_PutItem_S() => await _putClient.PutItemAsync(_putItemS);
+    [Benchmark] public async Task awsJson10_e2e_PutItem_M() => await _putClient.PutItemAsync(_putItemM);
+    [Benchmark] public async Task awsJson10_e2e_PutItem_L() => await _putClient.PutItemAsync(_putItemL);
+    [Benchmark] public async Task awsJson10_e2e_GetItem_S() => await _getClientS.GetItemAsync(_getItemRequest);
+    [Benchmark] public async Task awsJson10_e2e_GetItem_M() => await _getClientM.GetItemAsync(_getItemRequest);
+    [Benchmark] public async Task awsJson10_e2e_GetItem_L() => await _getClientL.GetItemAsync(_getItemRequest);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _healthcheckClient?.Dispose();
+        _putClient?.Dispose();
+        _getClientS?.Dispose();
+        _getClientM?.Dispose();
+        _getClientL?.Dispose();
+    }
+}

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/AwsQueryE2EBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/AwsQueryE2EBenchmarks.cs
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Text;
+using Amazon.QueryDataPlane;
+using Amazon.QueryDataPlane.Model;
+using Amazon.Runtime;
+using BenchmarkDotNet.Attributes;
+
+namespace AWSSDK.Benchmarks.Serde;
+
+/// <summary>
+/// E2E benchmarks for AWS Query protocol (CloudWatch-like operations).
+/// Full SDK client pipeline with mocked HTTP.
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(E2EBenchmarkConfig))]
+public class AwsQueryE2EBenchmarks
+{
+    private AmazonQueryDataPlaneClient _healthcheckClient = null!;
+    private AmazonQueryDataPlaneClient _putClientS = null!;
+    private AmazonQueryDataPlaneClient _putClientM = null!;
+    private AmazonQueryDataPlaneClient _getClientS = null!;
+    private AmazonQueryDataPlaneClient _getClientM = null!;
+
+    private HealthcheckRequest _healthcheckRequest = null!;
+    private PutMetricDataRequest _putMetricDataS = null!;
+    private PutMetricDataRequest _putMetricDataM = null!;
+    private GetMetricDataRequest _getMetricDataRequestS = null!;
+    private GetMetricDataRequest _getMetricDataRequestM = null!;
+
+    private static readonly byte[] HealthcheckResponse = Encoding.UTF8.GetBytes(
+        "<HealthcheckResponse xmlns=\"https://query.amazonaws.com/doc/2024-01-01/\"><HealthcheckResult/><ResponseMetadata><RequestId>test-id</RequestId></ResponseMetadata></HealthcheckResponse>");
+    private static readonly byte[] PutMetricResponse = Encoding.UTF8.GetBytes(
+        "<PutMetricDataResponse xmlns=\"https://query.amazonaws.com/doc/2024-01-01/\"><PutMetricDataResult/><ResponseMetadata><RequestId>test-id</RequestId></ResponseMetadata></PutMetricDataResponse>");
+    private static readonly byte[] GetMetricResponseS = Encoding.UTF8.GetBytes(BuildGetMetricXml(5));
+    private static readonly byte[] GetMetricResponseM = Encoding.UTF8.GetBytes(BuildGetMetricXml(50));
+
+    private static string BuildGetMetricXml(int datapoints)
+    {
+        var sb = new StringBuilder("<GetMetricDataResponse xmlns=\"https://query.amazonaws.com/doc/2024-01-01/\"><GetMetricDataResult><MetricDataResults><member><Id>m1</Id><Label>CPUUtilization</Label><Values>");
+        for (int i = 0; i < datapoints; i++) sb.Append($"<member>{42.0 + i * 0.1}</member>");
+        sb.Append("</Values><Timestamps>");
+        for (int i = 0; i < datapoints; i++)
+        {
+            var ts = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMinutes(i * 5);
+            sb.Append($"<member>{ts:yyyy-MM-ddTHH:mm:ssZ}</member>");
+        }
+        sb.Append("</Timestamps></member></MetricDataResults></GetMetricDataResult><ResponseMetadata><RequestId>test-id</RequestId></ResponseMetadata></GetMetricDataResponse>");
+        return sb.ToString();
+    }
+
+    private AmazonQueryDataPlaneClient CreateClient(byte[] responseBody)
+    {
+        var handler = new MockHttpHandler(responseBody, "text/xml");
+        var config = new AmazonQueryDataPlaneConfig
+        {
+            RegionEndpoint = Amazon.RegionEndpoint.USWest2,
+            HttpClientFactory = new MockHttpClientFactory(handler)
+        };
+        return new AmazonQueryDataPlaneClient(new BasicAWSCredentials("AKID", "SECRET"), config);
+    }
+
+    private static List<MetricDatum> CreateMetricData(int count)
+    {
+        var data = new List<MetricDatum>();
+        for (int i = 0; i < count; i++)
+            data.Add(new MetricDatum { MetricName = $"Metric{i}", Value = 42.0 + i, Unit = "Count" });
+        return data;
+    }
+
+    private static List<MetricDataQuery> CreateQueries(int count)
+    {
+        var queries = new List<MetricDataQuery>();
+        for (int i = 0; i < count; i++)
+            queries.Add(new MetricDataQuery { Id = $"m{i}", MetricStat = new MetricStat { Metric = new Amazon.QueryDataPlane.Model.Metric { MetricName = $"CPU{i}", Namespace = "AWS/EC2" }, Period = 300, Stat = "Average" } });
+        return queries;
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _healthcheckClient = CreateClient(HealthcheckResponse);
+        _putClientS = CreateClient(PutMetricResponse);
+        _putClientM = CreateClient(PutMetricResponse);
+        _getClientS = CreateClient(GetMetricResponseS);
+        _getClientM = CreateClient(GetMetricResponseM);
+
+        _healthcheckRequest = new HealthcheckRequest();
+        _putMetricDataS = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(3) };
+        _putMetricDataM = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(20) };
+        _getMetricDataRequestS = new GetMetricDataRequest { StartTime = DateTime.UtcNow.AddHours(-1), EndTime = DateTime.UtcNow, MetricDataQueries = CreateQueries(1) };
+        _getMetricDataRequestM = new GetMetricDataRequest { StartTime = DateTime.UtcNow.AddHours(-1), EndTime = DateTime.UtcNow, MetricDataQueries = CreateQueries(5) };
+    }
+
+    [Benchmark] public async Task awsQuery_e2e_Healthcheck() => await _healthcheckClient.HealthcheckAsync(_healthcheckRequest);
+    [Benchmark] public async Task awsQuery_e2e_PutMetricData_S() => await _putClientS.PutMetricDataAsync(_putMetricDataS);
+    [Benchmark] public async Task awsQuery_e2e_PutMetricData_M() => await _putClientM.PutMetricDataAsync(_putMetricDataM);
+    [Benchmark] public async Task awsQuery_e2e_GetMetricData_S() => await _getClientS.GetMetricDataAsync(_getMetricDataRequestS);
+    [Benchmark] public async Task awsQuery_e2e_GetMetricData_M() => await _getClientM.GetMetricDataAsync(_getMetricDataRequestM);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _healthcheckClient?.Dispose();
+        _putClientS?.Dispose();
+        _putClientM?.Dispose();
+        _getClientS?.Dispose();
+        _getClientM?.Dispose();
+    }
+}

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/E2EBenchmarkConfig.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/E2EBenchmarkConfig.cs
@@ -23,34 +23,26 @@ using Perfolizer.Horology;
 namespace AWSSDK.Benchmarks.Serde;
 
 /// <summary>
-/// Shared BenchmarkDotNet configuration for serde benchmarks.
-/// 
-/// Configures RunStrategy.Throughput with 5 warmup iterations and max 20 measurement
-/// iterations, letting BenchmarkDotNet automatically determine invocation counts for
-/// accurate measurement of fast micro-benchmarks (μs-scale serde operations).
-/// With 71 tests, this configuration targets ~12-18 minutes total runtime.
-/// 
-/// BDN Throughput mode reports P50, P90, P95 from per-iteration averages.
-/// Max is included as an upper-bound outlier indicator.
+/// BenchmarkDotNet configuration for E2E benchmarks.
+/// Uses InProcessEmitToolchain so benchmarks can run from a published DLL
+/// without needing the source .csproj or dotnet SDK for child process generation.
+/// BDN auto-determines warmup and iteration counts for statistically stable results.
 /// </summary>
-public class SerdeBenchmarkConfig : ManualConfig
+public class E2EBenchmarkConfig : ManualConfig
 {
-    public SerdeBenchmarkConfig()
+    public E2EBenchmarkConfig()
     {
-        // Performance Baselines Report used: WarmupCount=10, no Min/MaxIterationCount (BDN auto)
-        // Optimized for CI/build system runtime: WarmupCount=5, MinIter=5, MaxIter=20
+        // InProcessEmitToolchain runs benchmarks in the same process.
+        // This avoids BDN's need to find the .csproj and spawn child processes,
+        // making it compatible with published/deployed artifacts.
         AddJob(Job.Default
-            .WithToolchain(InProcessEmitToolchain.Instance)
-            .WithStrategy(BenchmarkDotNet.Engines.RunStrategy.Throughput)
-            .WithWarmupCount(5)
-            .WithMinIterationCount(5)
-            .WithMaxIterationCount(20));
+            .WithToolchain(InProcessEmitToolchain.Instance));
 
         // Add percentile columns
         AddColumn(StatisticColumn.P50);
         AddColumn(StatisticColumn.P90);
         AddColumn(StatisticColumn.P95);
-        AddColumn(StatisticColumn.Max);  // P100 = Max, useful as upper-bound outlier indicator
+        AddColumn(StatisticColumn.Max);
 
         WithSummaryStyle(SummaryStyle.Default
             .WithTimeUnit(TimeUnit.Nanosecond)

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/MockHttpHandler.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/MockHttpHandler.cs
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Net;
+using System.Net.Http;
+using Amazon.Runtime;
+
+namespace AWSSDK.Benchmarks.Serde;
+
+/// <summary>
+/// A mock HttpMessageHandler that returns a pre-configured response without network I/O.
+/// Used for E2E benchmarks to exercise the full SDK client pipeline (credentials, signing,
+/// serialization, HTTP dispatch, deserialization) without actual service calls.
+/// </summary>
+public class MockHttpHandler : HttpMessageHandler
+{
+    private readonly byte[] _responseBody;
+    private readonly string _contentType;
+    private readonly HttpStatusCode _statusCode;
+    private readonly Dictionary<string, string> _responseHeaders;
+
+    public MockHttpHandler(byte[] responseBody, string contentType, HttpStatusCode statusCode = HttpStatusCode.OK, Dictionary<string, string>? responseHeaders = null)
+    {
+        _responseBody = responseBody;
+        _contentType = contentType;
+        _statusCode = statusCode;
+        _responseHeaders = responseHeaders ?? new Dictionary<string, string>();
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // Drain the request content to simulate full serialization
+        request.Content?.ReadAsByteArrayAsync(cancellationToken);
+
+        var response = new HttpResponseMessage(_statusCode)
+        {
+            Content = new ByteArrayContent(_responseBody)
+        };
+        response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(_contentType);
+
+        foreach (var header in _responseHeaders)
+        {
+            response.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        // Add required AWS headers
+        if (!response.Headers.Contains("x-amzn-RequestId"))
+            response.Headers.TryAddWithoutValidation("x-amzn-RequestId", "benchmark-request-id");
+
+        return Task.FromResult(response);
+    }
+}
+
+/// <summary>
+/// HttpClientFactory that creates an HttpClient backed by a MockHttpHandler.
+/// Inject via ClientConfig.HttpClientFactory to bypass real HTTP.
+/// </summary>
+public class MockHttpClientFactory : HttpClientFactory
+{
+    private readonly HttpClient _client;
+
+    public MockHttpClientFactory(MockHttpHandler handler)
+    {
+        _client = new HttpClient(handler);
+    }
+
+    public override HttpClient CreateHttpClient(IClientConfig clientConfig) => _client;
+    public override bool UseSDKHttpClientCaching(IClientConfig clientConfig) => false;
+    public override bool DisposeHttpClientsAfterUse(IClientConfig clientConfig) => false;
+    public override string GetConfigUniqueString(IClientConfig clientConfig) => "mock-benchmark";
+}

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/MockHttpHandler.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/MockHttpHandler.cs
@@ -39,10 +39,11 @@ public class MockHttpHandler : HttpMessageHandler
         _responseHeaders = responseHeaders ?? new Dictionary<string, string>();
     }
 
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        // Drain the request content to simulate full serialization
-        request.Content?.ReadAsByteArrayAsync(cancellationToken);
+        // Drain the request content to ensure full serialization cost is measured
+        if (request.Content != null)
+            await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 
         var response = new HttpResponseMessage(_statusCode)
         {
@@ -59,7 +60,7 @@ public class MockHttpHandler : HttpMessageHandler
         if (!response.Headers.Contains("x-amzn-RequestId"))
             response.Headers.TryAddWithoutValidation("x-amzn-RequestId", "benchmark-request-id");
 
-        return Task.FromResult(response);
+        return response;
     }
 }
 

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/Program.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/Program.cs
@@ -26,21 +26,63 @@ namespace AWSSDK.Benchmarks.Serde;
 /// Entry point for the serde benchmark runner using BenchmarkDotNet.
 /// 
 /// Usage:
-///   dotnet run -c Release                              # Run all serde benchmarks
-///   dotnet run -c Release -- --filter *RestJson1*      # Run only RestJson1 benchmarks
-///   dotnet run -c Release -- --filter *AwsJson*        # Run only AwsJson1.0 benchmarks
-///   dotnet run -c Release -- --filter *RpcV2Cbor*      # Run only RpcV2Cbor benchmarks
-///   dotnet run -c Release -- --filter *RestXml*        # Run only RestXml benchmarks
-///   dotnet run -c Release -- --filter *AwsQuery*       # Run only AwsQuery benchmarks
+///   dotnet run -c Release -- --filter '*'                    # Run E2E benchmarks (default)
+///   dotnet run -c Release -- --suite e2e --filter '*'        # Run E2E benchmarks (explicit)
+///   dotnet run -c Release -- --suite serde --filter '*'      # Run only marshal/unmarshal benchmarks
+///   dotnet run -c Release -- --filter '*RestJson1*'          # Run only RestJson1 benchmarks
+///   dotnet run -c Release -- --suite serde --filter '*RestJson1*'  # Serde RestJson1 only
+///
+/// Suites:
+///   e2e    - Full SDK client pipeline with mocked HTTP (default)
+///   serde  - Isolated marshaller/unmarshaller micro-benchmarks
 ///
 /// Results are output to BenchmarkDotNet.Artifacts/results/ in CSV, GitHub Markdown, and HTML formats.
-/// Each benchmark class uses [SimpleJob] with explicit warmupCount=10 and iterationCount=1000
-/// to ensure verifiable, reproducible iteration counts meeting the minimum 1,000 requirement.
 /// </summary>
 internal class Program
 {
+    private static readonly Type[] SerdeBenchmarkTypes = new[]
+    {
+        typeof(RestJson1Benchmarks),
+        typeof(AwsJson10Benchmarks),
+        typeof(RpcV2CborBenchmarks),
+        typeof(RestXmlBenchmarks),
+        typeof(AwsQueryBenchmarks)
+    };
+
+    private static readonly Type[] E2EBenchmarkTypes = new[]
+    {
+        typeof(RestJson1E2EBenchmarks),
+        typeof(AwsJson10E2EBenchmarks),
+        typeof(RpcV2CborE2EBenchmarks),
+        typeof(RestXmlE2EBenchmarks),
+        typeof(AwsQueryE2EBenchmarks)
+    };
+
     static void Main(string[] args)
     {
+        // Parse --suite argument before passing remaining args to BDN
+        var suite = "e2e";
+        var bdnArgs = new List<string>();
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (args[i] == "--suite" && i + 1 < args.Length)
+            {
+                suite = args[++i].ToLowerInvariant();
+            }
+            else
+            {
+                bdnArgs.Add(args[i]);
+            }
+        }
+
+        var types = suite switch
+        {
+            "e2e" => E2EBenchmarkTypes,
+            "serde" => SerdeBenchmarkTypes,
+            "all" => SerdeBenchmarkTypes.Concat(E2EBenchmarkTypes).ToArray(),
+            _ => throw new ArgumentException($"Unknown suite '{suite}'. Valid: e2e, serde, all")
+        };
+
         var config = ManualConfig.Create(DefaultConfig.Instance);
 
         // Configure summary style for nanosecond reporting
@@ -65,14 +107,7 @@ internal class Program
         config.AddColumn(StatisticColumn.P95);
         config.AddColumn(StatisticColumn.Max);  // P100 = Max, upper-bound outlier indicator
 
-        // Run all serde benchmark classes via BenchmarkSwitcher
-        BenchmarkSwitcher.FromTypes(new[]
-        {
-            typeof(RestJson1Benchmarks),
-            typeof(AwsJson10Benchmarks),
-            typeof(RpcV2CborBenchmarks),
-            typeof(RestXmlBenchmarks),
-            typeof(AwsQueryBenchmarks)
-        }).Run(args, config);
+        Console.WriteLine($"Running suite: {suite} ({types.Length} benchmark classes)");
+        BenchmarkSwitcher.FromTypes(types).Run(bdnArgs.ToArray(), config);
     }
 }

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestJson1E2EBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestJson1E2EBenchmarks.cs
@@ -1,0 +1,114 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Text;
+using Amazon.RestJsonDataPlane;
+using Amazon.RestJsonDataPlane.Model;
+using Amazon.Runtime;
+using BenchmarkDotNet.Attributes;
+
+namespace AWSSDK.Benchmarks.Serde;
+
+/// <summary>
+/// E2E benchmarks for RestJson1 protocol exercising the full SDK client pipeline:
+/// credentials → signing → marshalling → HTTP dispatch (mocked) → unmarshalling → response.
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(E2EBenchmarkConfig))]
+public class RestJson1E2EBenchmarks
+{
+    private AmazonRestJsonDataPlaneClient _copyClientBaseline = null!;
+    private AmazonRestJsonDataPlaneClient _copyClientM = null!;
+    private AmazonRestJsonDataPlaneClient _putClient = null!;
+    private AmazonRestJsonDataPlaneClient _getClientS = null!;
+    private AmazonRestJsonDataPlaneClient _getClientM = null!;
+    private AmazonRestJsonDataPlaneClient _getClientL = null!;
+
+    private CopyObjectRequest _copyObjectBaseline = null!;
+    private CopyObjectRequest _copyObjectMedium = null!;
+    private PutObjectRequest _putObjectS = null!;
+    private PutObjectRequest _putObjectM = null!;
+    private PutObjectRequest _putObjectL = null!;
+    private GetObjectRequest _getObjectRequest = null!;
+
+    private static readonly byte[] CopyOutputBaseline = Encoding.UTF8.GetBytes("{}");
+    private static readonly byte[] CopyOutputM = Encoding.UTF8.GetBytes(
+        "{\"ETag\":\"\\\"d41d8cd98f00b204e9800998ecf8427e\\\"\",\"LastModified\":1704067200," +
+        "\"ChecksumCRC32\":\"abc123\",\"ServerSideEncryption\":\"aws:kms\",\"VersionId\":\"v1.0\"}");
+    private static readonly byte[] GetObjectS = new byte[1024];
+    private static readonly byte[] GetObjectM = new byte[100 * 1024];
+    private static readonly byte[] GetObjectL = new byte[1024 * 1024];
+
+    private AmazonRestJsonDataPlaneClient CreateClient(byte[] responseBody)
+    {
+        var handler = new MockHttpHandler(responseBody, "application/json");
+        var config = new AmazonRestJsonDataPlaneConfig
+        {
+            RegionEndpoint = Amazon.RegionEndpoint.USWest2,
+            HttpClientFactory = new MockHttpClientFactory(handler)
+        };
+        return new AmazonRestJsonDataPlaneClient(new BasicAWSCredentials("AKID", "SECRET"), config);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Random.Shared.NextBytes(GetObjectS);
+        Random.Shared.NextBytes(GetObjectM);
+        Random.Shared.NextBytes(GetObjectL);
+
+        _copyClientBaseline = CreateClient(CopyOutputBaseline);
+        _copyClientM = CreateClient(CopyOutputM);
+        _putClient = CreateClient(Array.Empty<byte>());
+        _getClientS = CreateClient(GetObjectS);
+        _getClientM = CreateClient(GetObjectM);
+        _getClientL = CreateClient(GetObjectL);
+
+        _copyObjectBaseline = new CopyObjectRequest { Bucket = "bucket", Key = "key", CopySource = "src/key" };
+        _copyObjectMedium = new CopyObjectRequest
+        {
+            Bucket = "my-destination-bucket", Key = "destination/path/to/my-object.dat",
+            CopySource = "my-source-bucket/source/path/to/original-object.dat",
+            ACL = "bucket-owner-full-control", CacheControl = "max-age=86400",
+            ContentType = "application/octet-stream", MetadataDirective = "REPLACE",
+            ServerSideEncryption = "aws:kms", StorageClass = "STANDARD_IA",
+            SSEKMSKeyId = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+        };
+        _putObjectS = new PutObjectRequest { Bucket = "bucket", Key = "key", Body = new MemoryStream(new byte[1024]) };
+        _putObjectM = new PutObjectRequest { Bucket = "bucket", Key = "key", Body = new MemoryStream(new byte[100 * 1024]) };
+        _putObjectL = new PutObjectRequest { Bucket = "bucket", Key = "key", Body = new MemoryStream(new byte[1024 * 1024]) };
+        _getObjectRequest = new GetObjectRequest { Bucket = "bucket", Key = "key" };
+    }
+
+    [Benchmark] public async Task restJson1_e2e_CopyObject_Baseline() => await _copyClientBaseline.CopyObjectAsync(_copyObjectBaseline);
+    [Benchmark] public async Task restJson1_e2e_CopyObject_M() => await _copyClientM.CopyObjectAsync(_copyObjectMedium);
+    [Benchmark] public async Task restJson1_e2e_PutObject_S() { _putObjectS.Body.Position = 0; await _putClient.PutObjectAsync(_putObjectS); }
+    [Benchmark] public async Task restJson1_e2e_PutObject_M() { _putObjectM.Body.Position = 0; await _putClient.PutObjectAsync(_putObjectM); }
+    [Benchmark] public async Task restJson1_e2e_PutObject_L() { _putObjectL.Body.Position = 0; await _putClient.PutObjectAsync(_putObjectL); }
+    [Benchmark] public async Task restJson1_e2e_GetObject_S() => await _getClientS.GetObjectAsync(_getObjectRequest);
+    [Benchmark] public async Task restJson1_e2e_GetObject_M() => await _getClientM.GetObjectAsync(_getObjectRequest);
+    [Benchmark] public async Task restJson1_e2e_GetObject_L() => await _getClientL.GetObjectAsync(_getObjectRequest);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _copyClientBaseline?.Dispose();
+        _copyClientM?.Dispose();
+        _putClient?.Dispose();
+        _getClientS?.Dispose();
+        _getClientM?.Dispose();
+        _getClientL?.Dispose();
+    }
+}

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestXmlE2EBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestXmlE2EBenchmarks.cs
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Text;
+using Amazon.RestXmlDataPlane;
+using Amazon.RestXmlDataPlane.Model;
+using Amazon.Runtime;
+using BenchmarkDotNet.Attributes;
+
+namespace AWSSDK.Benchmarks.Serde;
+
+/// <summary>
+/// E2E benchmarks for REST XML protocol (S3-like operations).
+/// Full SDK client pipeline with mocked HTTP.
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(E2EBenchmarkConfig))]
+public class RestXmlE2EBenchmarks
+{
+    private AmazonRestXmlDataPlaneClient _copyClient = null!;
+    private AmazonRestXmlDataPlaneClient _putClient = null!;
+    private AmazonRestXmlDataPlaneClient _getClientS = null!;
+    private AmazonRestXmlDataPlaneClient _getClientM = null!;
+    private AmazonRestXmlDataPlaneClient _getClientL = null!;
+
+    private CopyObjectRequest _copyObjectRequest = null!;
+    private PutObjectRequest _putObjectS = null!;
+    private PutObjectRequest _putObjectM = null!;
+    private PutObjectRequest _putObjectL = null!;
+    private GetObjectRequest _getObjectRequest = null!;
+
+    private static readonly byte[] CopyResponse = Encoding.UTF8.GetBytes(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><CopyObjectResult><ETag>\"d41d8cd98f00b204e9800998ecf8427e\"</ETag><LastModified>2024-01-01T00:00:00Z</LastModified></CopyObjectResult>");
+    private static readonly byte[] EmptyXml = Encoding.UTF8.GetBytes("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response/>");
+    private static readonly byte[] GetObjectS = new byte[1024];
+    private static readonly byte[] GetObjectM = new byte[100 * 1024];
+    private static readonly byte[] GetObjectL = new byte[1024 * 1024];
+
+    private AmazonRestXmlDataPlaneClient CreateClient(byte[] responseBody, string contentType = "application/xml")
+    {
+        var handler = new MockHttpHandler(responseBody, contentType);
+        var config = new AmazonRestXmlDataPlaneConfig
+        {
+            RegionEndpoint = Amazon.RegionEndpoint.USWest2,
+            HttpClientFactory = new MockHttpClientFactory(handler)
+        };
+        return new AmazonRestXmlDataPlaneClient(new BasicAWSCredentials("AKID", "SECRET"), config);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Random.Shared.NextBytes(GetObjectS);
+        Random.Shared.NextBytes(GetObjectM);
+        Random.Shared.NextBytes(GetObjectL);
+
+        _copyClient = CreateClient(CopyResponse);
+        _putClient = CreateClient(EmptyXml);
+        _getClientS = CreateClient(GetObjectS, "application/octet-stream");
+        _getClientM = CreateClient(GetObjectM, "application/octet-stream");
+        _getClientL = CreateClient(GetObjectL, "application/octet-stream");
+
+        _copyObjectRequest = new CopyObjectRequest { Bucket = "b", Key = "k", CopySource = "src/k" };
+        _putObjectS = new PutObjectRequest { Bucket = "b", Key = "k", ContentType = "application/octet-stream", Body = new MemoryStream(new byte[1024]) };
+        _putObjectM = new PutObjectRequest { Bucket = "b", Key = "k", ContentType = "application/octet-stream", Body = new MemoryStream(new byte[100 * 1024]) };
+        _putObjectL = new PutObjectRequest { Bucket = "b", Key = "k", ContentType = "application/octet-stream", Body = new MemoryStream(new byte[1024 * 1024]) };
+        _getObjectRequest = new GetObjectRequest { Bucket = "b", Key = "k" };
+    }
+
+    [Benchmark] public async Task restXml_e2e_CopyObject() => await _copyClient.CopyObjectAsync(_copyObjectRequest);
+    [Benchmark] public async Task restXml_e2e_PutObject_S() { _putObjectS.Body.Position = 0; await _putClient.PutObjectAsync(_putObjectS); }
+    [Benchmark] public async Task restXml_e2e_PutObject_M() { _putObjectM.Body.Position = 0; await _putClient.PutObjectAsync(_putObjectM); }
+    [Benchmark] public async Task restXml_e2e_PutObject_L() { _putObjectL.Body.Position = 0; await _putClient.PutObjectAsync(_putObjectL); }
+    [Benchmark] public async Task restXml_e2e_GetObject_S() => await _getClientS.GetObjectAsync(_getObjectRequest);
+    [Benchmark] public async Task restXml_e2e_GetObject_M() => await _getClientM.GetObjectAsync(_getObjectRequest);
+    [Benchmark] public async Task restXml_e2e_GetObject_L() => await _getClientL.GetObjectAsync(_getObjectRequest);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _copyClient?.Dispose();
+        _putClient?.Dispose();
+        _getClientS?.Dispose();
+        _getClientM?.Dispose();
+        _getClientL?.Dispose();
+    }
+}

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RpcV2CborE2EBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RpcV2CborE2EBenchmarks.cs
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Formats.Cbor;
+using Amazon.RpcCborDataPlane;
+using Amazon.RpcCborDataPlane.Model;
+using Amazon.Runtime;
+using BenchmarkDotNet.Attributes;
+using AV = Amazon.RpcCborDataPlane.Model.AttributeValue;
+
+namespace AWSSDK.Benchmarks.Serde;
+
+/// <summary>
+/// E2E benchmarks for Smithy RPC V2 CBOR protocol.
+/// Full SDK client pipeline with mocked HTTP.
+/// Uses separate clients for PutItem (empty response) and GetItem (sized responses).
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(E2EBenchmarkConfig))]
+public class RpcV2CborE2EBenchmarks
+{
+    private AmazonRpcCborDataPlaneClient _putClient = null!;
+    private AmazonRpcCborDataPlaneClient _getClientS = null!;
+    private AmazonRpcCborDataPlaneClient _getClientM = null!;
+    private AmazonRpcCborDataPlaneClient _getClientL = null!;
+    private PutItemRequest _putItemS = null!;
+    private PutItemRequest _putItemM = null!;
+    private PutItemRequest _putItemL = null!;
+    private GetItemRequest _getItemRequest = null!;
+
+    private static readonly byte[] EmptyCborMap = new byte[] { 0xA0 };
+    private static readonly byte[] GetItemResponseS = BuildCborGetItemResponse(5);
+    private static readonly byte[] GetItemResponseM = BuildCborGetItemResponse(20);
+    private static readonly byte[] GetItemResponseL = BuildCborGetItemResponse(50);
+
+    private static byte[] BuildCborGetItemResponse(int attributeCount)
+    {
+        var writer = new CborWriter();
+        writer.WriteStartMap(attributeCount > 0 ? 1 : 0);
+        if (attributeCount > 0)
+        {
+            writer.WriteTextString("Item");
+            writer.WriteStartMap(attributeCount);
+            for (int i = 0; i < attributeCount; i++)
+            {
+                writer.WriteTextString($"attr_{i}");
+                writer.WriteStartMap(1);
+                writer.WriteTextString("S");
+                writer.WriteTextString($"value-{i}-{new string('x', 20)}");
+                writer.WriteEndMap();
+            }
+            writer.WriteEndMap();
+        }
+        writer.WriteEndMap();
+        return writer.Encode();
+    }
+
+    private static AV S(string v) => new AV { S = v };
+
+    private AmazonRpcCborDataPlaneClient CreateClient(byte[] responseBody)
+    {
+        var headers = new Dictionary<string, string> { ["smithy-protocol"] = "rpc-v2-cbor" };
+        var handler = new MockHttpHandler(responseBody, "application/cbor", responseHeaders: headers);
+        var config = new AmazonRpcCborDataPlaneConfig
+        {
+            RegionEndpoint = Amazon.RegionEndpoint.USWest2,
+            HttpClientFactory = new MockHttpClientFactory(handler)
+        };
+        return new AmazonRpcCborDataPlaneClient(new BasicAWSCredentials("AKID", "SECRET"), config);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _putClient = CreateClient(EmptyCborMap);
+        _getClientS = CreateClient(GetItemResponseS);
+        _getClientM = CreateClient(GetItemResponseM);
+        _getClientL = CreateClient(GetItemResponseL);
+
+        _putItemS = new PutItemRequest { TableName = "T", Item = TestDataHelpers.CreateSmallItem<AV>(S, n => new AV { N = n.ToString() }, b => new AV { BOOL = b }) };
+        _putItemM = new PutItemRequest { TableName = "T", Item = TestDataHelpers.CreateMediumItem<AV>(S, n => new AV { N = n.ToString() }, b => new AV { BOOL = b }, l => new AV { L = l }, m => new AV { M = m }) };
+        _putItemL = new PutItemRequest { TableName = "T", Item = TestDataHelpers.CreateLargeItem<AV>(S, n => new AV { N = n.ToString() }, b => new AV { BOOL = b }, l => new AV { L = l }, m => new AV { M = m }) };
+        _getItemRequest = new GetItemRequest { TableName = "T", Key = TestDataHelpers.CreateBaselineItem<AV>(S) };
+    }
+
+    [Benchmark] public async Task rpcV2Cbor_e2e_PutItem_S() => await _putClient.PutItemAsync(_putItemS);
+    [Benchmark] public async Task rpcV2Cbor_e2e_PutItem_M() => await _putClient.PutItemAsync(_putItemM);
+    [Benchmark] public async Task rpcV2Cbor_e2e_PutItem_L() => await _putClient.PutItemAsync(_putItemL);
+    [Benchmark] public async Task rpcV2Cbor_e2e_GetItem_S() => await _getClientS.GetItemAsync(_getItemRequest);
+    [Benchmark] public async Task rpcV2Cbor_e2e_GetItem_M() => await _getClientM.GetItemAsync(_getItemRequest);
+    [Benchmark] public async Task rpcV2Cbor_e2e_GetItem_L() => await _getClientL.GetItemAsync(_getItemRequest);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _putClient?.Dispose();
+        _getClientS?.Dispose();
+        _getClientM?.Dispose();
+        _getClientL?.Dispose();
+    }
+}

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/test.ps1
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/test.ps1
@@ -1,0 +1,112 @@
+# Performance test wrapper for Windows.
+# Runs the published SerdeBenchmarks binary and converts BDN JSON output to
+# the expected results format for CI performance test evaluation.
+#
+# Usage: .\test.ps1 --suite serde|e2e
+# This script expects to be in the same directory as the published SerdeBenchmarksRunner.dll.
+
+$ErrorActionPreference = 'Stop'
+
+# Parse --suite and --product-id from args
+$suite = "e2e"
+$productId = "dotnetv4"
+for ($i = 0; $i -lt $args.Count; $i++) {
+    if ($args[$i] -eq "--suite" -and ($i + 1) -lt $args.Count) {
+        $suite = $args[$i + 1]
+    }
+    if ($args[$i] -eq "--product-id" -and ($i + 1) -lt $args.Count) {
+        $productId = $args[$i + 1]
+    }
+}
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Get git commit ID
+$CommitId = if ($env:CODEBUILD_RESOLVED_SOURCE_VERSION) { $env:CODEBUILD_RESOLVED_SOURCE_VERSION } else {
+    try { git rev-parse HEAD 2>$null } catch { "unknown" }
+}
+
+# Clean previous artifacts
+Remove-Item -Recurse -Force "$ScriptDir\BenchmarkDotNet.Artifacts" -ErrorAction SilentlyContinue
+
+# Run the published benchmark DLL with dotnet (redirect all output to stderr to keep stdout clean for JSON)
+$null = & dotnet "$ScriptDir\SerdeBenchmarksRunner.dll" --suite $suite --filter '*' --exporters JSON 2>&1 | ForEach-Object { [Console]::Error.WriteLine($_) }
+if ($LASTEXITCODE -ne 0) { throw "Benchmark execution failed with exit code $LASTEXITCODE" }
+
+# Find JSON result files
+$ResultsDir = Join-Path $ScriptDir "BenchmarkDotNet.Artifacts\results"
+$JsonFiles = Get-ChildItem -Path $ResultsDir -Filter "*-report-full-compressed.json" -ErrorAction SilentlyContinue
+
+if (-not $JsonFiles -or $JsonFiles.Count -eq 0) {
+    throw "ERROR: No benchmark results produced. Benchmarks likely failed."
+}
+
+# Verify all benchmarks produced results (BDN skips crashed benchmarks silently)
+$totalBenchmarks = 0
+$failedBenchmarks = 0
+foreach ($file in $JsonFiles) {
+    $data = Get-Content $file.FullName | ConvertFrom-Json
+    foreach ($b in $data.Benchmarks) {
+        $totalBenchmarks++
+        if ($null -eq $b.Statistics) { $failedBenchmarks++ }
+    }
+}
+if ($failedBenchmarks -gt 0) {
+    throw "ERROR: $failedBenchmarks of $totalBenchmarks benchmarks failed (no Statistics). Aborting."
+}
+
+$Epoch = [int][double]::Parse((Get-Date -UFormat %s))
+
+# Parse all BDN JSON files and build output with latency + memory metrics
+$AllResults = @()
+foreach ($file in $JsonFiles) {
+    $bdnData = Get-Content $file.FullName | ConvertFrom-Json
+    foreach ($benchmark in $bdnData.Benchmarks) {
+        if ($null -eq $benchmark.Statistics) { continue }
+
+        $name = $benchmark.Method -replace '_', '.'
+        $name = $name.ToLowerInvariant()
+
+        # Latency metric (convert ns → μs to match CloudWatch storage unit)
+        $measurements = @()
+        if ($benchmark.Statistics.Mean) { $measurements += $benchmark.Statistics.Mean / 1000 }
+        if ($benchmark.Statistics.Median) { $measurements += $benchmark.Statistics.Median / 1000 }
+        if ($benchmark.Statistics.Percentiles.P50) { $measurements += $benchmark.Statistics.Percentiles.P50 / 1000 }
+        if ($benchmark.Statistics.Percentiles.P90) { $measurements += $benchmark.Statistics.Percentiles.P90 / 1000 }
+        if ($benchmark.Statistics.Percentiles.P95) { $measurements += $benchmark.Statistics.Percentiles.P95 / 1000 }
+
+        $AllResults += @{
+            name         = $name
+            description  = if ($benchmark.FullName) { $benchmark.FullName } else { $benchmark.Method }
+            unit         = "Microseconds"
+            date         = $Epoch
+            dimensions   = @( @{ name = "OS"; value = "Windows" } )
+            measurements = $measurements
+        }
+
+        # Memory allocation metric
+        $allocatedBytes = 0
+        if ($benchmark.Memory -and $benchmark.Memory.BytesAllocatedPerOperation) {
+            $allocatedBytes = $benchmark.Memory.BytesAllocatedPerOperation
+        }
+
+        $AllResults += @{
+            name         = "$name.allocated"
+            description  = "$(if ($benchmark.FullName) { $benchmark.FullName } else { $benchmark.Method }) - Memory Allocated"
+            unit         = "Bytes"
+            date         = $Epoch
+            dimensions   = @( @{ name = "OS"; value = "Windows" } )
+            measurements = @($allocatedBytes)
+        }
+    }
+}
+
+# Build output
+$output = @{
+    productId = $productId
+    commitId  = $CommitId
+    results   = $AllResults
+}
+
+# Output JSON to stdout (CI captures via pipe to output.json)
+$output | ConvertTo-Json -Depth 10 -Compress

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/test.sh
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Performance test wrapper for Linux.
+# Runs the published SerdeBenchmarks DLL and converts BDN JSON output to
+# the expected results format for CI performance test evaluation.
+#
+# Usage: ./test.sh [--suite serde|e2e]
+# This script expects to be in the same directory as the published SerdeBenchmarksRunner.dll.
+# Requires: dotnet runtime in PATH, jq installed.
+
+set -e
+
+SUITE="e2e"
+PRODUCT_ID="dotnetv4"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --suite) SUITE="$2"; shift 2 ;;
+        --product-id) PRODUCT_ID="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Get git commit ID
+COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}"
+
+# Clean previous artifacts
+rm -rf "$SCRIPT_DIR/BenchmarkDotNet.Artifacts"
+
+# Run the published benchmark DLL with dotnet (BDN output goes to stderr)
+dotnet "$SCRIPT_DIR/SerdeBenchmarksRunner.dll" --suite "$SUITE" --filter '*' --exporters JSON 1>&2
+
+# Verify all benchmarks produced results (BDN exits 0 even when benchmarks crash)
+RESULTS_DIR="$SCRIPT_DIR/BenchmarkDotNet.Artifacts/results"
+TOTAL=$(find "$RESULTS_DIR" -name '*-report-full-compressed.json' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | jq -s '[.[] | .Benchmarks[]] | length' 2>/dev/null || echo 0)
+SUCCEEDED=$(find "$RESULTS_DIR" -name '*-report-full-compressed.json' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | jq -s '[.[] | .Benchmarks[] | select(.Statistics != null)] | length' 2>/dev/null || echo 0)
+if [ "$TOTAL" -eq 0 ]; then
+    echo "ERROR: No benchmark results produced. Benchmarks likely failed." >&2
+    exit 1
+fi
+if [ "$TOTAL" -ne "$SUCCEEDED" ]; then
+    echo "ERROR: $((TOTAL - SUCCEEDED)) of $TOTAL benchmarks failed (no Statistics). Aborting." >&2
+    exit 1
+fi
+
+EPOCH=$(date +%s)
+
+# Convert BDN JSON to performance test results format.
+# Emits two metrics per benchmark: latency (μs) and memory allocation (bytes).
+# Note: BDN reports in nanoseconds. We convert to Microseconds here because
+# the CI publisher converts Nanoseconds→Microseconds before CloudWatch publish,
+# but the evaluator compares raw measurements against CloudWatch values without
+# converting. Using Microseconds directly avoids this unit mismatch.
+find "$RESULTS_DIR" -name "*-report-full-compressed.json" -print0 | xargs -0 cat | jq -s --arg productId "$PRODUCT_ID" --arg commitId "$COMMIT_ID" --argjson date "$EPOCH" '
+{
+    productId: $productId,
+    commitId: $commitId,
+    results: [
+        .[] | .Benchmarks[]? | select(.Statistics != null) |
+        (
+            {
+                name: (.Method | gsub("_"; ".") | ascii_downcase),
+                description: (.FullName // .Method),
+                unit: "Microseconds",
+                date: $date,
+                dimensions: [
+                    { name: "OS", value: "Linux" }
+                ],
+                measurements: [
+                    .Statistics.Mean,
+                    .Statistics.Median,
+                    .Statistics.Percentiles.P50,
+                    .Statistics.Percentiles.P90,
+                    .Statistics.Percentiles.P95
+                ] | map(select(. != null)) | map(. / 1000)
+            }
+        ),
+        (
+            {
+                name: ((.Method | gsub("_"; ".") | ascii_downcase) + ".allocated"),
+                description: ((.FullName // .Method) + " - Memory Allocated"),
+                unit: "Bytes",
+                date: $date,
+                dimensions: [
+                    { name: "OS", value: "Linux" }
+                ],
+                measurements: [
+                    .Memory.BytesAllocatedPerOperation // 0
+                ]
+            }
+        )
+    ]
+}'


### PR DESCRIPTION
## Description

Add automated performance benchmarks for SDK serialization/deserialization operations. This includes 33 end-to-end benchmarks covering 5 protocols (RestJson1, AwsJson10, RpcV2Cbor, RestXml, AwsQuery) with mocked HTTP to measure full SDK pipeline latency (credentials → signing → marshalling → HTTP → unmarshalling) and memory allocation without network dependencies.

## Motivation and Context

The .NET SDK lacks automated performance regression detection in CI. This change establishes a benchmark suite that runs on every release build, enabling detection of latency or memory regressions introduced by code changes before they reach customers.

## Testing

- All 33 benchmarks pass locally on both Linux and Windows
- Benchmarks verified as truly end-to-end (SigV4 signing confirmed in traces)
- CI integration validated with successful RELEASE builds (66/66 Linux metrics evaluated, 0 regressions)
- Memory allocation metrics validated alongside latency metrics

### Dry-runs
- **DotNet Dry-run ID:** 795dd17c-7bb1-4ae8-a1b2-dfeda0e9c2bc
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 8188fc89-dc8e-49b1-9915-f3e901e25a9c
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

No breaking changes. This PR adds test infrastructure only — no changes to shipping SDK code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
