### PR TITLE
Apply PooledContentStream optimization to S3 custom XML marshallers

### DIFF
--- a/generator/.DevConfigs/7aa26d13-a234-41c9-ae9e-cc0c07f0d89b.json
+++ b/generator/.DevConfigs/7aa26d13-a234-41c9-ae9e-cc0c07f0d89b.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Apply PooledContentStream optimization to S3 custom XML marshallers."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutACLRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/PutACLRequestMarshaller.cs
@@ -65,16 +65,16 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             if (putObjectAclRequest.IsSetVersionId())
                 request.AddSubResource("versionId", S3Transforms.ToStringValue(putObjectAclRequest.VersionId));
 
-            var stringWriter = new XMLEncodedStringWriter(System.Globalization.CultureInfo.InvariantCulture);
-            using (
-                var xmlWriter = XmlWriter.Create(stringWriter,
-                                                 new XmlWriterSettings()
-                                                     {
-                                                         Encoding = Encoding.UTF8,
-                                                         OmitXmlDeclaration = true,
-                                                         NewLineHandling = NewLineHandling.Entitize
-                                                     }))
+#if !NETFRAMEWORK
+            request.ContentStream = new PooledContentStream();
+            var bufferTextWriter = new XMLEncodedBufferTextWriter(((PooledContentStream)request.ContentStream).BufferWriter);
+            using (var xmlWriter = XmlWriter.Create(bufferTextWriter, new XmlWriterSettings() { Encoding = Encoding.UTF8, OmitXmlDeclaration = true, NewLineHandling = NewLineHandling.Entitize }))
             {
+#else
+            var stringWriter = new XMLEncodedStringWriter(System.Globalization.CultureInfo.InvariantCulture);
+            using (var xmlWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings() { Encoding = Encoding.UTF8, OmitXmlDeclaration = true, NewLineHandling = NewLineHandling.Entitize }))
+            {
+#endif
                 var accessControlPolicyAccessControlPolicy = putObjectAclRequest.AccessControlList;
                 if (accessControlPolicyAccessControlPolicy != null)
                 {
@@ -92,7 +92,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                             xmlWriter.WriteStartElement("Owner");
                             if (ownerOwner.IsSetDisplayName())
                             {
-                                xmlWriter.WriteElementString("DisplayName", 
+                                xmlWriter.WriteElementString("DisplayName",
                                                              S3Transforms.ToXmlStringValue(ownerOwner.DisplayName));
                             }
                             if (ownerOwner.IsSetId())
@@ -109,14 +109,16 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             try
             {
+#if NETFRAMEWORK
                 var content = stringWriter.ToString();
                 request.Content = Encoding.UTF8.GetBytes(content);
+#endif
                 request.Headers[HeaderKeys.ContentTypeHeader] = "application/xml";
 
                 ChecksumUtils.SetChecksumData(
-                    request, 
-                    putObjectAclRequest.ChecksumAlgorithm, 
-                    fallbackToMD5: false, 
+                    request,
+                    putObjectAclRequest.ChecksumAlgorithm,
+                    fallbackToMD5: false,
                     isRequestChecksumRequired: true,
                     headerName: S3Constants.AmzHeaderSdkChecksumAlgorithm
                 );

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/SelectObjectContentRequestMarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/SelectObjectContentRequestMarshaller.cs
@@ -127,47 +127,54 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             request.AddSubResource("select-type", "2");
 
             // Parameters
-            using (var stringWriter = new XMLEncodedStringWriter(CultureInfo.InvariantCulture))
+            var xmlWriterSettings = new XmlWriterSettings()
             {
-                var xmlWriterSettings = new XmlWriterSettings()
+                Encoding = Encoding.UTF8,
+                OmitXmlDeclaration = true,
+                NewLineHandling = NewLineHandling.Entitize
+            };
+#if !NETFRAMEWORK
+            request.ContentStream = new PooledContentStream();
+            var bufferTextWriter = new XMLEncodedBufferTextWriter(((PooledContentStream)request.ContentStream).BufferWriter);
+            using (var xmlWriter = XmlWriter.Create(bufferTextWriter, xmlWriterSettings))
+            {
+#else
+            var stringWriter = new XMLEncodedStringWriter(CultureInfo.InvariantCulture);
+            using (var xmlWriter = XmlWriter.Create(stringWriter, xmlWriterSettings))
+            {
+#endif
+                xmlWriter.WriteStartElement("SelectObjectContentRequest", S3Constants.S3RequestXmlNamespace);
+                xmlWriter.WriteElementString("Expression",
+                    S3Transforms.ToXmlStringValue(selectObjectContentRequest.Expression));
+                xmlWriter.WriteElementString("ExpressionType",
+                    S3Transforms.ToXmlStringValue(selectObjectContentRequest.ExpressionType.Value));
+                selectObjectContentRequest.InputSerialization.Marshall("InputSerialization", xmlWriter);
+                selectObjectContentRequest.OutputSerialization.Marshall("OutputSerialization", xmlWriter);
+                xmlWriter.WriteStartElement("RequestProgress");
+                xmlWriter.WriteElementString("Enabled",
+                    selectObjectContentRequest.RequestProgress.GetValueOrDefault(false).ToString()
+                        .ToUpperInvariant());
+                xmlWriter.WriteEndElement();
+                if (selectObjectContentRequest.IsSetScanRange())
                 {
-                    Encoding = Encoding.UTF8,
-                    OmitXmlDeclaration = true,
-                    NewLineHandling = NewLineHandling.Entitize
-                };
-                using (var xmlWriter = XmlWriter.Create(stringWriter, xmlWriterSettings))
-                {
-                    xmlWriter.WriteStartElement("SelectObjectContentRequest", S3Constants.S3RequestXmlNamespace);
-                    xmlWriter.WriteElementString("Expression",
-                        S3Transforms.ToXmlStringValue(selectObjectContentRequest.Expression));
-                    xmlWriter.WriteElementString("ExpressionType",
-                        S3Transforms.ToXmlStringValue(selectObjectContentRequest.ExpressionType.Value));
-                    selectObjectContentRequest.InputSerialization.Marshall("InputSerialization", xmlWriter);
-                    selectObjectContentRequest.OutputSerialization.Marshall("OutputSerialization", xmlWriter);
-                    xmlWriter.WriteStartElement("RequestProgress");
-                    xmlWriter.WriteElementString("Enabled",
-                        selectObjectContentRequest.RequestProgress.GetValueOrDefault(false).ToString()
-                            .ToUpperInvariant());
-                    xmlWriter.WriteEndElement();
-                    if (selectObjectContentRequest.IsSetScanRange())
-                    {
-                        selectObjectContentRequest.ScanRange.Marshall("ScanRange", xmlWriter);
-                    }
-                    xmlWriter.WriteEndElement();
+                    selectObjectContentRequest.ScanRange.Marshall("ScanRange", xmlWriter);
                 }
+                xmlWriter.WriteEndElement();
+            }
 
-                try
-                {
-                    var content = stringWriter.ToString();
-                    request.Content = Encoding.UTF8.GetBytes(content);
-                    request.Headers[HeaderKeys.ContentTypeHeader] = "application/xml";
+            try
+            {
+#if NETFRAMEWORK
+                var content = stringWriter.ToString();
+                request.Content = Encoding.UTF8.GetBytes(content);
+#endif
+                request.Headers[HeaderKeys.ContentTypeHeader] = "application/xml";
 
-                    ChecksumUtils.SetChecksumData(request);
-                }
-                catch (EncoderFallbackException e)
-                {
-                    throw new AmazonServiceException("Unable to marshall request to XML", e);
-                }
+                ChecksumUtils.SetChecksumData(request);
+            }
+            catch (EncoderFallbackException e)
+            {
+                throw new AmazonServiceException("Unable to marshall request to XML", e);
             }
 
             return request;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Applies the same `PooledContentStream` + `XMLEncodedBufferTextWriter` optimization to the two hand-written S3 custom marshallers that were missed by the template generator update in #4424.

## Motivation and Context
`DOTNET-8683`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
Tests the affected operations.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 15452733-231b-4fd5-964d-982b04613923
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** c403b42c-6108-4b76-b81a-ed0baacac534
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement