### PR TITLE
Reduce allocations and cpu load on Fn.Interpolate code paths

### DIFF
--- a/generator/.DevConfigs/2f3c7777-3d1e-40fc-8c4a-559d22054408.json
+++ b/generator/.DevConfigs/2f3c7777-3d1e-40fc-8c4a-559d22054408.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "Optimize Fn.Interpolate"
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Fn.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Fn.cs
@@ -57,39 +57,66 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
         /// </summary>
         public static object GetAttr(object value, string path)
         {
-            if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path");
+#if NET8_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(path);
+#else
+            if (path is null) throw new ArgumentNullException(nameof(path));
+#endif
+
+            return GetAttr(value, path.AsSpan());
+        }
+
+        private static object GetAttr(object value, ReadOnlySpan<char> path)
+        {
+            if (path.Length == 0) throw new ArgumentNullException(nameof(path));
 
             var propertyValue = value;
-            var segStart = 0;
 
-            while (true)
+            bool isLastSegment = false;
+            var remainder = path;
+            while (!isLastSegment)
             {
-                var dotPos = path.IndexOf('.', segStart);
-                var segEnd = dotPos < 0 ? path.Length : dotPos;
-                var isLast = dotPos < 0;
+                var dotPos = remainder.IndexOf('.');
+                isLastSegment = dotPos == -1;
+                ReadOnlySpan<char> segment;
+                if (isLastSegment)
+                {
+                    segment = remainder;
+                }
+                else
+                {
+                    segment = remainder.Slice(0, dotPos);
+                    remainder = remainder.Slice(dotPos + 1);
+                }
+
 
                 // indexer is always at the end of path e.g. "Part1.Part2[3]" or "[0]"
-                if (isLast)
+                // multiple indexers only consume the last segment e.g. "Part1[1][2]" consumes [2]
+                if (isLastSegment)
                 {
-                    var bracketPos = path.IndexOf('[', segStart);
+                    var bracketPos = segment.LastIndexOf('[');
                     if (bracketPos >= 0)
                     {
+                        var indexSegment = segment.Slice(bracketPos + 1, segment.Length - bracketPos - 2);
+
+#if NETCOREAPP3_1_OR_GREATER
+                        var index = int.Parse(indexSegment);
+#else
+                        var index = int.Parse(indexSegment.ToString());
+#endif
+
                         // property segment before the bracket e.g. "Part2[3]"
-                        if (bracketPos > segStart)
+                        if (bracketPos > 0)
                         {
                             if (propertyValue is not IPropertyBag propBag)
-                                throw new ArgumentException($"Object addressing by pathing segment must be IPropertyBag");
-                            propertyValue = propBag[path.Substring(segStart, bracketPos - segStart)];
+                                throw new InvalidCastException($"Object addressing by pathing segment must be IPropertyBag");
+                            propertyValue = propBag[segment.Slice(0, bracketPos).ToString()];
                         }
 
                         if (propertyValue is not IEnumerable enumerable)
                             throw new ArgumentException($"Object addressing by pathing segment with indexer must be IEnumerable");
 
-#if NETCOREAPP3_1_OR_GREATER
-                        var index = int.Parse(path.AsSpan(bracketPos + 1, segEnd - bracketPos - 2));
-#else
-                        var index = int.Parse(path.Substring(bracketPos + 1, segEnd - bracketPos - 2));
-#endif
+
 
                         // avoid Cast<object>().ToList() – use IList direct access when possible
                         if (enumerable is IList directList)
@@ -107,11 +134,9 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
 
                 if (propertyValue is not IPropertyBag bag)
                     throw new ArgumentException($"Object addressing by pathing segment must be IPropertyBag");
-                propertyValue = bag[path.Substring(segStart, segEnd - segStart)];
-
-                if (isLast) return propertyValue;
-                segStart = dotPos + 1;
+                propertyValue = bag[segment.ToString()];
             }
+            return propertyValue;
         }
 
         /// <summary>
@@ -272,9 +297,9 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
 
 #if NET8_0_OR_GREATER
         private static readonly FrozenSet<string> SupportedSchemas = new HashSet<string> { "http", "https", "wss" }
-            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+            .ToFrozenSet(StringComparer.Ordinal);
 #else
-        private static readonly HashSet<string> SupportedSchemas = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "http", "https", "wss" };
+        private static readonly HashSet<string> SupportedSchemas = new HashSet<string>(StringComparer.Ordinal) { "http", "https", "wss" };
 #endif
 
         /// <summary>
@@ -328,49 +353,63 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
         {
             const char OpenBracket = '{';
             const char CloseBracket = '}';
-            var result = new StringBuilder();
-            for (int i = 0; i < template.Length; i++)
+            const char Hash = '#';
+            var result = new ValueStringBuilder(template.Length); // preallocate to template length, will grow if needed
+            var remainder = template.AsSpan();
+            while (remainder.Length > 0)
             {
-                var currentChar = template[i];
-                char nextChar = (i < template.Length - 1) ? template[i + 1] : default(char);
-                // translate {{ -> { and }} -> }
-                if (currentChar == OpenBracket && nextChar == OpenBracket || currentChar == CloseBracket && nextChar == CloseBracket)
+                var specialPos = remainder.IndexOfAny(OpenBracket, CloseBracket);
+                if (specialPos < 0)
+                {
+                    result.Append(remainder);
+                    break;
+                }
+
+                // copy the literal segment before the special character
+                if (specialPos > 0)
+                {
+                    result.Append(remainder.Slice(0, specialPos));
+                    remainder = remainder.Slice(specialPos);
+                }
+
+                var currentChar = remainder[0];
+                var nextChar = remainder.Length > 1 ? remainder[1] : default(char);
+
+                // {{ -> { and }} -> } escape sequences
+                if (currentChar == nextChar)
                 {
                     result.Append(currentChar);
-                    i++;
+                    remainder = remainder.Slice(2);
                     continue;
                 }
 
-                // translate {object#path} -> value
-                if (currentChar == OpenBracket)
-                {
-                    var placeholderStart = i + 1;
-                    var closingBracket = template.IndexOf(CloseBracket, placeholderStart);
-                    if (closingBracket < 0)
-                        throw new ArgumentException("template is missing closing }");
-
-                    var hashPos = template.IndexOf('#', placeholderStart, closingBracket - placeholderStart);
-                    if (hashPos >= 0)
-                    {
-                        var refName = template.Substring(placeholderStart, hashPos - placeholderStart);
-                        var path = template.Substring(hashPos + 1, closingBracket - hashPos - 1);
-                        result.Append(GetAttr(refs[refName], path).ToString());
-                    }
-                    else
-                    {
-                        var refName = template.Substring(placeholderStart, closingBracket - placeholderStart);
-                        result.Append(refs[refName].ToString());
-                    }
-                    i = closingBracket; // outer i++ will advance past }
-                }
-                else if (currentChar == CloseBracket)
-                {
+                if (currentChar == CloseBracket)
                     throw new ArgumentException("template has non-matching closing bracket, use }} to output }");
+
+                // currentChar == OpenBracket: resolve {ref} or {ref#path}
+                var closingBracket = remainder.IndexOf(CloseBracket);
+                if (closingBracket < 0)
+                    throw new ArgumentException("template is missing closing }");
+
+                var segment = remainder.Slice(1, closingBracket - 1);
+                var hashPos = segment.IndexOf(Hash);
+                if (hashPos >= 0)
+                {
+                    var refName = segment.Slice(0, hashPos).ToString();
+                    segment = segment.Slice(hashPos + 1);
+
+                    // If there is a secondary hash, we only want the path up to that point
+                    var secondaryHashPos = segment.IndexOf(Hash);
+                    if (secondaryHashPos >= 0)
+                        segment = segment.Slice(0, secondaryHashPos);
+
+                    result.Append(GetAttr(refs[refName], segment).ToString());
                 }
                 else
                 {
-                    result.Append(currentChar);
+                    result.Append(refs[segment.ToString()].ToString());
                 }
+                remainder = remainder.Slice(closingBracket + 1);
             }
 
             return result.ToString();

--- a/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Fn.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Fn.cs
@@ -16,11 +16,15 @@ using Amazon.Runtime.Endpoints;
 using Amazon.Util;
 using System;
 using System.Collections;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using ThirdParty.RuntimeBackports;
 
 namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
 {
@@ -55,48 +59,59 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
         {
             if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path");
 
-            var parts = path.Split('.');
             var propertyValue = value;
-            
-            for (int i = 0; i < parts.Length; i++)
+            var segStart = 0;
+
+            while (true)
             {
-                var part = parts[i];
+                var dotPos = path.IndexOf('.', segStart);
+                var segEnd = dotPos < 0 ? path.Length : dotPos;
+                var isLast = dotPos < 0;
 
-                // indexer is always at the end of path e.g. "Part1.Part2[3]"
-                if (i == parts.Length - 1)
+                // indexer is always at the end of path e.g. "Part1.Part2[3]" or "[0]"
+                if (isLast)
                 {
-                    var indexerStart = part.LastIndexOf('[');
-                    var indexerEnd = part.Length - 1;
-
-                    // indexer detected
-                    if (indexerStart >= 0)
+                    var bracketPos = path.IndexOf('[', segStart);
+                    if (bracketPos >= 0)
                     {
-                        var propertyPath = part.Substring(0, indexerStart);
-                        var index = int.Parse(part.Substring(indexerStart + 1, indexerEnd - indexerStart - 1));
-
-                        // indexer can be passed directly as a path e.g. "[1]"
-                        if (indexerStart > 0)
+                        // property segment before the bracket e.g. "Part2[3]"
+                        if (bracketPos > segStart)
                         {
-                            propertyValue = ((IPropertyBag)propertyValue)[propertyPath];
+                            if (propertyValue is not IPropertyBag propBag)
+                                throw new ArgumentException($"Object addressing by pathing segment must be IPropertyBag");
+                            propertyValue = propBag[path.Substring(segStart, bracketPos - segStart)];
                         }
 
-                        if (!(propertyValue is IEnumerable)) throw new ArgumentException("Object addressing by pathing segment '{part}' with indexer must be IEnumerable");
+                        if (propertyValue is not IEnumerable enumerable)
+                            throw new ArgumentException($"Object addressing by pathing segment with indexer must be IEnumerable");
 
-                        var enumerable = (IEnumerable)propertyValue;
-                        var list = enumerable.Cast<object>().ToList();
-                        if (index < 0 || index > list.Count - 1) 
+#if NETCOREAPP3_1_OR_GREATER
+                        var index = int.Parse(path.AsSpan(bracketPos + 1, segEnd - bracketPos - 2));
+#else
+                        var index = int.Parse(path.Substring(bracketPos + 1, segEnd - bracketPos - 2));
+#endif
+
+                        // avoid Cast<object>().ToList() – use IList direct access when possible
+                        if (enumerable is IList directList)
+                            return index >= 0 && index < directList.Count ? directList[index] : null;
+
+                        // fallback for non-IList enumerables: walk without allocating a list
+                        int pos = 0;
+                        foreach (var item in enumerable)
                         {
-                            return null;
+                            if (pos++ == index) return item;
                         }
-                        return list[index];
+                        return null;
                     }
                 }
 
-                if (!(propertyValue is IPropertyBag)) throw new ArgumentException("Object addressing by pathing segment '{part}' must be IPropertyBag");
-                propertyValue = ((IPropertyBag)propertyValue)[part];
-            }
+                if (propertyValue is not IPropertyBag bag)
+                    throw new ArgumentException($"Object addressing by pathing segment must be IPropertyBag");
+                propertyValue = bag[path.Substring(segStart, segEnd - segStart)];
 
-            return propertyValue;
+                if (isLast) return propertyValue;
+                segStart = dotPos + 1;
+            }
         }
 
         /// <summary>
@@ -158,7 +173,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
             {
                 return false;
             }
-            if (!char.IsLetterOrDigit(name[0]) || !char.IsLetterOrDigit(name.Last()))
+            if (!char.IsLetterOrDigit(name[0]) || !char.IsLetterOrDigit(name[name.Length - 1]))
             {
                 return false;
             }
@@ -212,7 +227,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
             {
                 return false;
             }
-            if (char.IsUpper(name[0]) || !char.IsLetterOrDigit(name[0]) || !char.IsLetterOrDigit(name.Last()))
+            if (char.IsUpper(name[0]) || !char.IsLetterOrDigit(name[0]) || !char.IsLetterOrDigit(name[name.Length-1]))
             {
                 return false;
             }
@@ -255,7 +270,13 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
             return AWSSDKUtils.UrlEncode(value, false);
         }
 
-        private static string[] SupportedSchemas = new string[] { "http", "https", "wss" };
+#if NET8_0_OR_GREATER
+        private static readonly FrozenSet<string> SupportedSchemas = new HashSet<string> { "http", "https", "wss" }
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+#else
+        private static readonly HashSet<string> SupportedSchemas = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "http", "https", "wss" };
+#endif
+
         /// <summary>
         /// Parses url string into URL object.
         /// Given a string the function will attempt to parse the string into it’s URL components.
@@ -313,42 +334,34 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 var currentChar = template[i];
                 char nextChar = (i < template.Length - 1) ? template[i + 1] : default(char);
                 // translate {{ -> { and }} -> }
-                if (currentChar == OpenBracket && nextChar == OpenBracket)
+                if (currentChar == OpenBracket && nextChar == OpenBracket || currentChar == CloseBracket && nextChar == CloseBracket)
                 {
-                    result.Append(OpenBracket);
+                    result.Append(currentChar);
                     i++;
                     continue;
                 }
-                if (currentChar == CloseBracket && nextChar == CloseBracket)
-                {
-                    result.Append(CloseBracket);
-                    i++;
-                    continue;
-                }
+
                 // translate {object#path} -> value
                 if (currentChar == OpenBracket)
                 {
-                    var placeholder = new StringBuilder();
-                    while (i < template.Length - 1 && template[i + 1] != CloseBracket)
-                    {
-                        i++;
-                        placeholder.Append(template[i]);
-                    }
-                    if (i == template.Length - 1)
-                    {
+                    var placeholderStart = i + 1;
+                    var closingBracket = template.IndexOf(CloseBracket, placeholderStart);
+                    if (closingBracket < 0)
                         throw new ArgumentException("template is missing closing }");
-                    }
-                    i++;
-                    var refParts = placeholder.ToString().Split('#');
-                    var refName = refParts[0];
-                    if (refParts.Length > 1) // has path after #
+
+                    var hashPos = template.IndexOf('#', placeholderStart, closingBracket - placeholderStart);
+                    if (hashPos >= 0)
                     {
-                        result.Append(GetAttr(refs[refName], refParts[1]).ToString());
+                        var refName = template.Substring(placeholderStart, hashPos - placeholderStart);
+                        var path = template.Substring(hashPos + 1, closingBracket - hashPos - 1);
+                        result.Append(GetAttr(refs[refName], path).ToString());
                     }
                     else
                     {
+                        var refName = template.Substring(placeholderStart, closingBracket - placeholderStart);
                         result.Append(refs[refName].ToString());
                     }
+                    i = closingBracket; // outer i++ will advance past }
                 }
                 else if (currentChar == CloseBracket)
                 {
@@ -374,13 +387,24 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
             {
                 using JsonDocument doc = JsonDocument.Parse(json);
                 var element = doc.RootElement;
-                using var stream = new MemoryStream();
-                using var writer = new Utf8JsonWriter(stream);
+#if !NETFRAMEWORK
+				// We assume new json will be at least similar size to the original json, so we can use the original json length as the initial buffer size.
+				using var baseWriter = new ArrayPoolBufferWriter<byte>(json.Length);
+                using var utf8Writer = new Utf8JsonWriter(baseWriter);
 
-                InterpolateJson(element, refs, writer);
-                writer.Flush();
+                InterpolateJson(element, refs, utf8Writer);
+                utf8Writer.Flush();
+
+                return Encoding.UTF8.GetString(baseWriter.WrittenSpan);
+#else
+                using var stream = new MemoryStream();
+                using var utfWriter = new Utf8JsonWriter(stream);
+
+                InterpolateJson(element, refs, utfWriter);
+                utfWriter.Flush();
 
                 return Encoding.UTF8.GetString(stream.ToArray());
+#endif
             }
             catch (JsonException)
             {

--- a/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Fn.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Fn.cs
@@ -109,14 +109,12 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                         if (bracketPos > 0)
                         {
                             if (propertyValue is not IPropertyBag propBag)
-                                throw new InvalidCastException($"Object addressing by pathing segment must be IPropertyBag");
+                                throw new InvalidCastException("Object addressing by pathing segment must be IPropertyBag");
                             propertyValue = propBag[segment.Slice(0, bracketPos).ToString()];
                         }
 
                         if (propertyValue is not IEnumerable enumerable)
-                            throw new ArgumentException($"Object addressing by pathing segment with indexer must be IEnumerable");
-
-
+                            throw new ArgumentException("Object addressing by pathing segment with indexer must be IEnumerable");
 
                         // avoid Cast<object>().ToList() – use IList direct access when possible
                         if (enumerable is IList directList)
@@ -354,7 +352,7 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
             const char OpenBracket = '{';
             const char CloseBracket = '}';
             const char Hash = '#';
-            var result = new ValueStringBuilder(template.Length); // preallocate to template length, will grow if needed
+            using var result = new ValueStringBuilder(template.Length); // preallocate to template length, will grow if needed
             var remainder = template.AsSpan();
             while (remainder.Length > 0)
             {

--- a/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Fn.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Endpoints/StandardLibrary/Fn.cs
@@ -388,8 +388,8 @@ namespace Amazon.Runtime.Internal.Endpoints.StandardLibrary
                 using JsonDocument doc = JsonDocument.Parse(json);
                 var element = doc.RootElement;
 #if !NETFRAMEWORK
-				// We assume new json will be at least similar size to the original json, so we can use the original json length as the initial buffer size.
-				using var baseWriter = new ArrayPoolBufferWriter<byte>(json.Length);
+                // We assume new json will be at least similar size to the original json, so we can use the original json length as the initial buffer size.
+                using var baseWriter = new ArrayPoolBufferWriter<byte>(json.Length);
                 using var utf8Writer = new Utf8JsonWriter(baseWriter);
 
                 InterpolateJson(element, refs, utf8Writer);

--- a/sdk/test/UnitTests/Custom/EndpointsStandardLibraryTests.cs
+++ b/sdk/test/UnitTests/Custom/EndpointsStandardLibraryTests.cs
@@ -194,7 +194,7 @@ namespace AWSSDK.UnitTests
         public void GetAttr_PropertyValueIsNotListWhenInRange_ReturnsValue()
         {
             var bag = new PropertyBag();
-            bag["NotList"] = new HashSet<string> { "a", "b" }; // not IList, but is IEnumerable
+            bag["NotList"] = new Queue<string>(new[] { "a", "b" });
             Assert.AreEqual("a", Fn.GetAttr(bag, "NotList[0]"));
         }
 

--- a/sdk/test/UnitTests/Custom/EndpointsStandardLibraryTests.cs
+++ b/sdk/test/UnitTests/Custom/EndpointsStandardLibraryTests.cs
@@ -130,5 +130,113 @@ namespace AWSSDK.UnitTests
         {
             Assert.ThrowsExactly<ArgumentException>(() => Fn.Interpolate("{Region}}", refs));
         }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void Interpolate_MultipleHash_KeepsOnlyFirstPathSegment()
+        {
+            var localRefs = new Dictionary<string, object>
+            {
+                { "obj", new Test2 { Prop2 = "value" } }
+            };
+            Assert.AreEqual("value", Fn.Interpolate("{obj#Prop2#extra}", localRefs));
+        }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_NestedIndexer_UsesLastBracket()
+        {
+            var bag = new PropertyBag();
+            bag["List[0]"] = new List<string> { "a", "b" };
+            Assert.AreEqual("b", Fn.GetAttr(bag, "List[0][1]"));
+        }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_IndexerOnNonBag_ThrowsInvalidCast()
+        {
+            Assert.ThrowsExactly<InvalidCastException>(() => Fn.GetAttr("not-a-bag", "Foo[0]"));
+        }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_BadIndexOnNonBag_ThrowsFormat()
+        {
+            Assert.ThrowsExactly<FormatException>(() => Fn.GetAttr("not-a-bag", "Foo[x]"));
+        }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_PathNullOrEmpty_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(() => Fn.GetAttr("not-a-bag", null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => Fn.GetAttr("not-a-bag", ""));
+        }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_PropertyValueIsNotEnumerable_ThrowsArgumentException()
+        {
+            var bag = new PropertyBag();
+            bag["NotEnumerable"] = 42; // int is not enumerable
+            Assert.ThrowsExactly<ArgumentException>(() => Fn.GetAttr(bag, "NotEnumerable[0]"));
+        }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_PropertyValueIsNotListWhenInRange_ReturnsValue()
+        {
+            var bag = new PropertyBag();
+            bag["NotList"] = new HashSet<string> { "a", "b" }; // not IList, but is IEnumerable
+            Assert.AreEqual("a", Fn.GetAttr(bag, "NotList[0]"));
+        }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_PropertyValueIsNotListWhenNotInRange_ReturnsNull()
+        {
+            var bag = new PropertyBag();
+            bag["NotList"] = new HashSet<string> { "a", "b" }; // not IList, but is IEnumerable
+            Assert.AreEqual(null, Fn.GetAttr(bag, "NotList[2]"));
+        }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_PropertyValueIsListWhenInRange_ReturnsValue()
+        {
+            var bag = new PropertyBag();
+            bag["List"] = new List<string> { "a", "b" };
+            Assert.AreEqual("a", Fn.GetAttr(bag, "List[0]"));
+        }
+
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_PropertyValueIsListWhenNotInRange_ReturnsNull()
+        {
+            var bag = new PropertyBag();
+            bag["List"] = new List<string> { "a", "b" };
+            Assert.AreEqual(null, Fn.GetAttr(bag, "List[2]"));
+        }
+
+        [TestMethod]
+        [TestCategory("Endpoints")]
+        [TestCategory("StandardLibrary")]
+        public void GetAttr_NestedPropertyValueIsNotBag_ThrowsArgumentException()
+        {
+            var bag = new PropertyBag();
+            bag["property"] = 42; // int is not a PropertyBag
+            Assert.ThrowsExactly<ArgumentException>(() => Fn.GetAttr(bag, "property.subproperty"));
+        }
     }
 }


### PR DESCRIPTION
## Description
Optimization of Fn class - reduce allocations (unnecessary intermediates) and cpu load where possible (some allocations are still necessary due to missing IAlternateLookup in old .NET versions)

Savings ~ 50-60% memory, 10-20% cpu.


| Method                                | Categories        | Mean       | Ratio | Gen0   | Allocated | Alloc Ratio |
|-------------------------------------- |------------------ |-----------:|------:|-------:|----------:|------------:|
| InterpolateJson_AuthSchemesFull       | AuthSchemesFull   |   813.1 ns |  1.00 | 0.1421 |   2.63 KB |        1.00 |
| InterpolateJson_new_AuthSchemesFull   | AuthSchemesFull   |   645.6 ns |  0.79 | 0.0582 |   1.34 KB |        0.51 |
|                                       |                   |            |       |        |           |             |
| InterpolateJson_AuthSchemesMulti      | AuthSchemesMulti  | 1,019.8 ns |  1.00 | 0.1755 |   3.24 KB |        1.00 |
| InterpolateJson_new_AuthSchemesMulti  | AuthSchemesMulti  |   877.4 ns |  0.86 | 0.0725 |   1.34 KB |        0.41 |
|                                       |                   |            |       |        |           |             |
| InterpolateJson_AuthSchemesSimple     | AuthSchemesSimple |   604.1 ns |  1.00 | 0.1202 |   2.21 KB |        1.00 |
| InterpolateJson_new_AuthSchemesSimple | AuthSchemesSimple |   523.9 ns |  0.87 | 0.0439 |   0.82 KB |        0.37 |
|                                       |                   |            |       |        |           |             |
| InterpolateJson_NoPlaceholders        | NoPlaceholders    |   696.1 ns |  1.00 | 0.1049 |   1.95 KB |        1.00 |
| InterpolateJson_new_NoPlaceholders    | NoPlaceholders    |   626.0 ns |  0.90 | 0.0486 |   0.91 KB |        0.46 |

| Method                  | Categories  | Mean      | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------------ |------------ |----------:|------:|-------:|----------:|------------:|
| GetAttr_NestedIndex     | NestedIndex | 72.762 ns |  1.00 | 0.0156 |     296 B |        1.00 |
| GetAttr_new_NestedIndex | NestedIndex | 31.985 ns |  0.44 | 0.0034 |      64 B |        0.22 |
|                         |             |           |       |        |           |             |
| GetAttr_NestedProp      | NestedProp  | 35.611 ns |  1.00 | 0.0055 |     104 B |        1.00 |
| GetAttr_new_NestedProp  | NestedProp  | 33.301 ns |  0.94 | 0.0034 |      64 B |        0.62 |
|                         |             |           |       |        |           |             |
| GetAttr_RootIndex       | RootIndex   | 41.896 ns |  1.00 | 0.0098 |     184 B |        1.00 |
| GetAttr_new_RootIndex   | RootIndex   |  6.906 ns |  0.16 |      - |         - |        0.00 |
|                         |             |           |       |        |           |             |
| GetAttr_SimpleProp      | SimpleProp  | 14.011 ns |  1.00 | 0.0017 |      32 B |        1.00 |
| GetAttr_new_SimpleProp  | SimpleProp  |  14.862 ns |  1.06 | 0.0017 |      32 B |        1.00 |

6% regression on getting simple property. Should be acceptable with overall improvements.


## Motivation and Context
GC pressure reductions on Fn.Interpolate paths.

## Testing
Existing unit tests in `EndpointStandardLibraryTests`

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

No breaking changes intended.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

edit: updated benchmarks with new code version