### PR TITLE
Small improvements in AWSSDKUtils

### DIFF
--- a/generator/.DevConfigs/746814c7-08ab-4cac-9ec6-f5658272c911.json
+++ b/generator/.DevConfigs/746814c7-08ab-4cac-9ec6-f5658272c911.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fix StreamWriter missing disposal"
+    ]
+  }
+}

--- a/generator/.DevConfigs/efda8c09-ff70-4dcc-b5cc-f9bb5c8b1c99.json
+++ b/generator/.DevConfigs/efda8c09-ff70-4dcc-b5cc-f9bb5c8b1c99.json
@@ -3,7 +3,7 @@
     "updateMinimum": false,
     "type": "patch",
     "changeLogMessages": [
-      "Fix StreamWriter missing disposal"
+      "small improvements in AWSSDKUtils"
     ]
   }
 }

--- a/generator/.DevConfigs/efda8c09-ff70-4dcc-b5cc-f9bb5c8b1c99.json
+++ b/generator/.DevConfigs/efda8c09-ff70-4dcc-b5cc-f9bb5c8b1c99.json
@@ -3,7 +3,7 @@
     "updateMinimum": false,
     "type": "patch",
     "changeLogMessages": [
-      "small improvements in AWSSDKUtils"
+      "Small performance improvements in `AWSSDKUtils` class (https://github.com/aws/aws-sdk-net/pull/4447)"
     ]
   }
 }

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -308,42 +308,42 @@ namespace Amazon.Util
          * Determines the string to be signed based on the input parameters for
          * AWS Signature Version 2
          */
-		internal static string CalculateStringToSignV2(ParameterCollection parameterCollection, string serviceUrl)
-		{
-			StringBuilder data = new StringBuilder("POST\n", 512);
-			var sortedParameters = parameterCollection.GetParametersEnumerable();
-			Uri endpoint = new Uri(serviceUrl);
+        internal static string CalculateStringToSignV2(ParameterCollection parameterCollection, string serviceUrl)
+        {
+            StringBuilder data = new StringBuilder("POST\n", 512);
+            var sortedParameters = parameterCollection.GetParametersEnumerable();
+            Uri endpoint = new Uri(serviceUrl);
 
-			data.Append(endpoint.Host);
-			data.Append('\n');
-			string uri = endpoint.AbsolutePath;
-			if (string.IsNullOrEmpty(uri))
-			{
-				uri = "/";
-			}
+            data.Append(endpoint.Host);
+            data.Append('\n');
+            string uri = endpoint.AbsolutePath;
+            if (string.IsNullOrEmpty(uri))
+            {
+                uri = "/";
+            }
 
-			data.Append(AWSSDKUtils.UrlEncode(uri, true));
-			data.Append('\n');
+            data.Append(AWSSDKUtils.UrlEncode(uri, true));
+            data.Append('\n');
 
-			foreach (KeyValuePair<string, string> pair in sortedParameters)
-			{
-				if (pair.Value != null)
-				{
-					data.Append(AWSSDKUtils.UrlEncode(pair.Key, false));
-					data.Append('=');
-					data.Append(AWSSDKUtils.UrlEncode(pair.Value, false));
+            foreach (KeyValuePair<string, string> pair in sortedParameters)
+            {
+                if (pair.Value != null)
+                {
+                    data.Append(AWSSDKUtils.UrlEncode(pair.Key, false));
+                    data.Append('=');
+                    data.Append(AWSSDKUtils.UrlEncode(pair.Value, false));
                     data.Append('&');
-				}
-			}
+                }
+            }
 
             data.Remove(data.Length - 1, 1); // Remove the trailing '\n' or '&' character
-			return data.ToString();
-		}
+            return data.ToString();
+        }
 
-		/**
+        /**
          * Convert request parameters to Url encoded query string
          */
-		internal static string GetParametersAsString(IRequest request)
+        internal static string GetParametersAsString(IRequest request)
         {
             return GetParametersAsString(request.ParameterCollection);
         }
@@ -1766,14 +1766,14 @@ namespace Amazon.Util
             return stringBuilder.ToString();
         }
 
-		/// <summary>
-		/// Extracts the operation name from a given request name.
-		/// </summary>
-		/// <param name="requestName">The name of the request from which the operation name is to be extracted.</param>
-		/// <returns>
-		/// The operation name if the request name ends with "Request"; otherwise, returns the original request name.
-		/// </returns>
-		internal static string ExtractOperationName(string requestName)
+        /// <summary>
+        /// Extracts the operation name from a given request name.
+        /// </summary>
+        /// <param name="requestName">The name of the request from which the operation name is to be extracted.</param>
+        /// <returns>
+        /// The operation name if the request name ends with "Request"; otherwise, returns the original request name.
+        /// </returns>
+        internal static string ExtractOperationName(string requestName)
         {
             if (requestName.EndsWith("Request", StringComparison.Ordinal))
             {

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -308,48 +308,42 @@ namespace Amazon.Util
          * Determines the string to be signed based on the input parameters for
          * AWS Signature Version 2
          */
-        internal static string CalculateStringToSignV2(ParameterCollection parameterCollection, string serviceUrl)
-        {
-            StringBuilder data = new StringBuilder("POST\n", 512);
-            var sortedParameters = parameterCollection.GetParametersEnumerable();
-            Uri endpoint = new Uri(serviceUrl);
+		internal static string CalculateStringToSignV2(ParameterCollection parameterCollection, string serviceUrl)
+		{
+			StringBuilder data = new StringBuilder("POST\n", 512);
+			var sortedParameters = parameterCollection.GetParametersEnumerable();
+			Uri endpoint = new Uri(serviceUrl);
 
-            data.Append(endpoint.Host);
-            data.Append('\n');
-            string uri = endpoint.AbsolutePath;
-            if (uri == null || uri.Length == 0)
-            {
-                uri = "/";
-            }
+			data.Append(endpoint.Host);
+			data.Append('\n');
+			string uri = endpoint.AbsolutePath;
+			if (string.IsNullOrEmpty(uri))
+			{
+				uri = "/";
+			}
 
-            data.Append(AWSSDKUtils.UrlEncode(uri, true));
-            data.Append('\n');
-            bool followup = false;
-            foreach (KeyValuePair<string, string> pair in sortedParameters)
-            {
-                if (pair.Value != null)
-                {
-                    if (followup)
-                    {
-                        data.Append('&');
-                    }
-                    else
-                    {
-                        followup = true;
-                    }
-                    data.Append(AWSSDKUtils.UrlEncode(pair.Key, false));
-                    data.Append('=');
-                    data.Append(AWSSDKUtils.UrlEncode(pair.Value, false));
-                }
-            }
+			data.Append(AWSSDKUtils.UrlEncode(uri, true));
+			data.Append('\n');
 
-            return data.ToString();
-        }
+			foreach (KeyValuePair<string, string> pair in sortedParameters)
+			{
+				if (pair.Value != null)
+				{
+					data.Append(AWSSDKUtils.UrlEncode(pair.Key, false));
+					data.Append('=');
+					data.Append(AWSSDKUtils.UrlEncode(pair.Value, false));
+                    data.Append('&');
+				}
+			}
 
-        /**
+            data.Remove(data.Length - 1, 1); // Remove the trailing '\n' or '&' character
+			return data.ToString();
+		}
+
+		/**
          * Convert request parameters to Url encoded query string
          */
-        internal static string GetParametersAsString(IRequest request)
+		internal static string GetParametersAsString(IRequest request)
         {
             return GetParametersAsString(request.ParameterCollection);
         }
@@ -1371,30 +1365,31 @@ namespace Amazon.Util
         /// <returns>Byte array corresponding to the hex string.</returns>
         public static byte[] HexStringToBytes(string hex)
         {
+            if (string.IsNullOrEmpty(hex) || hex.Length % 2 == 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(hex));
+            }
 #if NET8_0_OR_GREATER
-            ArgumentOutOfRangeException.ThrowIfNullOrEmpty(hex, nameof(hex));
             return Convert.FromHexString(hex);
 #else
-            if (string.IsNullOrEmpty(hex) || hex.Length % 2 == 1)
-                throw new ArgumentOutOfRangeException(nameof(hex));
-
             byte[] buffer = new byte[hex.Length / 2];
             for (int i = 0, j = 0; i < hex.Length; i += 2, j++)
                 buffer[j] = (byte)((HexCharToNibble(hex[i]) << 4) | HexCharToNibble(hex[i + 1]));
 
             return buffer;
-
+#endif
         }
 
+#if !NET8_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int HexCharToNibble(char c)
         {
             if ((uint)(c - '0') <= 9) return c - '0';
             if ((uint)(c - 'A') <= 5) return c - 'A' + 10;
             if ((uint)(c - 'a') <= 5) return c - 'a' + 10;
-			throw new FormatException("Invalid hex character: " + c);
+            throw new FormatException("Invalid hex character: " + c);
+        }
 #endif
-		}
 
         /// <summary>
         /// Returns DateTime.UtcNow + ManualClockCorrection when
@@ -1716,6 +1711,7 @@ namespace Amazon.Util
         /// <returns></returns>
         public static string CompressSpaces(string data)
         {
+            const char SPACE = ' ';
             if (data == null)
             {
                 return null;
@@ -1727,14 +1723,15 @@ namespace Amazon.Util
                 return string.Empty;
             }
 
-            // Fast path: scan for the first run of consecutive whitespace.
+            // Fast path: scan for the first run of consecutive whitespace or non-space whitespacecharacter.
             // If none exists the string is already compact — return it unchanged with no allocation.
             bool prevWasWhiteSpace = false;
             int firstRunIndex = -1;
             for (int i = 0; i < dataLength; i++)
             {
-                bool isWS = char.IsWhiteSpace(data[i]);
-                if (isWS && prevWasWhiteSpace)
+                char c = data[i];
+                bool isWS = char.IsWhiteSpace(c);
+                if (isWS && (prevWasWhiteSpace || c != SPACE))
                 {
                     firstRunIndex = i - 1;
                     break;
@@ -1756,7 +1753,7 @@ namespace Amazon.Util
             {
                 if (char.IsWhiteSpace(data[pos]))
                 {
-                    stringBuilder.Append(' ');
+                    stringBuilder.Append(SPACE);
                     do { pos++; } while (pos < dataLength && char.IsWhiteSpace(data[pos]));
                 }
                 else
@@ -1769,14 +1766,14 @@ namespace Amazon.Util
             return stringBuilder.ToString();
         }
 
-        /// <summary>
-        /// Extracts the operation name from a given request name.
-        /// </summary>
-        /// <param name="requestName">The name of the request from which the operation name is to be extracted.</param>
-        /// <returns>
-        /// The operation name if the request name ends with "Request"; otherwise, returns the original request name.
-        /// </returns>
-        internal static string ExtractOperationName(string requestName)
+		/// <summary>
+		/// Extracts the operation name from a given request name.
+		/// </summary>
+		/// <param name="requestName">The name of the request from which the operation name is to be extracted.</param>
+		/// <returns>
+		/// The operation name if the request name ends with "Request"; otherwise, returns the original request name.
+		/// </returns>
+		internal static string ExtractOperationName(string requestName)
         {
             if (requestName.EndsWith("Request", StringComparison.Ordinal))
             {

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -308,27 +308,27 @@ namespace Amazon.Util
          * Determines the string to be signed based on the input parameters for
          * AWS Signature Version 2
          */
-		internal static string CalculateStringToSignV2(ParameterCollection parameterCollection, string serviceUrl)
-		{
-			StringBuilder data = new StringBuilder("POST\n", 512);
+        internal static string CalculateStringToSignV2(ParameterCollection parameterCollection, string serviceUrl)
+        {
+            StringBuilder data = new StringBuilder("POST\n", 512);
             var sortedParameters = parameterCollection.GetParametersEnumerable();
-			Uri endpoint = new Uri(serviceUrl);
+            Uri endpoint = new Uri(serviceUrl);
 
-			data.Append(endpoint.Host);
-			data.Append('\n');
-			string uri = endpoint.AbsolutePath;
-			if (uri == null || uri.Length == 0)
-			{
-				uri = "/";
-			}
+            data.Append(endpoint.Host);
+            data.Append('\n');
+            string uri = endpoint.AbsolutePath;
+            if (uri == null || uri.Length == 0)
+            {
+                uri = "/";
+            }
 
-			data.Append(AWSSDKUtils.UrlEncode(uri, true));
-			data.Append('\n');
+            data.Append(AWSSDKUtils.UrlEncode(uri, true));
+            data.Append('\n');
             bool followup = false;
-			foreach (KeyValuePair<string, string> pair in sortedParameters)
-			{
-				if (pair.Value != null)
-				{
+            foreach (KeyValuePair<string, string> pair in sortedParameters)
+            {
+                if (pair.Value != null)
+                {
                     if (followup)
                     {
                         data.Append('&');
@@ -337,19 +337,19 @@ namespace Amazon.Util
                     {
                         followup = true;
                     }
-					data.Append(AWSSDKUtils.UrlEncode(pair.Key, false));
-					data.Append('=');
-					data.Append(AWSSDKUtils.UrlEncode(pair.Value, false));
-				}
-			}
+                    data.Append(AWSSDKUtils.UrlEncode(pair.Key, false));
+                    data.Append('=');
+                    data.Append(AWSSDKUtils.UrlEncode(pair.Value, false));
+                }
+            }
 
             return data.ToString();
-		}
+        }
 
-		/**
+        /**
          * Convert request parameters to Url encoded query string
          */
-		internal static string GetParametersAsString(IRequest request)
+        internal static string GetParametersAsString(IRequest request)
         {
             return GetParametersAsString(request.ParameterCollection);
         }
@@ -576,14 +576,14 @@ namespace Amazon.Util
         }
 
 
-		/// <summary>
-		/// Takes a patterned resource path and resolves it using the key/value path resources into
-		/// a segmented encoded URL.
-		/// </summary>
-		/// <param name="resourcePath">The patterned resourcePath</param>
-		/// <param name="pathResources">The key/value lookup for the patterned resourcePath</param>
-		/// <returns></returns>
-		public static string ResolveResourcePathV2(string resourcePath, IDictionary<string, string> pathResources)
+        /// <summary>
+        /// Takes a patterned resource path and resolves it using the key/value path resources into
+        /// a segmented encoded URL.
+        /// </summary>
+        /// <param name="resourcePath">The patterned resourcePath</param>
+        /// <param name="pathResources">The key/value lookup for the patterned resourcePath</param>
+        /// <returns></returns>
+        public static string ResolveResourcePathV2(string resourcePath, IDictionary<string, string> pathResources)
         {
             if (string.IsNullOrEmpty(resourcePath))
             {
@@ -765,13 +765,13 @@ namespace Amazon.Util
 #endif
         }
 
-		/// <summary>
-		/// Calls a specific EventHandler in a background thread
-		/// </summary>
-		/// <param name="handler"></param>
-		/// <param name="args"></param>
-		/// <param name="sender"></param>
-		public static void InvokeInBackground<T>(EventHandler<T> handler, T args, object sender) where T : EventArgs
+        /// <summary>
+        /// Calls a specific EventHandler in a background thread
+        /// </summary>
+        /// <param name="handler"></param>
+        /// <param name="args"></param>
+        /// <param name="sender"></param>
+        public static void InvokeInBackground<T>(EventHandler<T> handler, T args, object sender) where T : EventArgs
         {
             if (handler == null) return;
 
@@ -834,7 +834,7 @@ namespace Amazon.Util
             return parameters;
         }
 
-		internal static bool AreEqual(object[] itemsA, object[] itemsB)
+        internal static bool AreEqual(object[] itemsA, object[] itemsB)
         {
             if (itemsA == null || itemsB == null)
                 return (itemsA == itemsB);
@@ -865,29 +865,29 @@ namespace Amazon.Util
             return (a.Equals(b));
         }
 
-		public static bool DictionariesAreEqual<TKey,TValue>(Dictionary<TKey, TValue> a, Dictionary<TKey, TValue> b)
-		{
-			if (a == null || b == null)
-				return (a == b);
+        internal static bool DictionariesAreEqual<TKey,TValue>(Dictionary<TKey, TValue> a, Dictionary<TKey, TValue> b)
+        {
+            if (a == null || b == null)
+                return (a == b);
 
-			if (object.ReferenceEquals(a, b))
-				return true;
+            if (object.ReferenceEquals(a, b))
+                return true;
 
-			return a.Count == b.Count && a.All(aKV => b.TryGetValue(aKV.Key, out var bVal) && EqualityComparer<TValue>.Default.Equals(aKV.Value, bVal));
-		}
+            return a.Count == b.Count && a.All(aKV => b.TryGetValue(aKV.Key, out var bVal) && EqualityComparer<TValue>.Default.Equals(aKV.Value, bVal));
+        }
 
-		/// <summary>
-		/// Utility method for converting a string to a MemoryStream.
-		/// </summary>
-		/// <param name="s"></param>
-		/// <returns></returns>
-		public static MemoryStream GenerateMemoryStreamFromString(string s)
-		{
-			MemoryStream stream = new MemoryStream();
-			StreamWriter writer = new StreamWriter(stream);
-			writer.Write(s);
-			writer.Flush();
-			stream.Position = 0;
+        /// <summary>
+        /// Utility method for converting a string to a MemoryStream.
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        public static MemoryStream GenerateMemoryStreamFromString(string s)
+        {
+            MemoryStream stream = new MemoryStream();
+            StreamWriter writer = new StreamWriter(stream);
+            writer.Write(s);
+            writer.Flush();
+            stream.Position = 0;
             return stream;
         }
 
@@ -1229,19 +1229,19 @@ namespace Amazon.Util
         private static readonly char[] upperHex = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 
         private static void ToHexString(ReadOnlySpan<byte> source, Span<char> destination, bool lowercase)
-		{
-			var converter = lowercase ? lowerHex : upperHex;
-			for (int i = source.Length - 1; i >= 0; i--)
-			{
-				// Break apart the byte into two four-bit components and
-				// then convert each into their hexadecimal equivalent.
-				byte b = source[i];
-				int hiNibble = b >> 4;
-				int loNibble = b & 0xF;
-				destination[i * 2] = converter[hiNibble];
-				destination[i * 2 + 1] = converter[loNibble];
-			}
-		}
+        {
+            var converter = lowercase ? lowerHex : upperHex;
+            for (int i = source.Length - 1; i >= 0; i--)
+            {
+                // Break apart the byte into two four-bit components and
+                // then convert each into their hexadecimal equivalent.
+                byte b = source[i];
+                int hiNibble = b >> 4;
+                int loNibble = b & 0xF;
+                destination[i * 2] = converter[hiNibble];
+                destination[i * 2 + 1] = converter[loNibble];
+            }
+        }
 
         internal static string UrlEncodeSlash(string data)
         {
@@ -1369,39 +1369,39 @@ namespace Amazon.Util
         /// </summary>
         /// <param name="hex">Hexadecimal string</param>
         /// <returns>Byte array corresponding to the hex string.</returns>
-		public static byte[] HexStringToBytes(string hex)
-		{
+        public static byte[] HexStringToBytes(string hex)
+        {
 #if NET8_0_OR_GREATER
             ArgumentOutOfRangeException.ThrowIfNullOrEmpty(hex, nameof(hex));
-			return Convert.FromHexString(hex);
+            return Convert.FromHexString(hex);
 #else
             if (string.IsNullOrEmpty(hex) || hex.Length % 2 == 1)
                 throw new ArgumentOutOfRangeException(nameof(hex));
 
             byte[] buffer = new byte[hex.Length / 2];
-			for (int i = 0, j = 0; i < hex.Length; i += 2, j++)
-				buffer[j] = (byte)((HexCharToNibble(hex[i]) << 4) | HexCharToNibble(hex[i + 1]));
+            for (int i = 0, j = 0; i < hex.Length; i += 2, j++)
+                buffer[j] = (byte)((HexCharToNibble(hex[i]) << 4) | HexCharToNibble(hex[i + 1]));
 
-			return buffer;
+            return buffer;
 
-		}
+        }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private static int HexCharToNibble(char c)
-		{
-			if ((uint)(c - '0') <= 9) return c - '0';
-			if ((uint)(c - 'A') <= 5) return c - 'A' + 10;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int HexCharToNibble(char c)
+        {
+            if ((uint)(c - '0') <= 9) return c - '0';
+            if ((uint)(c - 'A') <= 5) return c - 'A' + 10;
             if ((uint)(c - 'a') <= 5) return c - 'a' + 10;
             throw new ArgumentOutOfRangeException(nameof(c), "Invalid hex character: " + c);
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Returns DateTime.UtcNow + ManualClockCorrection when
-		/// <seealso cref="AWSConfigs.ManualClockCorrection"/> is set.
-		/// This value should be used instead of DateTime.UtcNow to factor in manual clock correction
-		/// </summary>
-		public static DateTime CorrectedUtcNow
+        /// <summary>
+        /// Returns DateTime.UtcNow + ManualClockCorrection when
+        /// <seealso cref="AWSConfigs.ManualClockCorrection"/> is set.
+        /// This value should be used instead of DateTime.UtcNow to factor in manual clock correction
+        /// </summary>
+        public static DateTime CorrectedUtcNow
         {
             get
             {
@@ -1412,37 +1412,37 @@ namespace Amazon.Util
             }
         }
 
-		private static readonly char[] _bidiControlChars =
-		{
-			'\u200E', // LRM
-			'\u200F', // RLM
-			'\u202A', // LRE
-			'\u202B', // RLE
-			'\u202C', // PDF
-			'\u202D', // LRO
-			'\u202E'  // RLO
-		};
+        private static readonly char[] _bidiControlChars =
+        {
+            '\u200E', // LRM
+            '\u200F', // RLM
+            '\u202A', // LRE
+            '\u202B', // RLE
+            '\u202C', // PDF
+            '\u202D', // LRO
+            '\u202E'  // RLO
+        };
 
 #if NET8_0_OR_GREATER
-		private static readonly SearchValues<char> _bidiControlCharSearchValues =
-			SearchValues.Create(_bidiControlChars);
+        private static readonly SearchValues<char> _bidiControlCharSearchValues =
+            SearchValues.Create(_bidiControlChars);
 #endif
 
-		/// <summary>
-		/// Returns true if the string has any bidirectional control characters.
-		/// </summary>
-		/// <param name="input"></param>
-		/// <returns></returns>
-		public static bool HasBidiControlCharacters(string input)
-		{
-			if (string.IsNullOrEmpty(input))
-				return false;
+        /// <summary>
+        /// Returns true if the string has any bidirectional control characters.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static bool HasBidiControlCharacters(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return false;
 #if NET8_0_OR_GREATER
-			return input.AsSpan().IndexOfAny(_bidiControlCharSearchValues) >= 0;
+            return input.AsSpan().IndexOfAny(_bidiControlCharSearchValues) >= 0;
 #else
-			return input.AsSpan().IndexOfAny(_bidiControlChars) >= 0;
+            return input.AsSpan().IndexOfAny(_bidiControlChars) >= 0;
 #endif
-		}
+        }
 
         public static string DownloadStringContent(Uri uri)
         {
@@ -1709,12 +1709,12 @@ namespace Amazon.Util
 #endif
         }
 
-		/// <summary>
-		/// Utility method that accepts a string and replaces white spaces with a space.
-		/// </summary>
-		/// <param name="data"></param>
-		/// <returns></returns>
-		public static string CompressSpaces(string data)
+        /// <summary>
+        /// Utility method that accepts a string and replaces white spaces with a space.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static string CompressSpaces(string data)
         {
             if (data == null)
             {

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -110,7 +110,7 @@ namespace Amazon.Util
         /// <summary>
         /// The set of accepted and valid Url path characters per RFC3986.
         /// </summary>
-        private static string ValidPathCharacters = DetermineValidPathCharacters();
+        private static readonly string ValidPathCharacters = DetermineValidPathCharacters();
 
         /// <summary>
         /// The set of characters which are not to be encoded as part of the X-Amzn-Trace-Id header values
@@ -308,41 +308,48 @@ namespace Amazon.Util
          * Determines the string to be signed based on the input parameters for
          * AWS Signature Version 2
          */
-        internal static string CalculateStringToSignV2(ParameterCollection parameterCollection, string serviceUrl)
-        {
-            StringBuilder data = new StringBuilder("POST\n", 512);
-            var sortedParameters = parameterCollection.GetSortedParametersList();
-            Uri endpoint = new Uri(serviceUrl);
+		internal static string CalculateStringToSignV2(ParameterCollection parameterCollection, string serviceUrl)
+		{
+			StringBuilder data = new StringBuilder("POST\n", 512);
+            var sortedParameters = parameterCollection.GetParametersEnumerable();
+			Uri endpoint = new Uri(serviceUrl);
 
-            data.Append(endpoint.Host);
-            data.Append("\n");
-            string uri = endpoint.AbsolutePath;
-            if (uri == null || uri.Length == 0)
-            {
-                uri = "/";
-            }
+			data.Append(endpoint.Host);
+			data.Append('\n');
+			string uri = endpoint.AbsolutePath;
+			if (uri == null || uri.Length == 0)
+			{
+				uri = "/";
+			}
 
-            data.Append(AWSSDKUtils.UrlEncode(uri, true));
-            data.Append("\n");
-            foreach (KeyValuePair<string, string> pair in sortedParameters)
-            {
-                if (pair.Value != null)
-                {
-                    data.Append(AWSSDKUtils.UrlEncode(pair.Key, false));
-                    data.Append("=");
-                    data.Append(AWSSDKUtils.UrlEncode(pair.Value, false));
-                    data.Append("&");
-                }
-            }
+			data.Append(AWSSDKUtils.UrlEncode(uri, true));
+			data.Append('\n');
+            bool followup = false;
+			foreach (KeyValuePair<string, string> pair in sortedParameters)
+			{
+				if (pair.Value != null)
+				{
+                    if (followup)
+                    {
+                        data.Append('&');
+                    }
+                    else
+                    {
+                        followup = true;
+                    }
+					data.Append(AWSSDKUtils.UrlEncode(pair.Key, false));
+					data.Append('=');
+					data.Append(AWSSDKUtils.UrlEncode(pair.Value, false));
+				}
+			}
 
-            string result = data.ToString();
-            return result.Remove(result.Length - 1);
-        }
+            return data.ToString();
+		}
 
-        /**
+		/**
          * Convert request parameters to Url encoded query string
          */
-        internal static string GetParametersAsString(IRequest request)
+		internal static string GetParametersAsString(IRequest request)
         {
             return GetParametersAsString(request.ParameterCollection);
         }
@@ -557,26 +564,26 @@ namespace Amazon.Util
         /// <returns></returns>
         public static string JoinResourcePathSegmentsV2(IEnumerable<UriComponent> pathSegments)
         {
-            List<string> encodedSegments = pathSegments.Select(segment =>
+            string[] encodedSegments = pathSegments.Select(segment =>
             {
                 if (segment.SegmentType == SegmentType.Label)
                     return UrlEncode(segment.Value, false);
                 else
                     return UrlEncode(segment.Value, true);
-            }).ToList();
+            }).ToArray();
             // join the encoded segments with /
             return string.Join(Slash, encodedSegments);
         }
 
 
-        /// <summary>
-        /// Takes a patterned resource path and resolves it using the key/value path resources into
-        /// a segmented encoded URL.
-        /// </summary>
-        /// <param name="resourcePath">The patterned resourcePath</param>
-        /// <param name="pathResources">The key/value lookup for the patterned resourcePath</param>
-        /// <returns></returns>
-        public static string ResolveResourcePathV2(string resourcePath, IDictionary<string, string> pathResources)
+		/// <summary>
+		/// Takes a patterned resource path and resolves it using the key/value path resources into
+		/// a segmented encoded URL.
+		/// </summary>
+		/// <param name="resourcePath">The patterned resourcePath</param>
+		/// <param name="pathResources">The key/value lookup for the patterned resourcePath</param>
+		/// <returns></returns>
+		public static string ResolveResourcePathV2(string resourcePath, IDictionary<string, string> pathResources)
         {
             if (string.IsNullOrEmpty(resourcePath))
             {
@@ -758,13 +765,13 @@ namespace Amazon.Util
 #endif
         }
 
-        /// <summary>
-        /// Calls a specific EventHandler in a background thread
-        /// </summary>
-        /// <param name="handler"></param>
-        /// <param name="args"></param>
-        /// <param name="sender"></param>
-        public static void InvokeInBackground<T>(EventHandler<T> handler, T args, object sender) where T : EventArgs
+		/// <summary>
+		/// Calls a specific EventHandler in a background thread
+		/// </summary>
+		/// <param name="handler"></param>
+		/// <param name="args"></param>
+		/// <param name="sender"></param>
+		public static void InvokeInBackground<T>(EventHandler<T> handler, T args, object sender) where T : EventArgs
         {
             if (handler == null) return;
 
@@ -827,7 +834,7 @@ namespace Amazon.Util
             return parameters;
         }
 
-        internal static bool AreEqual(object[] itemsA, object[] itemsB)
+		internal static bool AreEqual(object[] itemsA, object[] itemsB)
         {
             if (itemsA == null || itemsB == null)
                 return (itemsA == itemsB);
@@ -858,22 +865,16 @@ namespace Amazon.Util
             return (a.Equals(b));
         }
 
-        internal static bool DictionariesAreEqual<K,V>(Dictionary<K, V> a, Dictionary<K, V> b)
-        {
-            if (a == null || b == null)
-                return (a == b);
+		public static bool DictionariesAreEqual<TKey,TValue>(Dictionary<TKey, TValue> a, Dictionary<TKey, TValue> b)
+		{
+			if (a == null || b == null)
+				return (a == b);
 
-            if (object.ReferenceEquals(a, b))
-                return true;
+			if (object.ReferenceEquals(a, b))
+				return true;
 
-            return a.Count == b.Count && !a.Except(b).Any();
-        }
-
-#if !NETCOREAPP
-		//mirrors defaults used by more modern StreamWriter constructors
-		private static readonly Encoding UTF8NoBOM = new UTF8Encoding(false, true);
-		private const int DefaultStreamWriterBufferSize = 1024;
-#endif
+			return a.Count == b.Count && a.All(aKV => b.TryGetValue(aKV.Key, out var bVal) && EqualityComparer<TValue>.Default.Equals(aKV.Value, bVal));
+		}
 
 		/// <summary>
 		/// Utility method for converting a string to a MemoryStream.
@@ -883,14 +884,10 @@ namespace Amazon.Util
 		public static MemoryStream GenerateMemoryStreamFromString(string s)
 		{
 			MemoryStream stream = new MemoryStream();
-#if NETCOREAPP
-            using StreamWriter writer = new(stream, leaveOpen: true);
-#else
-			using StreamWriter writer = new(stream, UTF8NoBOM, DefaultStreamWriterBufferSize, leaveOpen: true);
-#endif
+			StreamWriter writer = new StreamWriter(stream);
 			writer.Write(s);
-            writer.Flush();
-            stream.Position = 0;
+			writer.Flush();
+			stream.Position = 0;
             return stream;
         }
 
@@ -1192,8 +1189,8 @@ namespace Amazon.Util
                         // then convert each into their hexadecimal equivalent.
                         var hiNibble = symbol >> 4;
                         var loNibble = symbol & 0xF;
-                        dataBuffer[index++] = (byte)ToUpperHex(hiNibble);
-                        dataBuffer[index++] = (byte)ToUpperHex(loNibble);
+                        dataBuffer[index++] = (byte)upperHex[hiNibble];
+                        dataBuffer[index++] = (byte)upperHex[loNibble];
                     }
                 }
 
@@ -1228,44 +1225,23 @@ namespace Amazon.Util
             return false;
         }
 
-        private static void ToHexString(Span<byte> source, Span<char> destination, bool lowercase)
-        {
-            Func<int, char> converter = lowercase ? (Func<int, char>)ToLowerHex : (Func<int, char>)ToUpperHex;
+        private static readonly char[] lowerHex = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+        private static readonly char[] upperHex = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 
-            for (int i = source.Length - 1; i >= 0; i--)
-            {
-                // Break apart the byte into two four-bit components and
-                // then convert each into their hexadecimal equivalent.
-                byte b = source[i];
-                int hiNibble = b >> 4;
-                int loNibble = b & 0xF;
-
-                destination[i * 2] = converter(hiNibble);
-                destination[i * 2 + 1] = converter(loNibble);
-            }
-        }
-
-        private static char ToUpperHex(int value)
-        {
-            // Maps 0-9 to the Unicode range of '0' - '9' (0x30 - 0x39).
-            if (value <= 9)
-            {
-                return (char)(value + '0');
-            }
-            // Maps 10-15 to the Unicode range of 'A' - 'F' (0x41 - 0x46).
-            return (char)(value - 10 + 'A');
-        }
-
-        private static char ToLowerHex(int value)
-        {
-            // Maps 0-9 to the Unicode range of '0' - '9' (0x30 - 0x39).
-            if (value <= 9)
-            {
-                return (char)(value + '0');
-            }
-            // Maps 10-15 to the Unicode range of 'a' - 'f' (0x61 - 0x66).
-            return (char)(value - 10 + 'a');
-        }
+        private static void ToHexString(ReadOnlySpan<byte> source, Span<char> destination, bool lowercase)
+		{
+			var converter = lowercase ? lowerHex : upperHex;
+			for (int i = source.Length - 1; i >= 0; i--)
+			{
+				// Break apart the byte into two four-bit components and
+				// then convert each into their hexadecimal equivalent.
+				byte b = source[i];
+				int hiNibble = b >> 4;
+				int loNibble = b & 0xF;
+				destination[i * 2] = converter[hiNibble];
+				destination[i * 2 + 1] = converter[loNibble];
+			}
+		}
 
         internal static string UrlEncodeSlash(string data)
         {
@@ -1294,7 +1270,7 @@ namespace Amazon.Util
                 }
                 else
                 {
-                    encoded.Append("%").Append(string.Format(CultureInfo.InvariantCulture, "{0:X2}", (int)symbol));
+                    encoded.Append('%').Append(string.Format(CultureInfo.InvariantCulture, "{0:X2}", (int)symbol));
                 }
             }
 
@@ -1375,7 +1351,11 @@ namespace Amazon.Util
             }
             else
             {
+#if NET8_0_OR_GREATER
+                return Convert.ToHexString(hashed);
+#else
                 return BitConverter.ToString(hashed).Replace("-", String.Empty);
+#endif
             }
         }
 
@@ -1389,30 +1369,39 @@ namespace Amazon.Util
         /// </summary>
         /// <param name="hex">Hexadecimal string</param>
         /// <returns>Byte array corresponding to the hex string.</returns>
-        public static byte[] HexStringToBytes(string hex)
-        {
+		public static byte[] HexStringToBytes(string hex)
+		{
+#if NET8_0_OR_GREATER
+            ArgumentOutOfRangeException.ThrowIfNullOrEmpty(hex, nameof(hex));
+			return Convert.FromHexString(hex);
+#else
             if (string.IsNullOrEmpty(hex) || hex.Length % 2 == 1)
-                throw new ArgumentOutOfRangeException("hex");
+                throw new ArgumentOutOfRangeException(nameof(hex));
 
-            int count = 0;
             byte[] buffer = new byte[hex.Length / 2];
-            for (int i = 0; i < hex.Length; i += 2)
-            {
-                string sub = hex.Substring(i, 2);
-                byte b = Convert.ToByte(sub, 16);
-                buffer[count] = b;
-                count++;
-            }
+			for (int i = 0, j = 0; i < hex.Length; i += 2, j++)
+				buffer[j] = (byte)((HexCharToNibble(hex[i]) << 4) | HexCharToNibble(hex[i + 1]));
 
-            return buffer;
-        }
+			return buffer;
 
-        /// <summary>
-        /// Returns DateTime.UtcNow + ManualClockCorrection when
-        /// <seealso cref="AWSConfigs.ManualClockCorrection"/> is set.
-        /// This value should be used instead of DateTime.UtcNow to factor in manual clock correction
-        /// </summary>
-        public static DateTime CorrectedUtcNow
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private static int HexCharToNibble(char c)
+		{
+			if ((uint)(c - '0') <= 9) return c - '0';
+			if ((uint)(c - 'A') <= 5) return c - 'A' + 10;
+            if ((uint)(c - 'a') <= 5) return c - 'a' + 10;
+            throw new ArgumentOutOfRangeException(nameof(c), "Invalid hex character: " + c);
+#endif
+		}
+
+		/// <summary>
+		/// Returns DateTime.UtcNow + ManualClockCorrection when
+		/// <seealso cref="AWSConfigs.ManualClockCorrection"/> is set.
+		/// This value should be used instead of DateTime.UtcNow to factor in manual clock correction
+		/// </summary>
+		public static DateTime CorrectedUtcNow
         {
             get
             {
@@ -1423,40 +1412,37 @@ namespace Amazon.Util
             }
         }
 
-        /// <summary>
-        /// Returns true if the string has any bidirectional control characters.
-        /// </summary>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        public static bool HasBidiControlCharacters(string input)
-        {
-            if (string.IsNullOrEmpty(input))
-                return false;
+		private static readonly char[] _bidiControlChars =
+		{
+			'\u200E', // LRM
+			'\u200F', // RLM
+			'\u202A', // LRE
+			'\u202B', // RLE
+			'\u202C', // PDF
+			'\u202D', // LRO
+			'\u202E'  // RLO
+		};
 
-            foreach (var c in input)
-            {
-                if (IsBidiControlChar(c))
-                    return true;
-            }
-            return false;
-        }
-        private static bool IsBidiControlChar(char c)
-        {
-            // check general range
-            if (c < '\u200E' || c > '\u202E')
-                return false;
+#if NET8_0_OR_GREATER
+		private static readonly SearchValues<char> _bidiControlCharSearchValues =
+			SearchValues.Create(_bidiControlChars);
+#endif
 
-            // check specific characters
-            return (
-                c == '\u200E' || // LRM
-                c == '\u200F' || // RLM
-                c == '\u202A' || // LRE
-                c == '\u202B' || // RLE
-                c == '\u202C' || // PDF
-                c == '\u202D' || // LRO
-                c == '\u202E'    // RLO
-            );
-        }
+		/// <summary>
+		/// Returns true if the string has any bidirectional control characters.
+		/// </summary>
+		/// <param name="input"></param>
+		/// <returns></returns>
+		public static bool HasBidiControlCharacters(string input)
+		{
+			if (string.IsNullOrEmpty(input))
+				return false;
+#if NET8_0_OR_GREATER
+			return input.AsSpan().IndexOfAny(_bidiControlCharSearchValues) >= 0;
+#else
+			return input.AsSpan().IndexOfAny(_bidiControlChars) >= 0;
+#endif
+		}
 
         public static string DownloadStringContent(Uri uri)
         {
@@ -1723,12 +1709,12 @@ namespace Amazon.Util
 #endif
         }
 
-        /// <summary>
-        /// Utility method that accepts a string and replaces white spaces with a space.
-        /// </summary>
-        /// <param name="data"></param>
-        /// <returns></returns>
-        public static string CompressSpaces(string data)
+		/// <summary>
+		/// Utility method that accepts a string and replaces white spaces with a space.
+		/// </summary>
+		/// <param name="data"></param>
+		/// <returns></returns>
+		public static string CompressSpaces(string data)
         {
             if (data == null)
             {
@@ -1741,18 +1727,46 @@ namespace Amazon.Util
                 return string.Empty;
             }
 
-            var stringBuilder = new ValueStringBuilder(dataLength);
-            int index = 0;
-            var isWhiteSpace = false;
-            foreach (var character in data)
+            // Fast path: scan for the first run of consecutive whitespace.
+            // If none exists the string is already compact — return it unchanged with no allocation.
+            bool prevWasWhiteSpace = false;
+            int firstRunIndex = -1;
+            for (int i = 0; i < dataLength; i++)
             {
-                if (!isWhiteSpace | !(isWhiteSpace = char.IsWhiteSpace(character)))
+                bool isWS = char.IsWhiteSpace(data[i]);
+                if (isWS && prevWasWhiteSpace)
                 {
-                    stringBuilder.Append(isWhiteSpace ? ' ' : character);
-                    index++;
+                    firstRunIndex = i - 1;
+                    break;
+                }
+                prevWasWhiteSpace = isWS;
+            }
+
+            if (firstRunIndex < 0)
+                return data;
+
+            // Slow path: at least one run was found.  Copy the clean prefix directly,
+            // then process the remainder segment-by-segment: flush each non-WS run as a
+            // single Append(span) call and skip each WS run with a do-while.
+            var stringBuilder = new ValueStringBuilder(dataLength);
+            stringBuilder.Append(data.AsSpan(0, firstRunIndex));
+
+            int pos = firstRunIndex;
+            while (pos < dataLength)
+            {
+                if (char.IsWhiteSpace(data[pos]))
+                {
+                    stringBuilder.Append(' ');
+                    do { pos++; } while (pos < dataLength && char.IsWhiteSpace(data[pos]));
+                }
+                else
+                {
+                    int segStart = pos;
+                    do { pos++; } while (pos < dataLength && !char.IsWhiteSpace(data[pos]));
+                    stringBuilder.Append(data.AsSpan(segStart, pos - segStart));
                 }
             }
-            return stringBuilder.ToString(0, index);
+            return stringBuilder.ToString();
         }
 
         /// <summary>
@@ -1890,7 +1904,7 @@ namespace Amazon.Util
 
 #region Private Methods, Static Fields and Classes
 
-        private static LruCache<IsSetMethodsCacheKey, MethodInfo> IsSetMethodsCache = new LruCache<IsSetMethodsCacheKey, MethodInfo>(MaxIsSetMethodsCacheSize);
+        private static readonly LruCache<IsSetMethodsCacheKey, MethodInfo> IsSetMethodsCache = new LruCache<IsSetMethodsCacheKey, MethodInfo>(MaxIsSetMethodsCacheSize);
 
         private class IsSetMethodsCacheKey
         {
@@ -1926,10 +1940,10 @@ namespace Amazon.Util
 
     public class JitteredDelay
     {
-        private TimeSpan _maxDelay;
-        private TimeSpan _variance;
-        private TimeSpan _baseIncrement;
-        private Random _rand = null;
+        private readonly TimeSpan _maxDelay;
+        private readonly TimeSpan _variance;
+        private readonly TimeSpan _baseIncrement;
+        private readonly Random _rand = null;
         private int _count = 0;
 
         public JitteredDelay(TimeSpan baseIncrement, TimeSpan variance)

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -1392,9 +1392,9 @@ namespace Amazon.Util
             if ((uint)(c - '0') <= 9) return c - '0';
             if ((uint)(c - 'A') <= 5) return c - 'A' + 10;
             if ((uint)(c - 'a') <= 5) return c - 'a' + 10;
-            throw new ArgumentOutOfRangeException(nameof(c), "Invalid hex character: " + c);
+			throw new FormatException("Invalid hex character: " + c);
 #endif
-        }
+		}
 
         /// <summary>
         /// Returns DateTime.UtcNow + ManualClockCorrection when

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -869,16 +869,26 @@ namespace Amazon.Util
             return a.Count == b.Count && !a.Except(b).Any();
         }
 
-        /// <summary>
-        /// Utility method for converting a string to a MemoryStream.
-        /// </summary>
-        /// <param name="s"></param>
-        /// <returns></returns>
-        public static MemoryStream GenerateMemoryStreamFromString(string s)
-        {
-            MemoryStream stream = new MemoryStream();
-            StreamWriter writer = new StreamWriter(stream);
-            writer.Write(s);
+#if !NETCOREAPP
+		//mirrors defaults used by more modern StreamWriter constructors
+		private static readonly Encoding UTF8NoBOM = new UTF8Encoding(false, true);
+		private const int DefaultStreamWriterBufferSize = 1024;
+#endif
+
+		/// <summary>
+		/// Utility method for converting a string to a MemoryStream.
+		/// </summary>
+		/// <param name="s"></param>
+		/// <returns></returns>
+		public static MemoryStream GenerateMemoryStreamFromString(string s)
+		{
+			MemoryStream stream = new MemoryStream();
+#if NETCOREAPP
+            using StreamWriter writer = new(stream, leaveOpen: true);
+#else
+			using StreamWriter writer = new(stream, UTF8NoBOM, DefaultStreamWriterBufferSize, leaveOpen: true);
+#endif
+			writer.Write(s);
             writer.Flush();
             stream.Position = 0;
             return stream;

--- a/sdk/src/Core/ThirdParty/RuntimeBackports/ValueStringBuilder.cs
+++ b/sdk/src/Core/ThirdParty/RuntimeBackports/ValueStringBuilder.cs
@@ -196,6 +196,18 @@ namespace ThirdParty.RuntimeBackports
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(ReadOnlySpan<char> value)
+		{
+			int pos = _pos;
+			if (pos > _chars.Length - value.Length)
+			{
+				Grow(value.Length);
+			}
+			value.CopyTo(_chars.Slice(pos));
+			_pos += value.Length;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(string? s)
         {
             if (s == null)

--- a/sdk/src/Core/ThirdParty/RuntimeBackports/ValueStringBuilder.cs
+++ b/sdk/src/Core/ThirdParty/RuntimeBackports/ValueStringBuilder.cs
@@ -197,17 +197,17 @@ namespace ThirdParty.RuntimeBackports
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(ReadOnlySpan<char> value)
-		{
-			int pos = _pos;
-			if (pos > _chars.Length - value.Length)
-			{
-				Grow(value.Length);
-			}
-			value.CopyTo(_chars.Slice(pos));
-			_pos += value.Length;
-		}
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - value.Length)
+            {
+                Grow(value.Length);
+            }
+            value.CopyTo(_chars.Slice(pos));
+            _pos += value.Length;
+        }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(string? s)
         {
             if (s == null)

--- a/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
+++ b/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
@@ -206,5 +206,18 @@ namespace AWSSDK.UnitTests
 
             Assert.AreEqual(expected, actual);
         }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void GenerateMemoryStreamFromString_ReturnsReadableStream_WhenInputIsValid()
+        {
+            var input = "Hello World";
+            var expectedBytes = Encoding.UTF8.GetBytes(input);
+            using var memoryStream = AWSSDKUtils.GenerateMemoryStreamFromString(input);
+            var actualBytes = new byte[memoryStream.Length];
+            memoryStream.Read(actualBytes, 0, actualBytes.Length);
+            CollectionAssert.AreEqual(expectedBytes, actualBytes);
+        }
     }
 }

--- a/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
+++ b/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+using Amazon.Runtime.Internal;
 using Amazon.Util;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -64,14 +65,26 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         [TestCategory("UnitTest")]
         [TestCategory("Util")]
-        public void TestWhiteSpaceCompression()
+        [DataRow("qqdglmcdoxtqiwwlucjv      xtehwhfhchtkhgoufyzgtkxvgcmcyvifp  sgseqpnzvaecjcwdjsylcilfkh", "qqdglmcdoxtqiwwlucjv xtehwhfhchtkhgoufyzgtkxvgcmcyvifp sgseqpnzvaecjcwdjsylcilfkh")]
+        [DataRow("input \ttext", "input text")]
+        [DataRow("input \ntext", "input text")]
+        [DataRow("input \r\ntext", "input text")]
+        [DataRow("input\ttext", "input text")]
+        [DataRow(" input text ", " input text ")]
+        public void CompressSpaces_ReplacesWhitespaceWithSingleSpace_WhenInputContainsVariousWhitespaceCharacters(string inputText, string expected)
         {
-            const string text = "qqdglmcdoxtqiwwlucjv      xtehwhfhchtkhgoufyzgtkxvgcmcyvifp  sgseqpnzvaecjcwdjsylcilfkh";
-            const string expected = "qqdglmcdoxtqiwwlucjv xtehwhfhchtkhgoufyzgtkxvgcmcyvifp sgseqpnzvaecjcwdjsylcilfkh";
-
-            var compressed = AWSSDKUtils.CompressSpaces(text);
-            Assert.IsFalse(compressed.Contains("  "));
+            var compressed = AWSSDKUtils.CompressSpaces(inputText);
             Assert.AreEqual(expected, compressed);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        public void CompressSpaces_ReturnsSameString_WhenInputContainsSingleSpaceOnly()
+        {
+            const string input = "input text";
+            var compressed = AWSSDKUtils.CompressSpaces(input);
+            Assert.AreSame(input, compressed);
         }
 
         [TestMethod]
@@ -265,13 +278,19 @@ namespace AWSSDK.UnitTests
         [TestCategory("Util")]
         [DataRow("")]
         [DataRow(null)]
-        [DataRow("invalid-hex-string")]
-        [DataRow("123H")]
         [DataRow("12345")]
         [TestMethod]
-        public void HexStringToBytes_Throws_WhenInputIsNotValidHexString(string input)
+        public void HexStringToBytes_ThrowsArgumentOutOfRangeException_WhenInputIsInvalid(string input)
         {
-            Assert.Throws<Exception>(() => AWSSDKUtils.HexStringToBytes(input));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => AWSSDKUtils.HexStringToBytes(input));
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void HexStringToBytes_ThrowsFormatException_WhenInputIsNotValidHexString()
+        {
+            Assert.ThrowsExactly<FormatException>(() => AWSSDKUtils.HexStringToBytes("123H"));
         }
 
         [TestCategory("UnitTest")]
@@ -296,6 +315,91 @@ namespace AWSSDK.UnitTests
             var expectedChecksum = "B10A8DB164E0754105B7A99BE72E3FE5";
             var actualChecksum = AWSSDKUtils.GenerateChecksumForBytes(inputBytes, false);
             Assert.AreEqual(expectedChecksum, actualChecksum);
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        [DataRow("https://example.com", "POST\nexample.com\n/")]
+        [DataRow("https://example.com/", "POST\nexample.com\n/")]
+        [DataRow("https://example.com/path", "POST\nexample.com\n/path")]
+        public void CalculateStringToSignV2_ShouldReturnStringWithoutTrailingWhitespace_WhenCalledWithEmptyParameterCollection(string serviceUrl, string expectedResult)
+        {
+            var actualResult = AWSSDKUtils.CalculateStringToSignV2(new ParameterCollection(), serviceUrl);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void CalculateStringToSignV2_ShouldReturnStringWithSingleParameter_WhenCalledWithParameterCollectionSizedOne()
+        {
+            var parameters = new ParameterCollection
+            {
+                { "param1", "value1" }
+            };
+            var serviceUrl = "https://example.com/path";
+            var actualResult = AWSSDKUtils.CalculateStringToSignV2(parameters, serviceUrl);
+            var expectedResult = "POST\nexample.com\n/path\nparam1=value1";
+            
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void CalculateStringToSignV2_ShouldReturnStringWithMultipleParameters_WhenCalledWithNonEmptyParameterCollectionSizedTwo()
+        {
+            var parameters = new ParameterCollection
+            {
+                { "param1", "value1" },
+                { "param2", "value2" }
+            };
+            var serviceUrl = "https://example.com/path";
+            var actualResult = AWSSDKUtils.CalculateStringToSignV2(parameters, serviceUrl);
+            var expectedResult = "POST\nexample.com\n/path\nparam1=value1&param2=value2";
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void CalculateStringToSignV2_ShouldReturnSanitizedString_WhenServiceUrlContainsSpecialCharacters()
+        {
+            var parameters = new ParameterCollection();
+            var serviceUrl = "https://example.com/path with spaces";
+            var expectedResult = "POST\nexample.com\n/path%2520with%2520spaces";
+            var actualResult = AWSSDKUtils.CalculateStringToSignV2(parameters, serviceUrl);
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void CalculateStringToSignV2_ShouldReturnSanitizedStringWithoutQuery_WhenServiceUrlContainsQuery()
+        {
+            var parameters = new ParameterCollection();
+            var serviceUrl = "https://example.com/path?query=param";
+            var expectedResult = "POST\nexample.com\n/path";
+            var actualResult = AWSSDKUtils.CalculateStringToSignV2(parameters, serviceUrl);
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void CalculateStringToSignV2_ShouldReturnSanitizedStringWithEncodedParameters_WhenParametersContainSpecialCharacters()
+        {
+            var parameters = new ParameterCollection
+            {
+                { "param1&", "value1=" }
+            };
+            var serviceUrl = "https://example.com";
+            var expectedResult = "POST\nexample.com\n/\nparam1%26=value1%3D";
+            var actualResult = AWSSDKUtils.CalculateStringToSignV2(parameters, serviceUrl);
+            Assert.AreEqual(expectedResult, actualResult);
         }
     }
 }

--- a/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
+++ b/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
@@ -15,6 +15,7 @@
 using Amazon.Util;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -66,7 +67,11 @@ namespace AWSSDK.UnitTests
         public void TestWhiteSpaceCompression()
         {
             const string text = "qqdglmcdoxtqiwwlucjv      xtehwhfhchtkhgoufyzgtkxvgcmcyvifp  sgseqpnzvaecjcwdjsylcilfkh";
-            Assert.IsFalse(AWSSDKUtils.CompressSpaces(text).Contains("  "));
+            const string expected = "qqdglmcdoxtqiwwlucjv xtehwhfhchtkhgoufyzgtkxvgcmcyvifp sgseqpnzvaecjcwdjsylcilfkh";
+
+            var compressed = AWSSDKUtils.CompressSpaces(text);
+            Assert.IsFalse(compressed.Contains("  "));
+            Assert.AreEqual(expected, compressed);
         }
 
         [TestMethod]
@@ -159,7 +164,7 @@ namespace AWSSDK.UnitTests
             // Sample UTC value: 9/8/2020 18:48:34
             var expectedDateTime = new DateTime(2020, 9, 8, 18, 48, 34, DateTimeKind.Utc);
             var dateTime = AWSSDKUtils.ConvertFromUnixEpochMilliseconds(1599590914000);
-            
+
             Assert.AreEqual(expectedDateTime, dateTime);
         }
 
@@ -171,7 +176,7 @@ namespace AWSSDK.UnitTests
             // Sample UTC value: 9/8/2020 18:48:34.970
             var expectedDateTime = new DateTime(2020, 9, 8, 18, 48, 34, DateTimeKind.Utc).AddMilliseconds(970);
             var dateTime = AWSSDKUtils.ConvertFromUnixEpochMilliseconds(1599590914970);
-            
+
             Assert.AreEqual(expectedDateTime, dateTime);
         }
 
@@ -219,5 +224,78 @@ namespace AWSSDK.UnitTests
             memoryStream.Read(actualBytes, 0, actualBytes.Length);
             CollectionAssert.AreEqual(expectedBytes, actualBytes);
         }
-    }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void DictionariesAreEqual_ReturnsTrue_WhenDictionariesAreEqual()
+        {
+            var dict1 = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+            var dict2 = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+            Assert.IsTrue(AWSSDKUtils.DictionariesAreEqual(dict1, dict2));
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void DictionariesAreEqual_ReturnsFalse_WhenDictionariesAreNotEqual()
+        {
+            var dict1 = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+            var dict2 = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "differentValue" }
+            };
+            Assert.IsFalse(AWSSDKUtils.DictionariesAreEqual(dict1, dict2));
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [DataRow("")]
+        [DataRow(null)]
+        [DataRow("invalid-hex-string")]
+        [DataRow("123H")]
+		[DataRow("12345")]
+		[TestMethod]
+        public void HexStringToBytes_Throws_WhenInputIsNotValidHexString(string input)
+        {
+            Assert.Throws<Exception>(() => AWSSDKUtils.HexStringToBytes(input));
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [DataRow("48656c6c6f20576f726c64", "Hello World")]
+        [DataRow("48656C6C6F20576F726C64", "Hello World")]
+        [TestMethod]
+        public void HexStringToBytes_ReturnsCorrectBytes_WhenInputIsValidHexString(string hexString, string expectedString)
+        {
+            var expectedBytes = Encoding.UTF8.GetBytes(expectedString);
+            var actualBytes = AWSSDKUtils.HexStringToBytes(hexString);
+            CollectionAssert.AreEqual(expectedBytes, actualBytes);
+        }
+
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
+        [TestMethod]
+        public void GenerateChecksumForBytes_ReturnsCorrectChecksum()
+		{
+			var input = "Hello World";
+			var inputBytes = Encoding.UTF8.GetBytes(input);
+			var expectedChecksum = "B10A8DB164E0754105B7A99BE72E3FE5";
+            var actualChecksum = AWSSDKUtils.GenerateChecksumForBytes(inputBytes, false);
+			Assert.AreEqual(expectedChecksum, actualChecksum);
+		}
+	}
 }

--- a/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
+++ b/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
@@ -267,8 +267,8 @@ namespace AWSSDK.UnitTests
         [DataRow(null)]
         [DataRow("invalid-hex-string")]
         [DataRow("123H")]
-		[DataRow("12345")]
-		[TestMethod]
+        [DataRow("12345")]
+        [TestMethod]
         public void HexStringToBytes_Throws_WhenInputIsNotValidHexString(string input)
         {
             Assert.Throws<Exception>(() => AWSSDKUtils.HexStringToBytes(input));
@@ -289,13 +289,13 @@ namespace AWSSDK.UnitTests
         [TestCategory("UnitTest")]
         [TestCategory("Util")]
         [TestMethod]
-        public void GenerateChecksumForBytes_ReturnsCorrectChecksum()
-		{
-			var input = "Hello World";
-			var inputBytes = Encoding.UTF8.GetBytes(input);
-			var expectedChecksum = "B10A8DB164E0754105B7A99BE72E3FE5";
+        public void GenerateChecksumForBytes_ReturnsCorrectChecksum_WhenHexEncodingIsUsed()
+        {
+            var input = "Hello World";
+            var inputBytes = Encoding.UTF8.GetBytes(input);
+            var expectedChecksum = "B10A8DB164E0754105B7A99BE72E3FE5";
             var actualChecksum = AWSSDKUtils.GenerateChecksumForBytes(inputBytes, false);
-			Assert.AreEqual(expectedChecksum, actualChecksum);
-		}
-	}
+            Assert.AreEqual(expectedChecksum, actualChecksum);
+        }
+    }
 }


### PR DESCRIPTION
## Description
1. Adding `readonly` modifier where appropriate
2. Altered `CalculateStringToSignV2` to drop excessive allocations

| Method                  | ParamCount | Mean       | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
|------------------------ |----------- |-----------:|------:|-------:|-------:|----------:|------------:|
| **CalculateStringToSignV2_old** | **3**          |   **396.5 ns** |  **1.00** | **0.1259** |      **-** |   **2.32 KB** |        **1.00** |
| CalculateStringToSignV2_new | 3          |   361.6 ns |  0.91 | 0.1054 |      - |   1.94 KB |        0.84 |
|                         |            |            |       |        |        |           |             |
| **CalculateStringToSignV2_old** | **10**         |   **878.4 ns** |  **1.00** | **0.2127** | **0.0010** |   **3.91 KB** |        **1.00** |
| CalculateStringToSignV2_new | 10         |   761.4 ns |  0.87 | 0.1450 |      - |   2.67 KB |        0.68 |
|                         |            |            |       |        |        |           |             |
| **CalculateStringToSignV2_old** | **50**         | **3,295.3 ns** |  **1.00** | **0.7973** | **0.0114** |  **14.67 KB** |        **1.00** |
| CalculateStringToSignV2_new | 50         | 2,983.7 ns |  0.91 | 0.5150 | 0.0076 |   9.47 KB |        0.65 |

3. Altered `CompressSpaces` - drop allocation on happy path, use span copies on unhappy paths

| Method          | Scenario  | Length | Mean      | Ratio | Gen0   | Allocated | Alloc Ratio |
|---------------- |---------- |------- |----------:|------:|-------:|----------:|------------:|
| **CompressSpaces_old**  | **compact**   | **30**     |  **39.92 ns** |  **1.00** | **0.0046** |      **88 B** |        **1.00** |
| CompressSpaces_new | compact   | 30     |  11.34 ns |  0.28 |      - |         - |        0.00 |
|                 |           |        |           |       |        |           |             |
| **CompressSpaces_old**  | **compact**   | **100**    | **102.43 ns** |  **1.00** | **0.0118** |     **224 B** |        **1.00** |
| CompressSpaces_new | compact   | 100    |  41.54 ns |  0.41 |      - |         - |        0.00 |
|                 |           |        |           |       |        |           |             |
| **CompressSpaces_old**  | **run_mid**   | **30**     |  **39.60 ns** |  **1.00** | **0.0042** |      **80 B** |        **1.00** |
| CompressSpaces_new | run_mid   | 30     |  28.86 ns |  0.73 | 0.0042 |      80 B |        1.00 |
|                 |           |        |           |       |        |           |             |
| **CompressSpaces_old**  | **run_mid**   | **100**    | **105.56 ns** |  **1.00** | **0.0118** |     **224 B** |        **1.00** |
| CompressSpaces_new | run_mid   | 100    |  68.13 ns |  0.65 | 0.0118 |     224 B |        1.00 |
|                 |           |        |           |       |        |           |             |
| **CompressSpaces_old**  | **run_start** | **30**     |  **39.34 ns** |  **1.00** | **0.0042** |      **80 B** |        **1.00** |
| CompressSpaces_new | run_start | 30     |  31.89 ns |  0.81 | 0.0042 |      80 B |        1.00 |
|                 |           |        |           |       |        |           |             |
| **CompressSpaces_old**  | **run_start** | **100**    | **101.93 ns** |  **1.00** | **0.0118** |     **224 B** |        **1.00** |
| CompressSpaces_new | run_start | 100    |  57.58 ns |  0.56 | 0.0119 |     224 B |        1.00 |

4. Altered `DictionariesAreEqual` - entirely drop the need for intermediate collection

| Method                | DictSize | Equal | Mean        | Ratio | Gen0   | Allocated | Alloc Ratio |
|---------------------- |--------- |------ |------------:|------:|-------:|----------:|------------:|
| **DictionariesAreEqual_old**  | **3**        | **False** |   **502.47 ns** |  **1.00** | **0.0620** |    **1168 B** |        **1.00** |
| DictionariesAreEqual_new | 3        | False |    62.79 ns |  0.12 | 0.0076 |     144 B |        0.12 |
|                       |          |       |             |       |        |           |             |
| **DictionariesAreEqual_old**  | **3**        | **True**  |   **479.92 ns** |  **1.00** | **0.0486** |     **920 B** |        **1.00** |
| DictionariesAreEqual_new | 3        | True  |    61.62 ns |  0.13 | 0.0076 |     144 B |        0.16 |
|                       |          |       |             |       |        |           |             |
| **DictionariesAreEqual_old**  | **10**       | **False** | **1,490.33 ns** |  **1.00** | **0.1221** |    **2320 B** |        **1.00** |
| DictionariesAreEqual_new | 10       | False |   198.48 ns |  0.13 | 0.0076 |     144 B |        0.06 |
|                       |          |       |             |       |        |           |             |
| **DictionariesAreEqual_old**  | **10**       | **True**  | **1,475.09 ns** |  **1.00** | **0.1221** |    **2320 B** |        **1.00** |
| DictionariesAreEqual_new | 10       | True  |   179.37 ns |  0.12 | 0.0076 |     144 B |        0.06 |
|                       |          |       |             |       |        |           |             |
| **DictionariesAreEqual_old**  | **50**       | **False** | **7,145.57 ns** |  **1.00** | **0.5493** |   **10384 B** |        **1.00** |
| DictionariesAreEqual_new | 50       | False |   934.68 ns |  0.13 | 0.0076 |     144 B |        0.01 |
|                       |          |       |             |       |        |           |             |
| **DictionariesAreEqual_old**  | **50**       | **True**  | **7,317.97 ns** |  **1.00** | **0.5493** |   **10384 B** |        **1.00** |
| DictionariesAreEqual_new | 50       | True  |   879.74 ns |  0.12 | 0.0076 |     144 B |        0.01 |

5. Altered `HasBidiControlCharacters` to favor clean or hit at the end scenarios (at small cost of hit at the start)

| Method                    | Scenario  | Length | Mean       | Ratio | Allocated | Alloc Ratio |
|-------------------------- |---------- |------- |-----------:|------:|----------:|------------:|
| **HasBidiControlCharacters_old**  | **clean**     | **30**     |  **6.0802 ns** |  **1.00** |         **-** |          **NA** |
| HasBidiControlCharacters_new | clean     | 30     |  4.5523 ns |  0.75 |         - |          NA |
|                           |           |        |            |       |           |             |
| **HasBidiControlCharacters_old**  | **clean**     | **100**    | **25.4258 ns** |  **1.00** |         **-** |          **NA** |
| HasBidiControlCharacters_new | clean     | 100    |  8.8908 ns |  0.35 |         - |          NA |
|                           |           |        |            |       |           |             |
| **HasBidiControlCharacters_old**  | **hit_end**   | **30**     |  **6.3209 ns** |  **1.00** |         **-** |          **NA** |
| HasBidiControlCharacters_new | hit_end   | 30     |  5.7778 ns |  0.91 |         - |          NA |
|                           |           |        |            |       |           |             |
| **HasBidiControlCharacters_old**  | **hit_end**   | **100**    | **27.0306 ns** |  **1.00** |         **-** |          **NA** |
| HasBidiControlCharacters_new | hit_end   | 100    |  9.9073 ns |  0.37 |         - |          NA |
|                           |           |        |            |       |           |             |
| **HasBidiControlCharacters_old**  | **hit_start** | **30**     |  **0.3995 ns** |  **1.00** |         **-** |          **NA** |
| HasBidiControlCharacters_new | hit_start | 30     |  4.1767 ns | 10.46 |         - |          NA |
|                           |           |        |            |       |           |             |
| **HasBidiControlCharacters_old**  | **hit_start** | **100**    |  **0.4452 ns** |  **1.00** |         **-** |          **NA** |
| HasBidiControlCharacters_new | hit_start | 100    |  4.6274 ns | 10.40 |         - |          NA |

6. Altered `HexStringToBytes` - reduce allocations, improve performance (esp. with .NET8)

| Method            | Casing | Length | Mean       | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------ |------- |------- |-----------:|------:|-------:|----------:|------------:|
| **HexStringToBytes_old**  | **lower**  | **32**     | **102.512 ns** |  **1.00** | **0.0293** |     **552 B** |        **1.00** |
| HexStringToBytes_new | lower  | 32     |   4.865 ns |  0.05 | 0.0021 |      40 B |        0.07 |
|                   |        |        |            |       |        |           |             |
| **HexStringToBytes_old**  | **lower**  | **64**     | **211.897 ns** |  **1.00** | **0.0572** |    **1080 B** |        **1.00** |
| HexStringToBytes_new | lower  | 64     |   6.715 ns |  0.03 | 0.0030 |      56 B |        0.05 |
|                   |        |        |            |       |        |           |             |
| **HexStringToBytes_old**  | **upper**  | **32**     | **104.486 ns** |  **1.00** | **0.0293** |     **552 B** |        **1.00** |
| HexStringToBytes_new | upper  | 32     |   4.907 ns |  0.05 | 0.0021 |      40 B |        0.07 |
|                   |        |        |            |       |        |           |             |
| **HexStringToBytes_old**  | **upper**  | **64**     | **211.330 ns** |  **1.00** | **0.0572** |    **1080 B** |        **1.00** |
| HexStringToBytes_new | upper  | 64     |   6.590 ns |  0.03 | 0.0030 |      56 B |        0.05 |

7. Altered `ToHexString` - improve performance

| Method       | InputSize | Lowercase | Mean       | Ratio | Allocated | Alloc Ratio |
|------------- |---------- |---------- |-----------:|------:|----------:|------------:|
| **ToHexString_old**  | **8**         | **False**     |  **14.686 ns** |  **1.00** |         **-** |          **NA** |
| ToHexString_new | 8         | False     |   5.410 ns |  0.37 |         - |          NA |
|              |           |           |            |       |           |             |
| **ToHexString_old**  | **8**         | **True**      |  **14.660 ns** |  **1.00** |         **-** |          **NA** |
| ToHexString_new | 8         | True      |   5.435 ns |  0.37 |         - |          NA |
|              |           |           |            |       |           |             |
| **ToHexString_old**  | **32**        | **False**     |  **66.377 ns** |  **1.00** |         **-** |          **NA** |
| ToHexString_new | 32        | False     |  16.824 ns |  0.25 |         - |          NA |
|              |           |           |            |       |           |             |
| **ToHexString_old**  | **32**        | **True**      |  **66.366 ns** |  **1.00** |         **-** |          **NA** |
| ToHexString_new | 32        | True      |  16.660 ns |  0.25 |         - |          NA |
|              |           |           |            |       |           |             |
| **ToHexString_old**  | **256**       | **False**     | **449.548 ns** |  **1.00** |         **-** |          **NA** |
| ToHexString_new | 256       | False     | 130.696 ns |  0.29 |         - |          NA |
|              |           |           |            |       |           |             |
| **ToHexString_old**  | **256**       | **True**      | **451.832 ns** |  **1.00** |         **-** |          **NA** |
| ToHexString_new | 256       | True      | 130.508 ns |  0.29 |         - |          NA |

## Motivation and Context
While reading the file I have noticed multiple low hanging fruit improvements. Where possible without affecting maintainability, changes were applied.

## Testing
I have used existing unit tests and added some more to cover altered methods.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment
No breaking changes.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement