### PR TITLE
Fix regression with AmazonUnmarshallingException.LastKnownLocation

### DIFF
--- a/generator/.DevConfigs/7983c882-01d2-4f31-93c4-9e04324fbd19.json
+++ b/generator/.DevConfigs/7983c882-01d2-4f31-93c4-9e04324fbd19.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fix for regression where LastKnownLocation of marshalling exception would not display correct path."
+    ]
+  }
+}

--- a/generator/.DevConfigs/7983c882-01d2-4f31-93c4-9e04324fbd19.json
+++ b/generator/.DevConfigs/7983c882-01d2-4f31-93c4-9e04324fbd19.json
@@ -3,7 +3,7 @@
     "updateMinimum": true,
     "type": "patch",
     "changeLogMessages": [
-      "Fix for regression where LastKnownLocation of marshalling exception would not display correct path."
+      "Fix regression where AmazonUnmarshallingException.LastKnownLocation did not display the correct path."
     ]
   }
 }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
@@ -46,7 +46,6 @@ namespace Amazon.Runtime.Internal.Transform
     /// </summary>
     public class JsonUnmarshallerContext : UnmarshallerContext
     {
-        private const string DELIMITER = "/";
         #region Private members
 
         private Stream baseStream;
@@ -57,20 +56,17 @@ namespace Amazon.Runtime.Internal.Transform
         private bool disposed = false;
         private bool wasPeeked = false;
 
-        // Property names are no longer pushed onto the path stack (that was the per-property string
-        // allocation we removed). But AWSSDK.Core must stay compatible with service packages that were
-        // generated before reader-based matching existed: those still call the legacy path-based
-        // TestExpression(string, int) overload, which matches against CurrentPath. To keep that working
-        // without re-introducing an allocation on the hot path, we capture the current property name as
-        // raw UTF-8 bytes into a reused, pooled buffer on each Read, and only materialize a string lazily
-        // when CurrentPath is actually read (i.e. by old packages or by exception diagnostics).
+        // Property names are pushed onto the path stack's StringBuilder on each PropertyName token
+        // via a pooled char[] (no string allocation on the hot path). The path string is only
+        // materialized (via StringBuilder.ToString) when CurrentPath is actually read — typically only
+        // on exception for diagnostics, or by the legacy path-based TestExpression(string, int) overload
+        // used by older service packages. We also capture the current property name into a reused pooled
+        // buffer for reader-based TestExpression matching (ValueTextEquals).
         private byte[] currentPropertyNameBuffer = null;
         private int currentPropertyNameLength = 0;
         // Set only when a property name contains JSON escapes, where a raw-byte copy can't be compared
         // against the unescaped expression the legacy overload expects.
         private string currentPropertyNameEscaped = null;
-        private bool onPropertyName = false;
-        private string cachedCurrentPath = null;
         #endregion
 
         #region Constructors
@@ -231,27 +227,15 @@ namespace Amazon.Runtime.Internal.Transform
         /// The current Json path that is being unmarshalled.
         /// </summary>
         /// <remarks>
-        /// Property names are not tracked on the path stack, so the stack only contributes the depth
-        /// delimiters. When positioned on a property name we append the captured name lazily so the
-        /// legacy path-based <c>TestExpression(string, int)</c> overload (used by service packages
-        /// generated before reader-based matching) and exception diagnostics still see the field name.
-        /// The built string is cached until the next token is read.
+        /// The path stack tracks both depth delimiters and property names. The string is only
+        /// materialized (via StringBuilder.ToString) when this property is read — typically on
+        /// exception for diagnostics, or by the legacy path-based TestExpression overload.
         /// </remarks>
         public override string CurrentPath
         {
             get
             {
-                if (!onPropertyName)
-                    return this.stack.CurrentPath;
-
-                if (cachedCurrentPath == null)
-                {
-                    string name = currentPropertyNameEscaped
-                        ?? Encoding.UTF8.GetString(currentPropertyNameBuffer, 0, currentPropertyNameLength);
-                    cachedCurrentPath = this.stack.CurrentPath + name;
-                }
-
-                return cachedCurrentPath;
+                return this.stack.CurrentPath;
             }
         }
 
@@ -410,23 +394,17 @@ namespace Amazon.Runtime.Internal.Transform
         }
 
         /// <summary>
-        /// Captures the current property name so the legacy path-based <c>TestExpression(string, int)</c>
-        /// overload can match against <see cref="CurrentPath"/> without us pushing names onto the stack.
-        /// The common (unescaped) case only copies bytes into a reused pooled buffer; no string is
-        /// allocated until <see cref="CurrentPath"/> is read.
+        /// Captures the current property name into a reused pooled buffer for reader-based
+        /// TestExpression matching (ValueTextEquals). The name is also pushed onto the path
+        /// stack in <see cref="UpdateContext"/> for CurrentPath diagnostics.
         /// </summary>
         private void CaptureCurrentPropertyName(ref StreamingUtf8JsonReader reader)
         {
-            // The position is changing, so any previously built path string is now stale.
-            cachedCurrentPath = null;
-
             if (currentToken != JsonTokenType.PropertyName)
             {
-                onPropertyName = false;
                 return;
             }
 
-            onPropertyName = true;
             currentPropertyNameEscaped = null;
 
             ReadOnlySpan<byte> name = reader.Reader.ValueSpan;
@@ -461,11 +439,7 @@ namespace Amazon.Runtime.Internal.Transform
             if (currentToken.Value == JsonTokenType.StartObject || currentToken.Value == JsonTokenType.StartArray)
             {
                 // Push '/' for object start and array start.
-                stack.Push(new PathSegment
-                {
-                    SegmentType = PathSegmentType.Delimiter,
-                    Value = DELIMITER
-                });
+                stack.PushDelimiter();
             }
             else if (currentToken.Value == JsonTokenType.EndObject || currentToken.Value == JsonTokenType.EndArray)
             {
@@ -475,32 +449,33 @@ namespace Amazon.Runtime.Internal.Transform
                     stack.Pop();
                     if (stack.Count > 0 && stack.Peek().SegmentType != PathSegmentType.Delimiter)
                     {
-                        // Pop a non-delimiter Value segment sitting beneath the closed scope. Property
-                        // names are no longer pushed, so in normal documents nothing is popped here.
+                        // Pop the property name segment sitting beneath the closed scope.
                         stack.Pop();
                     }
                 }
             }
-            // Property names are intentionally not pushed onto the stack; they only ever served to
-            // build CurrentPath for path-based matching, which JSON unmarshalling no longer uses.
-            // Depth is unaffected, as property names never carried a delimiter.
+            else if (currentToken.Value == JsonTokenType.PropertyName)
+            {
+                if (currentPropertyNameEscaped != null)
+                {
+                    stack.PushPropertyName(currentPropertyNameEscaped);
+                }
+                else
+                {
+                    stack.PushPropertyName(currentPropertyNameBuffer, currentPropertyNameLength);
+                }
+            }
             else if (stack.Count == 0 && currentToken == JsonTokenType.String)
             {
                 // if the stack is empty and the token type is a string, then the document is a raw string with no opening or
                 // closing delimeter. Per smithy spec https://smithy.io/2.0/spec/simple-types.html#document this is allowed
                 // so we should just push the value so that it can be retrieved later.
                 string t = ReadText(ref reader);
-                stack.Push(new PathSegment
-                {
-                    SegmentType = PathSegmentType.Value,
-                    Value = t
-                });
+                stack.PushPropertyName(t);
             }
             else if (currentToken.Value != JsonTokenType.None && stack.Peek().SegmentType != PathSegmentType.Delimiter)
             {
-                // Pop a previously pushed Value segment when a scalar or null follows it. Since property
-                // names are no longer pushed, the only such segment is a raw top-level string; the
-                // Delimiter guard leaves scalars nested inside an object or array untouched.
+                // Pop the property name segment when its value (scalar/null) follows it.
                 stack.Pop();
             }
 
@@ -546,14 +521,14 @@ namespace Amazon.Runtime.Internal.Transform
         private struct PathSegment
         {
             internal PathSegmentType SegmentType { get; set; }
-            internal string Value { get; set; }
+            internal int Length { get; set; }
         }
 
         private class JsonPathStack
         {
-            private Stack<PathSegment> stack = new Stack<PathSegment>();
+            private readonly Stack<PathSegment> stack = new Stack<PathSegment>();
             int currentDepth = 0;
-            private StringBuilder stackStringBuilder = new StringBuilder(128);
+            private readonly StringBuilder stackStringBuilder = new StringBuilder(128);
             private string stackString;
 
             public int CurrentDepth
@@ -565,25 +540,42 @@ namespace Amazon.Runtime.Internal.Transform
             {
                 get
                 {
-                    if (this.stackString == null)                    
+                    if (this.stackString == null)
                         this.stackString = this.stackStringBuilder.ToString();
-                    
+
                     return this.stackString;
                 }
-            }                        
-
-            internal void Push(PathSegment segment)
-            {
-                if (segment.SegmentType == PathSegmentType.Delimiter)
-                {
-                    currentDepth++;
-                }
-
-                stackStringBuilder.Append(segment.Value);
-                stackString = null;
-                stack.Push(segment);
             }
-                        
+
+            internal void PushDelimiter()
+            {
+                currentDepth++;
+                stackStringBuilder.Append('/');
+                stackString = null;
+                stack.Push(new PathSegment { SegmentType = PathSegmentType.Delimiter, Length = 1 });
+            }
+
+            internal void PushPropertyName(byte[] buffer, int length)
+            {
+                // No try/finally needed: buffer contents are already validated UTF-8 by System.Text.Json,
+                // so GetChars and Append cannot throw here.
+                var charCount = Encoding.UTF8.GetCharCount(buffer, 0, length);
+                var chars = ArrayPool<char>.Shared.Rent(charCount);
+                Encoding.UTF8.GetChars(buffer, 0, length, chars, 0);
+                stackStringBuilder.Append(chars, 0, charCount);
+                ArrayPool<char>.Shared.Return(chars);
+
+                stackString = null;
+                stack.Push(new PathSegment { SegmentType = PathSegmentType.Value, Length = charCount });
+            }
+
+            internal void PushPropertyName(string escaped)
+            {
+                stackStringBuilder.Append(escaped);
+                stackString = null;
+                stack.Push(new PathSegment { SegmentType = PathSegmentType.Value, Length = escaped.Length });
+            }
+
             internal PathSegment Pop()
             {
                 var segment = this.stack.Pop();
@@ -592,11 +584,11 @@ namespace Amazon.Runtime.Internal.Transform
                     currentDepth--;
                 }
 
-                stackStringBuilder.Remove(stackStringBuilder.Length - segment.Value.Length, segment.Value.Length);
+                stackStringBuilder.Remove(stackStringBuilder.Length - segment.Length, segment.Length);
                 stackString = null;
                 return segment;
             }
-            
+
             internal PathSegment Peek()
             {
                 return this.stack.Peek();

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -55,18 +54,6 @@ namespace Amazon.Runtime.Internal.Transform
         private JsonTokenType? currentToken = null;
         private bool disposed = false;
         private bool wasPeeked = false;
-
-        // Property names are pushed onto the path stack's StringBuilder on each PropertyName token
-        // via a pooled char[] (no string allocation on the hot path). The path string is only
-        // materialized (via StringBuilder.ToString) when CurrentPath is actually read — typically only
-        // on exception for diagnostics, or by the legacy path-based TestExpression(string, int) overload
-        // used by older service packages. We also capture the current property name into a reused pooled
-        // buffer for reader-based TestExpression matching (ValueTextEquals).
-        private byte[] currentPropertyNameBuffer = null;
-        private int currentPropertyNameLength = 0;
-        // Set only when a property name contains JSON escapes, where a raw-byte copy can't be compared
-        // against the unescaped expression the legacy overload expects.
-        private string currentPropertyNameEscaped = null;
         #endregion
 
         #region Constructors
@@ -228,8 +215,8 @@ namespace Amazon.Runtime.Internal.Transform
         /// </summary>
         /// <remarks>
         /// The path stack tracks both depth delimiters and property names. The string is only
-        /// materialized (via StringBuilder.ToString) when this property is read — typically on
-        /// exception for diagnostics, or by the legacy path-based TestExpression overload.
+        /// materialized when this property is read — typically on exception for diagnostics,
+        /// or by the legacy path-based TestExpression overload.
         /// </remarks>
         public override string CurrentPath
         {
@@ -393,48 +380,9 @@ namespace Amazon.Runtime.Internal.Transform
             return peek;
         }
 
-        /// <summary>
-        /// Captures the current property name into a reused pooled buffer for reader-based
-        /// TestExpression matching (ValueTextEquals). The name is also pushed onto the path
-        /// stack in <see cref="UpdateContext"/> for CurrentPath diagnostics.
-        /// </summary>
-        private void CaptureCurrentPropertyName(ref StreamingUtf8JsonReader reader)
-        {
-            if (currentToken != JsonTokenType.PropertyName)
-            {
-                return;
-            }
-
-            currentPropertyNameEscaped = null;
-
-            ReadOnlySpan<byte> name = reader.Reader.ValueSpan;
-
-            // Property names containing JSON escape sequences are vanishingly rare for AWS shapes. In that
-            // case decode to a string so the legacy comparison sees the unescaped name; the hot path for
-            // ordinary identifiers only copies the raw bytes.
-            if (name.IndexOf((byte)'\\') >= 0)
-            {
-                currentPropertyNameEscaped = reader.Reader.GetString();
-                currentPropertyNameLength = 0;
-                return;
-            }
-
-            if (currentPropertyNameBuffer == null || currentPropertyNameBuffer.Length < name.Length)
-            {
-                if (currentPropertyNameBuffer != null)
-                    ArrayPool<byte>.Shared.Return(currentPropertyNameBuffer);
-                currentPropertyNameBuffer = ArrayPool<byte>.Shared.Rent(name.Length);
-            }
-
-            name.CopyTo(currentPropertyNameBuffer);
-            currentPropertyNameLength = name.Length;
-        }
-
         private void UpdateContext(ref StreamingUtf8JsonReader reader)
         {
             if (!currentToken.HasValue) return;
-
-            CaptureCurrentPropertyName(ref reader);
 
             if (currentToken.Value == JsonTokenType.StartObject || currentToken.Value == JsonTokenType.StartArray)
             {
@@ -456,13 +404,15 @@ namespace Amazon.Runtime.Internal.Transform
             }
             else if (currentToken.Value == JsonTokenType.PropertyName)
             {
-                if (currentPropertyNameEscaped != null)
+                ReadOnlySpan<byte> name = reader.Reader.ValueSpan;
+                if (name.IndexOf((byte)'\\') >= 0)
                 {
-                    stack.PushPropertyName(currentPropertyNameEscaped);
+                    // The name contains JSON escape sequences; decode it so the path shows the unescaped name.
+                    stack.PushPropertyName(reader.Reader.GetString());
                 }
                 else
                 {
-                    stack.PushPropertyName(currentPropertyNameBuffer, currentPropertyNameLength);
+                    stack.PushPropertyName(name);
                 }
             }
             else if (stack.Count == 0 && currentToken == JsonTokenType.String)
@@ -499,12 +449,6 @@ namespace Amazon.Runtime.Internal.Transform
                         baseStream.Dispose();
                         baseStream = null;
                     }
-
-                    if (currentPropertyNameBuffer != null)
-                    {
-                        ArrayPool<byte>.Shared.Return(currentPropertyNameBuffer);
-                        currentPropertyNameBuffer = null;
-                    }
                 }
                 disposed = true;
             }
@@ -528,7 +472,13 @@ namespace Amazon.Runtime.Internal.Transform
         {
             private readonly Stack<PathSegment> stack = new Stack<PathSegment>();
             int currentDepth = 0;
-            private readonly StringBuilder stackStringBuilder = new StringBuilder(128);
+            // The current path as UTF-8 bytes. Delimiters and property names are appended as they
+            // are read and trimmed back off (by adjusting pathLength) as their scopes close. The
+            // path string is only materialized when CurrentPath is read — typically on exception
+            // for diagnostics, or by the legacy path-based TestExpression(string, int) overload
+            // used by service packages generated before reader-based matching existed.
+            private byte[] pathBytes = new byte[256];
+            private int pathLength = 0;
             private string stackString;
 
             public int CurrentDepth
@@ -540,8 +490,7 @@ namespace Amazon.Runtime.Internal.Transform
             {
                 get
                 {
-                    if (this.stackString == null)
-                        this.stackString = this.stackStringBuilder.ToString();
+                    this.stackString ??= Encoding.UTF8.GetString(pathBytes, 0, pathLength);
 
                     return this.stackString;
                 }
@@ -550,30 +499,29 @@ namespace Amazon.Runtime.Internal.Transform
             internal void PushDelimiter()
             {
                 currentDepth++;
-                stackStringBuilder.Append('/');
+                EnsureCapacity(1);
+                pathBytes[pathLength++] = (byte)'/';
                 stackString = null;
                 stack.Push(new PathSegment { SegmentType = PathSegmentType.Delimiter, Length = 1 });
             }
 
-            internal void PushPropertyName(byte[] buffer, int length)
+            internal void PushPropertyName(ReadOnlySpan<byte> utf8Name)
             {
-                // No try/finally needed: buffer contents are already validated UTF-8 by System.Text.Json,
-                // so GetChars and Append cannot throw here.
-                var charCount = Encoding.UTF8.GetCharCount(buffer, 0, length);
-                var chars = ArrayPool<char>.Shared.Rent(charCount);
-                Encoding.UTF8.GetChars(buffer, 0, length, chars, 0);
-                stackStringBuilder.Append(chars, 0, charCount);
-                ArrayPool<char>.Shared.Return(chars);
-
+                EnsureCapacity(utf8Name.Length);
+                utf8Name.CopyTo(pathBytes.AsSpan(pathLength));
+                pathLength += utf8Name.Length;
                 stackString = null;
-                stack.Push(new PathSegment { SegmentType = PathSegmentType.Value, Length = charCount });
+                stack.Push(new PathSegment { SegmentType = PathSegmentType.Value, Length = utf8Name.Length });
             }
 
-            internal void PushPropertyName(string escaped)
+            internal void PushPropertyName(string name)
             {
-                stackStringBuilder.Append(escaped);
+                var byteCount = Encoding.UTF8.GetByteCount(name);
+                EnsureCapacity(byteCount);
+                Encoding.UTF8.GetBytes(name, 0, name.Length, pathBytes, pathLength);
+                pathLength += byteCount;
                 stackString = null;
-                stack.Push(new PathSegment { SegmentType = PathSegmentType.Value, Length = escaped.Length });
+                stack.Push(new PathSegment { SegmentType = PathSegmentType.Value, Length = byteCount });
             }
 
             internal PathSegment Pop()
@@ -584,9 +532,25 @@ namespace Amazon.Runtime.Internal.Transform
                     currentDepth--;
                 }
 
-                stackStringBuilder.Remove(stackStringBuilder.Length - segment.Length, segment.Length);
+                pathLength -= segment.Length;
                 stackString = null;
                 return segment;
+            }
+
+            /// <summary>
+            /// Grows <see cref="pathBytes"/> if needed to fit <paramref name="additionalBytes"/> more bytes.
+            /// The buffer is doubled (or grown to the required size, whichever is larger) and never
+            /// shrinks; Pop only moves <see cref="pathLength"/> back, so the buffer is reused for the
+            /// remainder of the document.
+            /// </summary>
+            private void EnsureCapacity(int additionalBytes)
+            {
+                if (pathLength + additionalBytes <= pathBytes.Length)
+                {
+                    return;
+                }
+
+                Array.Resize(ref pathBytes, Math.Max(pathBytes.Length * 2, pathLength + additionalBytes));
             }
 
             internal PathSegment Peek()

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
@@ -418,7 +418,7 @@ namespace Amazon.Runtime.Internal.Transform
             else if (stack.Count == 0 && currentToken == JsonTokenType.String)
             {
                 // if the stack is empty and the token type is a string, then the document is a raw string with no opening or
-                // closing delimeter. Per smithy spec https://smithy.io/2.0/spec/simple-types.html#document this is allowed
+                // closing delimiter. Per smithy spec https://smithy.io/2.0/spec/simple-types.html#document this is allowed
                 // so we should just push the value so that it can be retrieved later.
                 string t = ReadText(ref reader);
                 stack.PushPropertyName(t);

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/JsonUnmarshallerContext.cs
@@ -13,8 +13,8 @@
  * permissions and limitations under the License.
  */
 using System;
+using System.Buffers;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Text;
 using Amazon.Runtime.Internal.Util;
@@ -449,6 +449,8 @@ namespace Amazon.Runtime.Internal.Transform
                         baseStream.Dispose();
                         baseStream = null;
                     }
+
+                    stack.Dispose();
                 }
                 disposed = true;
             }
@@ -468,7 +470,7 @@ namespace Amazon.Runtime.Internal.Transform
             internal int Length { get; set; }
         }
 
-        private class JsonPathStack
+        private class JsonPathStack : IDisposable
         {
             private readonly Stack<PathSegment> stack = new Stack<PathSegment>();
             int currentDepth = 0;
@@ -477,7 +479,7 @@ namespace Amazon.Runtime.Internal.Transform
             // path string is only materialized when CurrentPath is read — typically on exception
             // for diagnostics, or by the legacy path-based TestExpression(string, int) overload
             // used by service packages generated before reader-based matching existed.
-            private byte[] pathBytes = new byte[256];
+            private byte[] pathBytes = ArrayPool<byte>.Shared.Rent(256);
             private int pathLength = 0;
             private string stackString;
 
@@ -539,9 +541,8 @@ namespace Amazon.Runtime.Internal.Transform
 
             /// <summary>
             /// Grows <see cref="pathBytes"/> if needed to fit <paramref name="additionalBytes"/> more bytes.
-            /// The buffer is doubled (or grown to the required size, whichever is larger) and never
-            /// shrinks; Pop only moves <see cref="pathLength"/> back, so the buffer is reused for the
-            /// remainder of the document.
+            /// The old buffer is returned to the pool and a new one rented. Pop only moves
+            /// <see cref="pathLength"/> back, so the buffer is reused for the remainder of the document.
             /// </summary>
             private void EnsureCapacity(int additionalBytes)
             {
@@ -550,7 +551,20 @@ namespace Amazon.Runtime.Internal.Transform
                     return;
                 }
 
-                Array.Resize(ref pathBytes, Math.Max(pathBytes.Length * 2, pathLength + additionalBytes));
+                var newSize = Math.Max(pathBytes.Length * 2, pathLength + additionalBytes);
+                var newBuffer = ArrayPool<byte>.Shared.Rent(newSize);
+                Buffer.BlockCopy(pathBytes, 0, newBuffer, 0, pathLength);
+                ArrayPool<byte>.Shared.Return(pathBytes);
+                pathBytes = newBuffer;
+            }
+
+            public void Dispose()
+            {
+                if (pathBytes != null)
+                {
+                    ArrayPool<byte>.Shared.Return(pathBytes);
+                    pathBytes = null;
+                }
             }
 
             internal PathSegment Peek()

--- a/sdk/test/UnitTests/Custom/Marshalling/ErrorUnmarshallingTests.cs
+++ b/sdk/test/UnitTests/Custom/Marshalling/ErrorUnmarshallingTests.cs
@@ -176,9 +176,10 @@ namespace AWSSDK.UnitTests.Custom.Marshalling
 
         [TestMethod]
         [TestCategory("UnitTest")]
-        public void UnmarshalJsonExceptionIncludesDeeplyNestedPropertyInLastKnownLocation()
+        [DataRow("{\"Item\":{\"topKey\":{\"M\":{\"deepKey\":{\"M\":{\"deeperKey\":{\"S\":[[[invalid}}}}}}}", "/Item/topKey/M/deepKey/M/deeperKey/S/", DisplayName = "Deeply nested")]
+        [DataRow("{\"Item\":{\"top\\u0041Key\":{\"S\":[[[invalid}}}", "/Item/topAKey/S/", DisplayName = "Escaped property name")]
+        public void UnmarshalJsonExceptionLastKnownLocationReflectsFullPath(string json, string expectedPath)
         {
-            var json = "{\"Item\":{\"topKey\":{\"M\":{\"deepKey\":{\"M\":{\"deeperKey\":{\"S\":[[[invalid}}}}}}}";
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
             var webResponse = new WebResponseData { StatusCode = HttpStatusCode.OK };
             webResponse.Headers.Add("Content-Length", stream.Length.ToString());
@@ -192,8 +193,7 @@ namespace AWSSDK.UnitTests.Custom.Marshalling
             }
             catch (AmazonUnmarshallingException ex)
             {
-                Assert.IsNotNull(ex.LastKnownLocation);
-                Assert.AreEqual("/Item/topKey/M/deepKey/M/deeperKey/S/", ex.LastKnownLocation);
+                Assert.AreEqual(expectedPath, ex.LastKnownLocation);
             }
         }
 

--- a/sdk/test/UnitTests/Custom/Marshalling/ErrorUnmarshallingTests.cs
+++ b/sdk/test/UnitTests/Custom/Marshalling/ErrorUnmarshallingTests.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.DynamoDBv2.Model.Internal.MarshallTransformations;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Transform;
@@ -20,6 +21,7 @@ using Amazon.Runtime.Internal.Util;
 using Amazon.Util;
 using AWSSDK_DotNet.UnitTests.TestTools;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Net;
 using System.Text;
 
@@ -170,6 +172,29 @@ namespace AWSSDK.UnitTests.Custom.Marshalling
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Message);
             Assert.AreEqual(ErrorType.Unknown, response.Type);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        public void UnmarshalJsonExceptionIncludesDeeplyNestedPropertyInLastKnownLocation()
+        {
+            var json = "{\"Item\":{\"topKey\":{\"M\":{\"deepKey\":{\"M\":{\"deeperKey\":{\"S\":[[[invalid}}}}}}}";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            var webResponse = new WebResponseData { StatusCode = HttpStatusCode.OK };
+            webResponse.Headers.Add("Content-Length", stream.Length.ToString());
+            webResponse.Headers.Add(HeaderKeys.RequestIdHeader, "test-request-id");
+            var context = new JsonUnmarshallerContext(stream, false, webResponse);
+
+            try
+            {
+                GetItemResponseUnmarshaller.Instance.UnmarshallResponse(context);
+                Assert.Fail("Expected AmazonUnmarshallingException");
+            }
+            catch (AmazonUnmarshallingException ex)
+            {
+                Assert.IsNotNull(ex.LastKnownLocation);
+                Assert.AreEqual("/Item/topKey/M/deepKey/M/deeperKey/S/", ex.LastKnownLocation);
+            }
         }
 
         private void RunJsonErrorUnmarshallingTest(string body, string xAmzErrorTypeValue, string xAmznErrorMessageValue,


### PR DESCRIPTION
After #4422 was merged, Muhammad noticed there was a regression where the `LastKnownLocation` property of the `AmazonUnmarshallingException` (which is thrown if the JSON parsing fails) did not contain the same value as before. I added a test, but the code in `main` today would only return the delimiters (i.e. "////////").

I have two commits on this branch:
- First one is the initial attempt to restore the previous behaviour. It worked (the dry-run succeeded), but it erased the latency wins from the PR (which we're still interested in)
- Second one leverages the fact that the `Utf8JsonReader` already has the property names as UTF-8 bytes, and it uses a single `byte[]` instead of a StringBuilder

## Testing
Ran the relevant benchmarks on my personal laptop (a Mac but ran before and after so that we could compare apples-to-apples):
| Benchmark | pre-PR #4422 | main | proposed fix |
|---|---:|---:|---:|
| GetItemOutput_S | 1,714.9 ns / 7.34 KB | 1,414.5 ns / 6.57 KB | 1,390.4 ns / 6.55 KB |
| GetItemOutput_M | 5,461.3 ns / 13.76 KB | 4,464.8 ns / 11.23 KB | 4,382.0 ns / 11.21 KB |
| GetItemOutput_L | 12,951.4 ns / 25.85 KB | 10,200.5 ns / 19.80 KB | 10,113.3 ns / 19.79 KB |

### Dry-runs
- **DotNet Dry-run ID:** `289cd0f7-dfb5-4297-9727-dc35ad67409f`
  - [X] Completed
- **PowerShell Dry-run ID:** `5fa7fcdb-38de-4fe2-a3e6-4d3c8abff6ef`
  - [X] Completed

## Breaking Changes Assessment
N/A

## License
- [X] I confirm that this pull request can be released under the Apache 2 license