### PR TITLE
Fix missing disposal in AWSSDKUtils.GenerateMemoryStreamFromString

### DIFF
--- a/generator/.DevConfigs/746814c7-08ab-4cac-9ec6-f5658272c911.json
+++ b/generator/.DevConfigs/746814c7-08ab-4cac-9ec6-f5658272c911.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fix StreamWriter missing disposal"
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -869,16 +869,26 @@ namespace Amazon.Util
             return a.Count == b.Count && !a.Except(b).Any();
         }
 
-        /// <summary>
-        /// Utility method for converting a string to a MemoryStream.
-        /// </summary>
-        /// <param name="s"></param>
-        /// <returns></returns>
-        public static MemoryStream GenerateMemoryStreamFromString(string s)
-        {
-            MemoryStream stream = new MemoryStream();
-            StreamWriter writer = new StreamWriter(stream);
-            writer.Write(s);
+#if !NETCOREAPP
+		//mirrors defaults used by more modern StreamWriter constructors
+		private static readonly Encoding UTF8NoBOM = new UTF8Encoding(false, true);
+		private const int DefaultStreamWriterBufferSize = 1024;
+#endif
+
+		/// <summary>
+		/// Utility method for converting a string to a MemoryStream.
+		/// </summary>
+		/// <param name="s"></param>
+		/// <returns></returns>
+		public static MemoryStream GenerateMemoryStreamFromString(string s)
+		{
+			MemoryStream stream = new MemoryStream();
+#if NETCOREAPP
+            using StreamWriter writer = new(stream, leaveOpen: true);
+#else
+			using StreamWriter writer = new(stream, UTF8NoBOM, DefaultStreamWriterBufferSize, leaveOpen: true);
+#endif
+			writer.Write(s);
             writer.Flush();
             stream.Position = 0;
             return stream;

--- a/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
+++ b/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
@@ -206,5 +206,18 @@ namespace AWSSDK.UnitTests
 
             Assert.AreEqual(expected, actual);
         }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void GenerateMemoryStreamFromString_ReturnsReadableStream_WhenInputIsValid()
+        {
+            var input = "Hello World";
+            var expectedBytes = Encoding.UTF8.GetBytes(input);
+            using var memoryStream = AWSSDKUtils.GenerateMemoryStreamFromString(input);
+            var actualBytes = new byte[memoryStream.Length];
+            memoryStream.Read(actualBytes, 0, actualBytes.Length);
+            CollectionAssert.AreEqual(expectedBytes, actualBytes);
+        }
     }
 }


### PR DESCRIPTION
Fixing missing disposal of IDisposable StreamWriter

## Description
StreamWriter is now correctly created (with keep open) and disposed when GenerateMemoryStreamFromString is called. For old frameworks default values were used in ctor where necessary

## Motivation and Context
Old method causes slow memory leak with every usage.

## Testing
Added unit test to validate underlaying stream is accessible and readable with expected content

## Breaking Changes Assessment
No breaking changes

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement