### PR TITLE
Reduce allocations and cpu load on AWSSDKUtils.EncodeTraceIdHeaderValue

### DIFF
--- a/generator/.DevConfigs/caf9d1a5-6002-4b64-ba34-17d1be8fc7c6.json
+++ b/generator/.DevConfigs/caf9d1a5-6002-4b64-ba34-17d1be8fc7c6.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "AWSSDKUtils.EncodeTraceIdHeaderValue now uses rented buffers and O(1) lookup"
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -1267,7 +1267,7 @@ namespace Amazon.Util
         /// <returns>An encoded X-Amzn-Trace-Id header value.</returns>
         internal static string EncodeTraceIdHeaderValue(string value)
         {
-            var encoded = new ValueStringBuilder(value.Length * 2);
+            using var encoded = new ValueStringBuilder(value.Length * 2);
             var utf8Bytes = ArrayPool<byte>.Shared.Rent(Encoding.UTF8.GetMaxByteCount(value.Length));
             try
             {

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -117,6 +117,18 @@ namespace Amazon.Util
         /// </summary>
         public const string ValidTraceIdHeaderValueCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=;:+&[]{}\"',";
 
+        private static readonly bool[] ValidTraceIdHeaderValueCharactersLookup = BuildTraceIdHeaderValueLookup(ValidTraceIdHeaderValueCharacters);
+
+        private static bool[] BuildTraceIdHeaderValueLookup(string validTraceIdHeaderValueCharacters)
+        {
+            var lookup = new bool[128];
+            foreach (var c in validTraceIdHeaderValueCharacters)
+            {
+                if (c < 128) lookup[c] = true;
+            }
+            return lookup;
+        }
+
 
         // Valid path characters per RFC 3986 https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
         // segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" ) ; non-zero-length segment without any colon ":"
@@ -537,7 +549,7 @@ namespace Amazon.Util
 
             return uriComponentSegments;
         }
-        
+
         /// <summary>
         /// Joins all path segments with the / character and encodes each segment before joining
         /// </summary>
@@ -1256,21 +1268,33 @@ namespace Amazon.Util
         internal static string EncodeTraceIdHeaderValue(string value)
         {
             var encoded = new StringBuilder(value.Length * 2);
-            foreach (char symbol in System.Text.Encoding.UTF8.GetBytes(value))
+            var utf8Bytes = ArrayPool<byte>.Shared.Rent(Encoding.UTF8.GetMaxByteCount(value.Length));
+            try
             {
-                if (ValidTraceIdHeaderValueCharacters.IndexOf(symbol) != -1)
+#if NETCOREAPP3_1_OR_GREATER
+                var length = Encoding.UTF8.GetBytes(value, utf8Bytes);
+#else
+                var length = Encoding.UTF8.GetBytes(value, 0, value.Length, utf8Bytes, 0);
+#endif
+                for (int i = 0; i < length; i++)
                 {
-                    encoded.Append(symbol);
-                }
-                else
-                {
-                    encoded.Append('%').Append(string.Format(CultureInfo.InvariantCulture, "{0:X2}", (int)symbol));
+                    var b = utf8Bytes[i];
+                    if (b < 128 && ValidTraceIdHeaderValueCharactersLookup[b])
+                    {
+                        encoded.Append((char)b);
+                    }
+                    else
+                    {
+                        encoded.Append('%').Append(upperHex[b >> 4]).Append(upperHex[b & 0xF]);
+                    }
                 }
             }
-
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(utf8Bytes);
+            }
             return encoded.ToString();
         }
-
 
         /// <summary>
         /// Generates an MD5 Digest for the stream specified

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -117,19 +117,6 @@ namespace Amazon.Util
         /// </summary>
         public const string ValidTraceIdHeaderValueCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=;:+&[]{}\"',";
 
-        private static readonly bool[] ValidTraceIdHeaderValueCharactersLookup = BuildTraceIdHeaderValueLookup(ValidTraceIdHeaderValueCharacters);
-
-        private static bool[] BuildTraceIdHeaderValueLookup(string validTraceIdHeaderValueCharacters)
-        {
-            var lookup = new bool[128];
-            foreach (var c in validTraceIdHeaderValueCharacters)
-            {
-                if (c < 128) lookup[c] = true;
-            }
-            return lookup;
-        }
-
-
         // Valid path characters per RFC 3986 https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
         // segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" ) ; non-zero-length segment without any colon ":"
         // check https://datatracker.ietf.org/doc/html/rfc3986#section-2.2 for sub-delims
@@ -1259,6 +1246,19 @@ namespace Amazon.Util
             return data.Replace("/", EncodedSlash);
         }
 
+
+        private static readonly bool[] ValidTraceIdHeaderValueCharactersLookup = BuildTraceIdHeaderValueLookup(ValidTraceIdHeaderValueCharacters);
+
+        private static bool[] BuildTraceIdHeaderValueLookup(string validTraceIdHeaderValueCharacters)
+        {
+            var lookup = new bool[128];
+            foreach (var c in validTraceIdHeaderValueCharacters)
+            {
+                if (c < 128) lookup[c] = true;
+            }
+            return lookup;
+        }
+
         /// <summary>
         /// Percent encodes the X-Amzn-Trace-Id header value skipping any characters within the
         /// ValidTraceIdHeaderValueCharacters character set.
@@ -1276,9 +1276,8 @@ namespace Amazon.Util
 #else
                 var length = Encoding.UTF8.GetBytes(value, 0, value.Length, utf8Bytes, 0);
 #endif
-                for (int i = 0; i < length; i++)
+                foreach (var b in utf8Bytes.AsSpan(0, length))
                 {
-                    var b = utf8Bytes[i];
                     if (b < 128 && ValidTraceIdHeaderValueCharactersLookup[b])
                     {
                         encoded.Append((char)b);

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -1267,7 +1267,7 @@ namespace Amazon.Util
         /// <returns>An encoded X-Amzn-Trace-Id header value.</returns>
         internal static string EncodeTraceIdHeaderValue(string value)
         {
-            var encoded = new StringBuilder(value.Length * 2);
+            var encoded = new ValueStringBuilder(value.Length * 2);
             var utf8Bytes = ArrayPool<byte>.Shared.Rent(Encoding.UTF8.GetMaxByteCount(value.Length));
             try
             {
@@ -1285,7 +1285,9 @@ namespace Amazon.Util
                     }
                     else
                     {
-                        encoded.Append('%').Append(upperHex[b >> 4]).Append(upperHex[b & 0xF]);
+                        encoded.Append('%');
+                        encoded.Append(upperHex[b >> 4]);
+                        encoded.Append(upperHex[b & 0xF]);
                     }
                 }
             }

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -1294,7 +1294,7 @@ namespace Amazon.Util
             {
                 ArrayPool<byte>.Shared.Return(utf8Bytes);
             }
-            return encoded.ToString();
+            return encoded.AsSpan().ToString();
         }
 
         /// <summary>

--- a/sdk/test/UnitTests/Custom/Runtime/RecursionDetectionTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/RecursionDetectionTests.cs
@@ -69,7 +69,7 @@ namespace AWSSDK.UnitTests
             foreach(var header in expectedHeaders)
             {
                 Assert.IsTrue(requestHeaders.ContainsKey(header.Key));
-                Assert.AreEqual(requestHeaders[header.Key], header.Value);
+                Assert.AreEqual(header.Value, requestHeaders[header.Key]);
             }
         }
 


### PR DESCRIPTION
## Description
1. Change EncodeTradeIdHeaderValue to use rented buffer for intermediate encoded utf8 value.
2. Use precalculated bool array of whitelisted characters to avoid O(m x n) complexity.
3. Avoid using String.Format to convert byte to hex (way too much overhead plus we already have means for fast allocation-less conversion).
4. Use ValueStringBuilder
5. Fix expected and evaluated values position in assert to avoid confusing error message.

| Method                       | Scenario   | Mean        | Ratio | Gen0   | Allocated | Alloc Ratio |
|----------------------------- |----------- |------------:|------:|-------:|----------:|------------:|
| **EncodeTraceIdHeaderValue**     | **clean**      |   **170.03 ns** |  **1.00** | **0.0343** |     **648 B** |        **1.00** |
| EncodeTraceIdHeaderValue_new | clean      |    81.17 ns |  0.48 | 0.0093 |     176 B |        0.27 |
|                              |            |             |       |        |           |             |
| **EncodeTraceIdHeaderValue**     | **typical**    |   **289.26 ns** |  **1.00** | **0.0529** |    **1000 B** |        **1.00** |
| EncodeTraceIdHeaderValue_new | typical    |   112.18 ns |  0.39 | 0.0123 |     232 B |        0.23 |
|                              |            |             |       |        |           |             |
| **EncodeTraceIdHeaderValue**     | **worst_case** | **2,051.68 ns** |  **1.00** | **0.3090** |    **5872 B** |        **1.00** |
| EncodeTraceIdHeaderValue_new | worst_case |   143.98 ns |  0.07 | 0.0267 |     504 B |        0.09 |

clean value: `"Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"`
typical value: `Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;Lineage=a87bd80c:1 <tag>`
worst case value: `new string ('\x01', 80)`

## Motivation and Context
Reduce GC pressure and improve performance

## Testing
Covered by existing tests in `RecursionDetectionTests`

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

No breaking changes

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement