### PR TITLE
Fix benchmark request-size measurement and buffer disposal for PooledContentStream marshallers

### DIFF
--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/BaseBenchmarks.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/BaseBenchmarks.cs
@@ -43,7 +43,7 @@ public abstract class BaseBenchmarks
     [GlobalCleanup(Target = nameof(Marshall))]
     public virtual void AfterMarshall()
     {
-        RequestSizeBytes = Math.Max(RequestSizeBytes, MarshalledRequest.Content.Length);
+        RequestSizeBytes = Math.Max(RequestSizeBytes, Utils.GetContentLengthAndDispose(MarshalledRequest));
 
         var record = new BenchmarkRecord(Service, TestCase, Protocol, DimensionValue, "Request payload size (bytes)", RequestSizeBytes, RequestSizeBytes, RequestSizeBytes);
         Utils.StoreBenchmarkRecords(new List<BenchmarkRecord> { record });

--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/BaseDoubleBenchmarks.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/BaseDoubleBenchmarks.cs
@@ -30,7 +30,7 @@ public abstract class BaseDoubleBenchmarks : BaseBenchmarks
     [GlobalCleanup(Target = nameof(Marshall2))]
     public virtual void AfterMarshall2()
     {
-        RequestSizeBytes2 = Math.Max(RequestSizeBytes2, MarshalledRequest2.Content.Length);
+        RequestSizeBytes2 = Math.Max(RequestSizeBytes2, Utils.GetContentLengthAndDispose(MarshalledRequest2));
 
         var record = new BenchmarkRecord(Service, TestCase2, Protocol, DimensionValue, "Request payload size (bytes)", RequestSizeBytes2, RequestSizeBytes2, RequestSizeBytes2);
         Utils.StoreBenchmarkRecords(new List<BenchmarkRecord> { record });

--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/FakeWebResponseData.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/FakeWebResponseData.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.Runtime.Internal.Transform;
+﻿using Amazon.Runtime.EventStreams;
+using Amazon.Runtime.Internal.Transform;
 using System.Net;
 
 

--- a/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/Utils.cs
+++ b/sdk/test/Performance/CborPerformanceBenchmarks/CborPerformanceBenchmarksRunner/Utils.cs
@@ -183,6 +183,29 @@ public static class Utils
             max: ToMs(stats.Max));
     }
 
+    /// <summary>
+    /// Returns the marshalled request body length and disposes the request, mirroring what the
+    /// production pipeline does after marshalling. Disposing matters when the request body is backed
+    /// by a pooled buffer: it returns that buffer to the pool. Reads the length from the byte[]
+    /// Content when present, otherwise from a seekable ContentStream (covers both the pooled buffer
+    /// and user-provided body streams). Works whether or not the marshaller used a pooled buffer.
+    /// </summary>
+    public static long GetContentLengthAndDispose(IRequest request)
+    {
+        try
+        {
+            if (request.Content != null)
+                return request.Content.Length;
+            if (request.ContentStream != null && request.ContentStream.CanSeek)
+                return request.ContentStream.Length;
+            return 0;
+        }
+        finally
+        {
+            request.Dispose();
+        }
+    }
+
     public static string GetParametersAsString(ParameterCollection parameterCollection)
     {
         var parameterBuilder = new StringBuilder(512);

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/AwsJson10Benchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/AwsJson10Benchmarks.cs
@@ -123,11 +123,11 @@ public class AwsJson10Benchmarks
     }
 
     // --- Healthcheck ---
-    [Benchmark] public void awsJson1_0_HealthcheckRequest_Example() => HealthcheckRequestMarshaller.Instance.Marshall(_healthcheckRequest);
+    [Benchmark] public long awsJson1_0_HealthcheckRequest_Example() => TestDataHelpers.GetContentLengthAndDispose(HealthcheckRequestMarshaller.Instance.Marshall(_healthcheckRequest));
     [Benchmark] public void awsJson1_0_HealthcheckResponse_Example() => UnmarshallJson(_healthcheckResponseBytes, _healthcheckUnmarshaller);
 
     // --- GetItem ---
-    [Benchmark] public void awsJson1_0_GetItemInput_Baseline() => GetItemRequestMarshaller.Instance.Marshall(_getItemBaseline);
+    [Benchmark] public long awsJson1_0_GetItemInput_Baseline() => TestDataHelpers.GetContentLengthAndDispose(GetItemRequestMarshaller.Instance.Marshall(_getItemBaseline));
     [Benchmark] public void awsJson1_0_GetItemOutput_Baseline() => UnmarshallJson(_getItemOutputBaselineBytes, _getItemUnmarshaller);
     [Benchmark] public void awsJson1_0_GetItemOutput_S() => UnmarshallJson(_getItemOutputSBytes, _getItemUnmarshaller);
     [Benchmark] public void awsJson1_0_GetItemOutput_M() => UnmarshallJson(_getItemOutputMBytes, _getItemUnmarshaller);
@@ -137,16 +137,16 @@ public class AwsJson10Benchmarks
     [Benchmark] public void awsJson1_0_GetItemOutputBinary_L() => UnmarshallJson(_getItemOutputBinaryLBytes, _getItemUnmarshaller);
 
     // --- PutItem ---
-    [Benchmark] public void awsJson1_0_PutItemRequest_Baseline() => PutItemRequestMarshaller.Instance.Marshall(_putItemBaseline);
-    [Benchmark] public void awsJson1_0_PutItemRequest_BinaryData_S() => PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryS);
-    [Benchmark] public void awsJson1_0_PutItemRequest_BinaryData_M() => PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryM);
-    [Benchmark] public void awsJson1_0_PutItemRequest_BinaryData_L() => PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryL);
-    [Benchmark] public void awsJson1_0_PutItemRequest_MixedItem_S() => PutItemRequestMarshaller.Instance.Marshall(_putItemMixedS);
-    [Benchmark] public void awsJson1_0_PutItemRequest_MixedItem_M() => PutItemRequestMarshaller.Instance.Marshall(_putItemMixedM);
-    [Benchmark] public void awsJson1_0_PutItemRequest_MixedItem_L() => PutItemRequestMarshaller.Instance.Marshall(_putItemMixedL);
-    [Benchmark] public void awsJson1_0_PutItemRequest_Nested_M() => PutItemRequestMarshaller.Instance.Marshall(_putItemNestedM);
-    [Benchmark] public void awsJson1_0_PutItemRequest_Nested_L() => PutItemRequestMarshaller.Instance.Marshall(_putItemNestedL);
-    [Benchmark] public void awsJson1_0_PutItemRequest_ShallowMap_S() => PutItemRequestMarshaller.Instance.Marshall(_putItemShallowS);
-    [Benchmark] public void awsJson1_0_PutItemRequest_ShallowMap_M() => PutItemRequestMarshaller.Instance.Marshall(_putItemShallowM);
-    [Benchmark] public void awsJson1_0_PutItemRequest_ShallowMap_L() => PutItemRequestMarshaller.Instance.Marshall(_putItemShallowL);
+    [Benchmark] public long awsJson1_0_PutItemRequest_Baseline() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemBaseline));
+    [Benchmark] public long awsJson1_0_PutItemRequest_BinaryData_S() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryS));
+    [Benchmark] public long awsJson1_0_PutItemRequest_BinaryData_M() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryM));
+    [Benchmark] public long awsJson1_0_PutItemRequest_BinaryData_L() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryL));
+    [Benchmark] public long awsJson1_0_PutItemRequest_MixedItem_S() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemMixedS));
+    [Benchmark] public long awsJson1_0_PutItemRequest_MixedItem_M() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemMixedM));
+    [Benchmark] public long awsJson1_0_PutItemRequest_MixedItem_L() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemMixedL));
+    [Benchmark] public long awsJson1_0_PutItemRequest_Nested_M() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemNestedM));
+    [Benchmark] public long awsJson1_0_PutItemRequest_Nested_L() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemNestedL));
+    [Benchmark] public long awsJson1_0_PutItemRequest_ShallowMap_S() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemShallowS));
+    [Benchmark] public long awsJson1_0_PutItemRequest_ShallowMap_M() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemShallowM));
+    [Benchmark] public long awsJson1_0_PutItemRequest_ShallowMap_L() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemShallowL));
 }

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/AwsQueryBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/AwsQueryBenchmarks.cs
@@ -58,15 +58,15 @@ public class AwsQueryBenchmarks
     }
 
     // --- PutMetricData Request ---
-    [Benchmark] public void awsQuery_PutMetricDataRequest_Baseline() => PutMetricDataRequestMarshaller.Instance.Marshall(_putMetricBaseline);
-    [Benchmark] public void awsQuery_PutMetricDataRequest_S() => PutMetricDataRequestMarshaller.Instance.Marshall(_putMetricS);
-    [Benchmark] public void awsQuery_PutMetricDataRequest_M() => PutMetricDataRequestMarshaller.Instance.Marshall(_putMetricM);
-    [Benchmark] public void awsQuery_PutMetricDataRequest_L() => PutMetricDataRequestMarshaller.Instance.Marshall(_putMetricL);
+    [Benchmark] public long awsQuery_PutMetricDataRequest_Baseline() => TestDataHelpers.GetContentLengthAndDispose(PutMetricDataRequestMarshaller.Instance.Marshall(_putMetricBaseline));
+    [Benchmark] public long awsQuery_PutMetricDataRequest_S() => TestDataHelpers.GetContentLengthAndDispose(PutMetricDataRequestMarshaller.Instance.Marshall(_putMetricS));
+    [Benchmark] public long awsQuery_PutMetricDataRequest_M() => TestDataHelpers.GetContentLengthAndDispose(PutMetricDataRequestMarshaller.Instance.Marshall(_putMetricM));
+    [Benchmark] public long awsQuery_PutMetricDataRequest_L() => TestDataHelpers.GetContentLengthAndDispose(PutMetricDataRequestMarshaller.Instance.Marshall(_putMetricL));
 
     // --- GetMetricData Request ---
-    [Benchmark] public void awsQuery_GetMetricDataRequest_S() => GetMetricDataRequestMarshaller.Instance.Marshall(_getMetricReqS);
-    [Benchmark] public void awsQuery_GetMetricDataRequest_M() => GetMetricDataRequestMarshaller.Instance.Marshall(_getMetricReqM);
-    [Benchmark] public void awsQuery_GetMetricDataRequest_L() => GetMetricDataRequestMarshaller.Instance.Marshall(_getMetricReqL);
+    [Benchmark] public long awsQuery_GetMetricDataRequest_S() => TestDataHelpers.GetContentLengthAndDispose(GetMetricDataRequestMarshaller.Instance.Marshall(_getMetricReqS));
+    [Benchmark] public long awsQuery_GetMetricDataRequest_M() => TestDataHelpers.GetContentLengthAndDispose(GetMetricDataRequestMarshaller.Instance.Marshall(_getMetricReqM));
+    [Benchmark] public long awsQuery_GetMetricDataRequest_L() => TestDataHelpers.GetContentLengthAndDispose(GetMetricDataRequestMarshaller.Instance.Marshall(_getMetricReqL));
 
     // --- GetMetricData Response ---
     [Benchmark] public void awsQuery_GetMetricDataResponse_S() => UnmarshallXml(_getMetricRespSBytes);

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestJson1Benchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestJson1Benchmarks.cs
@@ -125,11 +125,11 @@ public class RestJson1Benchmarks
     };
 
     // --- CopyObject Request (serialization) ---
-    [Benchmark] public void restJson1_CopyObjectRequest_Baseline() =>
-        CopyObjectRequestMarshaller.Instance.Marshall(_copyObjectBaseline);
+    [Benchmark] public long restJson1_CopyObjectRequest_Baseline() =>
+        TestDataHelpers.GetContentLengthAndDispose(CopyObjectRequestMarshaller.Instance.Marshall(_copyObjectBaseline));
 
-    [Benchmark] public void restJson1_CopyObjectRequest_M() =>
-        CopyObjectRequestMarshaller.Instance.Marshall(_copyObjectMedium);
+    [Benchmark] public long restJson1_CopyObjectRequest_M() =>
+        TestDataHelpers.GetContentLengthAndDispose(CopyObjectRequestMarshaller.Instance.Marshall(_copyObjectMedium));
 
     // --- CopyObject Response (deserialization) ---
     [Benchmark]
@@ -151,9 +151,9 @@ public class RestJson1Benchmarks
     }
 
     // --- PutObject Request (serialization) ---
-    [Benchmark] public void restJson1_PutObject_S() { _putObjectS.Body.Position = 0; PutObjectRequestMarshaller.Instance.Marshall(_putObjectS); }
-    [Benchmark] public void restJson1_PutObject_M() { _putObjectM.Body.Position = 0; PutObjectRequestMarshaller.Instance.Marshall(_putObjectM); }
-    [Benchmark] public void restJson1_PutObject_L() { _putObjectL.Body.Position = 0; PutObjectRequestMarshaller.Instance.Marshall(_putObjectL); }
+    [Benchmark] public long restJson1_PutObject_S() { _putObjectS.Body.Position = 0; return TestDataHelpers.GetContentLengthAndDispose(PutObjectRequestMarshaller.Instance.Marshall(_putObjectS)); }
+    [Benchmark] public long restJson1_PutObject_M() { _putObjectM.Body.Position = 0; return TestDataHelpers.GetContentLengthAndDispose(PutObjectRequestMarshaller.Instance.Marshall(_putObjectM)); }
+    [Benchmark] public long restJson1_PutObject_L() { _putObjectL.Body.Position = 0; return TestDataHelpers.GetContentLengthAndDispose(PutObjectRequestMarshaller.Instance.Marshall(_putObjectL)); }
 
     // --- GetObject Response (deserialization) ---
     [Benchmark]

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestXmlBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RestXmlBenchmarks.cs
@@ -96,13 +96,13 @@ public class RestXmlBenchmarks
         unmarshaller.Unmarshall(ctx);
     }
 
-    [Benchmark] public void restXml_CopyObjectRequest_Baseline() => CopyObjectRequestMarshaller.Instance.Marshall(_copyObjectBaseline);
-    [Benchmark] public void restXml_CopyObjectRequest_M() => CopyObjectRequestMarshaller.Instance.Marshall(_copyObjectMedium);
+    [Benchmark] public long restXml_CopyObjectRequest_Baseline() => TestDataHelpers.GetContentLengthAndDispose(CopyObjectRequestMarshaller.Instance.Marshall(_copyObjectBaseline));
+    [Benchmark] public long restXml_CopyObjectRequest_M() => TestDataHelpers.GetContentLengthAndDispose(CopyObjectRequestMarshaller.Instance.Marshall(_copyObjectMedium));
     [Benchmark] public void restXml_CopyObjectOutput_Baseline() => UnmarshallXml(_copyOutputBaselineBytes, _copyObjectUnmarshaller);
     [Benchmark] public void restXml_CopyObjectOutput_M() => UnmarshallXml(_copyOutputMBytes, _copyObjectUnmarshaller);
