### PR TITLE
Re-resolve default-chain credentials when the shared credentials file changes

### DIFF
--- a/generator/.DevConfigs/4fc0120c-965d-42cc-a1e2-1ab9427e6525.json
+++ b/generator/.DevConfigs/4fc0120c-965d-42cc-a1e2-1ab9427e6525.json
@@ -3,7 +3,7 @@
     "updateMinimum": true,
     "type": "patch",
     "changeLogMessages": [
-      "Invalidate the DefaultAWSCredentialsIdentityResolver default-chain credential cache when the shared credentials file is modified, so static credentials (BasicAWSCredentials/SessionAWSCredentials) rotated by an external tool are picked up mid-process without requiring a restart. "
+      "Invalidate the DefaultAWSCredentialsIdentityResolver default-chain credential cache when the shared credentials file is modified, so credentials rotated by an external tool are picked up mid-process without requiring a restart."
     ]
   }
 }

--- a/generator/.DevConfigs/4fc0120c-965d-42cc-a1e2-1ab9427e6525.json
+++ b/generator/.DevConfigs/4fc0120c-965d-42cc-a1e2-1ab9427e6525.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Invalidate the DefaultAWSCredentialsIdentityResolver default-chain credential cache when the shared credentials file is modified, so static credentials (BasicAWSCredentials/SessionAWSCredentials) rotated by an external tool are picked up mid-process without requiring a restart. "
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/CachedProfileCredentialResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/CachedProfileCredentialResolver.cs
@@ -191,7 +191,7 @@ namespace Amazon.Runtime.Credentials
         /// 2. Else if <see cref="AWSConfigs.AWSProfilesLocation"/> is set, use that.
         /// 3. Else fall back to <see cref="SharedCredentialsFile.DefaultFilePath"/>.
         /// </summary>
-        private static string GetEffectiveCredentialsFilePath(string profilesLocation)
+        internal static string GetEffectiveCredentialsFilePath(string profilesLocation)
         {
             if (!string.IsNullOrEmpty(profilesLocation))
                 return profilesLocation;
@@ -212,7 +212,7 @@ namespace Amazon.Runtime.Credentials
         /// 3. <see cref="AWSConfigs.DisableLegacyPersistenceStore"/> is false.
         /// This mirrors the same conditions used by <see cref="CredentialProfileStoreChain.TryGetProfile"/>.
         /// </summary>
-        private static string GetNetSdkCredentialsFilePath(string profilesLocation)
+        internal static string GetNetSdkCredentialsFilePath(string profilesLocation)
         {
             if (!string.IsNullOrEmpty(profilesLocation))
                 return null;
@@ -228,74 +228,6 @@ namespace Amazon.Runtime.Credentials
                 return null;
 
             return Path.Combine(settingsFolder, SettingsConstants.RegisteredProfiles + ".json");
-        }
-
-        /// <summary>
-        /// A shared file system watcher for a single file path. Multiple <see cref="ProfileCredentialEntry"/>
-        /// instances may depend on the same file (e.g., <c>~/.aws/config</c>), but only one OS-level
-        /// watcher is created per unique file path.
-        /// <para />
-        /// When a change is detected, a monotonic <see cref="ChangeToken"/> is incremented. Each
-        /// <see cref="ProfileCredentialEntry"/> stores the token value it last observed; validity is
-        /// determined by comparing the stored token to the current token rather than resetting shared state.
-        /// This avoids cross-entry interference when multiple profiles depend on the same file.
-        /// </summary>
-        private sealed class SharedFileWatcher : IDisposable
-        {
-            private long _changeToken;
-            private readonly FileSystemWatcher _watcher;
-
-            /// <summary>
-            /// Gets the current monotonic change token. Each file system event increments this value.
-            /// Entries compare their last-seen token against this to determine staleness.
-            /// </summary>
-            public long ChangeToken => Interlocked.Read(ref _changeToken);
-
-            public SharedFileWatcher(string filePath)
-            {
-                _watcher = TryCreateWatcher(filePath);
-            }
-
-            private FileSystemWatcher TryCreateWatcher(string filePath)
-            {
-                var directory = Path.GetDirectoryName(filePath);
-                var fileName = Path.GetFileName(filePath);
-
-                if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
-                    return null;
-
-                try
-                {
-                    var watcher = new FileSystemWatcher(directory, fileName)
-                    {
-                        NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName,
-                        EnableRaisingEvents = true
-                    };
-                    watcher.Changed += OnFileEvent;
-                    watcher.Created += OnFileEvent;
-                    watcher.Deleted += OnFileEvent;
-                    watcher.Renamed += OnFileRenamed;
-                    // Treat buffer overflow as a change — fail safe rather than returning stale credentials.
-                    watcher.Error += OnWatcherError;
-                    return watcher;
-                }
-                catch (Exception ex) when (!(ex is OutOfMemoryException))
-                {
-                    // If we can't create a watcher (e.g., unsupported filesystem, invalid path,
-                    // or I/O error), return null. The cache will never auto-invalidate for this
-                    // file, but credentials will still be re-resolved on application restart.
-                    return null;
-                }
-            }
-
-            private void OnFileEvent(object sender, FileSystemEventArgs e) => Interlocked.Increment(ref _changeToken);
-            private void OnFileRenamed(object sender, RenamedEventArgs e) => Interlocked.Increment(ref _changeToken);
-            private void OnWatcherError(object sender, ErrorEventArgs e) => Interlocked.Increment(ref _changeToken);
-
-            public void Dispose()
-            {
-                _watcher?.Dispose();
-            }
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Credentials/CachedProfileCredentialResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/CachedProfileCredentialResolver.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Runtime.CredentialManagement;
 using Amazon.Runtime.Internal.Settings;
+using Amazon.Util.Internal;
 
 namespace Amazon.Runtime.Credentials
 {

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using Amazon.Runtime.CredentialManagement;
 using Amazon.Runtime.Identity;
 using Amazon.Runtime.Internal.Util;
+using Amazon.Util.Internal;
 
 namespace Amazon.Runtime.Credentials
 {
@@ -55,7 +56,6 @@ namespace Amazon.Runtime.Credentials
         private long _lastSeenCredentialsFileToken;
         private long _lastSeenConfigFileToken;
         private long _lastSeenNetSdkFileToken;
-        private volatile bool _cachedCredentialsAreFileBacked;
 
         public DefaultAWSCredentialsIdentityResolver()
         {
@@ -160,19 +160,19 @@ namespace Amazon.Runtime.Credentials
         }
 
         /// <summary>
-        /// Returns true if the cached credentials were resolved from a file (a static
-        /// BasicAWSCredentials / SessionAWSCredentials profile) and any of the backing files have
+        /// Returns true if any of the credentials/config files backing the cached credentials have
         /// changed since they were resolved. Purely an in-memory change-token comparison, no I/O on
         /// this path, so it is safe to call on every credential resolution.
         /// <para />
-        /// Returns false for credential types that refresh themselves (SSO, assume-role, web identity,
-        /// container, instance profile), so a file touch never forces a needless re-resolution of those.
+        /// Invalidation is intentionally not gated on the resolved credential type. Profile edits can
+        /// switch a profile between credential types (e.g., from static keys to <c>source_profile</c>/
+        /// assume-role, or repoint <c>source_profile</c> at a different role) — changes that a
+        /// self-refreshing credential object cannot detect on its own because it keeps using the
+        /// role/values it was constructed with. Re-resolving on any file change is cheap and rare and
+        /// avoids serving credentials from a stale profile definition.
         /// </summary>
         private bool HasCredentialsFileChanged()
         {
-            if (!_cachedCredentialsAreFileBacked)
-                return false;
-
             if (_credentialsFileWatcher != null && _credentialsFileWatcher.ChangeToken != _lastSeenCredentialsFileToken)
                 return true;
 
@@ -186,27 +186,18 @@ namespace Amazon.Runtime.Credentials
         }
 
         /// <summary>
-        /// After the credential chain resolves, set up (or tear down) file-change tracking for the
-        /// newly cached credentials. Tracking is only enabled for static, file-backed credential types
-        /// (<see cref="BasicAWSCredentials"/> / <see cref="SessionAWSCredentials"/>) — the only types
-        /// that read their values from the credentials/config file once and never refresh. Every other
-        /// type manages its own refresh, so file-change invalidation is intentionally skipped for them.
+        /// After the credential chain resolves, capture the current change tokens of the
+        /// credentials/config files so a later <see cref="HasCredentialsFileChanged"/> check can detect
+        /// edits made after this point. Tracking is set up regardless of the resolved credential type:
+        /// a file edit can switch a profile between credential types, which a self-refreshing credential
+        /// object cannot detect on its own, so any file change must invalidate the cache.
         /// <para />
         /// Must only be called while holding <see cref="_credentialResolutionLock"/>, before
         /// <see cref="_cachedCredentials"/> is published, so that a concurrent lock-free reader that
         /// observes the new credentials also observes the tracking state captured here.
         /// </summary>
-        private void UpdateFileChangeTracking(AWSCredentials resolvedCredentials)
+        private void UpdateFileChangeTracking()
         {
-            var type = resolvedCredentials.GetType();
-            var isFileBacked = type == typeof(BasicAWSCredentials) || type == typeof(SessionAWSCredentials);
-
-            if (!isFileBacked)
-            {
-                _cachedCredentialsAreFileBacked = false;
-                return;
-            }
-
             // The default chain resolves the profile with no explicit location override
             // (see _credentialProfileChain), so resolve file paths the same way.
             var credentialsFilePath = CachedProfileCredentialResolver.GetEffectiveCredentialsFilePath(null);
@@ -220,8 +211,6 @@ namespace Amazon.Runtime.Credentials
             _lastSeenCredentialsFileToken = _credentialsFileWatcher?.ChangeToken ?? 0;
             _lastSeenConfigFileToken = _configFileWatcher?.ChangeToken ?? 0;
             _lastSeenNetSdkFileToken = _netSdkCredentialsFileWatcher?.ChangeToken ?? 0;
-
-            _cachedCredentialsAreFileBacked = true;
         }
 
         /// <summary>
@@ -298,7 +287,7 @@ namespace Amazon.Runtime.Credentials
                 // snapshot is being updated.
                 _cachedCredentials = null;
                 _lastKnownEnvironmentState.UpdateEnvironment();
-                UpdateFileChangeTracking(resolvedCredentials);
+                UpdateFileChangeTracking();
                 _cachedCredentials = resolvedCredentials;
                 return resolvedCredentials;
             }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/DefaultAWSCredentialsIdentityResolver.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -47,6 +48,14 @@ namespace Amazon.Runtime.Credentials
         private readonly CachedProfileCredentialResolver _cachedProfileCredentialResolver = new();
         private static readonly Lazy<DefaultAWSCredentialsIdentityResolver> _defaultInstance = new();
         private bool _disposed;
+        private readonly ConcurrentDictionary<string, SharedFileWatcher> _fileWatchers = new();
+        private SharedFileWatcher _credentialsFileWatcher;
+        private SharedFileWatcher _configFileWatcher;
+        private SharedFileWatcher _netSdkCredentialsFileWatcher;
+        private long _lastSeenCredentialsFileToken;
+        private long _lastSeenConfigFileToken;
+        private long _lastSeenNetSdkFileToken;
+        private volatile bool _cachedCredentialsAreFileBacked;
 
         public DefaultAWSCredentialsIdentityResolver()
         {
@@ -142,12 +151,88 @@ namespace Amazon.Runtime.Credentials
             var cached = _cachedCredentials;
             if (cached != null)
             {
-                if (!_lastKnownEnvironmentState.HasEnvironmentChanged())
+                if (!_lastKnownEnvironmentState.HasEnvironmentChanged() && !HasCredentialsFileChanged())
                 {
                     return cached;
                 }
             }
             return null;
+        }
+
+        /// <summary>
+        /// Returns true if the cached credentials were resolved from a file (a static
+        /// BasicAWSCredentials / SessionAWSCredentials profile) and any of the backing files have
+        /// changed since they were resolved. Purely an in-memory change-token comparison, no I/O on
+        /// this path, so it is safe to call on every credential resolution.
+        /// <para />
+        /// Returns false for credential types that refresh themselves (SSO, assume-role, web identity,
+        /// container, instance profile), so a file touch never forces a needless re-resolution of those.
+        /// </summary>
+        private bool HasCredentialsFileChanged()
+        {
+            if (!_cachedCredentialsAreFileBacked)
+                return false;
+
+            if (_credentialsFileWatcher != null && _credentialsFileWatcher.ChangeToken != _lastSeenCredentialsFileToken)
+                return true;
+
+            if (_configFileWatcher != null && _configFileWatcher.ChangeToken != _lastSeenConfigFileToken)
+                return true;
+
+            if (_netSdkCredentialsFileWatcher != null && _netSdkCredentialsFileWatcher.ChangeToken != _lastSeenNetSdkFileToken)
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// After the credential chain resolves, set up (or tear down) file-change tracking for the
+        /// newly cached credentials. Tracking is only enabled for static, file-backed credential types
+        /// (<see cref="BasicAWSCredentials"/> / <see cref="SessionAWSCredentials"/>) — the only types
+        /// that read their values from the credentials/config file once and never refresh. Every other
+        /// type manages its own refresh, so file-change invalidation is intentionally skipped for them.
+        /// <para />
+        /// Must only be called while holding <see cref="_credentialResolutionLock"/>, before
+        /// <see cref="_cachedCredentials"/> is published, so that a concurrent lock-free reader that
+        /// observes the new credentials also observes the tracking state captured here.
+        /// </summary>
+        private void UpdateFileChangeTracking(AWSCredentials resolvedCredentials)
+        {
+            var type = resolvedCredentials.GetType();
+            var isFileBacked = type == typeof(BasicAWSCredentials) || type == typeof(SessionAWSCredentials);
+
+            if (!isFileBacked)
+            {
+                _cachedCredentialsAreFileBacked = false;
+                return;
+            }
+
+            // The default chain resolves the profile with no explicit location override
+            // (see _credentialProfileChain), so resolve file paths the same way.
+            var credentialsFilePath = CachedProfileCredentialResolver.GetEffectiveCredentialsFilePath(null);
+            var configFilePath = SharedCredentialsFile.DefaultConfigFilePath;
+            var netSdkCredentialsFilePath = CachedProfileCredentialResolver.GetNetSdkCredentialsFilePath(null);
+
+            _credentialsFileWatcher = GetOrCreateFileWatcher(credentialsFilePath);
+            _configFileWatcher = GetOrCreateFileWatcher(configFilePath);
+            _netSdkCredentialsFileWatcher = GetOrCreateFileWatcher(netSdkCredentialsFilePath);
+
+            _lastSeenCredentialsFileToken = _credentialsFileWatcher?.ChangeToken ?? 0;
+            _lastSeenConfigFileToken = _configFileWatcher?.ChangeToken ?? 0;
+            _lastSeenNetSdkFileToken = _netSdkCredentialsFileWatcher?.ChangeToken ?? 0;
+
+            _cachedCredentialsAreFileBacked = true;
+        }
+
+        /// <summary>
+        /// Gets or creates a shared file watcher for the given path. Returns null for a null/empty path.
+        /// Multiple resolutions that depend on the same file reuse one watcher, minimizing OS handles.
+        /// </summary>
+        private SharedFileWatcher GetOrCreateFileWatcher(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+                return null;
+            return _fileWatchers.GetOrAdd(filePath, path => new SharedFileWatcher(path));
         }
 
         /// <summary>
@@ -213,6 +298,7 @@ namespace Amazon.Runtime.Credentials
                 // snapshot is being updated.
                 _cachedCredentials = null;
                 _lastKnownEnvironmentState.UpdateEnvironment();
+                UpdateFileChangeTracking(resolvedCredentials);
                 _cachedCredentials = resolvedCredentials;
                 return resolvedCredentials;
             }
@@ -379,6 +465,9 @@ namespace Amazon.Runtime.Credentials
             {
                 _credentialResolutionLock.Dispose();
                 _cachedProfileCredentialResolver.Dispose();
+
+                foreach (var watcher in _fileWatchers.Values)
+                    watcher.Dispose();
             }
             _disposed = true;
         }

--- a/sdk/src/Core/Amazon.Runtime/Credentials/SharedFileWatcher.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/SharedFileWatcher.cs
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.IO;
+using System.Threading;
+
+namespace Amazon.Runtime.Credentials
+{
+    /// <summary>
+    /// A shared file system watcher for a single file path. Multiple consumers may depend on the
+    /// same file (e.g., <c>~/.aws/config</c>), but only one OS-level watcher is created per unique
+    /// file path.
+    /// <para />
+    /// When a change is detected, a monotonic <see cref="ChangeToken"/> is incremented. Each
+    /// consumer stores the token value it last observed; staleness is determined by comparing the
+    /// stored token to the current token rather than resetting shared state. This avoids cross-entry
+    /// interference when multiple consumers depend on the same file.
+    /// <para />
+    /// This is used both by <see cref="CachedProfileCredentialResolver"/> (for credentials resolved
+    /// from a profile set on the client config) and by <see cref="DefaultAWSCredentialsIdentityResolver"/>
+    /// (for static credentials resolved from a file via the default credential chain).
+    /// </summary>
+    internal sealed class SharedFileWatcher : IDisposable
+    {
+        private long _changeToken;
+        private readonly FileSystemWatcher _watcher;
+
+        /// <summary>
+        /// Gets the current monotonic change token. Each file system event increments this value.
+        /// Consumers compare their last-seen token against this to determine staleness.
+        /// </summary>
+        public long ChangeToken => Interlocked.Read(ref _changeToken);
+
+        public SharedFileWatcher(string filePath)
+        {
+            _watcher = TryCreateWatcher(filePath);
+        }
+
+        private FileSystemWatcher TryCreateWatcher(string filePath)
+        {
+            var directory = Path.GetDirectoryName(filePath);
+            var fileName = Path.GetFileName(filePath);
+
+            if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+                return null;
+
+            try
+            {
+                var watcher = new FileSystemWatcher(directory, fileName)
+                {
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName,
+                    EnableRaisingEvents = true
+                };
+                watcher.Changed += OnFileEvent;
+                watcher.Created += OnFileEvent;
+                watcher.Deleted += OnFileEvent;
+                watcher.Renamed += OnFileRenamed;
+                // Treat buffer overflow as a change — fail safe rather than returning stale credentials.
+                watcher.Error += OnWatcherError;
+                return watcher;
+            }
+            catch (Exception ex) when (!(ex is OutOfMemoryException))
+            {
+                // If we can't create a watcher (e.g., unsupported filesystem, invalid path,
+                // or I/O error), return null. The cache will never auto-invalidate for this
+                // file, but credentials will still be re-resolved on application restart.
+                return null;
+            }
+        }
+
+        private void OnFileEvent(object sender, FileSystemEventArgs e) => Interlocked.Increment(ref _changeToken);
+        private void OnFileRenamed(object sender, RenamedEventArgs e) => Interlocked.Increment(ref _changeToken);
+        private void OnWatcherError(object sender, ErrorEventArgs e) => Interlocked.Increment(ref _changeToken);
+
+        public void Dispose()
+        {
+            _watcher?.Dispose();
+        }
+    }
+}

--- a/sdk/src/Core/Amazon.Util/Internal/SharedFileWatcher.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/SharedFileWatcher.cs
@@ -17,7 +17,7 @@ using System;
 using System.IO;
 using System.Threading;
 
-namespace Amazon.Runtime.Credentials
+namespace Amazon.Util.Internal
 {
     /// <summary>
     /// A shared file system watcher for a single file path. Multiple consumers may depend on the
@@ -29,9 +29,9 @@ namespace Amazon.Runtime.Credentials
     /// stored token to the current token rather than resetting shared state. This avoids cross-entry
     /// interference when multiple consumers depend on the same file.
     /// <para />
-    /// This is used both by <see cref="CachedProfileCredentialResolver"/> (for credentials resolved
-    /// from a profile set on the client config) and by <see cref="DefaultAWSCredentialsIdentityResolver"/>
-    /// (for static credentials resolved from a file via the default credential chain).
+    /// This is used both by <c>CachedProfileCredentialResolver</c> (for credentials resolved
+    /// from a profile set on the client config) and by <c>DefaultAWSCredentialsIdentityResolver</c>
+    /// (for credentials resolved from a file via the default credential chain).
     /// </summary>
     internal sealed class SharedFileWatcher : IDisposable
     {
@@ -51,14 +51,17 @@ namespace Amazon.Runtime.Credentials
 
         private FileSystemWatcher TryCreateWatcher(string filePath)
         {
-            var directory = Path.GetDirectoryName(filePath);
-            var fileName = Path.GetFileName(filePath);
-
-            if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
-                return null;
-
             try
             {
+                // Path parsing is inside the try so that a bad path (e.g., invalid characters from an
+                // environment override) results in the same fail-safe "return null" as any other
+                // failure, rather than escaping and breaking credential resolution/cache invalidation.
+                var directory = Path.GetDirectoryName(filePath);
+                var fileName = Path.GetFileName(filePath);
+
+                if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+                    return null;
+
                 var watcher = new FileSystemWatcher(directory, fileName)
                 {
                     NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName,

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
@@ -349,15 +349,21 @@ namespace AWSSDK.UnitTests
         // where credentials are resolved via the generator chain and cached in _cachedCredentials. 
 
         /// <summary>
-        /// Clears the environment variables that the default credential chain inspects before it
-        /// reaches the profile generator, so these tests deterministically resolve from the file.
+        /// Clears every environment variable the default credential chain inspects before it reaches
+        /// the profile generator, so these tests deterministically resolve from the file.
         /// </summary>
         private void ClearChainEnvironmentVariables()
         {
             Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, null);
             Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, null);
             Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.LEGACY_ENVIRONMENT_VARIABLE_SECRETKEY, null);
             Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN, null);
+
+            // Web-identity credentials are resolved by the chain ahead of the profile generator.
+            Environment.SetEnvironmentVariable(AssumeRoleWithWebIdentityCredentials.WebIdentityTokenFileEnvVariable, null);
+            Environment.SetEnvironmentVariable(AssumeRoleWithWebIdentityCredentials.RoleArnEnvVariable, null);
+            Environment.SetEnvironmentVariable(AssumeRoleWithWebIdentityCredentials.RoleSessionNameEnvVariable, null);
         }
 
         /// <summary>

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/DefaultCredentialsResolverTests.cs
@@ -343,6 +343,229 @@ namespace AWSSDK.UnitTests
 
         #endregion
 
+        #region Default Chain (no clientConfig.Profile) File Rotation Tests
+
+        // These tests exercise the OTHER path: the default credential chain (clientConfig == null), 
+        // where credentials are resolved via the generator chain and cached in _cachedCredentials. 
+
+        /// <summary>
+        /// Clears the environment variables that the default credential chain inspects before it
+        /// reaches the profile generator, so these tests deterministically resolve from the file.
+        /// </summary>
+        private void ClearChainEnvironmentVariables()
+        {
+            Environment.SetEnvironmentVariable(AWS_PROFILE_ENVIRONMENT_VARIABLE, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SESSION_TOKEN, null);
+        }
+
+        /// <summary>
+        /// Points the default credential chain at the fixture's shared credentials file by setting
+        /// <see cref="AWSConfigs.AWSProfilesLocation"/>.
+        /// The returned value is the previous setting, to be restored by the caller.
+        /// </summary>
+        private string RedirectDefaultChainToFixture(SharedCredentialsFileTestFixture fixture)
+        {
+            var previous = AWSConfigs.AWSProfilesLocation;
+            AWSConfigs.AWSProfilesLocation = fixture.CredentialsFilePath;
+            return previous;
+        }
+
+        /// <summary>
+        /// The core regression test. With no profile on the client config, the default chain resolves
+        /// the "default" profile from the shared credentials file and caches it. After the file is
+        /// rotated externally, the next resolution must return the new credentials rather than the
+        /// stale cached ones.
+        /// </summary>
+        [TestMethod]
+        public void DefaultChain_CredentialsFileRotated_ReturnsNewCredentials()
+        {
+            ClearChainEnvironmentVariables();
+
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("default", "AKID_V1", "SECRET_V1")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var previousLocation = RedirectDefaultChainToFixture(fixture);
+                try
+                {
+                    var original = resolver.ResolveIdentity(clientConfig: null);
+                    Assert.AreEqual<string>("AKID_V1", original.GetCredentials().AccessKey);
+
+                    fixture.UpdateCredentialsFile(BasicProfileText("default", "AKID_V2", "SECRET_V2"));
+
+                    var updated = resolver.ResolveIdentity(clientConfig: null);
+                    Assert.AreEqual<string>("AKID_V2", updated.GetCredentials().AccessKey,
+                        "Default chain should pick up the rotated credentials file mid-process.");
+                    Assert.AreNotSame(original, updated, "A new credentials object should be resolved after rotation.");
+                }
+                finally
+                {
+                    AWSConfigs.AWSProfilesLocation = previousLocation;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Same as the sync test but exercises the async resolution path.
+        /// </summary>
+        [TestMethod]
+        public async Task DefaultChain_CredentialsFileRotatedAsync_ReturnsNewCredentials()
+        {
+            ClearChainEnvironmentVariables();
+
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("default", "AKID_V1", "SECRET_V1")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var previousLocation = RedirectDefaultChainToFixture(fixture);
+                try
+                {
+                    var original = await resolver.ResolveIdentityAsync(clientConfig: null).ConfigureAwait(false);
+                    Assert.AreEqual<string>("AKID_V1", original.GetCredentials().AccessKey);
+
+                    fixture.UpdateCredentialsFile(BasicProfileText("default", "AKID_V2", "SECRET_V2"));
+
+                    var updated = await resolver.ResolveIdentityAsync(clientConfig: null).ConfigureAwait(false);
+                    Assert.AreEqual<string>("AKID_V2", updated.GetCredentials().AccessKey,
+                        "Default chain (async) should pick up the rotated credentials file mid-process.");
+                    Assert.AreNotSame(original, updated, "A new credentials object should be resolved after rotation.");
+                }
+                finally
+                {
+                    AWSConfigs.AWSProfilesLocation = previousLocation;
+                }
+            }
+        }
+
+        /// <summary>
+        /// When the file is NOT changed, the default chain must keep returning the same cached object.
+        /// This guards against the file-change check causing cache churn (re-resolution) on every call.
+        /// </summary>
+        [TestMethod]
+        public void DefaultChain_NoFileChange_ReturnsCachedInstance()
+        {
+            ClearChainEnvironmentVariables();
+
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("default", "AKID_STABLE", "SECRET_STABLE")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var previousLocation = RedirectDefaultChainToFixture(fixture);
+                try
+                {
+                    var first = resolver.ResolveIdentity(clientConfig: null);
+                    for (int i = 0; i < 50; i++)
+                    {
+                        var subsequent = resolver.ResolveIdentity(clientConfig: null);
+                        Assert.AreSame(first, subsequent,
+                            $"Iteration {i}: expected the same cached instance when the file has not changed.");
+                    }
+                }
+                finally
+                {
+                    AWSConfigs.AWSProfilesLocation = previousLocation;
+                }
+            }
+        }
+
+        /// <summary>
+        /// After a rotation triggers re-resolution, subsequent calls with no further file change must
+        /// return the newly cached object (i.e. tracking state is refreshed on re-resolution, so we
+        /// don't re-resolve forever).
+        /// </summary>
+        [TestMethod]
+        public void DefaultChain_FileRotatedThenStable_CachesAfterRefresh()
+        {
+            ClearChainEnvironmentVariables();
+
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("default", "AKID_V1", "SECRET_V1")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var previousLocation = RedirectDefaultChainToFixture(fixture);
+                try
+                {
+                    var v1 = resolver.ResolveIdentity(clientConfig: null);
+
+                    fixture.UpdateCredentialsFile(BasicProfileText("default", "AKID_V2", "SECRET_V2"));
+                    var v2 = resolver.ResolveIdentity(clientConfig: null);
+                    Assert.AreNotSame(v1, v2, "Should have re-resolved after the file changed.");
+                    Assert.AreEqual<string>("AKID_V2", v2.GetCredentials().AccessKey);
+
+                    var v2Again = resolver.ResolveIdentity(clientConfig: null);
+                    Assert.AreSame(v2, v2Again, "Should cache again after re-resolution when the file is stable.");
+                }
+                finally
+                {
+                    AWSConfigs.AWSProfilesLocation = previousLocation;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Multiple sequential rotations must each be detected on the next resolution.
+        /// </summary>
+        [TestMethod]
+        public void DefaultChain_MultipleSequentialRotations_AllDetected()
+        {
+            ClearChainEnvironmentVariables();
+
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("default", "AKID_V1", "SECRET_V1")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var previousLocation = RedirectDefaultChainToFixture(fixture);
+                try
+                {
+                    Assert.AreEqual<string>("AKID_V1", resolver.ResolveIdentity(clientConfig: null).GetCredentials().AccessKey);
+
+                    fixture.UpdateCredentialsFile(BasicProfileText("default", "AKID_V2", "SECRET_V2"));
+                    Assert.AreEqual<string>("AKID_V2", resolver.ResolveIdentity(clientConfig: null).GetCredentials().AccessKey);
+
+                    fixture.UpdateCredentialsFile(BasicProfileText("default", "AKID_V3", "SECRET_V3"));
+                    Assert.AreEqual<string>("AKID_V3", resolver.ResolveIdentity(clientConfig: null).GetCredentials().AccessKey);
+                }
+                finally
+                {
+                    AWSConfigs.AWSProfilesLocation = previousLocation;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolution ordering must be preserved: environment-variable credentials take precedence over
+        /// the file profile. Setting the access/secret env vars AFTER the file profile was cached must
+        /// cause the env credentials to be used (this is the existing env-change invalidation, which the
+        /// file-change tracking must not interfere with).
+        /// </summary>
+        [TestMethod]
+        public void DefaultChain_EnvironmentVariablesStillTakePrecedenceOverFile()
+        {
+            ClearChainEnvironmentVariables();
+
+            using (var fixture = new SharedCredentialsFileTestFixture(BasicProfileText("default", "AKID_FILE", "SECRET_FILE")))
+            using (var resolver = new DefaultAWSCredentialsIdentityResolver())
+            {
+                var previousLocation = RedirectDefaultChainToFixture(fixture);
+                try
+                {
+                    var fromFile = resolver.ResolveIdentity(clientConfig: null);
+                    Assert.IsFalse(fromFile is EnvironmentVariablesAWSCredentials);
+                    Assert.AreEqual<string>("AKID_FILE", fromFile.GetCredentials().AccessKey);
+
+                    Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_ACCESSKEY, "AKID_ENV");
+                    Environment.SetEnvironmentVariable(EnvironmentVariablesAWSCredentials.ENVIRONMENT_VARIABLE_SECRETKEY, "SECRET_ENV");
+
+                    var afterEnv = resolver.ResolveIdentity(clientConfig: null);
+                    Assert.IsTrue(afterEnv is EnvironmentVariablesAWSCredentials,
+                        "Environment variables set after caching should take precedence (env-change invalidation).");
+                }
+                finally
+                {
+                    AWSConfigs.AWSProfilesLocation = previousLocation;
+                }
+            }
+        }
+
+        #endregion
+
         #region Threading / Concurrency Tests for Profile Credential Cache
 
         /// <summary>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When credentials are resolved through the default credential chain, the resolver caches them and only re-checks them when an environment variable changes. It never noticed when the shared credentials file (`~/.aws/credentials`) was changed on disk. So, if an external tool rotated the credentials in that file, the process kept using the old credentials until it was restarted.

This PR change makes the default chain watch the credentials/config file and re-read it when it changes. It reuses the file watcher that already exists for the client-config profile path (`CachedProfileCredentialResolver`), so the check is push-based and adds no per-request file access.

The cache is invalidated on any change to the backing credentials/config file, **regardless of the resolved credential type**. Invalidation is intentionally not gated on the credential type: a profile edit can switch a profile between credential types (e.g. from static keys to `source_profile`/assume-role) or repoint `source_profile` at a different role — changes a self-refreshing credential object (SSO, assume-role, web identity, container, instance profile) cannot detect on its own, because it keeps using the role/values it was constructed with. Re-resolving on any file change is cheap and rare (the check is an in-memory change-token comparison; the actual re-read only happens when the file truly changed), and avoids serving credentials from a stale profile definition.

**What changed**
- Extracted `SharedFileWatcher` into its own internal class (under `Amazon.Util.Internal`) so both the client-config profile path and the default chain can share it.
- `DefaultAWSCredentialsIdentityResolver` now tracks the backing credentials/config files and invalidates its cache on file change, for any credential type resolved via the default chain.
- Added unit tests covering default-chain file rotation (sync + async), no change when the file is unchanged, repeated rotations, and that environment variables still take precedence.

### Performance

Measured on net8.0 Release, cache-hit path (static `[default]` profile, file unchanged), 2,000,000 iterations per loop, best-of-3 timing with warmup. The "before" build is the pre-fix resolver; "after" is this change.

| Flow | Metric | Before | After | Delta |
|---|---|---|---|---|
| Default (`clientConfig = null`) | Time | 474.5 ns/call | 481.8 ns/call | +7.3 ns (~1.5%) |
| Default (`clientConfig = null`) | Memory | 144 B/call | 144 B/call | 0 B |
| Non-default (`clientConfig.Profile` set) | Time | 120.4 ns/call | 107.8 ns/call | no measurable change (noise) |
| Non-default (`clientConfig.Profile` set) | Memory | 144 B/call | 144 B/call | 0 B |

**Notes**
- **Zero added allocation.** The file-change check compares in-memory `long` change tokens and allocates nothing. The 144 B/call appears identically in both builds and is the pre-existing `CancellationTokenSource` allocated by `ResolveIdentity` (35s timeout wrapper) — unrelated to this change.
- **Default flow: +~7 ns/call** from three in-memory token comparisons in `HasCredentialsFileChanged()`. No per-request syscall on the hot path.

 
There is a PowerShell PR that has to be merged along with this PR to fix a failing test case - https://github.com/aws/PRIVATE-aws-tools-for-powershell-staging/pull/679

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
https://github.com/aws/aws-tools-for-powershell/issues/415 - Though this issue was reported for PS session variable caching, .NET SDK bug was found out while testing.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- New unit tests in `DefaultCredentialsResolverTests` for the default-chain
  (`clientConfig: null`) rotation cases.
- Verified in .NET with a standalone .NET 8 console app that references the built `AWSSDK.Core` and calls the static `DefaultAWSCredentialsIdentityResolver.GetCredentials()` — the process-wide singleton
  path used by real applications and service clients. 
  - After Change: credentials file rotated mid-process is picked up (AKID_V1 -> AKID_V2), 3/3 PASS.
  - Before Change: returns stale credentials (AKID_V1 -> AKID_V1), 3/3 FAIL.
- Verified end-to-end through the PowerShell module: credentials rotated mid session in credentials file are being refreshed and cached now.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** `d0851977-048a-4d83-8bd5-3bf7b24a5f8f`
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** `88107504-fa2d-40da-bbf2-0f8e6d5803e2`
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

Not a breaking change. Behavior changes only for static, file-backed credentials
resolved via the default chain, and only when the file is actually changed on disk. All other credential types and code paths behave exactly as before. 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement