### PR TITLE
Add native structured outputs support to Bedrock MEAI BedrockChatClient

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AmazonBedrockRuntimeExtensions.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/AmazonBedrockRuntimeExtensions.cs
@@ -54,6 +54,27 @@ public static class AmazonBedrockRuntimeExtensions
         runtime is not null ? new BedrockChatClient(runtime, defaultModelId) :
         throw new ArgumentNullException(nameof(runtime));
 
+    /// <summary>Gets an <see cref="IChatClient"/> for the specified <see cref="IAmazonBedrockRuntime"/> instance.</summary>
+    /// <param name="runtime">The runtime instance to be represented as an <see cref="IChatClient"/>.</param>
+    /// <param name="defaultModelId">
+    /// The default model ID to use when no model is specified in a request. If not specified,
+    /// a model must be provided in the <see cref="ChatOptions.ModelId"/> passed to <see cref="IChatClient.GetResponseAsync"/>
+    /// or <see cref="IChatClient.GetStreamingResponseAsync"/>.
+    /// </param>
+    /// <param name="structuredOutputMode">
+    /// Controls how <see cref="ChatOptions.ResponseFormat"/> is realized.
+    /// <see cref="BedrockStructuredOutputMode.Native"/> uses Bedrock native structured outputs
+    /// (composes with user-provided tools and supports streaming) and requires a model that supports
+    /// the feature. Use <see cref="BedrockStructuredOutputMode.SyntheticTool"/> for models without
+    /// native support.
+    /// </param>
+    /// <returns>A <see cref="IChatClient"/> instance representing the <see cref="IAmazonBedrockRuntime"/> instance.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="runtime"/> is <see langword="null"/>.</exception>
+    public static IChatClient AsIChatClient(this IAmazonBedrockRuntime runtime, string? defaultModelId,
+        BedrockStructuredOutputMode structuredOutputMode) =>
+        runtime is not null ? new BedrockChatClient(runtime, defaultModelId, structuredOutputMode) :
+        throw new ArgumentNullException(nameof(runtime));
+
     /// <summary>Gets an <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> for the specified <see cref="IAmazonBedrockRuntime"/> instance.</summary>
     /// <param name="runtime">The runtime instance to be represented as an <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/>.</param>
     /// <param name="defaultModelId">

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
@@ -268,7 +268,7 @@ internal sealed partial class BedrockChatClient : IChatClient
     /// <remarks>
     /// <para>
     /// <see cref="ChatOptions.ResponseFormat"/> is supported while streaming only in
-    /// <see cref="BedrockStructuredOutputMode.Native"/> mode (the default), where the constrained JSON
+    /// <see cref="BedrockStructuredOutputMode.Native"/> mode, where the constrained JSON
     /// streams back as ordinary text deltas. In <see cref="BedrockStructuredOutputMode.SyntheticTool"/>
     /// mode a JSON <see cref="ChatOptions.ResponseFormat"/> throws <see cref="NotSupportedException"/>;
     /// use <see cref="GetResponseAsync"/> for that strategy.
@@ -298,7 +298,7 @@ internal sealed partial class BedrockChatClient : IChatClient
             throw new NotSupportedException(
                 "ResponseFormat is not supported for streaming responses when using " +
                 "BedrockStructuredOutputMode.SyntheticTool. Use BedrockStructuredOutputMode.Native " +
-                "(the default) for streaming structured output, or GetResponseAsync for the synthetic-tool strategy.");
+                "for streaming structured output, or GetResponseAsync for the synthetic-tool strategy.");
         }
 
         ConverseStreamRequest request = options?.RawRepresentationFactory?.Invoke(this) as ConverseStreamRequest ?? new();

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
@@ -40,6 +40,12 @@ internal sealed partial class BedrockChatClient : IChatClient
     private const string ResponseFormatToolName = "generate_response";
     /// <summary>The description used for the synthetic tool that enforces response format.</summary>
     private const string ResponseFormatToolDescription = "Generate response in specified format";
+    /// <summary>
+    /// Permissive schema used for native structured outputs when the caller requests JSON output without
+    /// supplying a schema (<c>ChatResponseFormat.Json</c>). Mirrors the synthetic-tool path's behavior so
+    /// that schema-less JSON mode keeps working, and satisfies the required <c>jsonSchema.schema</c> field.
+    /// </summary>
+    private const string DefaultJsonSchema = "{\"type\":\"object\"}";
 
     /// <summary>The wrapped <see cref="IAmazonBedrockRuntime"/> instance.</summary>
     private readonly IAmazonBedrockRuntime _runtime;
@@ -57,7 +63,7 @@ internal sealed partial class BedrockChatClient : IChatClient
     /// <param name="defaultModelId">Model ID to use as the default when no model ID is specified in a request.</param>
     /// <param name="structuredOutputMode">How <see cref="ChatOptions.ResponseFormat"/> is realized against the Converse API.</param>
     public BedrockChatClient(IAmazonBedrockRuntime runtime, string? defaultModelId,
-        BedrockStructuredOutputMode structuredOutputMode = BedrockStructuredOutputMode.Native)
+        BedrockStructuredOutputMode structuredOutputMode = BedrockStructuredOutputMode.SyntheticTool)
     {
         Debug.Assert(runtime is not null);
 
@@ -78,15 +84,15 @@ internal sealed partial class BedrockChatClient : IChatClient
     /// <para>
     /// When <see cref="ChatOptions.ResponseFormat"/> is specified, structured output is realized
     /// according to the <see cref="BedrockStructuredOutputMode"/> the client was created with. In
-    /// <see cref="BedrockStructuredOutputMode.Native"/> mode (the default) the schema is sent via the
-    /// request's <c>outputConfig.textFormat</c> field, composes with user-provided
+    /// <see cref="BedrockStructuredOutputMode.SyntheticTool"/> mode (the default) the schema is enforced
+    /// with a forced synthetic tool, which requires ToolChoice support, cannot be combined with
+    /// user-provided tools, and throws <see cref="InvalidOperationException"/> if the model fails to
+    /// return the expected tool output. In <see cref="BedrockStructuredOutputMode.Native"/> mode the
+    /// schema is sent via the request's <c>outputConfig.textFormat</c> field, composes with user-provided
     /// <see cref="ChatOptions.Tools"/>, and the constrained JSON is returned as ordinary text content;
     /// native structured outputs is only supported on newer models (for example Anthropic Claude 4.5+
     /// and a number of open-weight models) and not on older models such as Claude 3.x, Amazon Titan,
-    /// Meta Llama, Cohere, or AI21. In <see cref="BedrockStructuredOutputMode.SyntheticTool"/> mode the
-    /// schema is enforced with a forced synthetic tool, which requires ToolChoice support, cannot be
-    /// combined with user-provided tools, and throws <see cref="InvalidOperationException"/> if the
-    /// model fails to return the expected tool output.
+    /// Meta Llama, Cohere, or AI21.
     /// </para>
     /// <para>
     /// The caller's schema is forwarded to Bedrock unchanged. If it uses JSON Schema features outside
@@ -990,8 +996,10 @@ internal sealed partial class BedrockChatClient : IChatClient
                 {
                     JsonSchema = new JsonSchemaDefinition
                     {
-                        // JsonElement -> raw JSON string; the field is a string on the wire.
-                        Schema = jsonFormat.Schema?.GetRawText(),
+                        // JsonElement -> raw JSON string; the field is a string on the wire. When the
+                        // caller requests JSON without a schema, fall back to a permissive object schema
+                        // (the schema field is required by the Bedrock model).
+                        Schema = jsonFormat.Schema?.GetRawText() ?? DefaultJsonSchema,
                         Name = jsonFormat.SchemaName ?? TryGetSchemaTitle(jsonFormat.Schema) ?? "output_schema",
                         Description = jsonFormat.SchemaDescription,
                     }

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
@@ -45,6 +45,8 @@ internal sealed partial class BedrockChatClient : IChatClient
     private readonly IAmazonBedrockRuntime _runtime;
     /// <summary>Default model ID to use when no model is specified in the request.</summary>
     private readonly string? _modelId;
+    /// <summary>How <see cref="ChatOptions.ResponseFormat"/> is realized against the Converse API.</summary>
+    private readonly BedrockStructuredOutputMode _structuredOutputMode;
     /// <summary>Metadata describing the chat client.</summary>
     private readonly ChatClientMetadata _metadata;
 
@@ -53,12 +55,15 @@ internal sealed partial class BedrockChatClient : IChatClient
     /// </summary>
     /// <param name="runtime">The <see cref="IAmazonBedrockRuntime"/> instance to wrap.</param>
     /// <param name="defaultModelId">Model ID to use as the default when no model ID is specified in a request.</param>
-    public BedrockChatClient(IAmazonBedrockRuntime runtime, string? defaultModelId)
+    /// <param name="structuredOutputMode">How <see cref="ChatOptions.ResponseFormat"/> is realized against the Converse API.</param>
+    public BedrockChatClient(IAmazonBedrockRuntime runtime, string? defaultModelId,
+        BedrockStructuredOutputMode structuredOutputMode = BedrockStructuredOutputMode.Native)
     {
         Debug.Assert(runtime is not null);
 
         _runtime = runtime!;
         _modelId = defaultModelId;
+        _structuredOutputMode = structuredOutputMode;
 
         _metadata = new(AmazonBedrockRuntimeExtensions.ProviderName, defaultModelId: defaultModelId);
     }
@@ -71,11 +76,24 @@ internal sealed partial class BedrockChatClient : IChatClient
     /// <inheritdoc />
     /// <remarks>
     /// <para>
-    /// When <see cref="ChatOptions.ResponseFormat"/> is specified, the model must support
-    /// the ToolChoice feature. Models without this support will return an error from the Bedrock API
-    /// (typically <see cref="Amazon.BedrockRuntime.AmazonBedrockRuntimeException"/> with ErrorCode "ValidationException").
-    /// If the model fails to return the expected structured output, <see cref="InvalidOperationException"/>
-    /// is thrown.
+    /// When <see cref="ChatOptions.ResponseFormat"/> is specified, structured output is realized
+    /// according to the <see cref="BedrockStructuredOutputMode"/> the client was created with. In
+    /// <see cref="BedrockStructuredOutputMode.Native"/> mode (the default) the schema is sent via the
+    /// request's <c>outputConfig.textFormat</c> field, composes with user-provided
+    /// <see cref="ChatOptions.Tools"/>, and the constrained JSON is returned as ordinary text content;
+    /// native structured outputs is only supported on newer models (for example Anthropic Claude 4.5+
+    /// and a number of open-weight models) and not on older models such as Claude 3.x, Amazon Titan,
+    /// Meta Llama, Cohere, or AI21. In <see cref="BedrockStructuredOutputMode.SyntheticTool"/> mode the
+    /// schema is enforced with a forced synthetic tool, which requires ToolChoice support, cannot be
+    /// combined with user-provided tools, and throws <see cref="InvalidOperationException"/> if the
+    /// model fails to return the expected tool output.
+    /// </para>
+    /// <para>
+    /// The caller's schema is forwarded to Bedrock unchanged. If it uses JSON Schema features outside
+    /// Bedrock's supported subset (for example, <c>additionalProperties</c> must be <c>false</c> and
+    /// numeric/length constraints are not supported), the Bedrock API returns a validation error
+    /// (typically <see cref="Amazon.BedrockRuntime.AmazonBedrockRuntimeException"/> with ErrorCode
+    /// "ValidationException") which is surfaced to the caller.
     /// </para>
     /// <para>
     /// When <see cref="ChatOptions.Reasoning"/> is specified with a non-<see cref="ReasoningEffort.None"/> effort,
@@ -95,7 +113,8 @@ internal sealed partial class BedrockChatClient : IChatClient
         request.ModelId ??= options?.ModelId ?? _modelId;
         request.Messages = CreateMessages(request.Messages, messages);
         request.System = CreateSystem(request.System, messages, options);
-        request.ToolConfig = CreateToolConfig(request.ToolConfig, options);
+        request.ToolConfig = CreateToolConfig(request.ToolConfig, options, _structuredOutputMode);
+        request.OutputConfig = CreateOutputConfig(request.OutputConfig, options, _structuredOutputMode);
         request.InferenceConfig = CreateInferenceConfiguration(request.InferenceConfig, options);
         request.AdditionalModelRequestFields = ApplyReasoningConfig(request.AdditionalModelRequestFields, request.InferenceConfig, options);
 
@@ -109,11 +128,14 @@ internal sealed partial class BedrockChatClient : IChatClient
             MessageId = Guid.NewGuid().ToString("N"),
         };
 
-        // Check if ResponseFormat was used and extract structured content
-        // When ResponseFormat is active, Bedrock returns the JSON response as a ToolUseBlock
-        // within the Message.Content array, rather than as plain text.
-        bool usingResponseFormat = options?.ResponseFormat is ChatResponseFormatJson;
-        if (usingResponseFormat)
+        // Check if the synthetic-tool ResponseFormat strategy was used and extract structured content.
+        // In SyntheticTool mode, Bedrock returns the JSON response as a ToolUseBlock within the
+        // Message.Content array, rather than as plain text. In Native mode the structured JSON arrives
+        // as an ordinary text ContentBlock and is handled by the normal content processing below.
+        bool usingSyntheticResponseFormat =
+            _structuredOutputMode == BedrockStructuredOutputMode.SyntheticTool &&
+            options?.ResponseFormat is ChatResponseFormatJson;
+        if (usingSyntheticResponseFormat)
         {
             // Search the response's ContentBlocks for our synthetic tool's input
             // (ConverseResponse.Output.Message.Content contains a list of ContentBlock objects)
@@ -239,6 +261,13 @@ internal sealed partial class BedrockChatClient : IChatClient
     /// <inheritdoc />
     /// <remarks>
     /// <para>
+    /// <see cref="ChatOptions.ResponseFormat"/> is supported while streaming only in
+    /// <see cref="BedrockStructuredOutputMode.Native"/> mode (the default), where the constrained JSON
+    /// streams back as ordinary text deltas. In <see cref="BedrockStructuredOutputMode.SyntheticTool"/>
+    /// mode a JSON <see cref="ChatOptions.ResponseFormat"/> throws <see cref="NotSupportedException"/>;
+    /// use <see cref="GetResponseAsync"/> for that strategy.
+    /// </para>
+    /// <para>
     /// When <see cref="ChatOptions.Reasoning"/> is specified with a non-<see cref="ReasoningEffort.None"/> effort,
     /// the model must support extended thinking (e.g. Anthropic Claude). Models without this support will return
     /// an error from the Bedrock API.
@@ -252,25 +281,26 @@ internal sealed partial class BedrockChatClient : IChatClient
             throw new ArgumentNullException(nameof(messages));
         }
 
-        // ResponseFormat is not supported for streaming because it requires forcing a specific
-        // tool via ToolChoice. Since we create a synthetic tool for ResponseFormat and set
-        // toolChoice to force its use, this conflicts with the dynamic nature of streaming responses
-        // where tool calls may be interleaved with text content.
-        //
-        // For more information about tool use in streaming, see:
-        // https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#conversation-inference-supported-models-features
-        if (options?.ResponseFormat is ChatResponseFormatJson)
+        // The synthetic-tool ResponseFormat strategy is not supported for streaming because it forces a
+        // specific tool via ToolChoice, which conflicts with the dynamic nature of streaming responses
+        // where tool calls may be interleaved with text content. Native structured outputs has no such
+        // limitation: outputConfig.textFormat is orthogonal to toolConfig and the constrained JSON
+        // streams back as ordinary text deltas, so only SyntheticTool mode is rejected here.
+        if (_structuredOutputMode == BedrockStructuredOutputMode.SyntheticTool &&
+            options?.ResponseFormat is ChatResponseFormatJson)
         {
             throw new NotSupportedException(
-                "ResponseFormat is not yet supported for streaming responses with Amazon Bedrock. " +
-                "Please use GetResponseAsync for structured output.");
+                "ResponseFormat is not supported for streaming responses when using " +
+                "BedrockStructuredOutputMode.SyntheticTool. Use BedrockStructuredOutputMode.Native " +
+                "(the default) for streaming structured output, or GetResponseAsync for the synthetic-tool strategy.");
         }
 
         ConverseStreamRequest request = options?.RawRepresentationFactory?.Invoke(this) as ConverseStreamRequest ?? new();
         request.ModelId ??= options?.ModelId ?? _modelId;
         request.Messages = CreateMessages(request.Messages, messages);
         request.System = CreateSystem(request.System, messages, options);
-        request.ToolConfig = CreateToolConfig(request.ToolConfig, options);
+        request.ToolConfig = CreateToolConfig(request.ToolConfig, options, _structuredOutputMode);
+        request.OutputConfig = CreateOutputConfig(request.OutputConfig, options, _structuredOutputMode);
         request.InferenceConfig = CreateInferenceConfiguration(request.InferenceConfig, options);
         request.AdditionalModelRequestFields = ApplyReasoningConfig(request.AdditionalModelRequestFields, request.InferenceConfig, options);
 
@@ -900,14 +930,19 @@ internal sealed partial class BedrockChatClient : IChatClient
     }
 
     /// <summary>Creates a <see cref="ToolConfiguration"/> from the specified options.</summary>
-    private static ToolConfiguration? CreateToolConfig(ToolConfiguration? toolConfig, ChatOptions? options)
+    private static ToolConfiguration? CreateToolConfig(ToolConfiguration? toolConfig, ChatOptions? options,
+        BedrockStructuredOutputMode mode)
     {
         if (options?.Tools is { Count: > 0 } tools)
         {
             toolConfig = AddUserTools(toolConfig, tools);
         }
 
-        if (options?.ResponseFormat is ChatResponseFormatJson jsonFormat)
+        // Only the legacy SyntheticTool strategy realizes ResponseFormat through the tool mechanism.
+        // In Native mode ResponseFormat is handled via OutputConfig (see CreateOutputConfig), leaving
+        // toolConfig free for the caller's own tools.
+        if (mode == BedrockStructuredOutputMode.SyntheticTool &&
+            options?.ResponseFormat is ChatResponseFormatJson jsonFormat)
         {
             toolConfig = AddResponseFormatTool(toolConfig, jsonFormat);
         }
@@ -918,6 +953,75 @@ internal sealed partial class BedrockChatClient : IChatClient
         }
 
         return toolConfig;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="OutputConfig"/> for Bedrock native structured outputs when
+    /// <see cref="BedrockStructuredOutputMode.Native"/> is in effect and the request specifies a JSON
+    /// <see cref="ChatOptions.ResponseFormat"/>. Returns <see langword="null"/> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// The caller's MEAI schema is forwarded verbatim as a serialized JSON string, matching the wire
+    /// shape used by the Converse API and other AWS SDKs. If the schema uses features outside Bedrock's
+    /// supported JSON Schema subset, Bedrock returns a validation error which is surfaced to the caller.
+    /// A caller-provided <see cref="OutputConfig"/> (via <see cref="ChatOptions.RawRepresentationFactory"/>)
+    /// is respected and never overwritten.
+    /// </remarks>
+    private static OutputConfig? CreateOutputConfig(OutputConfig? existing, ChatOptions? options,
+        BedrockStructuredOutputMode mode)
+    {
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        if (mode != BedrockStructuredOutputMode.Native ||
+            options?.ResponseFormat is not ChatResponseFormatJson jsonFormat)
+        {
+            return null;
+        }
+
+        return new OutputConfig
+        {
+            TextFormat = new OutputFormat
+            {
+                Type = OutputFormatType.Json_schema,
+                Structure = new OutputFormatStructure
+                {
+                    JsonSchema = new JsonSchemaDefinition
+                    {
+                        // JsonElement -> raw JSON string; the field is a string on the wire.
+                        Schema = jsonFormat.Schema?.GetRawText(),
+                        Name = jsonFormat.SchemaName ?? TryGetSchemaTitle(jsonFormat.Schema) ?? "output_schema",
+                        Description = jsonFormat.SchemaDescription,
+                    }
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Attempts to derive a schema name from the schema's own <c>title</c> (then <c>name</c>) string
+    /// property, mirroring how other AWS SDKs default the structured-output name.
+    /// </summary>
+    private static string? TryGetSchemaTitle(JsonElement? schema)
+    {
+        if (schema is not { ValueKind: JsonValueKind.Object } element)
+        {
+            return null;
+        }
+
+        if (element.TryGetProperty("title", out JsonElement title) && title.ValueKind == JsonValueKind.String)
+        {
+            return title.GetString();
+        }
+
+        if (element.TryGetProperty("name", out JsonElement name) && name.ValueKind == JsonValueKind.String)
+        {
+            return name.GetString();
+        }
+
+        return null;
     }
 
     /// <summary>Adds user-provided tools to the tool configuration.</summary>

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockStructuredOutputMode.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockStructuredOutputMode.cs
@@ -22,27 +22,27 @@ namespace Amazon.BedrockRuntime;
 public enum BedrockStructuredOutputMode
 {
     /// <summary>
+    /// Use the synthetic forced-tool strategy: a synthetic tool carrying the response schema is
+    /// added and forced via <c>toolConfig.toolChoice</c>, and its tool-use output is unwrapped as the
+    /// structured result. This is the default.
+    /// </summary>
+    /// <remarks>
+    /// This mode is the default because it works across the broadest set of models, including those
+    /// without native structured-output support, and therefore does not change the request shape for
+    /// existing callers. Because it consumes the single available forced tool it cannot be combined
+    /// with user-provided <see cref="Microsoft.Extensions.AI.ChatOptions.Tools"/> and is not supported
+    /// for streaming. For models that support native structured outputs, use <see cref="Native"/>.
+    /// </remarks>
+    SyntheticTool = 0,
+
+    /// <summary>
     /// Use Bedrock native structured outputs via the request's <c>outputConfig.textFormat</c> field.
-    /// This is the default.
     /// </summary>
     /// <remarks>
     /// Native structured outputs is supported on newer models (for example Anthropic Claude 4.5+ and a
     /// number of open-weight models) and is <b>not</b> supported on older models such as Claude 3.x,
     /// Amazon Titan, Meta Llama, Cohere, or AI21. Because <c>outputConfig</c> is orthogonal to
     /// <c>toolConfig</c>, this mode composes with user-provided tools and is supported for streaming.
-    /// For models that do not support native structured outputs, use <see cref="SyntheticTool"/>.
     /// </remarks>
-    Native = 0,
-
-    /// <summary>
-    /// Use the legacy synthetic forced-tool strategy: a synthetic tool carrying the response schema is
-    /// added and forced via <c>toolConfig.toolChoice</c>, and its tool-use output is unwrapped as the
-    /// structured result.
-    /// </summary>
-    /// <remarks>
-    /// This mode works on models without native structured-output support, but because it consumes the
-    /// single available forced tool it cannot be combined with user-provided
-    /// <see cref="Microsoft.Extensions.AI.ChatOptions.Tools"/> and is not supported for streaming.
-    /// </remarks>
-    SyntheticTool = 1,
+    Native = 1,
 }

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockStructuredOutputMode.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockStructuredOutputMode.cs
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.BedrockRuntime;
+
+/// <summary>
+/// Controls how <see cref="Microsoft.Extensions.AI.ChatOptions.ResponseFormat"/> (structured output)
+/// is realized against the Amazon Bedrock Converse API.
+/// </summary>
+public enum BedrockStructuredOutputMode
+{
+    /// <summary>
+    /// Use Bedrock native structured outputs via the request's <c>outputConfig.textFormat</c> field.
+    /// This is the default.
+    /// </summary>
+    /// <remarks>
+    /// Native structured outputs is supported on newer models (for example Anthropic Claude 4.5+ and a
+    /// number of open-weight models) and is <b>not</b> supported on older models such as Claude 3.x,
+    /// Amazon Titan, Meta Llama, Cohere, or AI21. Because <c>outputConfig</c> is orthogonal to
+    /// <c>toolConfig</c>, this mode composes with user-provided tools and is supported for streaming.
+    /// For models that do not support native structured outputs, use <see cref="SyntheticTool"/>.
+    /// </remarks>
+    Native = 0,
+
+    /// <summary>
+    /// Use the legacy synthetic forced-tool strategy: a synthetic tool carrying the response schema is
+    /// added and forced via <c>toolConfig.toolChoice</c>, and its tool-use output is unwrapped as the
+    /// structured result.
+    /// </summary>
+    /// <remarks>
+    /// This mode works on models without native structured-output support, but because it consumes the
+    /// single available forced tool it cannot be combined with user-provided
+    /// <see cref="Microsoft.Extensions.AI.ChatOptions.Tools"/> and is not supported for streaming.
+    /// </remarks>
+    SyntheticTool = 1,
+}

--- a/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
+++ b/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
@@ -105,7 +105,7 @@ public class BedrockChatClientTests
                 StopReason = new StopReason("tool_use")
             });
 
-        var client = mockRuntime.Object.AsIChatClient("claude-3");
+        var client = mockRuntime.Object.AsIChatClient("claude-3", BedrockStructuredOutputMode.SyntheticTool);
         var messages = new[] { new ChatMessage(ChatRole.User, "Test") };
 
         var schemaJson = """
@@ -198,7 +198,7 @@ public class BedrockChatClientTests
                 Usage = new TokenUsage { InputTokens = 10, OutputTokens = 20, TotalTokens = 30 }
             });
 
-        var client = mockRuntime.Object.AsIChatClient("claude-3");
+        var client = mockRuntime.Object.AsIChatClient("claude-3", BedrockStructuredOutputMode.SyntheticTool);
         var messages = new[] { new ChatMessage(ChatRole.User, "Get weather") };
         var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
 
@@ -218,11 +218,12 @@ public class BedrockChatClientTests
 
     [Fact]
     [Trait("UnitTest", "BedrockRuntime")]
-    public async Task ResponseFormat_Json_WithTools_ThrowsArgumentException()
+    public async Task ResponseFormat_Json_WithTools_SyntheticToolMode_ThrowsArgumentException()
     {
-        // Arrange
+        // Arrange - SyntheticTool mode consumes the single forced tool, so it cannot be combined with
+        // user-provided tools. (Native mode, exercised separately, composes the two.)
         var mockRuntime = new Mock<IAmazonBedrockRuntime>();
-        var client = mockRuntime.Object.AsIChatClient("claude-3");
+        var client = mockRuntime.Object.AsIChatClient("claude-3", BedrockStructuredOutputMode.SyntheticTool);
         var messages = new[] { new ChatMessage(ChatRole.User, "Test") };
 
         // Create test tool
@@ -254,7 +255,7 @@ public class BedrockChatClientTests
                 ErrorCode = "ValidationException"
             });
 
-        var client = mockRuntime.Object.AsIChatClient("titan");
+        var client = mockRuntime.Object.AsIChatClient("titan", BedrockStructuredOutputMode.SyntheticTool);
         var messages = new[] { new ChatMessage(ChatRole.User, "Test") };
         var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
 
@@ -291,7 +292,7 @@ public class BedrockChatClientTests
                 StopReason = new StopReason("end_turn")
             });
 
-        var client = mockRuntime.Object.AsIChatClient("claude-3");
+        var client = mockRuntime.Object.AsIChatClient("claude-3", BedrockStructuredOutputMode.SyntheticTool);
         var messages = new[] { new ChatMessage(ChatRole.User, "Generate data") };
         var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
 
@@ -339,7 +340,7 @@ public class BedrockChatClientTests
                 StopReason = new StopReason("tool_use")
             });
 
-        var client = mockRuntime.Object.AsIChatClient("claude-3");
+        var client = mockRuntime.Object.AsIChatClient("claude-3", BedrockStructuredOutputMode.SyntheticTool);
         var messages = new[] { new ChatMessage(ChatRole.User, "Generate data") };
         var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
 
@@ -383,7 +384,7 @@ public class BedrockChatClientTests
                 StopReason = new StopReason("tool_use")
             });
 
-        var client = mockRuntime.Object.AsIChatClient("claude-3");
+        var client = mockRuntime.Object.AsIChatClient("claude-3", BedrockStructuredOutputMode.SyntheticTool);
         var messages = new[] { new ChatMessage(ChatRole.User, "Generate data") };
         var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
 
@@ -429,7 +430,7 @@ public class BedrockChatClientTests
                 StopReason = new StopReason("tool_use")
             });
 
-        var client = mockRuntime.Object.AsIChatClient("claude-3");
+        var client = mockRuntime.Object.AsIChatClient("claude-3", BedrockStructuredOutputMode.SyntheticTool);
         var messages = new[] { new ChatMessage(ChatRole.User, "Generate data") };
         var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
 
@@ -438,6 +439,215 @@ public class BedrockChatClientTests
             await client.GetResponseAsync(messages, options));
 
         Assert.Contains("did not return structured output", ex.Message);
+    }
+
+    [Fact]
+    [Trait("UnitTest", "BedrockRuntime")]
+    public async Task ResponseFormat_Json_Native_SetsOutputConfigNotTool()
+    {
+        // Arrange
+        var mockRuntime = new Mock<IAmazonBedrockRuntime>();
+        ConverseRequest capturedRequest = null;
+
+        mockRuntime
+            .Setup(x => x.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ConverseRequest, CancellationToken>((req, ct) => capturedRequest = req)
+            .ReturnsAsync(new ConverseResponse
+            {
+                Output = new ConverseOutput
+                {
+                    Message = new Message
+                    {
+                        Role = ConversationRole.Assistant,
+                        Content = new List<ContentBlock> { new ContentBlock { Text = "{\"summary\":\"ok\"}" } }
+                    }
+                },
+                StopReason = new StopReason("end_turn")
+            });
+
+        // Default client => Native structured outputs mode.
+        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        var messages = new[] { new ChatMessage(ChatRole.User, "Summarize") };
+
+        var schemaJson = """
+            {
+                "type": "object",
+                "properties": { "summary": { "type": "string" } },
+                "required": ["summary"],
+                "additionalProperties": false
+            }
+            """;
+        var schemaElement = JsonDocument.Parse(schemaJson).RootElement;
+        var options = new ChatOptions
+        {
+            ResponseFormat = ChatResponseFormat.ForJsonSchema(schemaElement,
+                schemaName: "SummarySchema",
+                schemaDescription: "A summary object")
+        };
+
+        // Act
+        await client.GetResponseAsync(messages, options);
+
+        // Assert - native structured outputs is realized via OutputConfig, not a synthetic tool.
+        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedRequest.OutputConfig);
+        Assert.NotNull(capturedRequest.OutputConfig.TextFormat);
+        Assert.Equal(OutputFormatType.Json_schema, capturedRequest.OutputConfig.TextFormat.Type);
+
+        var jsonSchema = capturedRequest.OutputConfig.TextFormat.Structure.JsonSchema;
+        Assert.Equal("SummarySchema", jsonSchema.Name);
+        Assert.Equal("A summary object", jsonSchema.Description);
+
+        // Schema is the supplied schema serialized to a JSON string.
+        using var actualSchema = JsonDocument.Parse(jsonSchema.Schema);
+        Assert.Equal("object", actualSchema.RootElement.GetProperty("type").GetString());
+        Assert.True(actualSchema.RootElement.GetProperty("properties").TryGetProperty("summary", out _));
+
+        // No synthetic generate_response tool / forced ToolChoice was added.
+        bool hasSyntheticTool = capturedRequest.ToolConfig?.Tools?.Any(t => t.ToolSpec?.Name == "generate_response") ?? false;
+        Assert.False(hasSyntheticTool);
+    }
+
+    [Fact]
+    [Trait("UnitTest", "BedrockRuntime")]
+    public async Task ResponseFormat_Json_Native_WithTools_PassesBothThrough()
+    {
+        // Arrange - the core regression from issue #4425: Tools + ResponseFormat must compose in Native mode.
+        var mockRuntime = new Mock<IAmazonBedrockRuntime>();
+        ConverseRequest capturedRequest = null;
+
+        mockRuntime
+            .Setup(x => x.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ConverseRequest, CancellationToken>((req, ct) => capturedRequest = req)
+            .ReturnsAsync(new ConverseResponse
+            {
+                Output = new ConverseOutput
+                {
+                    Message = new Message
+                    {
+                        Role = ConversationRole.Assistant,
+                        Content = new List<ContentBlock> { new ContentBlock { Text = "{\"summary\":\"ok\"}" } }
+                    }
+                },
+                StopReason = new StopReason("end_turn")
+            });
+
+        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        var messages = new[] { new ChatMessage(ChatRole.User, "What's the weather in Melbourne?") };
+
+        var weatherSchema = JsonDocument.Parse("""{"type":"object","properties":{"city":{"type":"string"}}}""").RootElement;
+        var tool = new TestAIFunction("get_weather", "Get the weather", weatherSchema);
+
+        var responseSchema = JsonDocument.Parse(
+            """{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"],"additionalProperties":false}""").RootElement;
+
+        var options = new ChatOptions
+        {
+            Tools = new[] { tool },
+            ResponseFormat = ChatResponseFormat.ForJsonSchema(responseSchema)
+        };
+
+        // Act - must NOT throw (previously threw ArgumentException before reaching Bedrock).
+        var response = await client.GetResponseAsync(messages, options);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedRequest.ToolConfig);
+
+        // User tool survives, no synthetic tool injected.
+        Assert.Contains(capturedRequest.ToolConfig.Tools, t => t.ToolSpec?.Name == "get_weather");
+        Assert.DoesNotContain(capturedRequest.ToolConfig.Tools, t => t.ToolSpec?.Name == "generate_response");
+
+        // Structured output requested via OutputConfig.
+        Assert.NotNull(capturedRequest.OutputConfig);
+        Assert.Equal(OutputFormatType.Json_schema, capturedRequest.OutputConfig.TextFormat.Type);
+    }
+
+    [Fact]
+    [Trait("UnitTest", "BedrockRuntime")]
+    public async Task ResponseFormat_Json_Native_ModelReturnsText_ParsedAsContent()
+    {
+        // Arrange - in Native mode the constrained JSON arrives as a normal text ContentBlock.
+        var mockRuntime = new Mock<IAmazonBedrockRuntime>();
+        var json = "{\"summary\":\"all good\"}";
+
+        mockRuntime
+            .Setup(x => x.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConverseResponse
+            {
+                Output = new ConverseOutput
+                {
+                    Message = new Message
+                    {
+                        Role = ConversationRole.Assistant,
+                        Content = new List<ContentBlock> { new ContentBlock { Text = json } }
+                    }
+                },
+                StopReason = new StopReason("end_turn")
+            });
+
+        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        var messages = new[] { new ChatMessage(ChatRole.User, "Summarize") };
+        var schema = JsonDocument.Parse("""{"type":"object","properties":{"summary":{"type":"string"}}}""").RootElement;
+        var options = new ChatOptions { ResponseFormat = ChatResponseFormat.ForJsonSchema(schema) };
+
+        // Act - no InvalidOperationException (that path is SyntheticTool-only).
+        var response = await client.GetResponseAsync(messages, options);
+
+        // Assert
+        Assert.Equal(json, response.Text);
+        var parsed = JsonDocument.Parse(response.Text);
+        Assert.Equal("all good", parsed.RootElement.GetProperty("summary").GetString());
+    }
+
+    [Fact]
+    [Trait("UnitTest", "BedrockRuntime")]
+    public async Task ResponseFormat_Json_Native_Streaming_DoesNotThrow_AndSetsOutputConfig()
+    {
+        // Arrange
+        ConverseStreamRequest capturedRequest = null;
+        IAmazonBedrockRuntime mock = CreateMock(onConverseStreamRequest: request =>
+        {
+            capturedRequest = request;
+            var stream = CreateEventStream(
+                CreateMessageStartEvent(),
+                CreateContentBlockStartEvent(0),
+                CreateContentBlockDeltaEvent(0, "{\"summary\":"),
+                CreateContentBlockDeltaEvent(0, "\"ok\"}"),
+                CreateContentBlockStopEvent(0),
+                CreateMessageStopEvent("end_turn"),
+                CreateMetadataEvent(10, 5)
+            );
+            return new ConverseStreamResponse { Stream = new ConverseStreamOutput(stream) };
+        });
+
+        IChatClient client = mock.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        var schema = JsonDocument.Parse(
+            """{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"],"additionalProperties":false}""").RootElement;
+        var options = new ChatOptions { ResponseFormat = ChatResponseFormat.ForJsonSchema(schema) };
+
+        // Act - Native mode supports streaming ResponseFormat (no NotSupportedException).
+        var updates = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync([new(ChatRole.User, "Summarize")], options))
+        {
+            updates.Add(update);
+        }
+
+        // Assert
+        Assert.NotEmpty(updates);
+
+        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedRequest.OutputConfig);
+        Assert.Equal(OutputFormatType.Json_schema, capturedRequest.OutputConfig.TextFormat.Type);
+
+        // The constrained JSON streamed back as ordinary text deltas.
+        string fullText = string.Concat(updates
+            .SelectMany(u => u.Contents.OfType<TextContent>())
+            .Select(c => c.Text));
+        Assert.Equal("{\"summary\":\"ok\"}", fullText);
+        var parsed = JsonDocument.Parse(fullText);
+        Assert.Equal("ok", parsed.RootElement.GetProperty("summary").GetString());
     }
 
 

--- a/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
+++ b/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
@@ -465,8 +465,7 @@ public class BedrockChatClientTests
                 StopReason = new StopReason("end_turn")
             });
 
-        // Default client => Native structured outputs mode.
-        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0", BedrockStructuredOutputMode.Native);
         var messages = new[] { new ChatMessage(ChatRole.User, "Summarize") };
 
         var schemaJson = """
@@ -510,6 +509,48 @@ public class BedrockChatClientTests
 
     [Fact]
     [Trait("UnitTest", "BedrockRuntime")]
+    public async Task ResponseFormat_Json_Native_NoSchema_UsesDefaultObjectSchema()
+    {
+        // Arrange - ChatResponseFormat.Json carries no schema. The Bedrock model requires
+        // jsonSchema.schema, so Native mode must fall back to a permissive object schema rather
+        // than emitting a null (which would fail marshalling/validation).
+        var mockRuntime = new Mock<IAmazonBedrockRuntime>();
+        ConverseRequest capturedRequest = null;
+
+        mockRuntime
+            .Setup(x => x.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ConverseRequest, CancellationToken>((req, ct) => capturedRequest = req)
+            .ReturnsAsync(new ConverseResponse
+            {
+                Output = new ConverseOutput
+                {
+                    Message = new Message
+                    {
+                        Role = ConversationRole.Assistant,
+                        Content = new List<ContentBlock> { new ContentBlock { Text = "{}" } }
+                    }
+                },
+                StopReason = new StopReason("end_turn")
+            });
+
+        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0", BedrockStructuredOutputMode.Native);
+        var messages = new[] { new ChatMessage(ChatRole.User, "Summarize") };
+        var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
+
+        // Act
+        await client.GetResponseAsync(messages, options);
+
+        // Assert - schema is populated with a permissive object schema, not null.
+        Assert.NotNull(capturedRequest?.OutputConfig?.TextFormat?.Structure?.JsonSchema);
+        var jsonSchema = capturedRequest.OutputConfig.TextFormat.Structure.JsonSchema;
+        Assert.False(string.IsNullOrEmpty(jsonSchema.Schema));
+
+        using var actualSchema = JsonDocument.Parse(jsonSchema.Schema);
+        Assert.Equal("object", actualSchema.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    [Trait("UnitTest", "BedrockRuntime")]
     public async Task ResponseFormat_Json_Native_WithTools_PassesBothThrough()
     {
         // Arrange - the core regression from issue #4425: Tools + ResponseFormat must compose in Native mode.
@@ -532,7 +573,7 @@ public class BedrockChatClientTests
                 StopReason = new StopReason("end_turn")
             });
 
-        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0", BedrockStructuredOutputMode.Native);
         var messages = new[] { new ChatMessage(ChatRole.User, "What's the weather in Melbourne?") };
 
         var weatherSchema = JsonDocument.Parse("""{"type":"object","properties":{"city":{"type":"string"}}}""").RootElement;
@@ -587,7 +628,7 @@ public class BedrockChatClientTests
                 StopReason = new StopReason("end_turn")
             });
 
-        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        var client = mockRuntime.Object.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0", BedrockStructuredOutputMode.Native);
         var messages = new[] { new ChatMessage(ChatRole.User, "Summarize") };
         var schema = JsonDocument.Parse("""{"type":"object","properties":{"summary":{"type":"string"}}}""").RootElement;
         var options = new ChatOptions { ResponseFormat = ChatResponseFormat.ForJsonSchema(schema) };
@@ -622,7 +663,7 @@ public class BedrockChatClientTests
             return new ConverseStreamResponse { Stream = new ConverseStreamOutput(stream) };
         });
 
-        IChatClient client = mock.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        IChatClient client = mock.AsIChatClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0", BedrockStructuredOutputMode.Native);
         var schema = JsonDocument.Parse(
             """{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"],"additionalProperties":false}""").RootElement;
         var options = new ChatOptions { ResponseFormat = ChatResponseFormat.ForJsonSchema(schema) };

--- a/generator/.DevConfigs/9ecd2b44-43d0-4c97-b1b7-18f6ec03236b.json
+++ b/generator/.DevConfigs/9ecd2b44-43d0-4c97-b1b7-18f6ec03236b.json
@@ -1,0 +1,11 @@
+{
+  "extensions": [
+    {
+      "extensionName": "Extensions.Bedrock.MEAI",
+      "type": "minor",
+      "changeLogMessages": [
+        "Add support for native structured outputs (https://github.com/aws/aws-sdk-net/issues/4425)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adopts Bedrock **native structured outputs** (`outputConfig.textFormat`) for `ChatOptions.ResponseFormat` in the `BedrockChatClient` MEAI adapter, addressing #4425.

Previously, `ResponseFormat` was implemented by injecting a synthetic forced tool (`generate_response`) and forcing it via `toolConfig.toolChoice`. Because Bedrock's `ToolChoice` can only force one tool at a time, the adapter:

- threw `ArgumentException` when a caller supplied both `ResponseFormat` **and** their own `Tools`, and
- threw `NotSupportedException` for `ResponseFormat` on the streaming path.

Both restrictions were correct before native structured outputs shipped. Now that Bedrock exposes `outputConfig.textFormat` as a top-level request field that is orthogonal to `toolConfig` (and the generated `Amazon.BedrockRuntime.Model` types already exist), the adapter can map `ResponseFormat` directly and lift both restrictions.

## What changed

- **New `BedrockStructuredOutputMode` enum** (`Native` = default, `SyntheticTool`). Native uses `outputConfig.textFormat`; SyntheticTool keeps the legacy forced-tool strategy for models without native support (Claude 3.x, Titan, Llama, Cohere, AI21, ...).
- **New `AsIChatClient` overload** that accepts the mode. The existing `AsIChatClient(runtime, defaultModelId)` signature is **left unchanged** (the new overload's mode parameter has no default), so this is **source- and binary-compatible** — existing callers are unaffected.
- **Request building:** in `Native` mode, `ResponseFormat` maps to `OutputConfig.TextFormat` (`Type = json_schema`, `JsonSchema.Schema` = the caller's schema serialized to a JSON string, `Name`/`Description` from `SchemaName`/`SchemaDescription`, with the schema's own `title`/`name` used as a name fallback). The synthetic tool, the tool-output extraction, and the streaming guard are all gated to `SyntheticTool` mode only. A caller-supplied `OutputConfig` (via `RawRepresentationFactory`) is respected.
- **Behavior:** `Native` mode composes with user-provided `Tools` and supports streaming — the constrained JSON returns as ordinary text content (and as text deltas while streaming).

## Notes / design

- **Model coverage.** Native structured outputs is supported on newer models (e.g. Claude 4.5+ and a number of open-weight models) and not on older ones. Rather than break older models, the legacy synthetic-tool path is retained and selectable via `BedrockStructuredOutputMode.SyntheticTool`.
- **Schema validation.** The caller's schema is forwarded verbatim; schemas outside Bedrock's supported JSON Schema subset produce a `ValidationException` from the service, surfaced to the caller (matches other SDKs).
- `ToolSpecification.Strict` (enforcing tool *input* schemas) is intentionally out of scope here and can be a separate follow-up.

## Tests

- Existing `ResponseFormat_Json_*` tests repointed to `SyntheticTool` mode (their behavior is unchanged in that mode).
- New native-mode tests: `OutputConfig` shape (not a synthetic tool), `Tools` + `ResponseFormat` composing without throwing, text-response parsing, and streaming without throwing.
- Full `BedrockMEAITests` suite passes on net8.0 (232) and net472 (170); the project builds warning-clean (`TreatWarningsAsErrors`).

Relates to #4425