### PR TITLE
Reduce memory allocations in SQS MD5 validation pipeline.

### DIFF
--- a/generator/.DevConfigs/dfe70e8b-fe76-4bda-a0b7-4bc632876324.json
+++ b/generator/.DevConfigs/dfe70e8b-fe76-4bda-a0b7-4bc632876324.json
@@ -1,0 +1,21 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Added ComputeMD5Hash(byte[], int, int) overload to ICryptoUtil to support hashing from offset/count ranges without copying."
+    ],
+    "type": "patch",
+    "updateMinimum": true,
+    "backwardIncompatibilitiesToIgnore": [ 
+      "Amazon.Util.ICryptoUtil/MethodAbstractMethodAdded"
+    ]
+  },
+  "services": [
+    {
+      "serviceName": "SQS",
+      "type": "patch",
+      "changeLogMessages": [
+        "Reduce memory allocations in SQS MD5 validation pipeline."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Core/Amazon.Util/CryptoUtil.cs
+++ b/sdk/src/Core/Amazon.Util/CryptoUtil.cs
@@ -240,6 +240,31 @@ namespace Amazon.Util
             /// <summary>
             /// Computes an MD5 hash
             /// </summary>
+            /// <param name="data">Input to compute the hash code for</param>
+            /// <param name="offset">Offset into the byte array from which to begin using data</param>
+            /// <param name="count">Number of bytes in the array to use as data</param>
+            /// <returns>Computed hash code</returns>
+            public byte[] ComputeMD5Hash(byte[] data, int offset, int count)
+            {
+#if NET8_0_OR_GREATER
+                if (_md5HashDataAvailable)
+                {
+                    try
+                    {
+                        return MD5.HashData(data.AsSpan(offset, count));
+                    }
+                    catch (CryptographicException)
+                    {
+                        _md5HashDataAvailable = false;
+                    }
+                }
+#endif
+                return new MD5Managed().ComputeHash(data, offset, count);
+            }
+
+            /// <summary>
+            /// Computes an MD5 hash
+            /// </summary>
             /// <param name="steam">Input to compute the hash code for</param>
             /// <returns>Computed hash code</returns>
             public byte[] ComputeMD5Hash(Stream steam)

--- a/sdk/src/Core/Amazon.Util/ICryptoUtil.cs
+++ b/sdk/src/Core/Amazon.Util/ICryptoUtil.cs
@@ -31,6 +31,7 @@ namespace Amazon.Util
         byte[] ComputeSHA256Hash(Stream steam);
 
         byte[] ComputeMD5Hash(byte[] data);
+        byte[] ComputeMD5Hash(byte[] data, int offset, int count);
         byte[] ComputeMD5Hash(Stream steam);
 
         byte[] HMACSignBinary(byte[] data, byte[] key, SigningAlgorithm algorithmName);

--- a/sdk/src/Services/SQS/Custom/Internal/ValidationResponseHandler.cs
+++ b/sdk/src/Services/SQS/Custom/Internal/ValidationResponseHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -9,6 +10,7 @@ using Amazon.Runtime;
 using Amazon.Runtime.Internal.Util;
 using Amazon.SQS.Model;
 using Amazon.Runtime.Internal;
+using Amazon.Util;
 
 namespace Amazon.SQS.Internal
 {
@@ -103,14 +105,16 @@ namespace Amazon.SQS.Internal
                 if (ms == null) throw new ArgumentNullException("ms");
 
                 Write((int)ms.Length);
-                var bytes = ms.ToArray();
-                Write(bytes);
+                if (ms.TryGetBuffer(out var buffer))
+                    Write(buffer.Array, buffer.Offset, buffer.Count);
+                else
+                    Write(ms.ToArray());
             }
             public void Write(int value)
             {
                 var bytes = BitConverter.GetBytes(value);
                 if (shouldReverseInts)
-                    bytes = bytes.Reverse().ToArray();
+                    Array.Reverse(bytes);
                 Write(bytes);
             }
             public void Write(byte value)
@@ -121,14 +125,14 @@ namespace Amazon.SQS.Internal
             {
                 writer.Write(bytes);
             }
+            public void Write(byte[] bytes, int offset, int count)
+            {
+                writer.Write(bytes, offset, count);
+            }
 
             public void Dispose()
             {
-#if NETSTANDARD
                 writer.Dispose();
-#else
-                writer.Close();
-#endif
             }
         }
 
@@ -139,7 +143,7 @@ namespace Amazon.SQS.Internal
         /// <returns></returns>
         public static string CalculateMD5(Dictionary<string, MessageAttributeValue> attributes)
         {
-            List<KeyValuePair<string, MessageAttributeValue>> orderedAttributes = new List<KeyValuePair<string, MessageAttributeValue>>();
+            var orderedAttributes = new List<KeyValuePair<string, MessageAttributeValue>>(attributes.Count);
             foreach (var kvp in attributes)
             {
                 orderedAttributes.Add(kvp);
@@ -185,10 +189,9 @@ namespace Amazon.SQS.Internal
                         }
                     }
                 }
-            }
 
-            var bytes = ms.ToArray();
-            return CalculateMD5(bytes);
+                return CalculateMD5(ms.GetBuffer(), 0, (int)ms.Length);
+            }
         }
 
         /// <summary>
@@ -198,8 +201,19 @@ namespace Amazon.SQS.Internal
         /// <returns></returns>
         public static string CalculateMD5(string message)
         {
-            var messageBytes = System.Text.Encoding.UTF8.GetBytes(message);
-            return CalculateMD5(messageBytes);
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            var maxByteCount = Encoding.UTF8.GetMaxByteCount(message.Length);
+            var rentedBytes = ArrayPool<byte>.Shared.Rent(maxByteCount);
+            try
+            {
+                var written = Encoding.UTF8.GetBytes(message, 0, message.Length, rentedBytes, 0);
+                var md5Hash = CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(rentedBytes, 0, written);
+                return AWSSDKUtils.ToHex(md5Hash, true);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rentedBytes);
+            }
         }
 
         /// <summary>
@@ -209,9 +223,21 @@ namespace Amazon.SQS.Internal
         /// <returns></returns>
         public static string CalculateMD5(byte[] bytes)
         {
-            var md5Hash = Amazon.Util.CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(bytes);
-            var calculatedMd5 = BitConverter.ToString(md5Hash).Replace("-", string.Empty).ToLowerInvariant();
-            return calculatedMd5;
+            var md5Hash = CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(bytes);
+            return AWSSDKUtils.ToHex(md5Hash, true);
+        }
+
+        /// <summary>
+        /// Calculate the MD5
+        /// </summary>
+        /// <param name="bytes">bytes to compute the hash code for</param>
+        /// <param name="offset">Offset into the byte array from which to begin using data</param>
+        /// <param name="count">Number of bytes in the array to use as data</param>
+        /// <returns></returns>
+        public static string CalculateMD5(byte[] bytes, int offset, int count)
+        {
+            var md5Hash = CryptoUtilFactory.CryptoInstance.ComputeMD5Hash(bytes, offset, count);
+            return AWSSDKUtils.ToHex(md5Hash, true);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reduces per-message memory allocations in `ValidationResponseHandler` which runs on every `SendMessage`, `SendMessageBatch`, and `ReceiveMessage` operation.
Added `ComputeMD5Hash(byte[] data, int offset, int count)` overload to support hashing from rented/oversized buffers without copying.

The body MD5 path shows up to 99.8% allocation reduction because ArrayPool eliminates the per-call byte[] allocation entirely, rented buffers are reused across calls and never hit the GC.
The attribute MD5 path shows 33-51% reduction by avoiding intermediate buffer copies.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing

Created performance test for MD5 `ValidationResponseHandler` md5 calculation methods and here are the results before this change
| Method                   | PayloadSize | Mean       | Error     | StdDev     | Median     | P50        | P90        | Gen0   | Allocated |
|------------------------- |------------ |-----------:|----------:|-----------:|-----------:|-----------:|-----------:|-------:|----------:|
| CalculateMD5(body)       | large       | 145.390 us | 5.8047 us | 17.1153 us | 145.749 us | 145.749 us | 165.150 us | 5.1270 |   65896 B |
| CalculateMD5(attributes) | large       |   4.956 us | 0.0989 us |  0.2042 us |   4.886 us |   4.886 us |   5.172 us | 0.7553 |    9528 B |
| CalculateMD5(body)       | medium      |   7.679 us | 0.0919 us |  0.0859 us |   7.681 us |   7.681 us |   7.784 us | 0.3510 |    4456 B |
| CalculateMD5(attributes) | medium      |   2.286 us | 0.0397 us |  0.0457 us |   2.277 us |   2.277 us |   2.324 us | 0.2861 |    3592 B |
| CalculateMD5(body)       | small       |   1.087 us | 0.0352 us |  0.1020 us |   1.056 us |   1.056 us |   1.245 us | 0.0477 |     616 B |
| CalculateMD5(attributes) | small       |   2.455 us | 0.0491 us |  0.0778 us |   2.429 us |   2.429 us |   2.535 us | 0.2861 |    3592 B |

And after this change 

| Method                   | PayloadSize | Mean         | Error       | StdDev      | P50          | P90          | Gen0   | Allocated |
|------------------------- |------------ |-------------:|------------:|------------:|-------------:|-------------:|-------:|----------:|
| CalculateMD5(body)       | large       | 111,678.3 ns | 2,170.10 ns | 3,565.53 ns | 110,694.2 ns | 115,839.6 ns |      - |     192 B |
| CalculateMD5(attributes) | large       |   3,790.0 ns |    75.75 ns |   149.52 ns |   3,739.1 ns |   4,010.9 ns | 0.5112 |    6424 B |
| CalculateMD5(body)       | medium      |   7,423.9 ns |   147.52 ns |   175.61 ns |   7,382.5 ns |   7,732.7 ns | 0.0076 |     128 B |
| CalculateMD5(attributes) | medium      |   1,541.4 ns |    30.69 ns |    35.34 ns |   1,536.4 ns |   1,579.9 ns | 0.1392 |    1768 B |
| CalculateMD5(body)       | small       |     792.2 ns |    15.82 ns |    15.54 ns |     790.2 ns |     814.5 ns | 0.0095 |     128 B |
| CalculateMD5(attributes) | small       |   2,073.4 ns |   108.55 ns |   320.07 ns |   2,077.7 ns |   2,594.5 ns | 0.1392 |    1768 B |

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 0a283bba-d297-4bae-83fb-8445e59df1e5
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** d71bd742-9e00-4428-b11c-f4cf232eafa2
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?

        Added `ComputeMD5Hash(byte[] data, int offset, int count)` overload to the `ICryptoUtil` interface in `Amazon.Util`. This is a new method on a public interface.

    * How will this impact customers?

        This will **not** impact customers. The `ICryptoUtil` interface is decorated with `[AWSIsBackwardsCompatible]`, which indicates it follows the SDK's safe interface evolution pattern. Customers do not implement this interface — it is implemented internally by `CryptoUtilFactory.CryptoUtil` and consumed via the singleton `CryptoUtilFactory.CryptoInstance`. Adding a new method to the interface has no effect on existing code since no customer code needs to implement or override it.

    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?

        This is **not** a breaking change. The `[AWSIsBackwardsCompatible]` attribute signals that the interface is safe to extend. The method was added to support hashing from a rented `ArrayPool<byte>` buffer with offset/count parameters, avoiding the need to copy into an exact-size array first.

    * Are best practices being followed?

        - Follows the existing pattern established by `ComputeSHA256Hash(byte[] data, int offset, int count)` which was already on the same interface.
        - Uses `[AWSIsBackwardsCompatible]` consistent with other interface extensions in the SDK.
        - On .NET 8+, uses the static `MD5.HashData(ReadOnlySpan<byte>)` one-shot API (zero-allocation, no HashAlgorithm instance).
        - On older targets, falls back to `MD5Managed.ComputeHash(byte[], int, int)` which is the standard pattern.

    * How have you tested this breaking change?

        - All existing SQS unit tests pass (MD5 validation is exercised on every send/receive test).
        - The overload follows identical structure to the existing `ComputeSHA256Hash(byte[], int, int)` which has been in production.
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

