### PR TITLE
ILoggerAdapter ConfigureAWSSDKLogging now throws when called with null ILoggerFactory

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Logging.ILoggerAdaptor/Extensions.cs
+++ b/extensions/src/AWSSDK.Extensions.Logging.ILoggerAdaptor/Extensions.cs
@@ -18,6 +18,8 @@
  *  AWS SDK for .NET
  *
  */
+
+using System;
 using Amazon.Extensions.Logging.ILoggerAdaptor;
 
 namespace Microsoft.Extensions.Logging
@@ -34,6 +36,11 @@ namespace Microsoft.Extensions.Logging
         /// <returns></returns>
         public static void ConfigureAWSSDKLogging(this ILoggerFactory loggerFactory)
         {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
             var adaptorFactory = new AdaptorLoggerFactoryImpl(loggerFactory);
             Amazon.Runtime.Logging.AdaptorLoggerFactoryRegistry.RegisterAdaptorLoggerFactory(adaptorFactory);
         }

--- a/generator/.DevConfigs/bae394c7-6a38-4382-9c79-8d76b1b6eb90.json
+++ b/generator/.DevConfigs/bae394c7-6a38-4382-9c79-8d76b1b6eb90.json
@@ -1,0 +1,11 @@
+{
+  "extensions": [
+    {
+      "extensionName": "Extensions.Logging.ILoggerAdaptor",
+      "type": "patch",
+      "changeLogMessages": [
+        "ILoggerAdapter ConfigureAWSSDKLogging now throws when called with null ILoggerFactory"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
ILoggerAdapter ConfigureAWSSDKLogging now throws when called with null ILoggerFactory

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Trivial argument null check.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
The ILoggerFactory passed to ConfigureAWSSDKLogging is captured by AdaptorLoggerFactoryImpl without checking validity. In the case of null argument, the failure stacktrace is far removed from the actual bug. This makes it fail fast at the call site to make the error obvious.


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are no existing tests for this ILoggerAdapter extension.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?
Not a breaking change.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement