### PR TITLE
Fix PutObject with non-seekable zero-length stream

### DIFF
--- a/generator/.DevConfigs/e7a1ced7-357e-4f43-8fd4-c792d8b08a14.json
+++ b/generator/.DevConfigs/e7a1ced7-357e-4f43-8fd4-c792d8b08a14.json
@@ -1,4 +1,11 @@
 {
+  "core": {
+    "changeLogMessages": [
+      "Add fallback in the `ChecksumUtils` class for future services that won't support chunk encoding."
+    ],
+    "type": "patch",
+    "updateMinimum": false
+  },
   "services": [
     {
       "serviceName": "S3",

--- a/generator/.DevConfigs/e7a1ced7-357e-4f43-8fd4-c792d8b08a14.json
+++ b/generator/.DevConfigs/e7a1ced7-357e-4f43-8fd4-c792d8b08a14.json
@@ -11,7 +11,7 @@
       "serviceName": "S3",
       "type": "patch",
       "changeLogMessages": [
-        "Fix `PutObject` failing with `ArgumentException` when given a non-seekable zero-length stream (https://github.com/aws/aws-sdk-net/issues/4432). The SDK now forces chunked transfer encoding for non-seekable streams so the checksum is sent as a trailing header, instead of requiring seekability for upfront calculation. Seekable streams are unaffected."
+        "Fix `PutObject` failing with `ArgumentException` when given a non-seekable zero-length stream that reports its length (https://github.com/aws/aws-sdk-net/issues/4432). The SDK now forces chunked transfer encoding for non-seekable streams so the checksum is sent as a trailing header, instead of requiring seekability for upfront calculation. Seekable streams are unaffected. Note: non-seekable streams that do not report their length still require `ContentLength` to be set on the request."
       ]
     }
   ]

--- a/generator/.DevConfigs/e7a1ced7-357e-4f43-8fd4-c792d8b08a14.json
+++ b/generator/.DevConfigs/e7a1ced7-357e-4f43-8fd4-c792d8b08a14.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fix `PutObject` failing with `ArgumentException` when given a non-seekable zero-length stream (https://github.com/aws/aws-sdk-net/issues/4432). The SDK now forces chunked transfer encoding for non-seekable streams so the checksum is sent as a trailing header, instead of requiring seekability for upfront calculation. Seekable streams are unaffected."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
@@ -234,6 +234,14 @@ namespace Amazon.Runtime.Internal.Util
                     seekableStream.Seek(position, SeekOrigin.Begin);
                     return Convert.ToBase64String(checksumBytes);
                 }
+                else if (request.ContentStream.Length == 0)
+                {
+                    // Empty streams don't need seeking — the checksum is a known constant.
+                    // S3 handles this via trailing headers, but other services may not support
+                    // chunk encoding and will fall through to here.
+                    var checksumBytes = algorithm.ComputeHash(Array.Empty<byte>());
+                    return Convert.ToBase64String(checksumBytes);
+                }
                 else
                 {
                     throw new ArgumentException("Request must have a seekable content stream to calculate checksum");

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
@@ -234,16 +234,21 @@ namespace Amazon.Runtime.Internal.Util
                     seekableStream.Seek(position, SeekOrigin.Begin);
                     return Convert.ToBase64String(checksumBytes);
                 }
-                else if (request.ContentStream.Length == 0)
+                else
                 {
                     // Empty streams don't need seeking — the checksum is a known constant.
                     // S3 handles this via trailing headers, but other services may not support
                     // chunk encoding and will fall through to here.
-                    var checksumBytes = algorithm.ComputeHash(Array.Empty<byte>());
-                    return Convert.ToBase64String(checksumBytes);
-                }
-                else
-                {
+                    long length;
+                    try { length = request.ContentStream.Length; }
+                    catch (NotSupportedException) { length = -1; }
+
+                    if (length == 0)
+                    {
+                        var checksumBytes = algorithm.ComputeHash(Array.Empty<byte>());
+                        return Convert.ToBase64String(checksumBytes);
+                    }
+
                     throw new ArgumentException("Request must have a seekable content stream to calculate checksum");
                 }
             }

--- a/sdk/src/Services/S3/Custom/Internal/AmazonS3PostMarshallHandler.cs
+++ b/sdk/src/Services/S3/Custom/Internal/AmazonS3PostMarshallHandler.cs
@@ -184,10 +184,9 @@ namespace Amazon.S3.Internal
                 // Wrap the stream in a stream that has a length
                 var streamWithLength = GetStreamWithLength(putObjectRequest.InputStream, putObjectRequest.Headers.ContentLength);
 
-                // Non-seekable streams must use chunk encoding so the checksum can be computed incrementally and sent as a trailing header;
-                // the header-based checksum path requires seeking.
-                // This is enforced regardless of what the user set on UseChunkEncoding, since there's no other way to produce a
-                // valid checksum for a non-seekable stream (#4432).
+                // Non-seekable streams require trailing checksums since the header-based path requires seeking.
+                // When payload signing is enabled, chunk encoding is the mechanism that enables trailing headers.
+                // When payload signing is disabled, trailing headers are used regardless of chunk encoding (#4432).
                 if (!(putObjectRequest.DisablePayloadSigning ?? false))
                 {
                     if (!streamWithLength.CanSeek)

--- a/sdk/src/Services/S3/Custom/Internal/AmazonS3PostMarshallHandler.cs
+++ b/sdk/src/Services/S3/Custom/Internal/AmazonS3PostMarshallHandler.cs
@@ -183,8 +183,23 @@ namespace Amazon.S3.Internal
             {
                 // Wrap the stream in a stream that has a length
                 var streamWithLength = GetStreamWithLength(putObjectRequest.InputStream, putObjectRequest.Headers.ContentLength);
-                if (streamWithLength.Length > 0 && !(putObjectRequest.DisablePayloadSigning ?? false))
-                    request.UseChunkEncoding = putObjectRequest.UseChunkEncoding;
+
+                // Non-seekable streams must use chunk encoding so the checksum can be computed incrementally and sent as a trailing header;
+                // the header-based checksum path requires seeking.
+                // This is enforced regardless of what the user set on UseChunkEncoding, since there's no other way to produce a
+                // valid checksum for a non-seekable stream (#4432).
+                if (!(putObjectRequest.DisablePayloadSigning ?? false))
+                {
+                    if (!streamWithLength.CanSeek)
+                    {
+                        request.UseChunkEncoding = true;
+                    }
+                    else if (streamWithLength.Length > 0)
+                    {
+                        request.UseChunkEncoding = putObjectRequest.UseChunkEncoding;
+                    }
+                }
+
                 var length = streamWithLength.Length - streamWithLength.Position;
                 if (!request.Headers.ContainsKey(HeaderKeys.ContentLengthHeader))
                     request.Headers.Add(HeaderKeys.ContentLengthHeader, length.ToString(CultureInfo.InvariantCulture));

--- a/sdk/test/Services/S3/IntegrationTests/Checksum/ChecksumPutTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/Checksum/ChecksumPutTests.cs
@@ -195,6 +195,36 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             }
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/aws/aws-sdk-net/issues/4432
+        /// PutObject must succeed with a non-seekable zero-length stream.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(GetAlgorithmsToTest))]
+        public async Task TestPutObject_NonSeekableZeroLengthStream(CoreChecksumAlgorithm algorithm)
+        {
+            var key = $"non-seekable-zero-length-{algorithm}";
+            using (var stream = new NonSeekableStream())
+            {
+                await _client.PutObjectAsync(new PutObjectRequest
+                {
+                    BucketName = _bucketName,
+                    Key = key,
+                    InputStream = stream,
+                    ChecksumAlgorithm = ChecksumAlgorithm.FindValue(algorithm.ToString()),
+                });
+            }
+
+            var getResponse = await _client.GetObjectAsync(new GetObjectRequest
+            {
+                BucketName = _bucketName,
+                Key = key,
+                ChecksumMode = ChecksumMode.ENABLED
+            });
+            Assert.Equal(0, getResponse.ContentLength);
+            Assert.Equal(algorithm, getResponse.ResponseMetadata.ChecksumAlgorithm);
+        }
+
         [Theory]
         // When the user sets ResponseChecksumValidation to WHEN_SUPPORTED, and the user has set the requestValidationModeMember to ENABLED, assert that the response checksum is validated.
         [InlineData(ResponseChecksumValidation.WHEN_SUPPORTED, true, true)]

--- a/sdk/test/Services/S3/IntegrationTests/PutObjectTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/PutObjectTests.cs
@@ -410,7 +410,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                         {
                             BucketName = testBucketName,
                             Key = "TestKey3",
-                            InputStream = UtilityMethods.CreateStreamFromString("sample text", new NonRewindableStream())
+                            InputStream = new NonSeekableStream(Encoding.UTF8.GetBytes("sample text"))
                         })
                     );
                     Assert.Equal("TemporaryRedirect", exception.ErrorCode);
@@ -1515,9 +1515,5 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             }
         }
 
-        private class NonRewindableStream : MemoryStream
-        {
-            public override bool CanSeek => false;
-        }
     }
 }

--- a/sdk/test/Services/S3/IntegrationTests/S3TestUtils.cs
+++ b/sdk/test/Services/S3/IntegrationTests/S3TestUtils.cs
@@ -375,4 +375,33 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 throw new Exception($"Presigned URL content mismatch: expected '{testContent}', got '{content}'");
         }
     }
+
+    /// <summary>
+    /// A MemoryStream that reports CanSeek as false.
+    /// When reportsLength is true (default), Length and Position getter are still accessible
+    /// so the SDK can cap a nominal PartSize down to the actual remaining bytes.
+    /// When false, they throw NotSupportedException — the SDK must rely on PartSize.
+    /// </summary>
+    internal class NonSeekableStream : MemoryStream
+    {
+        private readonly bool _reportsLength;
+
+        public NonSeekableStream(bool reportsLength = true) : base()
+        {
+            _reportsLength = reportsLength;
+        }
+
+        public NonSeekableStream(byte[] buffer, bool reportsLength = true) : base(buffer)
+        {
+            _reportsLength = reportsLength;
+        }
+
+        public override bool CanSeek => false;
+        public override long Length => _reportsLength ? base.Length : throw new NotSupportedException();
+        public override long Position
+        {
+            get => _reportsLength ? base.Position : throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+    }
 }

--- a/sdk/test/Services/S3/IntegrationTests/S3TestUtils.cs
+++ b/sdk/test/Services/S3/IntegrationTests/S3TestUtils.cs
@@ -397,6 +397,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         }
 
         public override bool CanSeek => false;
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override long Length => _reportsLength ? base.Length : throw new NotSupportedException();
         public override long Position
         {

--- a/sdk/test/Services/S3/IntegrationTests/UploadPartUnseekableStreamTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/UploadPartUnseekableStreamTests.cs
@@ -41,7 +41,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         public async Task UploadPartWithUnseekableStream(bool disableDefaultChecksumValidation, bool useChunkEncoding, string checksumCRC32, bool streamReportsLength, bool setPartSize)
         {
             var data = Encoding.UTF8.GetBytes("Hello, S3!");
-            var stream = new UnseekableStream(data, streamReportsLength);
+            var stream = new NonSeekableStream(data, streamReportsLength);
 
             // When a PartSize is set on a length-reporting stream, make it oversized to verify
             // it is capped to the actual length; a forward-only stream needs the exact size.
@@ -108,7 +108,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         public async Task UploadPartWithUnseekableStreamAndPayloadSigningThrows()
         {
             var data = Encoding.UTF8.GetBytes("Hello, S3!");
-            var stream = new UnseekableStream(data);
+            var stream = new NonSeekableStream(data, reportsLength: false);
             var key = _keyPrefix + "should-fail.txt";
 
             var initiateResponse = await _client.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
@@ -148,7 +148,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         public async Task UploadPartWithUnseekableStreamAndNoPartSizeThrows()
         {
             var data = Encoding.UTF8.GetBytes("Hello, S3!");
-            var stream = new UnseekableStream(data);
+            var stream = new NonSeekableStream(data, reportsLength: false);
             var key = _keyPrefix + "no-partsize.txt";
 
             var initiateResponse = await _client.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
@@ -184,28 +184,5 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
             }
         }
 
-        private class UnseekableStream : MemoryStream
-        {
-            private readonly bool _reportsLength;
-
-            // When reportsLength is false the stream is forward-only and throws on
-            // Length/Position (the SDK must rely on PartSize). When true, the stream
-            // is still non-seekable but exposes its length, so the SDK can cap a
-            // nominal PartSize down to the actual remaining bytes.
-            public UnseekableStream(byte[] buffer, bool reportsLength = false) : base(buffer)
-            {
-                _reportsLength = reportsLength;
-            }
-
-            public override bool CanSeek => false;
-
-            public override long Length => _reportsLength ? base.Length : throw new NotSupportedException();
-
-            public override long Position
-            {
-                get => _reportsLength ? base.Position : throw new NotSupportedException();
-                set => throw new NotSupportedException();
-            }
-        }
     }
 }


### PR DESCRIPTION
Fixes #4432

I talked to the CRT team, and other SDKs handle this scenario of unseekable streams with zero-length by sending the checksum as a trailer (which doesn't require the input to be seekable). This PR tries to achieve the same by:
- Forcing chunk encoding in the scenario described in the issue (leaving the seekable code path as is)
- Adding a fallback in the checksum handler (no other service uses flexible checksums as of today, but if they do it's likely they won't include a chunk encoding option like S3 does)

Also moved the `UnseekableStream` to the S3 utils class since it was being repeated in multiple places.

### Dry-runs
- **DotNet Dry-run ID:** `f74d789c-4dcd-45c0-8d37-d2bc9e6ef248`
  - [X] Completed
- **PowerShell Dry-run ID:** `8e8d0618-6cd0-4b86-9fc6-3bc9036273fa`
  - [X] Completed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license