-    [Benchmark] public void restXml_PutObject_S() { _putObjectS.Body.Position = 0; PutObjectRequestMarshaller.Instance.Marshall(_putObjectS); }
-    [Benchmark] public void restXml_PutObject_M() { _putObjectM.Body.Position = 0; PutObjectRequestMarshaller.Instance.Marshall(_putObjectM); }
-    [Benchmark] public void restXml_PutObject_L() { _putObjectL.Body.Position = 0; PutObjectRequestMarshaller.Instance.Marshall(_putObjectL); }
+    [Benchmark] public long restXml_PutObject_S() { _putObjectS.Body.Position = 0; return TestDataHelpers.GetContentLengthAndDispose(PutObjectRequestMarshaller.Instance.Marshall(_putObjectS)); }
+    [Benchmark] public long restXml_PutObject_M() { _putObjectM.Body.Position = 0; return TestDataHelpers.GetContentLengthAndDispose(PutObjectRequestMarshaller.Instance.Marshall(_putObjectM)); }
+    [Benchmark] public long restXml_PutObject_L() { _putObjectL.Body.Position = 0; return TestDataHelpers.GetContentLengthAndDispose(PutObjectRequestMarshaller.Instance.Marshall(_putObjectL)); }
 
     [Benchmark]
     public void restXml_GetObject_S()

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RpcV2CborBenchmarks.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/RpcV2CborBenchmarks.cs
@@ -130,16 +130,16 @@ public class RpcV2CborBenchmarks
     [Benchmark] public void rpcv2Cbor_GetItemOutputBinary_L() => UnmarshallCbor(_getItemBinaryLBytes);
 
     // --- PutItem Request ---
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_Baseline() => PutItemRequestMarshaller.Instance.Marshall(_putItemBaseline);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_BinaryData_S() => PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryS);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_BinaryData_M() => PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryM);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_BinaryData_L() => PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryL);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_MixedItem_S() => PutItemRequestMarshaller.Instance.Marshall(_putItemMixedS);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_MixedItem_M() => PutItemRequestMarshaller.Instance.Marshall(_putItemMixedM);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_MixedItem_L() => PutItemRequestMarshaller.Instance.Marshall(_putItemMixedL);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_Nested_M() => PutItemRequestMarshaller.Instance.Marshall(_putItemNestedM);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_Nested_L() => PutItemRequestMarshaller.Instance.Marshall(_putItemNestedL);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_ShallowMap_S() => PutItemRequestMarshaller.Instance.Marshall(_putItemShallowS);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_ShallowMap_M() => PutItemRequestMarshaller.Instance.Marshall(_putItemShallowM);
-    [Benchmark] public void rpcv2Cbor_PutItemRequest_ShallowMap_L() => PutItemRequestMarshaller.Instance.Marshall(_putItemShallowL);
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_Baseline() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemBaseline));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_BinaryData_S() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryS));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_BinaryData_M() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryM));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_BinaryData_L() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemBinaryL));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_MixedItem_S() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemMixedS));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_MixedItem_M() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemMixedM));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_MixedItem_L() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemMixedL));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_Nested_M() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemNestedM));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_Nested_L() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemNestedL));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_ShallowMap_S() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemShallowS));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_ShallowMap_M() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemShallowM));
+    [Benchmark] public long rpcv2Cbor_PutItemRequest_ShallowMap_L() => TestDataHelpers.GetContentLengthAndDispose(PutItemRequestMarshaller.Instance.Marshall(_putItemShallowL));
 }

--- a/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/TestDataHelpers.cs
+++ b/sdk/test/Performance/SerdeBenchmarks/SerdeBenchmarksRunner/TestDataHelpers.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.Runtime.Internal;
+
 namespace AWSSDK.Benchmarks.Serde;
 
 /// <summary>
@@ -22,6 +24,29 @@ namespace AWSSDK.Benchmarks.Serde;
 /// </summary>
 public static class TestDataHelpers
 {
+    /// <summary>
+    /// Returns the marshalled request body length and disposes the request, mirroring what the
+    /// production pipeline does after marshalling. Disposing matters when the request body is backed
+    /// by a pooled buffer: it returns that buffer and keeps the pool warm, so the [MemoryDiagnoser]
+    /// numbers reflect the real per-request cost instead of a fresh allocation every iteration.
+    /// Works whether or not the marshaller used a pooled buffer.
+    /// </summary>
+    public static long GetContentLengthAndDispose(IRequest request)
+    {
+        try
+        {
+            if (request.Content != null)
+                return request.Content.Length;
+            if (request.ContentStream != null && request.ContentStream.CanSeek)
+                return request.ContentStream.Length;
+            return 0;
+        }
+        finally
+        {
+            request.Dispose();
+        }
+    }
+
     /// <summary>Creates a DynamoDB item with a single string key (Baseline).</summary>
     public static Dictionary<string, T> CreateBaselineItem<T>(Func<string, T> stringAttr)
     {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates the serde and CBOR performance benchmarks to read the marshalled request body size correctly and to dispose each marshalled request, matching the production pipeline.

Request body size is now read from whichever field the marshaller populated, so the benchmarks work whether or not a marshaller writes its body into a pooled buffer.

Each marshalled request is now disposed after measuring. The production pipeline disposes the request after marshalling so when the body is backed by a pooled buffer, that returns the buffer and keeps the pool warm. Without it, every iteration forced a fresh allocation and  `[MemoryDiagnoser]` overstated the real per-request cost.
<!--- Describe your changes in detail -->

## Motivation and Context
`DOTNET-8581`

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
Ran the updated benchmarks.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 5a906d62-708f-48cb-9706-75ab2910956f
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** cefb9ddf-20f2-4f2c-a1c8-dd414f3199c6
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement