### PR TITLE
Fix benchmark mock handler and add large payload benchmarks for RestJson1 E2E tests

### DIFF
--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/MockHttpHandler.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/MockHttpHandler.cs
@@ -41,9 +41,12 @@ public class MockHttpHandler : HttpMessageHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        // Drain the request content to ensure full serialization cost is measured
+        // Drain the request content to simulate the serialization cost.
+        // In production, HttpClient calls content.SerializeToStreamAsync(networkStream) which
+        // for ReadOnlyMemoryContent writes the span directly without allocating a byte[] copy.
+        // CopyToAsync(Stream.Null) mirrors this behavior without network I/O.
         if (request.Content != null)
-            await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            await request.Content.CopyToAsync(Stream.Null, cancellationToken).ConfigureAwait(false);
 
         var response = new HttpResponseMessage(_statusCode)
         {

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestJson1E2EBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestJson1E2EBenchmarks.cs
@@ -37,8 +37,10 @@ public class RestJson1E2EBenchmarks
     private AmazonRestJsonDataPlaneClient _getClientL = null!;
     private AmazonRestJsonDataPlaneClient _putMetricClientS = null!;
     private AmazonRestJsonDataPlaneClient _putMetricClientM = null!;
+    private AmazonRestJsonDataPlaneClient _putMetricClientL = null!;
     private AmazonRestJsonDataPlaneClient _getMetricClientS = null!;
     private AmazonRestJsonDataPlaneClient _getMetricClientM = null!;
+    private AmazonRestJsonDataPlaneClient _getMetricClientL = null!;
 
     private CopyObjectRequest _copyObjectBaseline = null!;
     private CopyObjectRequest _copyObjectMedium = null!;
@@ -48,8 +50,10 @@ public class RestJson1E2EBenchmarks
     private GetObjectRequest _getObjectRequest = null!;
     private PutMetricDataRequest _putMetricDataS = null!;
     private PutMetricDataRequest _putMetricDataM = null!;
+    private PutMetricDataRequest _putMetricDataL = null!;
     private GetMetricDataRequest _getMetricDataS = null!;
     private GetMetricDataRequest _getMetricDataM = null!;
+    private GetMetricDataRequest _getMetricDataL = null!;
 
     private static readonly byte[] CopyOutputBaseline = Encoding.UTF8.GetBytes("{}");
     private static readonly byte[] CopyOutputM = Encoding.UTF8.GetBytes(
@@ -61,6 +65,7 @@ public class RestJson1E2EBenchmarks
     private static readonly byte[] EmptyJson = Encoding.UTF8.GetBytes("{}");
     private static readonly byte[] GetMetricResponseS = Encoding.UTF8.GetBytes(BuildGetMetricJson(5));
     private static readonly byte[] GetMetricResponseM = Encoding.UTF8.GetBytes(BuildGetMetricJson(50));
+    private static readonly byte[] GetMetricResponseL = Encoding.UTF8.GetBytes(BuildGetMetricJson(500));
 
     private static string BuildGetMetricJson(int datapoints)
     {
@@ -103,8 +108,10 @@ public class RestJson1E2EBenchmarks
         _getClientL = CreateClient(GetObjectL);
         _putMetricClientS = CreateClient(EmptyJson);
         _putMetricClientM = CreateClient(EmptyJson);
+        _putMetricClientL = CreateClient(EmptyJson);
         _getMetricClientS = CreateClient(GetMetricResponseS);
         _getMetricClientM = CreateClient(GetMetricResponseM);
+        _getMetricClientL = CreateClient(GetMetricResponseL);
 
         _copyObjectBaseline = new CopyObjectRequest { Bucket = "bucket", Key = "key", CopySource = "src/key" };
         _copyObjectMedium = new CopyObjectRequest
@@ -120,10 +127,12 @@ public class RestJson1E2EBenchmarks
         _putObjectM = new PutObjectRequest { Bucket = "bucket", Key = "key", Body = new MemoryStream(new byte[100 * 1024]) };
         _putObjectL = new PutObjectRequest { Bucket = "bucket", Key = "key", Body = new MemoryStream(new byte[1024 * 1024]) };
         _getObjectRequest = new GetObjectRequest { Bucket = "bucket", Key = "key" };
-        _putMetricDataS = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(3) };
-        _putMetricDataM = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(20) };
+        _putMetricDataS = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(5) };
+        _putMetricDataM = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(50) };
+        _putMetricDataL = new PutMetricDataRequest { Namespace = "Test", MetricData = CreateMetricData(500) };
         _getMetricDataS = new GetMetricDataRequest { StartTime = DateTime.UtcNow.AddHours(-1), EndTime = DateTime.UtcNow, MetricDataQueries = CreateQueries(1) };
         _getMetricDataM = new GetMetricDataRequest { StartTime = DateTime.UtcNow.AddHours(-1), EndTime = DateTime.UtcNow, MetricDataQueries = CreateQueries(5) };
+        _getMetricDataL = new GetMetricDataRequest { StartTime = DateTime.UtcNow.AddHours(-1), EndTime = DateTime.UtcNow, MetricDataQueries = CreateQueries(25) };
     }
 
     private static List<MetricDatum> CreateMetricData(int count)
@@ -152,8 +161,10 @@ public class RestJson1E2EBenchmarks
     [Benchmark] public async Task restJson1_e2e_GetObject_L() => await _getClientL.GetObjectAsync(_getObjectRequest);
     [Benchmark] public async Task restJson1_e2e_PutMetricData_S() => await _putMetricClientS.PutMetricDataAsync(_putMetricDataS);
     [Benchmark] public async Task restJson1_e2e_PutMetricData_M() => await _putMetricClientM.PutMetricDataAsync(_putMetricDataM);
+    [Benchmark] public async Task restJson1_e2e_PutMetricData_L() => await _putMetricClientL.PutMetricDataAsync(_putMetricDataL);
     [Benchmark] public async Task restJson1_e2e_GetMetricData_S() => await _getMetricClientS.GetMetricDataAsync(_getMetricDataS);
     [Benchmark] public async Task restJson1_e2e_GetMetricData_M() => await _getMetricClientM.GetMetricDataAsync(_getMetricDataM);
+    [Benchmark] public async Task restJson1_e2e_GetMetricData_L() => await _getMetricClientL.GetMetricDataAsync(_getMetricDataL);
 
     [GlobalCleanup]
     public void Cleanup()
@@ -166,7 +177,9 @@ public class RestJson1E2EBenchmarks
         _getClientL?.Dispose();
         _putMetricClientS?.Dispose();
         _putMetricClientM?.Dispose();
+        _putMetricClientL?.Dispose();
         _getMetricClientS?.Dispose();
         _getMetricClientM?.Dispose();
+        _getMetricClientL?.Dispose();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed request content draining from `ReadAsByteArrayAsync()` to `CopyToAsync(Stream.Null)`.
In production, `HttpClient.SendAsync` calls `content.SerializeToStreamAsync(networkStream)` which for `ReadOnlyMemoryContent` writes the memory span directly to the stream without allocating a `byte[]` copy. The previous approach (`ReadAsByteArrayAsync`) forces an internal copy (MemoryStream → ToArray()), which inflated allocation numbers and masked the improvements from the zero-copy marshalling pipeline changes.

Add large (L) payload benchmarks for PutMetricData and GetMetricData operations
<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-8586`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
Verified serde benchmarks compile and run successfully locally.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 2f262f8e-d492-41ff-9300-d3afec8f2329
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 608a1d29-81e9-462e-89ba-a591da3f2794
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
