### PR TITLE
fix: Avoid sending empty expression maps in Save and BatchGet

### DIFF
--- a/generator/.DevConfigs/bd32e902-8758-42eb-a286-580718de4cb0.json
+++ b/generator/.DevConfigs/bd32e902-8758-42eb-a286-580718de4cb0.json
@@ -1,0 +1,12 @@
+{
+  "services": [
+    {
+      "serviceName": "DynamoDBv2",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fix regression where null properties cannot be used in a Save operation (https://github.com/aws/aws-sdk-net/issues/4438)",
+        "Fix empty ExpressionAttributeNames being sent for batch get ProjectionExpression"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentBatchGet.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/DocumentBatchGet.cs
@@ -554,7 +554,8 @@ namespace Amazon.DynamoDBv2.DocumentModel
                 if (requestSet.Batch.ProjectionExpression is { IsSet: true })
                 {
                     keys.ProjectionExpression = requestSet.Batch.ProjectionExpression.ExpressionStatement;
-                    keys.ExpressionAttributeNames = requestSet.Batch.ProjectionExpression.ExpressionAttributeNames;
+                    if (requestSet.Batch.ProjectionExpression.ExpressionAttributeNames?.Count > 0)
+                        keys.ExpressionAttributeNames = requestSet.Batch.ProjectionExpression.ExpressionAttributeNames;
                 }
                 else
                 {

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
@@ -173,9 +173,9 @@ namespace Amazon.DynamoDBv2.DocumentModel
         private void MergeAttributes(UpdateItemRequest request, Table table)
         {
             var convertToAttributeValues  = ConvertToAttributeValues(this.ExpressionAttributeValues, table);
-            request.ExpressionAttributeValues ??= new Dictionary<string, AttributeValue>(StringComparer.Ordinal);
             if (convertToAttributeValues != null)
             {
+                request.ExpressionAttributeValues ??= new Dictionary<string, AttributeValue>(StringComparer.Ordinal);
                 foreach (var kvp in convertToAttributeValues)
                 {
                     request.ExpressionAttributeValues[kvp.Key] = kvp.Value;

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DataModelOperationSpecificConfigTests.cs
@@ -715,6 +715,32 @@ namespace AWSSDK_DotNet.UnitTests
             Assert.AreEqual(4, typeof(GetTargetTableConfig).GetProperties().Length);
         }
 
+        [TestMethod]
+        public async Task SaveAsync_NullComplexProperty_DoesNotSendEmptyExpressionAttributeValues()
+        {
+            UpdateItemRequest capturedRequest = null;
+            var mockClient = new Mock<IAmazonDynamoDB>();
+            mockClient.Setup(client => client.UpdateItemAsync(It.IsAny<UpdateItemRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<UpdateItemRequest, CancellationToken>((req, _) => capturedRequest = req)
+                .ReturnsAsync(new UpdateItemResponse());
+
+            var context = new DynamoDBContext(mockClient.Object, new DynamoDBContextConfig
+            {
+                DisableFetchingTableMetadata = true
+            });
+
+            await context.SaveAsync(new DataModelWithComplexProperty
+            {
+                Id = "123",
+                Inner = null
+            });
+            Assert.IsNotNull(capturedRequest);
+            Assert.IsTrue(
+                capturedRequest.ExpressionAttributeValues == null || capturedRequest.ExpressionAttributeValues.Count > 0,
+                "ExpressionAttributeValues must be either null or non-empty; DynamoDB rejects empty maps."
+            );
+        }
+
         [DynamoDBTable("TableName")]
         private class DataModel
         {
@@ -722,6 +748,22 @@ namespace AWSSDK_DotNet.UnitTests
             public string Id { get; set; }
 
             [DynamoDBRangeKey]
+            public string Name { get; set; }
+        }
+
+        [DynamoDBTable("TableName")]
+        private class DataModelWithComplexProperty
+        {
+            [DynamoDBHashKey]
+            public string Id { get; set; }
+
+            [DynamoDBProperty("inner")]
+            public InnerModel Inner { get; set; }
+        }
+
+        private class InnerModel
+        {
+            [DynamoDBProperty("name")]
             public string Name { get; set; }
         }
     }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DocumentModel/DocumentBatchGetTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/DocumentModel/DocumentBatchGetTests.cs
@@ -157,6 +157,29 @@ namespace AWSSDK_DotNet.UnitTests
             Assert.AreEqual(0, results.Count);
         }
 
+        [TestMethod]
+        public async Task ExecuteAsync_ProjectionWithoutAttributeNames_DoesNotSendEmptyExpressionAttributeNames()
+        {
+            var sentEmptyExpressionAttributeNames = false;
+            ddbClientMock
+                .Setup(c => c.BatchGetItemAsync(It.IsAny<BatchGetItemRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<BatchGetItemRequest, CancellationToken>((req, _) =>
+                    sentEmptyExpressionAttributeNames = req.RequestItems.Values.Any(k => k.ExpressionAttributeNames != null && k.ExpressionAttributeNames.Count == 0)
+                )
+                .ReturnsAsync(new BatchGetItemResponse
+                {
+                    Responses = new Dictionary<string, List<Dictionary<string, AttributeValue>>>(),
+                    UnprocessedKeys = new Dictionary<string, KeysAndAttributes>()
+                });
+
+            var batch = addressTable.CreateBatchGet();
+            batch.AddKey(new Primitive("A1"));
+            batch.ProjectionExpression = new Expression { ExpressionStatement = "Id, Zip" };
+
+            await batch.ExecuteAsync();
+            Assert.IsFalse(sentEmptyExpressionAttributeNames, "ExpressionAttributeNames must be either null or non-empty; DynamoDB rejects empty maps.");
+        }
+
         private static (IDocumentBatchGet AddressBatch, IDocumentBatchGet PersonBatch) CreateBatches(Table addressTable, Table personTable)
         {
             var addressBatch = addressTable.CreateBatchGet();


### PR DESCRIPTION
Fixes #4438

Request sent before the refactoring:
```json
{
    "AttributeUpdates": {
        "inner": {
            "Action": "DELETE"
        }
    },
    "Key": {
        "recordId": {
            "S": "e41663cc-e0bd-4cdd-b52b-a89ea6179b16"
        }
    },
    "ReturnValues": "NONE",
    "TableName": "records"
}
```

Request before the fix (note the empty attribute values property):
```json
{
    "ExpressionAttributeNames": {
        "#awsavar1": "inner"
    },
    "ExpressionAttributeValues": {},
    "Key": {
        "recordId": {
            "S": "da10194c-810a-4f1b-97d9-ebb8fcfc5b78"
        }
    },
    "ReturnValues": "NONE",
    "TableName": "records",
    "UpdateExpression": "REMOVE #awsavar1"
}
```

Request after the fix:
```json
{
    "ExpressionAttributeNames": {
        "#awsavar1": "inner"
    },
    "Key": {
        "recordId": {
            "S": "5999665a-8ca7-4710-8b4c-73b2e6d61149"
        }
    },
    "ReturnValues": "NONE",
    "TableName": "records",
    "UpdateExpression": "REMOVE #awsavar1"
}
```

I also went through other recent PRs and found a similar behavior in `BatchGet.ProjectionExpression` (not a regression there since the feature is new, but same root cause). The following code fails before the fix (i.e. rejected by DDB):
```csharp
// BatchGet projection with no #-aliases sends empty ExpressionAttributeNames ---
var table = new TableBuilder(dynamoDbClient, "records").AddHashKey("recordId", DynamoDBEntryType.String).Build();
var batch = table.CreateBatchGet();
batch.AddKey(new Primitive(Guid.NewGuid().ToString()));
batch.ProjectionExpression = new Expression { ExpressionStatement = "recordId" }; // plain name, no #alias
await batch.ExecuteAsync();
```

Request before:
```json
{
    "RequestItems": {
        "records": {
            "ConsistentRead": false,
            "ExpressionAttributeNames": {},
            "Keys": [
                {
                    "recordId": {
                        "S": "30f4c207-e4ac-4d70-b811-a0e8530e61f6"
                    }
                }
            ],
            "ProjectionExpression": "recordId"
        }
    }
}
```

Request after:
```json
{
    "RequestItems": {
        "records": {
            "ConsistentRead": false,
            "Keys": [
                {
                    "recordId": {
                        "S": "08b22519-1136-484d-9914-b886c6c88d4f"
                    }
                }
            ],
            "ProjectionExpression": "recordId"
        }
    }
}
```

### Dry-runs
- **DotNet Dry-run ID:** `28a913d6-5dde-47e8-b33e-19ffcb904ea9`
  - [X] Completed
- **PowerShell Dry-run ID:** `f9fd325d-740c-4d26-8fdf-296b8ee76ee8`
  - [X] Completed

## Breaking Changes Assessment
N/A

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
