### PR TITLE
Add structured body marshalling benchmarks and populate commitId/sdkVersion in results

### DIFF
--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestJson1E2EBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestJson1E2EBenchmarks.cs
@@ -35,6 +35,10 @@ public class RestJson1E2EBenchmarks
     private AmazonRestJsonDataPlaneClient _getClientS = null!;
     private AmazonRestJsonDataPlaneClient _getClientM = null!;
     private AmazonRestJsonDataPlaneClient _getClientL = null!;
+    private AmazonRestJsonDataPlaneClient _putMetricClientS = null!;
+    private AmazonRestJsonDataPlaneClient _putMetricClientM = null!;
+    private AmazonRestJsonDataPlaneClient _getMetricClientS = null!;
+    private AmazonRestJsonDataPlaneClient _getMetricClientM = null!;
 
     private CopyObjectRequest _copyObjectBaseline = null!;
     private CopyObjectRequest _copyObjectMedium = null!;
@@ -42,6 +46,10 @@ public class RestJson1E2EBenchmarks
     private PutObjectRequest _putObjectM = null!;
     private PutObjectRequest _putObjectL = null!;
     private GetObjectRequest _getObjectRequest = null!;
+    private PutMetricDataRequest _putMetricDataS = null!;
+    private PutMetricDataRequest _putMetricDataM = null!;
+    private GetMetricDataRequest _getMetricDataS = null!;
+    private GetMetricDataRequest _getMetricDataM = null!;
 
     private static readonly byte[] CopyOutputBaseline = Encoding.UTF8.GetBytes("{}");
     private static readonly byte[] CopyOutputM = Encoding.UTF8.GetBytes(
@@ -50,6 +58,24 @@ public class RestJson1E2EBenchmarks
     private static readonly byte[] GetObjectS = new byte[1024];
     private static readonly byte[] GetObjectM = new byte[100 * 1024];
     private static readonly byte[] GetObjectL = new byte[1024 * 1024];
+    private static readonly byte[] EmptyJson = Encoding.UTF8.GetBytes("{}");
+    private static readonly byte[] GetMetricResponseS = Encoding.UTF8.GetBytes(BuildGetMetricJson(5));
+    private static readonly byte[] GetMetricResponseM = Encoding.UTF8.GetBytes(BuildGetMetricJson(50));
+
+    private static string BuildGetMetricJson(int datapoints)
+    {
+        var sb = new StringBuilder("{\"MetricDataResults\":[{\"Id\":\"m1\",\"Label\":\"CPUUtilization\",\"Values\":[");
+        for (int i = 0; i < datapoints; i++) { if (i > 0) sb.Append(','); sb.Append($"{42.0 + i * 0.1}"); }
+        sb.Append("],\"Timestamps\":[");
+        var baseTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        for (int i = 0; i < datapoints; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append($"{baseTime.AddMinutes(i * 5).ToUnixTimeSeconds()}");
+        }
+        sb.Append("]}]}");
+        return sb.ToString();
+    }
 
     private AmazonRestJsonDataPlaneClient CreateClient(byte[] responseBody)
     {
@@ -75,6 +101,10 @@ public class RestJson1E2EBenchmarks
         _getClientS = CreateClient(GetObjectS);
         _getClientM = CreateClient(GetObjectM);
         _getClientL = CreateClient(GetObjectL);
+        _putMetricClientS = CreateClient(EmptyJson);
+        _putMetricClientM = CreateClient(EmptyJson);
+        _getMetricClientS = CreateClient(GetMetricResponseS);
+        _getMetricClientM = CreateClient(GetMetricResponseM);
 
         _copyObjectBaseline = new CopyObjectRequest { Bucket = "bucket", Key = "key", CopySource = "src/key" };
         _copyObjectMedium = new CopyObjectRequest
@@ -90,6 +120,26 @@ public class RestJson1E2EBenchmarks
         _putObjectM = new PutObjectRequest { Bucket = "bucket", Key = "key", Body = new MemoryStream(new byte[100 * 1024]) };
         _putObjectL = new PutObjectRequest { Bucket = "bucket", Key = "key", Body = new MemoryStream(new byte[1024 * 1024]) };
         _getObjectRequest = new GetObjectRequest { Bucket = "bucket", Key = "key" };
+        _putMetricDataS = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(3) };
+        _putMetricDataM = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(20) };
+        _getMetricDataS = new GetMetricDataRequest { StartTime = DateTime.UtcNow.AddHours(-1), EndTime = DateTime.UtcNow, MetricDataQueries = CreateQueries(1) };
+        _getMetricDataM = new GetMetricDataRequest { StartTime = DateTime.UtcNow.AddHours(-1), EndTime = DateTime.UtcNow, MetricDataQueries = CreateQueries(5) };
+    }
+
+    private static List<MetricDatum> CreateMetricData(int count)
+    {
+        var data = new List<MetricDatum>();
+        for (int i = 0; i < count; i++)
+            data.Add(new MetricDatum { MetricName = $"Metric{i}", Value = 42.0 + i, Unit = "Count" });
+        return data;
+    }
+
+    private static List<MetricDataQuery> CreateQueries(int count)
+    {
+        var queries = new List<MetricDataQuery>();
+        for (int i = 0; i < count; i++)
+            queries.Add(new MetricDataQuery { Id = $"m{i}", MetricStat = new MetricStat { Metric = new Amazon.RestJsonDataPlane.Model.Metric { MetricName = $"CPU{i}", Namespace = "AWS/EC2" }, Period = 300, Stat = "Average" } });
+        return queries;
     }
 
     [Benchmark] public async Task restJson1_e2e_CopyObject_Baseline() => await _copyClientBaseline.CopyObjectAsync(_copyObjectBaseline);
@@ -100,6 +150,10 @@ public class RestJson1E2EBenchmarks
     [Benchmark] public async Task restJson1_e2e_GetObject_S() => await _getClientS.GetObjectAsync(_getObjectRequest);
     [Benchmark] public async Task restJson1_e2e_GetObject_M() => await _getClientM.GetObjectAsync(_getObjectRequest);
     [Benchmark] public async Task restJson1_e2e_GetObject_L() => await _getClientL.GetObjectAsync(_getObjectRequest);
+    [Benchmark] public async Task restJson1_e2e_PutMetricData_S() => await _putMetricClientS.PutMetricDataAsync(_putMetricDataS);
+    [Benchmark] public async Task restJson1_e2e_PutMetricData_M() => await _putMetricClientM.PutMetricDataAsync(_putMetricDataM);
+    [Benchmark] public async Task restJson1_e2e_GetMetricData_S() => await _getMetricClientS.GetMetricDataAsync(_getMetricDataS);
+    [Benchmark] public async Task restJson1_e2e_GetMetricData_M() => await _getMetricClientM.GetMetricDataAsync(_getMetricDataM);
 
     [GlobalCleanup]
     public void Cleanup()
@@ -110,5 +164,9 @@ public class RestJson1E2EBenchmarks
         _getClientS?.Dispose();
         _getClientM?.Dispose();
         _getClientL?.Dispose();
+        _putMetricClientS?.Dispose();
+        _putMetricClientM?.Dispose();
+        _getMetricClientS?.Dispose();
+        _getMetricClientM?.Dispose();
     }
 }

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestXmlE2EBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestXmlE2EBenchmarks.cs
@@ -34,12 +34,20 @@ public class RestXmlE2EBenchmarks
     private AmazonRestXmlDataPlaneClient _getClientS = null!;
     private AmazonRestXmlDataPlaneClient _getClientM = null!;
     private AmazonRestXmlDataPlaneClient _getClientL = null!;
+    private AmazonRestXmlDataPlaneClient _putMetricClientS = null!;
+    private AmazonRestXmlDataPlaneClient _putMetricClientM = null!;
+    private AmazonRestXmlDataPlaneClient _getMetricClientS = null!;
+    private AmazonRestXmlDataPlaneClient _getMetricClientM = null!;
 
     private CopyObjectRequest _copyObjectRequest = null!;
     private PutObjectRequest _putObjectS = null!;
     private PutObjectRequest _putObjectM = null!;
     private PutObjectRequest _putObjectL = null!;
     private GetObjectRequest _getObjectRequest = null!;
+    private PutMetricDataRequest _putMetricDataS = null!;
+    private PutMetricDataRequest _putMetricDataM = null!;
+    private GetMetricDataRequest _getMetricDataS = null!;
+    private GetMetricDataRequest _getMetricDataM = null!;
 
     private static readonly byte[] CopyResponse = Encoding.UTF8.GetBytes(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?><CopyObjectResult><ETag>\"d41d8cd98f00b204e9800998ecf8427e\"</ETag><LastModified>2024-01-01T00:00:00Z</LastModified></CopyObjectResult>");
@@ -47,6 +55,22 @@ public class RestXmlE2EBenchmarks
     private static readonly byte[] GetObjectS = new byte[1024];
     private static readonly byte[] GetObjectM = new byte[100 * 1024];
     private static readonly byte[] GetObjectL = new byte[1024 * 1024];
+    private static readonly byte[] GetMetricResponseS = Encoding.UTF8.GetBytes(BuildGetMetricXml(5));
+    private static readonly byte[] GetMetricResponseM = Encoding.UTF8.GetBytes(BuildGetMetricXml(50));
+
+    private static string BuildGetMetricXml(int datapoints)
+    {
+        var sb = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?><GetMetricDataResponse><GetMetricDataResult><MetricDataResults><member><Id>m1</Id><Label>CPUUtilization</Label><Values>");
+        for (int i = 0; i < datapoints; i++) sb.Append($"<member>{42.0 + i * 0.1}</member>");
+        sb.Append("</Values><Timestamps>");
+        for (int i = 0; i < datapoints; i++)
+        {
+            var ts = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMinutes(i * 5);
+            sb.Append($"<member>{ts:yyyy-MM-ddTHH:mm:ssZ}</member>");
+        }
+        sb.Append("</Timestamps></member></MetricDataResults></GetMetricDataResult></GetMetricDataResponse>");
+        return sb.ToString();
+    }
 
     private AmazonRestXmlDataPlaneClient CreateClient(byte[] responseBody, string contentType = "application/xml")
     {
@@ -71,12 +95,36 @@ public class RestXmlE2EBenchmarks
         _getClientS = CreateClient(GetObjectS, "application/octet-stream");
         _getClientM = CreateClient(GetObjectM, "application/octet-stream");
         _getClientL = CreateClient(GetObjectL, "application/octet-stream");
+        _putMetricClientS = CreateClient(EmptyXml);
+        _putMetricClientM = CreateClient(EmptyXml);
+        _getMetricClientS = CreateClient(GetMetricResponseS);
+        _getMetricClientM = CreateClient(GetMetricResponseM);
 
         _copyObjectRequest = new CopyObjectRequest { Bucket = "b", Key = "k", CopySource = "src/k" };
         _putObjectS = new PutObjectRequest { Bucket = "b", Key = "k", ContentType = "application/octet-stream", Body = new MemoryStream(new byte[1024]) };
         _putObjectM = new PutObjectRequest { Bucket = "b", Key = "k", ContentType = "application/octet-stream", Body = new MemoryStream(new byte[100 * 1024]) };
         _putObjectL = new PutObjectRequest { Bucket = "b", Key = "k", ContentType = "application/octet-stream", Body = new MemoryStream(new byte[1024 * 1024]) };
         _getObjectRequest = new GetObjectRequest { Bucket = "b", Key = "k" };
+        _putMetricDataS = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(3) };
+        _putMetricDataM = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(20) };
+        _getMetricDataS = new GetMetricDataRequest { StartTime = DateTime.UtcNow.AddHours(-1), EndTime = DateTime.UtcNow, MetricDataQueries = CreateQueries(1) };
+        _getMetricDataM = new GetMetricDataRequest { StartTime = DateTime.UtcNow.AddHours(-1), EndTime = DateTime.UtcNow, MetricDataQueries = CreateQueries(5) };
+    }
+
+    private static List<MetricDatum> CreateMetricData(int count)
+    {
+        var data = new List<MetricDatum>();
+        for (int i = 0; i < count; i++)
+            data.Add(new MetricDatum { MetricName = $"Metric{i}", Value = 42.0 + i, Unit = "Count" });
+        return data;
+    }
+
+    private static List<MetricDataQuery> CreateQueries(int count)
+    {
+        var queries = new List<MetricDataQuery>();
+        for (int i = 0; i < count; i++)
+            queries.Add(new MetricDataQuery { Id = $"m{i}", MetricStat = new MetricStat { Metric = new Amazon.RestXmlDataPlane.Model.Metric { MetricName = $"CPU{i}", Namespace = "AWS/EC2" }, Period = 300, Stat = "Average" } });
+        return queries;
     }
 
     [Benchmark] public async Task restXml_e2e_CopyObject() => await _copyClient.CopyObjectAsync(_copyObjectRequest);
@@ -86,6 +134,10 @@ public class RestXmlE2EBenchmarks
     [Benchmark] public async Task restXml_e2e_GetObject_S() => await _getClientS.GetObjectAsync(_getObjectRequest);
     [Benchmark] public async Task restXml_e2e_GetObject_M() => await _getClientM.GetObjectAsync(_getObjectRequest);
     [Benchmark] public async Task restXml_e2e_GetObject_L() => await _getClientL.GetObjectAsync(_getObjectRequest);
+    [Benchmark] public async Task restXml_e2e_PutMetricData_S() => await _putMetricClientS.PutMetricDataAsync(_putMetricDataS);
+    [Benchmark] public async Task restXml_e2e_PutMetricData_M() => await _putMetricClientM.PutMetricDataAsync(_putMetricDataM);
+    [Benchmark] public async Task restXml_e2e_GetMetricData_S() => await _getMetricClientS.GetMetricDataAsync(_getMetricDataS);
+    [Benchmark] public async Task restXml_e2e_GetMetricData_M() => await _getMetricClientM.GetMetricDataAsync(_getMetricDataM);
 
     [GlobalCleanup]
     public void Cleanup()
@@ -95,5 +147,9 @@ public class RestXmlE2EBenchmarks
         _getClientS?.Dispose();
         _getClientM?.Dispose();
         _getClientL?.Dispose();
+        _putMetricClientS?.Dispose();
+        _putMetricClientM?.Dispose();
+        _getMetricClientS?.Dispose();
+        _getMetricClientM?.Dispose();
     }
 }

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/test.ps1
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/test.ps1
@@ -21,9 +21,15 @@ for ($i = 0; $i -lt $args.Count; $i++) {
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
-# Get git commit ID
-$CommitId = if ($env:CODEBUILD_RESOLVED_SOURCE_VERSION) { $env:CODEBUILD_RESOLVED_SOURCE_VERSION } else {
-    try { git rev-parse HEAD 2>$null } catch { "unknown" }
+# Get build metadata (from build-metadata.json written by artifact step, or fallback)
+$metadataPath = Join-Path $ScriptDir "build-metadata.json"
+if (Test-Path $metadataPath) {
+    $metadata = Get-Content $metadataPath | ConvertFrom-Json
+    $CommitId = $metadata.commitId
+    $SdkVersion = $metadata.productVersion
+} else {
+    $CommitId = "unknown"
+    $SdkVersion = "unknown"
 }
 
 # Clean previous artifacts
@@ -103,9 +109,10 @@ foreach ($file in $JsonFiles) {
 
 # Build output
 $output = @{
-    productId = $productId
-    commitId  = $CommitId
-    results   = $AllResults
+    productId  = $productId
+    commitId   = $CommitId
+    sdkVersion = $SdkVersion
+    results    = $AllResults
 }
 
 # Output JSON to stdout (CI captures via pipe to output.json)

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/test.sh
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/test.sh
@@ -21,8 +21,14 @@ done
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Get git commit ID
-COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}"
+# Get build metadata (from build-metadata.json written by artifact step, or fallback)
+if [ -f "$SCRIPT_DIR/build-metadata.json" ]; then
+    COMMIT_ID="$(jq -r '.commitId' "$SCRIPT_DIR/build-metadata.json")"
+    SDK_VERSION="$(jq -r '.productVersion' "$SCRIPT_DIR/build-metadata.json")"
+else
+    COMMIT_ID="unknown"
+    SDK_VERSION="unknown"
+fi
 
 # Clean previous artifacts
 rm -rf "$SCRIPT_DIR/BenchmarkDotNet.Artifacts"
@@ -51,10 +57,11 @@ EPOCH=$(date +%s)
 # the CI publisher converts Nanoseconds→Microseconds before CloudWatch publish,
 # but the evaluator compares raw measurements against CloudWatch values without
 # converting. Using Microseconds directly avoids this unit mismatch.
-find "$RESULTS_DIR" -name "*-report-full-compressed.json" -print0 | xargs -0 cat | jq -s --arg productId "$PRODUCT_ID" --arg commitId "$COMMIT_ID" --argjson date "$EPOCH" '
+find "$RESULTS_DIR" -name "*-report-full-compressed.json" -print0 | xargs -0 cat | jq -s --arg productId "$PRODUCT_ID" --arg commitId "$COMMIT_ID" --arg sdkVersion "$SDK_VERSION" --argjson date "$EPOCH" '
 {
     productId: $productId,
     commitId: $commitId,
+    sdkVersion: $sdkVersion,
     results: [
         .[] | .Benchmarks[]? | select(.Statistics != null) |
         (


### PR DESCRIPTION
## Description

Two changes:

**1. Add PutMetricData and GetMetricData E2E benchmarks for RestXml and RestJson1 protocols.**

These benchmarks exercise the XML/JSON request body marshalling path that was previously untested — the existing S3-like operations (PutObject, CopyObject, GetObject) only exercise raw stream pass-through or header serialization, not structured body serialization.

New benchmarks added (S and M sizes for each):
- `restXml_e2e_PutMetricData_S/M` — XML request body marshalling
- `restXml_e2e_GetMetricData_S/M` — XML response body unmarshalling
- `restJson1_e2e_PutMetricData_S/M` — JSON request body marshalling
- `restJson1_e2e_GetMetricData_S/M` — JSON response body unmarshalling

Total E2E benchmark count: 33 → 41 (82 metrics with latency + memory).

**2. Populate `commitId` and `sdkVersion` in performance test results.json output.**

Previously these fields were always `"unknown"` because the perf test step runs from an extracted artifact zip with no git context. Now the test scripts read from a `build-metadata.json` file written during the artifact packaging step (which has access to the git repo and `_sdk-versions.json`). The results.json now correctly includes (Sample from test release run below):
```json
{"productId":"dotnetv4","commitId":"ace841d46af9646068444c087334e5af8591d047","sdkVersion":"4.0.267.0", ...}
```

## Motivation and Context

The existing RestXml and RestJson1 benchmarks did not exercise structured body serialization. S3 PutObject sends raw bytes (not marshalled XML/JSON), and CopyObject uses only headers. This meant regressions or improvements in the core marshalling code path would go undetected.

The RestXmlDataPlane and RestJsonDataPlane test service models already include PutMetricData (structured request body) and GetMetricData (structured response body) — we simply weren't benchmarking them.

Associated build system CR: CR-281048194

## Testing

- All 82 benchmarks pass locally via `dotnet run -c Release -- --filter "*e2e*" --job Dry`
- Deployed to dev account and ran full RELEASE E2E (RELEASE-7ad27872-c9d4-40c3-ad34-a6c4fad53073):
  - Linux: 82 metrics emitted, 0 failures
  - Windows: 82 metrics emitted, 0 failures
- Verified `commitId` and `sdkVersion` are correctly populated in both Linux and Windows results.json (previously showed `"unknown"`)

### Dry-runs

Validated via CI E2E tests on dev account:
- **RELEASE** (RELEASE-7ad27872-c9d4-40c3-ad34-a6c4fad53073): SUCCEEDED — 82 metrics emitted on both Linux and Windows, 0 failures
- **PREVIEW**: SUCCEEDED — correctly skipped perf tests (no customization involved)

Standard dry-runs not required — this change only adds benchmark test code with no impact on SDK production assemblies or generated code.

## Breaking Changes Assessment

No breaking changes. This adds new benchmark methods to existing test classes. No public API surface is modified.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
