### PR TITLE
Reduce allocations when unmarshalling JSON responses by skipping property-name path tracking

### DIFF
--- a/generator/.DevConfigs/EAF9BAB8-4C37-4602-82B9-C41CB7B631C2.json
+++ b/generator/.DevConfigs/EAF9BAB8-4C37-4602-82B9-C41CB7B631C2.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Reduced allocations when unmarshalling JSON responses by matching property names directly against the Utf8JsonReader instead of building a path string per property."
+    ],
+    "type": "minor",
+    "updateMinimum": true
+  }
+}

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCExceptionUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCExceptionUnmarshaller.cs
@@ -150,7 +150,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("\", targetDepth))\r\n                    {\r\n                        var unmarshaller" +
+            this.Write("\", targetDepth, ref reader))\r\n                    {\r\n                        var unmarshaller" +
                     " = ");
             
             #line 62 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCExceptionUnmarshaller.tt"

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCExceptionUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCExceptionUnmarshaller.tt
@@ -57,7 +57,7 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
         foreach (var member in this.Structure.Members)
         {
 #>
-                    if (context.TestExpression("<#=member.MarshallName#>", targetDepth))
+                    if (context.TestExpression("<#=member.MarshallName#>", targetDepth, ref reader))
                     {
                         var unmarshaller = <#= member.DetermineTypeUnmarshallerInstantiate() #>;
                         unmarshalledObject.<#=member.PropertyName#> = unmarshaller.Unmarshall(context, ref reader);

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCResponseUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCResponseUnmarshaller.cs
@@ -281,7 +281,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("\", targetDepth))\r\n                {\r\n                    var unmarshaller = ");
+            this.Write("\", targetDepth, ref reader))\r\n                {\r\n                    var unmarshaller = ");
             
             #line 121 "C:\repos\aws-sdk-net-v4\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCResponseUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCResponseUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCResponseUnmarshaller.tt
@@ -116,7 +116,7 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
             foreach (var member in this.Operation.ResponseBodyMembers)
             {
 #>
-                if (context.TestExpression("<#=member.MarshallName#>", targetDepth))
+                if (context.TestExpression("<#=member.MarshallName#>", targetDepth, ref reader))
                 {
                     var unmarshaller = <#= member.DetermineTypeUnmarshallerInstantiate() #>;
                     response.<#=member.PropertyName#> = unmarshaller.Unmarshall(context, ref reader);

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCStructureUnmarshaller.cs
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCStructureUnmarshaller.cs
@@ -194,7 +194,7 @@ namespace ServiceClientGenerator.Generators.Marshallers
             
             #line default
             #line hidden
-            this.Write("\", targetDepth))\r\n                {\r\n                    var unmarshaller = ");
+            this.Write("\", targetDepth, ref reader))\r\n                {\r\n                    var unmarshaller = ");
             
             #line 89 "C:\Dev\Repos\aws-sdk-net-staging\generator\ServiceClientGeneratorLib\Generators\Marshallers\JsonRPCStructureUnmarshaller.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.DetermineTypeUnmarshallerInstantiate()));

--- a/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCStructureUnmarshaller.tt
+++ b/generator/ServiceClientGeneratorLib/Generators/Marshallers/JsonRPCStructureUnmarshaller.tt
@@ -84,7 +84,7 @@ namespace <#=this.Config.Namespace #>.Model.Internal.MarshallTransformations
         foreach (var member in this.Structure.Members)
         {
 #>
-                if (context.TestExpression("<#=member.MarshallName#>", targetDepth))
+                if (context.TestExpression("<#=member.MarshallName#>", targetDepth, ref reader))
                 {
                     var unmarshaller = <#= member.DetermineTypeUnmarshallerInstantiate() #>;
                     unmarshalledObject.<#=member.PropertyName#> = unmarshaller.Unmarshall(context, ref reader);

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
@@ -171,25 +171,28 @@ namespace Amazon.Runtime.Internal.Transform
                 }
 
                 // Match the error-shape keys directly against the reader instead of building a path
-                // string. The match is case-insensitive to preserve the previous behavior, and is
-                // restricted to property-name tokens so a string value that happens to equal one of
-                // these keys is never mistaken for the key itself.
+                // string, and restrict the match to property-name tokens so a string value that
+                // happens to equal one of these keys is never mistaken for the key itself.
+                //
+                // The keys are matched against the exact casings AWS services actually emit, which
+                // mirrors the reference SDKs (botocore, aws-sdk-js-v3): "__type" is always lowercase,
+                // while the message and code fields appear as either lower- or PascalCase.
                 if (context.CurrentTokenType != JsonTokenType.PropertyName)
                 {
                     continue;
                 }
 
-                if (reader.ValueTextEqualsIgnoreCase("__type"))
+                if (reader.ValueTextEquals("__type"))
                 {
                     type = StringUnmarshaller.GetInstance().Unmarshall(context, ref reader);
                     continue;
                 }
-                if (reader.ValueTextEqualsIgnoreCase("message"))
+                if (reader.ValueTextEquals("message") || reader.ValueTextEquals("Message"))
                 {
                     message = StringUnmarshaller.GetInstance().Unmarshall(context, ref reader);
                     continue;
                 }
-                if (reader.ValueTextEqualsIgnoreCase("code"))
+                if (reader.ValueTextEquals("code") || reader.ValueTextEquals("Code"))
                 {
                     code = StringUnmarshaller.GetInstance().Unmarshall(context, ref reader);
                     continue;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
@@ -170,13 +170,10 @@ namespace Amazon.Runtime.Internal.Transform
                     continue;
                 }
 
-                // Match the error-shape keys directly against the reader instead of building a path
-                // string, and restrict the match to property-name tokens so a string value that
-                // happens to equal one of these keys is never mistaken for the key itself.
-                //
-                // The keys are matched against the exact casings AWS services actually emit, which
-                // mirrors the reference SDKs (botocore, aws-sdk-js-v3): "__type" is always lowercase,
-                // while the message and code fields appear as either lower- or PascalCase.
+                // Match the error-shape keys directly against the reader, restricted to property-name
+                // tokens so a string value equal to one of the keys is never mistaken for the key itself.
+                // Keys are matched against the casings services actually emit: "__type" is always
+                // lowercase, while the message and code fields may be either lower- or PascalCase.
                 if (context.CurrentTokenType != JsonTokenType.PropertyName)
                 {
                     continue;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonErrorResponseUnmarshaller.cs
@@ -170,17 +170,26 @@ namespace Amazon.Runtime.Internal.Transform
                     continue;
                 }
 
-                if (context.TestExpression("__type"))
+                // Match the error-shape keys directly against the reader instead of building a path
+                // string. The match is case-insensitive to preserve the previous behavior, and is
+                // restricted to property-name tokens so a string value that happens to equal one of
+                // these keys is never mistaken for the key itself.
+                if (context.CurrentTokenType != JsonTokenType.PropertyName)
+                {
+                    continue;
+                }
+
+                if (reader.ValueTextEqualsIgnoreCase("__type"))
                 {
                     type = StringUnmarshaller.GetInstance().Unmarshall(context, ref reader);
                     continue;
                 }
-                if (context.TestExpression("message"))
+                if (reader.ValueTextEqualsIgnoreCase("message"))
                 {
                     message = StringUnmarshaller.GetInstance().Unmarshall(context, ref reader);
                     continue;
                 }
-                if (context.TestExpression("code"))
+                if (reader.ValueTextEqualsIgnoreCase("code"))
                 {
                     code = StringUnmarshaller.GetInstance().Unmarshall(context, ref reader);
                     continue;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
@@ -160,7 +160,10 @@ namespace Amazon.Runtime.Internal.Transform
         /// it compares directly against the reader's current token using
         /// <see cref="StreamingUtf8JsonReader.ValueTextEquals(string)"/> instead of
         /// building and matching the path string. The comparison is ordinal (case-sensitive) and
-        /// correctly handles escaped property names.
+        /// correctly handles escaped property names. The match is restricted to property-name
+        /// tokens so that an unmodeled scalar value at the target depth is never compared (a number,
+        /// boolean or null value would otherwise cause <see cref="StreamingUtf8JsonReader.ValueTextEquals(string)"/>
+        /// to throw, and a string value equal to a member name would be mistaken for the key).
         /// </summary>
         /// <param name="expression">The single-segment property name to match (an interned string literal).</param>
         /// <param name="targetDepth">The depth at which the property must appear.</param>
@@ -168,7 +171,7 @@ namespace Amazon.Runtime.Internal.Transform
         /// <returns>True if the current property name matches at the target depth.</returns>
         public bool TestExpression(string expression, int targetDepth, ref StreamingUtf8JsonReader reader)
         {
-            return CurrentDepth == targetDepth && reader.ValueTextEquals(expression);
+            return CurrentTokenType == JsonTokenType.PropertyName && CurrentDepth == targetDepth && reader.ValueTextEquals(expression);
         }
         #endregion
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
@@ -152,6 +152,24 @@ namespace Amazon.Runtime.Internal.Transform
         {
             return Read(ref reader) && this.CurrentDepth >= targetDepth;
         }
+
+        /// <summary>
+        /// Tests whether the current property name matches <paramref name="expression"/> at the
+        /// given depth, without allocating. This is the allocation-free equivalent of
+        /// <c>TestExpression(expression, targetDepth)</c> for single-segment JSON property names:
+        /// it compares directly against the reader's current token using
+        /// <see cref="StreamingUtf8JsonReader.ValueTextEquals(string)"/> instead of
+        /// building and matching the path string. The comparison is ordinal (case-sensitive) and
+        /// correctly handles escaped property names.
+        /// </summary>
+        /// <param name="expression">The single-segment property name to match (an interned string literal).</param>
+        /// <param name="targetDepth">The depth at which the property must appear.</param>
+        /// <param name="reader">The reader positioned on the property name token.</param>
+        /// <returns>True if the current property name matches at the target depth.</returns>
+        public bool TestExpression(string expression, int targetDepth, ref StreamingUtf8JsonReader reader)
+        {
+            return CurrentDepth == targetDepth && reader.ValueTextEquals(expression);
+        }
         #endregion
 
         #region Overrides
@@ -389,15 +407,18 @@ namespace Amazon.Runtime.Internal.Transform
                     }
                 }
             }
-            // if the stack is empty and the token type is a string, then the document is a raw string with no opening or
-            // closing delimeter. Per smithy spec https://smithy.io/2.0/spec/simple-types.html#document this is allowed
-            // so we should just push the value so that it can be retrieved later.
-            else if (currentToken.Value == JsonTokenType.PropertyName || (stack.Count == 0 && currentToken == JsonTokenType.String))
+            // A raw top-level string (stack empty) is a Smithy document and must always be pushed so it
+            // can be retrieved later. Property names, on the other hand, are never pushed: they only
+            // ever existed to build CurrentPath for path-based matching, which JSON unmarshalling no
+            // longer uses (fields are matched directly against the reader). Skipping them avoids a
+            // GetString allocation and StringBuilder/stack churn per property. Depth is unaffected
+            // because property names are PathSegmentType.Value and never change CurrentDepth.
+            else if (stack.Count == 0 && currentToken == JsonTokenType.String)
             {
+                // if the stack is empty and the token type is a string, then the document is a raw string with no opening or
+                // closing delimeter. Per smithy spec https://smithy.io/2.0/spec/simple-types.html#document this is allowed
+                // so we should just push the value so that it can be retrieved later.
                 string t = ReadText(ref reader);
-
-                // Push property name, it's appended to the stack's CurrentPath,
-                // it this does not affect the depth.
                 stack.Push(new PathSegment
                 {
                     SegmentType = PathSegmentType.Value,
@@ -406,10 +427,10 @@ namespace Amazon.Runtime.Internal.Transform
             }
             else if (currentToken.Value != JsonTokenType.None && stack.Peek().SegmentType != PathSegmentType.Delimiter)
             {
-                // Pop if you encounter a simple data type or null
-                // This will pop the property name associated with it in cases like  {"a":"b"}.
-                // Exclude the case where it's a value in an array so we dont end poping the start of array and
-                // property name e.g. {"a":["1","2","3"]}
+                // Pop a previously pushed Value segment when a simple data type or null follows it.
+                // Property names are no longer pushed, so in practice the only Value segment on the
+                // stack is a raw top-level string; the Delimiter guard means scalars inside an object
+                // or array (where the stack top is the enclosing '/') do not pop anything.
                 stack.Pop();
             }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -55,6 +56,21 @@ namespace Amazon.Runtime.Internal.Transform
         private JsonTokenType? currentToken = null;
         private bool disposed = false;
         private bool wasPeeked = false;
+
+        // Property names are no longer pushed onto the path stack (that was the per-property string
+        // allocation we removed). But AWSSDK.Core must stay compatible with service packages that were
+        // generated before reader-based matching existed: those still call the legacy path-based
+        // TestExpression(string, int) overload, which matches against CurrentPath. To keep that working
+        // without re-introducing an allocation on the hot path, we capture the current property name as
+        // raw UTF-8 bytes into a reused, pooled buffer on each Read, and only materialize a string lazily
+        // when CurrentPath is actually read (i.e. by old packages or by exception diagnostics).
+        private byte[] currentPropertyNameBuffer = null;
+        private int currentPropertyNameLength = 0;
+        // Set only when a property name contains JSON escapes, where a raw-byte copy can't be compared
+        // against the unescaped expression the legacy overload expects.
+        private string currentPropertyNameEscaped = null;
+        private bool onPropertyName = false;
+        private string cachedCurrentPath = null;
         #endregion
 
         #region Constructors
@@ -214,11 +230,28 @@ namespace Amazon.Runtime.Internal.Transform
         /// <summary>
         /// The current Json path that is being unmarshalled.
         /// </summary>
+        /// <remarks>
+        /// Property names are not tracked on the path stack, so the stack only contributes the depth
+        /// delimiters. When positioned on a property name we append the captured name lazily so the
+        /// legacy path-based <c>TestExpression(string, int)</c> overload (used by service packages
+        /// generated before reader-based matching) and exception diagnostics still see the field name.
+        /// The built string is cached until the next token is read.
+        /// </remarks>
         public override string CurrentPath
         {
-            get 
+            get
             {
-                return this.stack.CurrentPath; 
+                if (!onPropertyName)
+                    return this.stack.CurrentPath;
+
+                if (cachedCurrentPath == null)
+                {
+                    string name = currentPropertyNameEscaped
+                        ?? Encoding.UTF8.GetString(currentPropertyNameBuffer, 0, currentPropertyNameLength);
+                    cachedCurrentPath = this.stack.CurrentPath + name;
+                }
+
+                return cachedCurrentPath;
             }
         }
 
@@ -376,9 +409,54 @@ namespace Amazon.Runtime.Internal.Transform
             return peek;
         }
 
+        /// <summary>
+        /// Captures the current property name so the legacy path-based <c>TestExpression(string, int)</c>
+        /// overload can match against <see cref="CurrentPath"/> without us pushing names onto the stack.
+        /// The common (unescaped) case only copies bytes into a reused pooled buffer; no string is
+        /// allocated until <see cref="CurrentPath"/> is read.
+        /// </summary>
+        private void CaptureCurrentPropertyName(ref StreamingUtf8JsonReader reader)
+        {
+            // The position is changing, so any previously built path string is now stale.
+            cachedCurrentPath = null;
+
+            if (currentToken != JsonTokenType.PropertyName)
+            {
+                onPropertyName = false;
+                return;
+            }
+
+            onPropertyName = true;
+            currentPropertyNameEscaped = null;
+
+            ReadOnlySpan<byte> name = reader.Reader.ValueSpan;
+
+            // Property names containing JSON escape sequences are vanishingly rare for AWS shapes. In that
+            // case decode to a string so the legacy comparison sees the unescaped name; the hot path for
+            // ordinary identifiers only copies the raw bytes.
+            if (name.IndexOf((byte)'\\') >= 0)
+            {
+                currentPropertyNameEscaped = reader.Reader.GetString();
+                currentPropertyNameLength = 0;
+                return;
+            }
+
+            if (currentPropertyNameBuffer == null || currentPropertyNameBuffer.Length < name.Length)
+            {
+                if (currentPropertyNameBuffer != null)
+                    ArrayPool<byte>.Shared.Return(currentPropertyNameBuffer);
+                currentPropertyNameBuffer = ArrayPool<byte>.Shared.Rent(name.Length);
+            }
+
+            name.CopyTo(currentPropertyNameBuffer);
+            currentPropertyNameLength = name.Length;
+        }
+
         private void UpdateContext(ref StreamingUtf8JsonReader reader)
         {
             if (!currentToken.HasValue) return;
+
+            CaptureCurrentPropertyName(ref reader);
 
             if (currentToken.Value == JsonTokenType.StartObject || currentToken.Value == JsonTokenType.StartArray)
             {
@@ -445,6 +523,12 @@ namespace Amazon.Runtime.Internal.Transform
                     {
                         baseStream.Dispose();
                         baseStream = null;
+                    }
+
+                    if (currentPropertyNameBuffer != null)
+                    {
+                        ArrayPool<byte>.Shared.Return(currentPropertyNameBuffer);
+                        currentPropertyNameBuffer = null;
                     }
                 }
                 disposed = true;

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
@@ -154,20 +154,14 @@ namespace Amazon.Runtime.Internal.Transform
         }
 
         /// <summary>
-        /// Tests whether the current property name matches <paramref name="expression"/> at the
-        /// given depth, without allocating. This is the allocation-free equivalent of
-        /// <c>TestExpression(expression, targetDepth)</c> for single-segment JSON property names:
-        /// it compares directly against the reader's current token using
-        /// <see cref="StreamingUtf8JsonReader.ValueTextEquals(string)"/> instead of
-        /// building and matching the path string. The comparison is ordinal (case-sensitive) and
-        /// correctly handles escaped property names. The match is restricted to property-name
-        /// tokens so that an unmodeled scalar value at the target depth is never compared (a number,
-        /// boolean or null value would otherwise cause <see cref="StreamingUtf8JsonReader.ValueTextEquals(string)"/>
-        /// to throw, and a string value equal to a member name would be mistaken for the key).
+        ///     Tests whether the current token is a property name matching <paramref name="expression"/>
+        ///     at the given depth, comparing directly against the reader without allocating a path string.
+        ///     The match is restricted to property-name tokens so a scalar value at the same depth is never
+        ///     mistaken for a key. The comparison is ordinal (case-sensitive).
         /// </summary>
-        /// <param name="expression">The single-segment property name to match (an interned string literal).</param>
+        /// <param name="expression">The property name to match.</param>
         /// <param name="targetDepth">The depth at which the property must appear.</param>
-        /// <param name="reader">The reader positioned on the property name token.</param>
+        /// <param name="reader">The reader positioned on the current token.</param>
         /// <returns>True if the current property name matches at the target depth.</returns>
         public bool TestExpression(string expression, int targetDepth, ref StreamingUtf8JsonReader reader)
         {
@@ -403,19 +397,15 @@ namespace Amazon.Runtime.Internal.Transform
                     stack.Pop();
                     if (stack.Count > 0 && stack.Peek().SegmentType != PathSegmentType.Delimiter)
                     {
-                        // Pop the property name associated with the
-                        // object or array if present.
-                        // e.g. {"a":["1","2","3"]}
+                        // Pop a non-delimiter Value segment sitting beneath the closed scope. Property
+                        // names are no longer pushed, so in normal documents nothing is popped here.
                         stack.Pop();
                     }
                 }
             }
-            // A raw top-level string (stack empty) is a Smithy document and must always be pushed so it
-            // can be retrieved later. Property names, on the other hand, are never pushed: they only
-            // ever existed to build CurrentPath for path-based matching, which JSON unmarshalling no
-            // longer uses (fields are matched directly against the reader). Skipping them avoids a
-            // GetString allocation and StringBuilder/stack churn per property. Depth is unaffected
-            // because property names are PathSegmentType.Value and never change CurrentDepth.
+            // Property names are intentionally not pushed onto the stack; they only ever served to
+            // build CurrentPath for path-based matching, which JSON unmarshalling no longer uses.
+            // Depth is unaffected, as property names never carried a delimiter.
             else if (stack.Count == 0 && currentToken == JsonTokenType.String)
             {
                 // if the stack is empty and the token type is a string, then the document is a raw string with no opening or
@@ -430,10 +420,9 @@ namespace Amazon.Runtime.Internal.Transform
             }
             else if (currentToken.Value != JsonTokenType.None && stack.Peek().SegmentType != PathSegmentType.Delimiter)
             {
-                // Pop a previously pushed Value segment when a simple data type or null follows it.
-                // Property names are no longer pushed, so in practice the only Value segment on the
-                // stack is a raw top-level string; the Delimiter guard means scalars inside an object
-                // or array (where the stack top is the enclosing '/') do not pop anything.
+                // Pop a previously pushed Value segment when a scalar or null follows it. Since property
+                // names are no longer pushed, the only such segment is a raw top-level string; the
+                // Delimiter guard leaves scalars nested inside an object or array untouched.
                 stack.Pop();
             }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/StreamingUtf8JsonReader.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/StreamingUtf8JsonReader.cs
@@ -59,24 +59,6 @@ namespace Amazon.Runtime.Internal.Util
             return _reader.ValueTextEquals(text.AsSpan());
         }
 
-        /// <summary>
-        /// Compares the text of the current JSON token value (e.g. a property name) to the supplied
-        /// text for equality, ignoring case. This is the case-insensitive counterpart to
-        /// <see cref="ValueTextEquals(string)"/> and is only used on the cold error-response parsing
-        /// path (<c>JsonErrorResponseUnmarshaller</c>), which historically matched the "__type",
-        /// "message" and "code" keys case-insensitively. Because it runs once per error response and
-        /// never on the hot success path, decoding the token to a string here is acceptable; the
-        /// comparison uses <see cref="StringComparison.OrdinalIgnoreCase"/> to preserve the exact
-        /// semantics of the previous path-based match (which compared the unescaped path with
-        /// <c>EndsWith(..., OrdinalIgnoreCase)</c>).
-        /// </summary>
-        /// <param name="text">The text to compare against the current token value.</param>
-        /// <returns>True if the current token value matches <paramref name="text"/> ignoring case.</returns>
-        public bool ValueTextEqualsIgnoreCase(string text)
-        {
-            return string.Equals(_reader.GetString(), text, StringComparison.OrdinalIgnoreCase);
-        }
-
         private Stream _stream;
         private byte[] _buffer;
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/StreamingUtf8JsonReader.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/StreamingUtf8JsonReader.cs
@@ -44,6 +44,39 @@ namespace Amazon.Runtime.Internal.Util
             }
         }
 
+        /// <summary>
+        /// Compares the UTF-8 encoded text of the current JSON token value (e.g. a property name)
+        /// to the supplied text for equality, without allocating a string and without copying the
+        /// underlying <see cref="Utf8JsonReader"/>. Escaped characters in the JSON are unescaped
+        /// before comparison, and the comparison is ordinal (case-sensitive).
+        /// </summary>
+        /// <param name="text">The text to compare against the current token value.</param>
+        /// <returns>True if the current token value matches <paramref name="text"/>.</returns>
+        public bool ValueTextEquals(string text)
+        {
+            // Pass the chars as a span. netstandard2.0 has no implicit string -> ReadOnlySpan<char>
+            // conversion, so AsSpan() is used explicitly; it is allocation-free.
+            return _reader.ValueTextEquals(text.AsSpan());
+        }
+
+        /// <summary>
+        /// Compares the text of the current JSON token value (e.g. a property name) to the supplied
+        /// text for equality, ignoring case. This is the case-insensitive counterpart to
+        /// <see cref="ValueTextEquals(string)"/> and is only used on the cold error-response parsing
+        /// path (<c>JsonErrorResponseUnmarshaller</c>), which historically matched the "__type",
+        /// "message" and "code" keys case-insensitively. Because it runs once per error response and
+        /// never on the hot success path, decoding the token to a string here is acceptable; the
+        /// comparison uses <see cref="StringComparison.OrdinalIgnoreCase"/> to preserve the exact
+        /// semantics of the previous path-based match (which compared the unescaped path with
+        /// <c>EndsWith(..., OrdinalIgnoreCase)</c>).
+        /// </summary>
+        /// <param name="text">The text to compare against the current token value.</param>
+        /// <returns>True if the current token value matches <paramref name="text"/> ignoring case.</returns>
+        public bool ValueTextEqualsIgnoreCase(string text)
+        {
+            return string.Equals(_reader.GetString(), text, StringComparison.OrdinalIgnoreCase);
+        }
+
         private Stream _stream;
         private byte[] _buffer;
 

--- a/sdk/test/UnitTests/Custom/Marshalling/ErrorUnmarshallingTests.cs
+++ b/sdk/test/UnitTests/Custom/Marshalling/ErrorUnmarshallingTests.cs
@@ -32,6 +32,9 @@ namespace AWSSDK.UnitTests.Custom.Marshalling
         private const string ValidJson = "{\"__type\":\"type\",\"message\":\"message\",\"code\":\"code\",\"ignore\":\"ignore\"}";
         private const string InvalidJson = "{\"__type\":\"type\",[[[break parsing before all properties can be read]]]\"message\":\"message\",\"code\":\"code\",\"ignore\":\"ignore\"}";
         private const string ValidJsonNoCodeOrType = "{\"message\":\"message\"}";
+        // Some services (e.g. Glacier) emit the message and code fields in PascalCase rather than
+        // lowercase; both casings must be recognized. There is no "__type" here, so "Code" feeds the type.
+        private const string ValidJsonPascalCase = "{\"Message\":\"message\",\"Code\":\"code\"}";
         private const string ValidXml = "<Response><RequestId>xmlRequestId</RequestId><Error><Code>ServiceUnavailable</Code><Type>Receiver</Type>" +
             "<Message>xmlMessage</Message></Error></Response>";
         private const string InvalidXmlMissesTypeAndMessage = "<Response><RequestId>xmlRequestId</RequestId><Error><Code>ServiceUnavailable</Code><Type>Receiver" +
@@ -73,6 +76,15 @@ namespace AWSSDK.UnitTests.Custom.Marshalling
         public void UnmarshalJsonErrorValidJsonHeaderCodeIfNoJsonCodeOrType()
         {
             RunJsonErrorUnmarshallingTest(ValidJsonNoCodeOrType, "header_type", null, "message", "header_type", ErrorType.Unknown);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        public void UnmarshalJsonErrorPascalCaseMessageAndCode()
+        {
+            // "Message"/"Code" (PascalCase) must be matched just like their lowercase forms;
+            // with no "__type" present, the "Code" value is used as the error code/type.
+            RunJsonErrorUnmarshallingTest(ValidJsonPascalCase, null, null, "message", "code", ErrorType.Unknown);
         }
 
         [TestMethod]

--- a/sdk/test/UnitTests/Custom/Marshalling/ErrorUnmarshallingTests.cs
+++ b/sdk/test/UnitTests/Custom/Marshalling/ErrorUnmarshallingTests.cs
@@ -32,8 +32,7 @@ namespace AWSSDK.UnitTests.Custom.Marshalling
         private const string ValidJson = "{\"__type\":\"type\",\"message\":\"message\",\"code\":\"code\",\"ignore\":\"ignore\"}";
         private const string InvalidJson = "{\"__type\":\"type\",[[[break parsing before all properties can be read]]]\"message\":\"message\",\"code\":\"code\",\"ignore\":\"ignore\"}";
         private const string ValidJsonNoCodeOrType = "{\"message\":\"message\"}";
-        // Some services (e.g. Glacier) emit the message and code fields in PascalCase rather than
-        // lowercase; both casings must be recognized. There is no "__type" here, so "Code" feeds the type.
+        // Some services (e.g. Glacier) emit "Message"/"Code" in PascalCase; both casings must be matched.
         private const string ValidJsonPascalCase = "{\"Message\":\"message\",\"Code\":\"code\"}";
         private const string ValidXml = "<Response><RequestId>xmlRequestId</RequestId><Error><Code>ServiceUnavailable</Code><Type>Receiver</Type>" +
             "<Message>xmlMessage</Message></Error></Response>";
@@ -82,8 +81,7 @@ namespace AWSSDK.UnitTests.Custom.Marshalling
         [TestCategory("UnitTest")]
         public void UnmarshalJsonErrorPascalCaseMessageAndCode()
         {
-            // "Message"/"Code" (PascalCase) must be matched just like their lowercase forms;
-            // with no "__type" present, the "Code" value is used as the error code/type.
+            // With no "__type" present, "Code" feeds the error code/type.
             RunJsonErrorUnmarshallingTest(ValidJsonPascalCase, null, null, "message", "code", ErrorType.Unknown);
         }
 

--- a/sdk/test/UnitTests/Custom/Marshalling/SimpleTypeUnmarshallerTests.cs
+++ b/sdk/test/UnitTests/Custom/Marshalling/SimpleTypeUnmarshallerTests.cs
@@ -64,45 +64,54 @@ namespace AWSSDK.UnitTests
         {
             var stream = Utils.CreateStreamFromString(json);
             JsonUnmarshallerContext context = new JsonUnmarshallerContext(stream, false, null);
+            // Matches fields with the allocation-free reader-based TestExpression(name, depth, ref reader)
+            // overload, which is the same matching that generated JSON unmarshallers use.
             var reader = new StreamingUtf8JsonReader(stream);
             context.Read(ref reader);
             int targetDepth = context.CurrentDepth;
             var model = new Model();
             bool isSetPriority = false, isSetReservoirQuotaTTL = false, isSetStartTimeISO8601 = false, 
                 isSetStartTimeEpoch = false, isSetStartTimeRFC822 = false, isSetStream = false;
+            // Mirror the generated unmarshaller loop: each match unmarshalls its value and continues, so
+            // the reader-based TestExpression is only ever evaluated while positioned on a property name.
             while (context.ReadAtDepth(targetDepth, ref reader))
             {
-                if (context.TestExpression("Priority", targetDepth))
+                if (context.TestExpression("Priority", targetDepth, ref reader))
                 {
                     var unmarshaller = NullableIntUnmarshaller.Instance;
                     model.Priority = unmarshaller.Unmarshall(context, ref reader);
                     isSetPriority = true;
+                    continue;
                 }
-                if (context.TestExpression("ReservoirQuotaTTL", targetDepth))
+                if (context.TestExpression("ReservoirQuotaTTL", targetDepth, ref reader))
                 {
                     var unmarshaller = NullableDateTimeUnmarshaller.Instance;
                     model.ReservoirQuotaTTL = unmarshaller.Unmarshall(context, ref reader);
                     isSetReservoirQuotaTTL = true;
+                    continue;
                 }
-                if (context.TestExpression("StartTimeISO8601", targetDepth))
+                if (context.TestExpression("StartTimeISO8601", targetDepth, ref reader))
                 {
                     var unmarshaller = DateTimeUnmarshaller.Instance;
                     model.StartTimeISO8601 = unmarshaller.Unmarshall(context, ref reader);
                     isSetStartTimeISO8601 = true;
+                    continue;
                 }
-                if (context.TestExpression("StartTimeEpoch", targetDepth))
+                if (context.TestExpression("StartTimeEpoch", targetDepth, ref reader))
                 {
                     var unmarshaller = DateTimeUnmarshaller.Instance;
                     model.StartTimeEpoch = unmarshaller.Unmarshall(context, ref reader);
                     isSetStartTimeEpoch = true;
+                    continue;
                 }
-                if (context.TestExpression("StartTimeRFC822", targetDepth))
+                if (context.TestExpression("StartTimeRFC822", targetDepth, ref reader))
                 {
                     var unmarshaller = DateTimeUnmarshaller.Instance;
                     model.StartTimeRFC822 = unmarshaller.Unmarshall(context, ref reader);
                     isSetStartTimeRFC822 = true;
+                    continue;
                 }
-                if (context.TestExpression("Stream", targetDepth))
+                if (context.TestExpression("Stream", targetDepth, ref reader))
                 {
                     var unmarshaller = MemoryStreamUnmarshaller.Instance;
                     model.Stream = unmarshaller.Unmarshall(context, ref reader);
@@ -114,6 +123,7 @@ namespace AWSSDK.UnitTests
                     }
 
                     isSetStream = true;
+                    continue;
                 }
             }
             if (!(isSetPriority && isSetReservoirQuotaTTL && isSetStartTimeISO8601 && isSetStartTimeEpoch && isSetStartTimeRFC822 && isSetStream))

--- a/sdk/test/UnitTests/Custom/Marshalling/SimpleTypeUnmarshallerTests.cs
+++ b/sdk/test/UnitTests/Custom/Marshalling/SimpleTypeUnmarshallerTests.cs
@@ -60,6 +60,89 @@ namespace AWSSDK.UnitTests
             Assert.AreEqual(DateTimeKind.Utc, nullModel.StartTimeRFC822.Kind);
         }
 
+        /// <summary>
+        /// Service packages generated before reader-based matching call the legacy path-based
+        /// <c>TestExpression(string, int)</c> overload, which matches against <see cref="JsonUnmarshallerContext.CurrentPath"/>.
+        /// AWSSDK.Core no longer pushes property names onto the path stack, so this verifies that those
+        /// older packages still unmarshall correctly against the current Core (CurrentPath must still end
+        /// with the current property name while positioned on it).
+        /// </summary>
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestJsonUnmarshalling_LegacyPathBasedTestExpression()
+        {
+            var model = UnmarshallModelLegacy(JsonWithValues);
+
+            Assert.AreEqual(1, model.Priority);
+            var expected = new DateTime(2018, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+            Assert.AreEqual(expected, model.ReservoirQuotaTTL.Value);
+            Assert.AreEqual(expected, model.StartTimeISO8601);
+            Assert.AreEqual(expected, model.StartTimeEpoch);
+            Assert.AreEqual(expected, model.StartTimeRFC822);
+            Assert.IsNotNull(model.Stream);
+        }
+
+        // Mirrors UnmarshallModel but uses the legacy two-argument TestExpression(name, depth) overload
+        // (no reader), exactly as pre-existing generated service packages call it.
+        private Model UnmarshallModelLegacy(string json)
+        {
+            var stream = Utils.CreateStreamFromString(json);
+            JsonUnmarshallerContext context = new JsonUnmarshallerContext(stream, false, null);
+            var reader = new StreamingUtf8JsonReader(stream);
+            context.Read(ref reader);
+            int targetDepth = context.CurrentDepth;
+            var model = new Model();
+            bool isSetPriority = false, isSetReservoirQuotaTTL = false, isSetStartTimeISO8601 = false,
+                isSetStartTimeEpoch = false, isSetStartTimeRFC822 = false, isSetStream = false;
+            while (context.ReadAtDepth(targetDepth, ref reader))
+            {
+                if (context.TestExpression("Priority", targetDepth))
+                {
+                    // CurrentPath must expose the current property name for the legacy overload to match.
+                    Assert.IsTrue(context.CurrentPath.EndsWith("/Priority"));
+                    model.Priority = NullableIntUnmarshaller.Instance.Unmarshall(context, ref reader);
+                    isSetPriority = true;
+                    continue;
+                }
+                if (context.TestExpression("ReservoirQuotaTTL", targetDepth))
+                {
+                    model.ReservoirQuotaTTL = NullableDateTimeUnmarshaller.Instance.Unmarshall(context, ref reader);
+                    isSetReservoirQuotaTTL = true;
+                    continue;
+                }
+                if (context.TestExpression("StartTimeISO8601", targetDepth))
+                {
+                    model.StartTimeISO8601 = DateTimeUnmarshaller.Instance.Unmarshall(context, ref reader);
+                    isSetStartTimeISO8601 = true;
+                    continue;
+                }
+                if (context.TestExpression("StartTimeEpoch", targetDepth))
+                {
+                    model.StartTimeEpoch = DateTimeUnmarshaller.Instance.Unmarshall(context, ref reader);
+                    isSetStartTimeEpoch = true;
+                    continue;
+                }
+                if (context.TestExpression("StartTimeRFC822", targetDepth))
+                {
+                    model.StartTimeRFC822 = DateTimeUnmarshaller.Instance.Unmarshall(context, ref reader);
+                    isSetStartTimeRFC822 = true;
+                    continue;
+                }
+                if (context.TestExpression("Stream", targetDepth))
+                {
+                    model.Stream = MemoryStreamUnmarshaller.Instance.Unmarshall(context, ref reader);
+                    isSetStream = true;
+                    continue;
+                }
+            }
+            if (!(isSetPriority && isSetReservoirQuotaTTL && isSetStartTimeISO8601 && isSetStartTimeEpoch && isSetStartTimeRFC822 && isSetStream))
+            {
+                throw new Exception($"Could not parse all properties in JSON '{json}'");
+            }
+            return model;
+        }
+
         private Model UnmarshallModel(string json)
         {
             var stream = Utils.CreateStreamFromString(json);

--- a/sdk/test/UnitTests/Custom/Marshalling/SimpleTypeUnmarshallerTests.cs
+++ b/sdk/test/UnitTests/Custom/Marshalling/SimpleTypeUnmarshallerTests.cs
@@ -64,16 +64,14 @@ namespace AWSSDK.UnitTests
         {
             var stream = Utils.CreateStreamFromString(json);
             JsonUnmarshallerContext context = new JsonUnmarshallerContext(stream, false, null);
-            // Matches fields with the allocation-free reader-based TestExpression(name, depth, ref reader)
-            // overload, which is the same matching that generated JSON unmarshallers use.
             var reader = new StreamingUtf8JsonReader(stream);
             context.Read(ref reader);
             int targetDepth = context.CurrentDepth;
             var model = new Model();
-            bool isSetPriority = false, isSetReservoirQuotaTTL = false, isSetStartTimeISO8601 = false, 
+            bool isSetPriority = false, isSetReservoirQuotaTTL = false, isSetStartTimeISO8601 = false,
                 isSetStartTimeEpoch = false, isSetStartTimeRFC822 = false, isSetStream = false;
-            // Mirror the generated unmarshaller loop: each match unmarshalls its value and continues, so
-            // the reader-based TestExpression is only ever evaluated while positioned on a property name.
+            // Mirror the generated unmarshaller loop, where each match continues so the reader-based
+            // TestExpression is only evaluated while positioned on a property name.
             while (context.ReadAtDepth(targetDepth, ref reader))
             {
                 if (context.TestExpression("Priority", targetDepth, ref reader))


### PR DESCRIPTION
## Description
JSON response unmarshalling previously built a `CurrentPath` string for every property name read — a `GetString` allocation per property plus `StringBuilder`/stack churn — purely so fields could be matched with the path-based `TestExpression(name, depth)`.

This change matches property names **directly against the `Utf8JsonReader`** instead:
- Adds `StreamingUtf8JsonReader.ValueTextEquals` (allocation-free, transcoded compare) and an allocation-free `JsonUnmarshallerContext.TestExpression(string, int, ref StreamingUtf8JsonReader)` overload that generated unmarshallers now use.
- `JsonUnmarshallerContext` no longer pushes property names onto the path stack, so the new reader-based overload never builds `CurrentPath`. `CurrentDepth` is unchanged (only object/array delimiters affect depth).
- Error-shape parsing (`JsonErrorResponseUnmarshaller`) matched `__type`/`message`/`code` against the path with a case-insensitive `EndsWith`. It now matches the reader directly against the exact casings AWS services actually emit — `__type` (always lowercase), `message`/`Message`, and `code`/`Code` — reusing the case-sensitive `ValueTextEquals`. This mirrors the reference SDKs (botocore, aws-sdk-js-v3) and needs no separate ignore-case helper.
- The generator templates emit the reader-based overload, so all generated JSON unmarshallers call it once regenerated. The generated files are intentionally **left out of this PR** to keep it reviewable — CI will regenerate them.

### Backward compatibility with older service packages
`AWSSDK.Core` and the service packages are versioned independently, so a customer can run a newer Core alongside a service package generated **before** this change (e.g. updating Core for a new S3 while keeping an older DynamoDB package). Those packages still call the legacy `TestExpression(string, int)` overload, which matches against `CurrentPath`. Core must keep working for them, so simply dropping property-name tracking would have caused those packages to silently stop matching fields (h/t @normj for catching this).

To keep them working **without** re-introducing the per-property allocation:
- On each `Read`, the current property name is captured as raw UTF-8 into a **reused, pooled buffer** — no managed allocation on the hot path. Property names containing JSON escapes (vanishingly rare for AWS shapes) fall back to a decoded string so the legacy unescaped comparison still matches.
- `CurrentPath` is rebuilt **lazily**, only when it is actually read. The reader-based unmarshallers never read it (they match via `ValueTextEquals`), so the new path stays fully allocation-free; older packages and exception diagnostics read it, see the field name, and the legacy overload matches exactly as before.
- `CurrentDepth` is untouched — property names never carried a delimiter, so the depth check in the legacy overload is unaffected. The in-repo JSON generators only ever emit single-segment property names (the multi-segment `X/member` expressions are Query/XML, which use `XmlUnmarshallerContext`), so reconstructing `CurrentPath` to end with `/<name>` is sufficient.

Net effect: regenerated packages pay **zero** per-property allocations; pre-existing packages pay a single `GetString` per property, lazily — their existing cost — and continue to unmarshal correctly. This also restores the failing field name in `AmazonUnmarshallingException` diagnostics.

## Motivation and Context
`DOTNET-8585`. Companion to #4409 (which addressed the request-marshalling side); this is the response-unmarshalling side. Reduces GC pressure on the response hot path for every JSON protocol (rest-json, aws-json 1.0/1.1, RpcV2).

## Testing
- **Unit:** `SimpleTypeUnmarshallerTests` — the reader-based overload, plus `TestJsonUnmarshalling_LegacyPathBasedTestExpression`, a regression test that unmarshals through the legacy `TestExpression(name, depth)` overload (i.e. exactly how a pre-existing service package calls it) and asserts every field populates against the new Core. `ErrorUnmarshallingTests` (15 tests, incl. XML/JSON error shapes).
- **Protocol tests:** 373 `ResponseTest` + `ErrorTest` across RestJson, AwsJson 1.0/1.1 and RpcV2 — all pass.
- **Build:** `AWSSDK.Core` (net8.0 + netstandard2.0) and `AWSSDK.SQS` build clean (0 warnings).
- **Benchmark** — `sdk/test/Performance/SerdeBenchmarks` (serde suite, isolated unmarshalling), baseline `origin/main` vs this change, Apple M2 Pro / .NET 8. Allocation reductions scale with the number of properties read (the change removes one `GetString` allocation per property name):

  **AWS JSON 1.0 — DynamoDB `GetItem` response**

  | Benchmark | Mean (before → after) | Allocated (before → after) |
  |---|---|---|
  | GetItemOutput_S | 2,225 → 1,619 ns (−27%) | 7,520 → 6,704 B (−11%) |
  | GetItemOutput_M | 6,440 → 5,000 ns (−22%) | 14,088 → 11,472 B (−19%) |
  | GetItemOutput_L | 15,487 → 11,582 ns (−25%) | 26,472 → 20,256 B (−24%) |

  **REST JSON 1**

  | Benchmark | Allocated (before → after) |
  |---|---|
  | CopyObjectOutput_M | 6.96 → 5.49 KB (−21%) |

  Marshalling benchmarks (untouched by this PR) allocate byte-for-byte identically across both runs, confirming the change is unmarshal-only. The backward-compatibility capture (pooled buffer + lazy `CurrentPath`) adds no per-property allocation on the regenerated path — the buffer is rented once and reused across reads — so the figures above are unchanged by it (verified on the E2E serde suite: allocations match the reader-only approach within noise).

### Dry-runs
- **DotNet Dry-run ID:** _(pending — to fill)_
- **PowerShell Dry-run ID:** _(pending — to fill)_

## Breaking Changes Assessment
No customer-facing breaking changes.
- New public members `StreamingUtf8JsonReader.ValueTextEquals` and the `JsonUnmarshallerContext.TestExpression(string, int, ref StreamingUtf8JsonReader)` overload are **additive**.
- These types live in `Amazon.Runtime.Internal.*` / `Amazon.Runtime.Internal.Util` (internal namespaces), consumed by generated code, not customer-facing contracts.
- **Mixed-version compatibility is preserved:** a newer Core continues to unmarshal correctly for service packages generated before this change. Those packages call the legacy path-based `TestExpression(string, int)` overload, which still matches because `CurrentPath` is reconstructed on demand from the captured property name. Covered by the `TestJsonUnmarshalling_LegacyPathBasedTestExpression` regression test.

## Types of changes
- [x] New feature (non-breaking change which adds functionality) — performance

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
