### PR TITLE
Reduce memory allocations in DynamoDB Document Model JSON serialization.

### DIFF
--- a/generator/.DevConfigs/b2626677-dca2-4ade-9565-4ae38b4d4e6e.json
+++ b/generator/.DevConfigs/b2626677-dca2-4ade-9565-4ae38b4d4e6e.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "DynamoDBv2",
+      "type": "patch",
+      "changeLogMessages": [
+        "Reduce memory allocations in DynamoDB Document Model JSON serialization."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentExtensions.cs
@@ -75,7 +75,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
             writer.WriteEndArray();
 
             writer.Flush();
-            return Encoding.UTF8.GetString(stream.ToArray());
+            return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
         }
     }
 }

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/JsonUtils.cs
@@ -93,7 +93,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
             WriteJson(document, writer, DynamoDBEntryConversion.V2);
 
             writer.Flush();
-            return Encoding.UTF8.GetString(stream.ToArray());
+            return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
         }
 
 

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Util.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Util.cs
@@ -562,7 +562,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
             {
                 WriteNextKey(nextKey, jsonWriter);
                 jsonWriter.Flush();
-                return Encoding.UTF8.GetString(memoryStream.ToArray());
+                return Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The ToJson(), SerializeEnumerable(), and SerializeClearString() methods uses `Encoding.UTF8.GetString(stream.ToArray()); ` MemoryStream.ToArray() allocates a new byte[] and copies the internal buffer into it. Since we only need the bytes temporarily to decode into a string, we can read directly from the internal buffer via GetBuffer(), eliminating one full-payload-size allocation per call.
My benchmarks are showing 13-14% allocation reduction and 8-24% latency improvement for the affected methods.

This is safe because the `MemoryStream` was created with the parameterless constructor (expandable, GetBuffer() accessible), and we pass the exact written length to avoid reading uninitialized bytes beyond it.

<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-8684`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
Created performance test for the affected methods and here are the results before this change
| Method              | AttributeCount | Mean           | Error        | StdDev        | P50            | P90            | Gen0      | Gen1     | Gen2     | Allocated  |
|-------------------- |--------------- |---------------:|-------------:|--------------:|---------------:|---------------:|----------:|---------:|---------:|-----------:|
| Document.ToJson     | 5              |     1,219.3 ns |     24.41 ns |      50.40 ns |     1,203.5 ns |     1,289.2 ns |    0.5093 |   0.0095 |        - |    6.24 KB |
| DocumentList.ToJson | 5              |    81,360.6 ns |  1,558.38 ns |   2,080.39 ns |    80,451.0 ns |    84,930.5 ns |   13.6719 |   2.0752 |        - |  168.72 KB |
| Document.ToJson     | 50             |     6,776.2 ns |     90.60 ns |      75.66 ns |     6,781.3 ns |     6,866.2 ns |    1.0986 |   0.0229 |        - |   13.49 KB |
| DocumentList.ToJson | 50             | 1,239,384.8 ns | 24,357.19 ns |  28,995.50 ns | 1,230,345.5 ns | 1,262,515.6 ns |  332.0313 | 332.0313 | 332.0313 | 1348.35 KB |
| Document.ToJson     | 200            |    24,728.2 ns |    443.80 ns |     393.42 ns |    24,817.9 ns |    25,105.5 ns |    4.1809 |   0.2747 |        - |   51.45 KB |
| DocumentList.ToJson | 200            | 3,230,313.2 ns | 91,685.60 ns | 265,996.57 ns | 3,180,375.0 ns | 3,628,607.0 ns | 1019.5313 | 960.9375 | 960.9375 | 5458.65 KB |
| ToPaginationToken   | *              |       619.9 ns |     11.71 ns |      10.96 ns |       618.6 ns |       633.1 ns |    0.4616 |   0.0067 |        - |    5.66 KB |

After this change
| Method              | AttributeCount | Mean           | Error        | StdDev        | Median         | P50            | P90            | Gen0     | Gen1     | Gen2     | Allocated  |
|-------------------- |--------------- |---------------:|-------------:|--------------:|---------------:|---------------:|---------------:|---------:|---------:|---------:|-----------:|
| Document.ToJson     | 5              |     1,061.0 ns |     21.08 ns |      44.92 ns |     1,056.5 ns |     1,056.5 ns |     1,131.5 ns |   0.4864 |   0.0076 |        - |    5.98 KB |
| DocumentList.ToJson | 5              |    70,644.3 ns |  1,353.07 ns |   3,794.16 ns |    69,211.2 ns |    69,211.2 ns |    77,366.5 ns |  11.7188 |   1.3428 |        - |  144.96 KB |
| Document.ToJson     | 50             |     5,849.5 ns |     99.57 ns |     201.14 ns |     5,817.2 ns |     5,817.2 ns |     6,118.5 ns |   0.9537 |   0.0229 |        - |   11.75 KB |
| DocumentList.ToJson | 50             |   937,976.5 ns | 18,420.35 ns |  17,230.40 ns |   932,394.5 ns |   932,394.5 ns |   962,697.9 ns | 285.1563 | 285.1563 | 285.1563 |  1176.7 KB |
| Document.ToJson     | 200            |    22,695.9 ns |    362.61 ns |     283.10 ns |    22,618.8 ns |    22,618.8 ns |    22,933.8 ns |   3.6316 |   0.2441 |        - |   44.56 KB |
| DocumentList.ToJson | 200            | 3,159,793.1 ns | 96,260.33 ns | 279,268.68 ns | 3,107,735.7 ns | 3,107,735.7 ns | 3,557,491.1 ns | 683.5938 | 625.0000 | 625.0000 | 4771.49 KB |
| ToPaginationToken   | *              |       544.8 ns |     10.98 ns |      15.39 ns |       543.3 ns |       543.3 ns |       564.0 ns |   0.4463 |   0.0076 |        - |    5.47 KB |
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** fe02bc9a-bf66-4b74-9a49-d583bb54320b
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** ff8d5344-9ea2-4792-80b4-f3f0f516a53f
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

