### PR TITLE
Reduce allocations and cpu load in AWS4Signer

### DIFF
--- a/generator/.DevConfigs/fde67f23-6ec4-4cbe-a217-d5323a125c9b.json
+++ b/generator/.DevConfigs/fde67f23-6ec4-4cbe-a217-d5323a125c9b.json
@@ -4,9 +4,6 @@
     "type": "patch",
     "changeLogMessages": [
       "Memory and CPU optimizations in AWS4Signer."
-    ],
-    "backwardIncompatibilitiesToIgnore": [ 
-      "Amazon.Util.AWSSDKUtils/MethodOverloadAdded"
     ]
   }
 }

--- a/generator/.DevConfigs/fde67f23-6ec4-4cbe-a217-d5323a125c9b.json
+++ b/generator/.DevConfigs/fde67f23-6ec4-4cbe-a217-d5323a125c9b.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "Memory \u0026 CPU optimizations in AWS4Signer"
+    ]
+  }
+}

--- a/generator/.DevConfigs/fde67f23-6ec4-4cbe-a217-d5323a125c9b.json
+++ b/generator/.DevConfigs/fde67f23-6ec4-4cbe-a217-d5323a125c9b.json
@@ -3,7 +3,10 @@
     "updateMinimum": false,
     "type": "patch",
     "changeLogMessages": [
-      "Memory \u0026 CPU optimizations in AWS4Signer"
+      "Memory and CPU optimizations in AWS4Signer."
+    ],
+    "backwardIncompatibilitiesToIgnore": [ 
+      "Amazon.Util.AWSSDKUtils/MethodOverloadAdded"
     ]
   }
 }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -795,6 +795,7 @@ namespace Amazon.Runtime.Internal.Auth
             canonicalRequest.Append(canonicalQueryString);
             canonicalRequest.Append('\n');
 
+            // We avoid using CanonicalizeHeaders() and CanonicalizeHeaderNames() here to avoid multiple passes of same collection
             foreach (var entry in sortedHeaders)
             {
                 AppendLowerInvariant(ref canonicalRequest, entry.Key);
@@ -1013,18 +1014,9 @@ namespace Amazon.Runtime.Internal.Auth
             if (parameters is ICollection<KeyValuePair<string, string>> coll && coll.Count == 0)
                 return string.Empty;
 
-            // Sort in-place when the caller passes a locally-owned List (avoids LINQ EnumerableSorter +
-            // key-array allocations); fall back to OrderBy for arbitrary enumerables.
-            List<KeyValuePair<string, string>> sortedParameters;
-            if (parameters is List<KeyValuePair<string, string>> paramList)
-            {
-                paramList.Sort((x, y) => StringComparer.Ordinal.Compare(x.Key, y.Key));
-                sortedParameters = paramList;
-            }
-            else
-            {
-                sortedParameters = parameters.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).ToList();
-            }
+            // Make a copy of the parameters so we can sort them without affecting the original collection.
+            List<KeyValuePair<string, string>> sortedParameters = new(parameters);
+            sortedParameters.Sort((x, y) => StringComparer.Ordinal.Compare(x.Key, y.Key));
 
             var canonicalQueryString = new ValueStringBuilder(sortedParameters.Count * 32);
             for (int i = 0; i < sortedParameters.Count; i++)

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -58,9 +58,9 @@ namespace Amazon.Runtime.Internal.Auth
 
         internal const SigningAlgorithm SignerAlgorithm = SigningAlgorithm.HmacSHA256;
 
-        // If this list is updated to include new headers, the SigV4a signer (in "AWSSDK.Extensions.CrtIntegration\CrtAWS4aSigner.cs") may need to
+        // If this set is updated to include new headers, the SigV4a signer (in "AWSSDK.Extensions.CrtIntegration\CrtAWS4aSigner.cs") may need to
         // be updated as well.
-        private static IEnumerable<string> _headersToIgnoreWhenSigning = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+        private static readonly HashSet<string> _headersToIgnoreWhenSigning = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             HeaderKeys.XAmznTraceIdHeader,
             HeaderKeys.TransferEncodingHeader,
             HeaderKeys.AmzSdkInvocationId,

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -205,14 +205,16 @@ namespace Amazon.Runtime.Internal.Auth
             var bodyHash = SetRequestBodyHash(request, SignPayload, bodySha, ChunkedUploadWrapperStream.V4_SIGNATURE_LENGTH);
             var sortedHeaders = SortAndPruneHeaders(request.Headers);
 
-            var canonicalRequest = CanonicalizeRequest(request.Endpoint,
-                                                       request.ResourcePath,
-                                                       request.HttpMethod,
-                                                       sortedHeaders,
-                                                       canonicalParameters,
-                                                       bodyHash,
-                                                       request.PathResources,
-                                                       request.UseDoubleEncoding);
+            var canonicalRequest = CanonicalizeRequestHelper(
+                                                             request.Endpoint,
+                                                             request.ResourcePath,
+                                                             request.HttpMethod,
+                                                             sortedHeaders,
+                                                             canonicalParameters,
+                                                             bodyHash,
+                                                             request.PathResources,
+                                                             request.UseDoubleEncoding,
+                                                             out var signedHeaderNames);
             if (metrics != null)
                 metrics.AddProperty(Metric.CanonicalRequest, canonicalRequest);
             request.SignatureVersion = SignatureVersion.SigV4;
@@ -221,7 +223,7 @@ namespace Amazon.Runtime.Internal.Auth
                                     request.DeterminedSigningRegion,
                                     signedAt,
                                     serviceSigningName,
-                                    CanonicalizeHeaderNames(sortedHeaders),
+                                    signedHeaderNames,
                                     canonicalRequest,
                                     metrics);
         }
@@ -424,23 +426,10 @@ namespace Amazon.Runtime.Internal.Auth
         /// <returns>Computed signing key</returns>
         public static byte[] ComposeSigningKey(string awsSecretAccessKey, string region, string date, string service)
         {
-            char[] ksecret = null;
-
-            try
-            {
-                ksecret = (Scheme + awsSecretAccessKey).ToCharArray();
-
-                var hashDate = ComputeKeyedHash(SignerAlgorithm, Encoding.UTF8.GetBytes(ksecret), Encoding.UTF8.GetBytes(date));
-                var hashRegion = ComputeKeyedHash(SignerAlgorithm, hashDate, Encoding.UTF8.GetBytes(region));
-                var hashService = ComputeKeyedHash(SignerAlgorithm, hashRegion, Encoding.UTF8.GetBytes(service));
-                return ComputeKeyedHash(SignerAlgorithm, hashService, TerminatorBytes);
-            }
-            finally
-            {
-                // clean up all secrets, regardless of how initially seeded (for simplicity)
-                if (ksecret != null)
-                    Array.Clear(ksecret, 0, ksecret.Length);
-            }
+            var hashDate = ComputeKeyedHash(SignerAlgorithm, Encoding.UTF8.GetBytes(Scheme + awsSecretAccessKey), Encoding.UTF8.GetBytes(date));
+            var hashRegion = ComputeKeyedHash(SignerAlgorithm, hashDate, Encoding.UTF8.GetBytes(region));
+            var hashService = ComputeKeyedHash(SignerAlgorithm, hashRegion, Encoding.UTF8.GetBytes(service));
+            return ComputeKeyedHash(SignerAlgorithm, hashService, TerminatorBytes);
         }
 
         /// <summary>
@@ -747,7 +736,8 @@ namespace Amazon.Runtime.Internal.Auth
                 canonicalQueryString,
                 precomputedBodyHash,
                 pathResources,
-                true);
+                true,
+                out _);
         }
 
         /// <summary>
@@ -781,7 +771,8 @@ namespace Amazon.Runtime.Internal.Auth
                 canonicalQueryString,
                 precomputedBodyHash,
                 pathResources,
-                doubleEncode);
+                doubleEncode,
+                out _);
         }
 
         private static string CanonicalizeRequestHelper(Uri endpoint,
@@ -791,49 +782,71 @@ namespace Amazon.Runtime.Internal.Auth
                                                     string canonicalQueryString,
                                                     string precomputedBodyHash,
                                                     IDictionary<string, string> pathResources,
-                                                    bool doubleEncode)
+                                                    bool doubleEncode,
+                                                    out string signedHeaderNames)
         {
+            var namesBuilder = new ValueStringBuilder(256);
+
             var canonicalRequest = new ValueStringBuilder(512);
             canonicalRequest.Append(httpMethod);
             canonicalRequest.Append('\n');
-            canonicalRequest.Append($"{AWSSDKUtils.CanonicalizeResourcePathV2(endpoint, resourcePath, doubleEncode, pathResources)}\n");
-            canonicalRequest.Append($"{canonicalQueryString}\n");
+            canonicalRequest.Append(AWSSDKUtils.CanonicalizeResourcePathV2(endpoint, resourcePath, doubleEncode, pathResources));
+            canonicalRequest.Append('\n');
+            canonicalRequest.Append(canonicalQueryString);
+            canonicalRequest.Append('\n');
 
-            canonicalRequest.Append($"{CanonicalizeHeaders(sortedHeaders)}\n");
-            canonicalRequest.Append($"{CanonicalizeHeaderNames(sortedHeaders)}\n");
+            foreach (var entry in sortedHeaders)
+            {
+                AppendLowerInvariant(ref canonicalRequest, entry.Key);
+                canonicalRequest.Append(':');
+                canonicalRequest.Append(AWSSDKUtils.CompressSpaces(entry.Value, trim: true));
+                canonicalRequest.Append('\n');
+
+                if (namesBuilder.Length > 0)
+                    namesBuilder.Append(';');
+                AppendLowerInvariant(ref namesBuilder, entry.Key);
+            }
+
+            canonicalRequest.Append('\n');
+            canonicalRequest.Append(namesBuilder.AsSpan());
+            canonicalRequest.Append('\n');
 
             if (precomputedBodyHash != null)
-            {
                 canonicalRequest.Append(precomputedBodyHash);
-            }
-            else
-            {
-                if (sortedHeaders.TryGetValue(HeaderKeys.XAmzContentSha256Header, out var contentHash))
-                    canonicalRequest.Append(contentHash);
-            }
+            else if (sortedHeaders.TryGetValue(HeaderKeys.XAmzContentSha256Header, out var contentHash))
+                canonicalRequest.Append(contentHash);
+
+            signedHeaderNames = namesBuilder.ToString();
 
             return canonicalRequest.ToString();
         }
+
+        private static void AppendLowerInvariant(ref ValueStringBuilder builder, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            var writeSpan = builder.AppendSpan(value.Length);
+            value.AsSpan().ToLowerInvariant(writeSpan);
+        }
+
 
         /// <summary>
         /// Reorders the headers for the request for canonicalization.
         /// </summary>
         /// <param name="requestHeaders">The set of proposed headers for the request</param>
-        /// <returns>List of headers that must be included in the signature</returns>
+        /// <returns>List of headers that must be included in the signature, with keys lowercased</returns>
         /// <remarks>For AWS4 signing, all headers are considered viable for inclusion</remarks>
         protected internal static IDictionary<string, string> SortAndPruneHeaders(IEnumerable<KeyValuePair<string, string>> requestHeaders)
         {
-            // Refer https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html. (Step #4: "Build the canonical headers list by sorting the (lowercase) headers by character code"). StringComparer.OrdinalIgnoreCase incorrectly places '_' after lowercase chracters.
-            var sortedHeaders = new SortedDictionary<string, string>(StringComparer.Ordinal);
+            // Refer https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html. (Step #4: "Build the canonical headers list by sorting the (lowercase) headers by character code"). StringComparer.OrdinalIgnoreCase incorrectly places '_' after lowercase characters.
+            int capacity = requestHeaders is ICollection<KeyValuePair<string, string>> c ? c.Count : 16;
+            var sortedHeaders = new SortedList<string, string>(capacity, StringComparer.Ordinal);
             foreach (var header in requestHeaders)
             {
-                if (_headersToIgnoreWhenSigning.Contains(header.Key))
-                {
-                    continue;
-                }
+                if (_headersToIgnoreWhenSigning.Contains(header.Key)) continue;
                 sortedHeaders.Add(header.Key.ToLowerInvariant(), header.Value);
             }
-            
             return sortedHeaders;
         }
 
@@ -859,8 +872,8 @@ namespace Amazon.Runtime.Internal.Auth
                 // Refer https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html. (Step #4: "To create the canonical headers list, convert all header names to lowercase and remove leading spaces and trailing spaces. Convert sequential spaces in the header value to a single space.").
                 builder.Append(entry.Key.ToLowerInvariant());
                 builder.Append(':');
-                builder.Append(AWSSDKUtils.CompressSpaces(entry.Value)?.Trim());
-                builder.Append("\n");
+                builder.Append(AWSSDKUtils.CompressSpaces(entry.Value, trim: true));
+                builder.Append('\n');
             }
             return builder.ToString();
         }
@@ -995,35 +1008,43 @@ namespace Amazon.Runtime.Internal.Auth
             if (parameters == null)
                 return string.Empty;
 
-            var sortedParameters = parameters.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).ToList();
-            var canonicalQueryString = new StringBuilder();
-            foreach (var param in sortedParameters)
-            {
-                var key = param.Key;
-                var value = param.Value;
+            // Short-circuit for the common case of no parameters (e.g. POST/PUT with no SubResources)
+            // to avoid allocating LINQ EnumerableSorter machinery for an empty collection.
+            if (parameters is ICollection<KeyValuePair<string, string>> coll && coll.Count == 0)
+                return string.Empty;
 
-                if (canonicalQueryString.Length > 0)
-                    canonicalQueryString.Append("&");
-                if (uriEncodeParameters)
-                {
-                    if (string.IsNullOrEmpty(value))
-                        canonicalQueryString.AppendFormat("{0}=", AWSSDKUtils.UrlEncode(key, false));
-                    else
-                        canonicalQueryString.AppendFormat("{0}={1}", AWSSDKUtils.UrlEncode(key, false), AWSSDKUtils.UrlEncode(value, false));
-                }
-                else
-                {
-                    if (string.IsNullOrEmpty(value))
-                        canonicalQueryString.AppendFormat("{0}=", key);
-                    else
-                        canonicalQueryString.AppendFormat("{0}={1}", key, value);
-                }
+            // Sort in-place when the caller passes a locally-owned List (avoids LINQ EnumerableSorter +
+            // key-array allocations); fall back to OrderBy for arbitrary enumerables.
+            List<KeyValuePair<string, string>> sortedParameters;
+            if (parameters is List<KeyValuePair<string, string>> paramList)
+            {
+                paramList.Sort((x, y) => StringComparer.Ordinal.Compare(x.Key, y.Key));
+                sortedParameters = paramList;
+            }
+            else
+            {
+                sortedParameters = parameters.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).ToList();
+            }
+
+            var canonicalQueryString = new ValueStringBuilder(sortedParameters.Count * 32);
+            for (int i = 0; i < sortedParameters.Count; i++)
+            {
+                var param = sortedParameters[i];
+                var key = uriEncodeParameters ? AWSSDKUtils.UrlEncode(param.Key, false) : param.Key;
+                var value = uriEncodeParameters ? AWSSDKUtils.UrlEncode(param.Value, false) : param.Value;
+
+                if (i > 0) canonicalQueryString.Append('&');
+
+                canonicalQueryString.Append(key);
+                canonicalQueryString.Append('=');
+                if (!string.IsNullOrEmpty(value))
+                    canonicalQueryString.Append(value);
             }
 
             return canonicalQueryString.ToString();
         }
 
-        #endregion
+#endregion
     }
 
     /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/ChecksumUtils.cs
@@ -102,9 +102,10 @@ namespace Amazon.Runtime.Internal.Util
             }
 
             // If a pre-calculated value was specified, we won't attempt to calculate it again.
-            if (request.Headers.Any(h => h.Key.StartsWith(_checksumHeaderPrefix, StringComparison.OrdinalIgnoreCase)))
+            foreach (var headerKey in request.Headers.Keys)
             {
-                return;
+                if (headerKey.StartsWith(_checksumHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+                    return;
             }
 
             var coreChecksumAlgoritm = ConvertToCoreChecksumAlgorithm(request.ChecksumData.SelectedChecksum);

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -1721,7 +1721,7 @@ namespace Amazon.Util
         /// <param name="data">The input string to process.</param>
         /// <param name="trim">When <see langword="true"/>, leading and trailing whitespace is also removed.</param>
         /// <returns>The processed string with compressed spaces.</returns>
-        public static string CompressSpaces(string data, bool trim = false)
+        public static string CompressSpaces(string data, bool trim)
         {
             const char SPACE = ' ';
             if (data == null)

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -1739,10 +1739,19 @@ namespace Amazon.Util
             // If none is found the string is already compact.
             bool prevWasWhiteSpace = false;
             int firstRunIndex = -1;
+            int firstNonWhiteSpace = -1;
             for (int i = 0; i < dataLength; i++)
             {
                 char c = data[i];
                 bool isWS = char.IsWhiteSpace(c);
+                if (!isWS)
+                {
+                    if (firstNonWhiteSpace < 0)
+                    {
+                        firstNonWhiteSpace = i;
+                    }
+                }
+
                 if (isWS && (prevWasWhiteSpace || c != SPACE))
                 {
                     firstRunIndex = i - 1;
@@ -1759,6 +1768,8 @@ namespace Amazon.Util
 
             // Trim once at the top as a free span pointer adjustment — no allocation.
             // All subsequent logic operates uniformly on this span.
+            var trimCorrection = trim && firstNonWhiteSpace > 0 ? firstRunIndex - firstNonWhiteSpace: firstRunIndex;
+
             var span = data.AsSpan();
             if (trim)
             {
@@ -1771,7 +1782,7 @@ namespace Amazon.Util
                 return string.Empty;
             }
 
-            return CompressSpacesSlow(span, firstRunIndex);
+            return CompressSpacesSlow(span, trimCorrection);
         }
 
         private static string CompressSpacesSlow(ReadOnlySpan<char> span, int firstRunIndex)

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -1704,7 +1704,6 @@ namespace Amazon.Util
 #endif
         }
 
-#if !NETCOREAPP
         /// <summary>
         /// Utility method that accepts a string and replaces white spaces with a space.
         /// </summary>
@@ -1715,7 +1714,6 @@ namespace Amazon.Util
         {
             return CompressSpaces(data, false);
         }
-#endif
 
         /// <summary>
         /// Utility method that accepts a string and replaces white spaces with a space.

--- a/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
+++ b/sdk/src/Core/Amazon.Util/AWSSDKUtils.cs
@@ -537,7 +537,7 @@ namespace Amazon.Util
 
             return uriComponentSegments;
         }
-        
+
         /// <summary>
         /// Joins all path segments with the / character and encodes each segment before joining
         /// </summary>
@@ -1704,12 +1704,26 @@ namespace Amazon.Util
 #endif
         }
 
+#if !NETCOREAPP
         /// <summary>
         /// Utility method that accepts a string and replaces white spaces with a space.
         /// </summary>
-        /// <param name="data"></param>
-        /// <returns></returns>
+        /// <param name="data">The input string to process.</param>
+        /// <returns>The processed string with compressed spaces.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string CompressSpaces(string data)
+        {
+            return CompressSpaces(data, false);
+        }
+#endif
+
+        /// <summary>
+        /// Utility method that accepts a string and replaces white spaces with a space.
+        /// </summary>
+        /// <param name="data">The input string to process.</param>
+        /// <param name="trim">When <see langword="true"/>, leading and trailing whitespace is also removed.</param>
+        /// <returns>The processed string with compressed spaces.</returns>
+        public static string CompressSpaces(string data, bool trim = false)
         {
             const char SPACE = ' ';
             if (data == null)
@@ -1723,8 +1737,8 @@ namespace Amazon.Util
                 return string.Empty;
             }
 
-            // Fast path: scan for the first run of consecutive whitespace or non-space whitespacecharacter.
-            // If none exists the string is already compact — return it unchanged with no allocation.
+            // Fast path: scan for the first run of consecutive whitespace or a non-space whitespace character.
+            // If none is found the string is already compact.
             bool prevWasWhiteSpace = false;
             int firstRunIndex = -1;
             for (int i = 0; i < dataLength; i++)
@@ -1740,30 +1754,56 @@ namespace Amazon.Util
             }
 
             if (firstRunIndex < 0)
-                return data;
+            {
+                // No inner compression needed.
+                return trim ? data.Trim() : data;
+            }
 
-            // Slow path: at least one run was found.  Copy the clean prefix directly,
-            // then process the remainder segment-by-segment: flush each non-WS run as a
-            // single Append(span) call and skip each WS run with a do-while.
-            var stringBuilder = new ValueStringBuilder(dataLength);
-            stringBuilder.Append(data.AsSpan(0, firstRunIndex));
+            // Trim once at the top as a free span pointer adjustment — no allocation.
+            // All subsequent logic operates uniformly on this span.
+            var span = data.AsSpan();
+            if (trim)
+            {
+                span = span.Trim();
+            }
+
+            var spanLength = span.Length;
+            if (spanLength == 0)
+            {
+                return string.Empty;
+            }
+
+            return CompressSpacesSlow(span, firstRunIndex);
+        }
+
+        private static string CompressSpacesSlow(ReadOnlySpan<char> span, int firstRunIndex)
+        {
+            const char SPACE = ' ';
+            int spanLength = span.Length;
+            // Use a stack-allocated buffer for typical inputs; fall back to ArrayPool for large ones.
+            // Needs to be in separate method from fast path to allow fast path inlining.
+            const int StackAllocThreshold = 256;
+            var sb = spanLength <= StackAllocThreshold
+                ? new ValueStringBuilder(stackalloc char[spanLength])
+                : new ValueStringBuilder(spanLength);
+            sb.Append(span.Slice(0, firstRunIndex));
 
             int pos = firstRunIndex;
-            while (pos < dataLength)
+            while (pos < spanLength)
             {
-                if (char.IsWhiteSpace(data[pos]))
+                if (char.IsWhiteSpace(span[pos]))
                 {
-                    stringBuilder.Append(SPACE);
-                    do { pos++; } while (pos < dataLength && char.IsWhiteSpace(data[pos]));
+                    sb.Append(SPACE);
+                    do { pos++; } while (pos < spanLength && char.IsWhiteSpace(span[pos]));
                 }
                 else
                 {
                     int segStart = pos;
-                    do { pos++; } while (pos < dataLength && !char.IsWhiteSpace(data[pos]));
-                    stringBuilder.Append(data.AsSpan(segStart, pos - segStart));
+                    do { pos++; } while (pos < spanLength && !char.IsWhiteSpace(span[pos]));
+                    sb.Append(span.Slice(segStart, pos - segStart));
                 }
             }
-            return stringBuilder.ToString();
+            return sb.ToString();
         }
 
         /// <summary>

--- a/sdk/src/Core/ThirdParty/RuntimeBackports/ValueStringBuilder.cs
+++ b/sdk/src/Core/ThirdParty/RuntimeBackports/ValueStringBuilder.cs
@@ -258,6 +258,11 @@ namespace ThirdParty.RuntimeBackports
             _pos += count;
         }
 
+        /// <summary>
+        /// Ensures required capacity of <paramref name="length"/> characters to the builder and returns a writable span to the appended characters.
+        /// </summary>
+        /// <param name="length">The number of characters to ensure capacity for.</param>
+        /// <returns>A writable span to the appended characters.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<char> AppendSpan(int length)
         {

--- a/sdk/test/UnitTests/Custom/Runtime/AWS4SignerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/AWS4SignerTests.cs
@@ -1,6 +1,8 @@
-#if !NETFRAMEWORK
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Amazon.Runtime.Internal.Auth;
+using Amazon.Util;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace AWSSDK.UnitTests
@@ -9,8 +11,12 @@ namespace AWSSDK.UnitTests
     [TestCategory("Core")]
     public class AWS4SignerTests
     {
+        // -----------------------------------------------------------------------
+        // CanonicalizeHeaderNames
+        // -----------------------------------------------------------------------
+
         [TestMethod]
-        public void CanonicalizeHeaderNames()
+        public void CanonicalizeHeaderNames_LowercasesAndJoinsWithSemicolon()
         {
             var headers = new Dictionary<string, string>
             {
@@ -19,14 +25,28 @@ namespace AWSSDK.UnitTests
                 { "Header3", "Value3" }
             };
 
-            var signer = new AWS4SignerTestee();
-            var canonicalizedHeaders = signer.TestCanonicalizeHeaderNames(headers);
-
-            Assert.AreEqual("header1;header2;header3", canonicalizedHeaders);
+            Assert.AreEqual("header1;header2;header3", AWS4SignerTestee.TestCanonicalizeHeaderNames(headers));
         }
 
         [TestMethod]
-        public void CanonicalizeHeaders()
+        public void CanonicalizeHeaderNames_AlreadyLowercasePassthrough()
+        {
+            var headers = new Dictionary<string, string> { { "content-type", "text/plain" }, { "host", "example.com" } };
+            Assert.AreEqual("content-type;host", AWS4SignerTestee.TestCanonicalizeHeaderNames(headers));
+        }
+
+        [TestMethod]
+        public void CanonicalizeHeaderNames_EmptyCollection_ReturnsEmpty()
+        {
+            Assert.AreEqual(string.Empty, AWS4SignerTestee.TestCanonicalizeHeaderNames(new Dictionary<string, string>()));
+        }
+
+        // -----------------------------------------------------------------------
+        // CanonicalizeHeaders
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public void CanonicalizeHeaders_LowercasesKeysAndTrimsValues()
         {
             var headers = new Dictionary<string, string>
             {
@@ -35,24 +55,337 @@ namespace AWSSDK.UnitTests
                 { "Header3", "   Value3   " }
             };
 
-            var signer = new AWS4SignerTestee();
-            var canonicalizedHeaders = signer.TestCanonicalizeHeaders(headers);
-
-            Assert.AreEqual("header1:Value1\nheader2:Value2\nheader3:Value3\n", canonicalizedHeaders);
+            Assert.AreEqual("header1:Value1\nheader2:Value2\nheader3:Value3\n",
+                AWS4SignerTestee.TestCanonicalizeHeaders(headers));
         }
 
-        class AWS4SignerTestee : AWS4Signer
+        [TestMethod]
+        public void CanonicalizeHeaders_CompressesMultipleSpacesInValue()
         {
-            public string TestCanonicalizeHeaderNames(IDictionary<string, string> headers)
-            {
-                return CanonicalizeHeaderNames(headers);
-            }
+            var headers = new Dictionary<string, string> { { "X-Custom", "a  b   c" } };
+            Assert.AreEqual("x-custom:a b c\n", AWS4SignerTestee.TestCanonicalizeHeaders(headers));
+        }
 
-            public string TestCanonicalizeHeaders(IDictionary<string, string> headers)
+        [TestMethod]
+        public void CanonicalizeHeaders_NullInput_ReturnsEmpty()
+        {
+            Assert.AreEqual(string.Empty, AWS4SignerTestee.TestCanonicalizeHeaders(null));
+        }
+
+        [TestMethod]
+        public void CanonicalizeHeaders_EmptyCollection_ReturnsEmpty()
+        {
+            Assert.AreEqual(string.Empty, AWS4SignerTestee.TestCanonicalizeHeaders(new Dictionary<string, string>()));
+        }
+
+        // -----------------------------------------------------------------------
+        // SortAndPruneHeaders
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public void SortAndPruneHeaders_SortsAscendingCaseInsensitive()
+        {
+            var headers = new Dictionary<string, string>
             {
-                return CanonicalizeHeaders(headers);
-            }
+                { "Zoo", "last" },
+                { "Alpha", "first" },
+                { "Middle", "mid" }
+            };
+            var sorted = AWS4Signer.SortAndPruneHeaders(headers);
+            var keys = sorted.Keys.ToList();
+            // Keys are lowercased; Ordinal sort on lowercase equals case-insensitive alphabetic order for plain ASCII.
+            Assert.AreEqual("alpha",  keys[0]);
+            Assert.AreEqual("middle", keys[1]);
+            Assert.AreEqual("zoo",    keys[2]);
+        }
+
+        [TestMethod]
+        public void SortAndPruneHeaders_LowercasesKeys()
+        {
+            // SortAndPruneHeaders lowercases keys as part of its public contract
+            // (required by callers such as ChunkedUploadWrapperStream).
+            var headers = new Dictionary<string, string> { { "Content-Type", "application/json" } };
+            var sorted = AWS4Signer.SortAndPruneHeaders(headers);
+            Assert.IsTrue(sorted.ContainsKey("content-type"));
+            Assert.IsFalse(sorted.ContainsKey("Content-Type"));
+        }
+
+        [TestMethod]
+        public void SortAndPruneHeaders_RemovesXAmznTraceId()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { HeaderKeys.XAmznTraceIdHeader, "Root=1-abc" },
+                { "host", "example.com" }
+            };
+            var sorted = AWS4Signer.SortAndPruneHeaders(headers);
+            Assert.IsFalse(sorted.ContainsKey(HeaderKeys.XAmznTraceIdHeader));
+            Assert.IsTrue(sorted.ContainsKey("host"));
+        }
+
+        [TestMethod]
+        public void SortAndPruneHeaders_RemovesAllIgnoredHeaders()
+        {
+            var ignored = new[]
+            {
+                HeaderKeys.XAmznTraceIdHeader,
+                HeaderKeys.TransferEncodingHeader,
+                HeaderKeys.AmzSdkInvocationId,
+                HeaderKeys.AmzSdkRequest,
+                HeaderKeys.UserAgentHeader,
+                HeaderKeys.XAmzUserAgentHeader
+            };
+
+            var headers = ignored.ToDictionary(k => k, _ => "value");
+            headers["host"] = "example.com";
+
+            var sorted = AWS4Signer.SortAndPruneHeaders(headers);
+
+            Assert.AreEqual(1, sorted.Count);
+            Assert.IsTrue(sorted.ContainsKey("host"));
+        }
+
+        [TestMethod]
+        public void SortAndPruneHeaders_IgnoreListMatchesCaseInsensitively()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { HeaderKeys.UserAgentHeader.ToUpperInvariant(), "aws-sdk" },
+                { "host", "example.com" }
+            };
+            var sorted = AWS4Signer.SortAndPruneHeaders(headers);
+            Assert.AreEqual(1, sorted.Count);
+            Assert.IsTrue(sorted.ContainsKey("host"));
+        }
+
+        [TestMethod]
+        public void SortAndPruneHeaders_EmptyInput_ReturnsEmptyDictionary()
+        {
+            var sorted = AWS4Signer.SortAndPruneHeaders(new Dictionary<string, string>());
+            Assert.AreEqual(0, sorted.Count);
+        }
+
+        [TestMethod]
+        public void SortAndPruneHeaders_UnderscoreHeaderSortsBeforeLowercaseLetters()
+        {
+            // SigV4 spec requires byte-value (Ordinal) sort on lowercased header names.
+            // '_' is 0x5F; lowercase letters start at 'a' = 0x61, so x_foo must sort
+            // BEFORE xa-foo and xb-foo. StringComparer.OrdinalIgnoreCase case-folds to
+            // uppercase first, making '_' (0x5F) > 'Z' (0x5A) and therefore placing
+            // underscore AFTER all letters — violating the spec.
+            var headers = new Dictionary<string, string>
+            {
+                { "xb-foo", "c" },
+                { "x_foo",  "a" },
+                { "xa-foo", "b" }
+            };
+            var sorted = AWS4Signer.SortAndPruneHeaders(headers);
+            var keys = sorted.Keys.ToList();
+            Assert.AreEqual("x_foo",  keys[0]); // '_' (0x5F) < 'a' (0x61)
+            Assert.AreEqual("xa-foo", keys[1]);
+            Assert.AreEqual("xb-foo", keys[2]);
+        }
+
+        [TestMethod]                                                                         
+        public void SortAndPruneHeaders_CaseVariantDuplicates_ThrowsOnAmbiguousValue()
+        {
+            // "X-Foo: first" and "x-FOO: second" both normalize to "x-foo" but carry
+            // different values. Silently picking one would produce an unpredictably signed
+            // request, so the method must fail loudly rather than swallow the conflict.
+            var headers = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("X-Foo", "first"),
+                new KeyValuePair<string, string>("x-FOO", "second"),
+                new KeyValuePair<string, string>("host", "example.com")
+            };
+            Assert.ThrowsExactly<ArgumentException>(
+                () => AWS4Signer.SortAndPruneHeaders(headers),
+                "Case-variant headers with conflicting values must throw rather than silently drop one.");
+        }
+
+        // -----------------------------------------------------------------------
+        // CanonicalizeRequest  (exercises CanonicalizeRequestHelper)
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public void CanonicalizeRequest_StructureMatchesSigV4Spec()
+        {
+            // Expected canonical-request format (per AWS docs):
+            //   HTTPMethod\n
+            //   CanonicalURI\n
+            //   CanonicalQueryString\n
+            //   CanonicalHeaders\n        <- one line per header ending in \n
+            //   \n                         <- blank line after headers block
+            //   SignedHeaders\n
+            //   HexEncodedBodyHash
+            var endpoint = new Uri("https://example.amazonaws.com");
+            var sortedHeaders = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "host", "example.amazonaws.com" },
+                { "X-Amz-Date", "20240101T000000Z" },
+                { HeaderKeys.XAmzContentSha256Header, "abc123" }
+            };
+
+            var result = AWS4SignerTestee.TestCanonicalizeRequest(
+                endpoint,
+                resourcePath: "/bucket/key",
+                httpMethod: "PUT",
+                sortedHeaders: sortedHeaders,
+                canonicalQueryString: string.Empty,
+                precomputedBodyHash: "abc123",
+                pathResources: null,
+                doubleEncode: true);
+
+            var lines = result.Split('\n');
+            Assert.AreEqual("PUT",                      lines[0], "HTTP method");
+            Assert.AreEqual("/bucket/key",              lines[1], "canonical URI");
+            Assert.AreEqual(string.Empty,               lines[2], "canonical query string");
+            // lines[3..5] are canonical headers (host:, x-amz-content-sha256:, x-amz-date:)
+            Assert.AreEqual(string.Empty,               lines[6], "blank line after headers");
+            Assert.IsTrue(lines[7].Contains(";"),                  "signed headers separator");
+            Assert.AreEqual("abc123",                   lines[8], "body hash");
+        }
+
+        [TestMethod]
+        public void CanonicalizeRequest_HeaderKeysAreLowercasedInOutput()
+        {
+            var endpoint = new Uri("https://s3.amazonaws.com");
+            var sortedHeaders = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Host", "s3.amazonaws.com" },
+                { "Content-Type", "application/json" }
+            };
+
+            var result = AWS4SignerTestee.TestCanonicalizeRequest(
+                endpoint, "/", "GET", sortedHeaders, string.Empty, "UNSIGNED-PAYLOAD", null, true);
+
+            Assert.IsTrue(result.Contains("\ncontent-type:"), "Content-Type must be lowercased");
+            Assert.IsTrue(result.Contains("\nhost:"),         "Host must be lowercased");
+            Assert.IsFalse(result.Contains("\nContent-Type:"), "Mixed-case key must not appear");
+        }
+
+        [TestMethod]
+        public void CanonicalizeRequest_SignedHeaderNamesAreLowercasedAndSorted()
+        {
+            var endpoint = new Uri("https://example.amazonaws.com");
+            var sortedHeaders = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Zoo", "zval" },
+                { "Alpha", "aval" }
+            };
+
+            var result = AWS4SignerTestee.TestCanonicalizeRequest(
+                endpoint, "/", "GET", sortedHeaders, string.Empty, "hash", null, true);
+
+            // signed-header line is the second-to-last line (before body hash)
+            var lines = result.Split('\n');
+            var signedHeaderLine = lines[lines.Length - 2];
+            Assert.AreEqual("alpha;zoo", signedHeaderLine);
+        }
+
+        [TestMethod]
+        public void CanonicalizeRequest_HeaderValuesAreTrimmedAndCompressed()
+        {
+            var endpoint = new Uri("https://example.amazonaws.com");
+            var sortedHeaders = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "x-custom", "  hello   world  " }
+            };
+
+            var result = AWS4SignerTestee.TestCanonicalizeRequest(
+                endpoint, "/", "GET", sortedHeaders, string.Empty, "hash", null, true);
+
+            Assert.IsTrue(result.Contains("\nx-custom:hello world\n"));
+        }
+
+        [TestMethod]
+        public void CanonicalizeRequest_FallsBackToXAmzContentSha256HeaderWhenNoPrecomputedHash()
+        {
+            var endpoint = new Uri("https://example.amazonaws.com");
+            var sha = "deadbeef";
+            var sortedHeaders = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { HeaderKeys.XAmzContentSha256Header, sha }
+            };
+
+            var result = AWS4SignerTestee.TestCanonicalizeRequest(
+                endpoint, "/", "GET", sortedHeaders,
+                canonicalQueryString: string.Empty,
+                precomputedBodyHash: null,
+                pathResources: null,
+                doubleEncode: true);
+
+            Assert.IsTrue(result.EndsWith(sha));
+        }
+
+        // -----------------------------------------------------------------------
+        // CanonicalizeQueryParameters
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public void CanonicalizeQueryParameters_SortsAndEncodesParameters()
+        {
+            var parameters = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("zoo", "last"),
+                new KeyValuePair<string, string>("alpha", "first"),
+                new KeyValuePair<string, string>("mid", "val ue")
+            };
+
+            var result = AWS4SignerTestee.TestCanonicalizeQueryParameters(parameters);
+            Assert.AreEqual("alpha=first&mid=val%20ue&zoo=last", result);
+        }
+
+        [TestMethod]
+        public void CanonicalizeQueryParameters_NullCollection_ReturnsEmpty()
+        {
+            Assert.AreEqual(string.Empty, AWS4SignerTestee.TestCanonicalizeQueryParameters(null));
+        }
+
+        [TestMethod]
+        public void CanonicalizeQueryParameters_EmptyCollection_ReturnsEmpty()
+        {
+            Assert.AreEqual(string.Empty,
+                AWS4SignerTestee.TestCanonicalizeQueryParameters(new List<KeyValuePair<string, string>>()));
+        }
+
+        [TestMethod]
+        public void CanonicalizeQueryParameters_NullValue_RenderedAsEmptyString()
+        {
+            var parameters = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("param", null)
+            };
+            var result = AWS4SignerTestee.TestCanonicalizeQueryParameters(parameters);
+            Assert.AreEqual("param=", result);
+        }
+
+        // -----------------------------------------------------------------------
+        // Testee shim
+        // -----------------------------------------------------------------------
+
+        private class AWS4SignerTestee : AWS4Signer
+        {
+            public static string TestCanonicalizeHeaderNames(IEnumerable<KeyValuePair<string, string>> headers)
+                => CanonicalizeHeaderNames(headers);
+
+            public static string TestCanonicalizeHeaders(IEnumerable<KeyValuePair<string, string>> headers)
+                => CanonicalizeHeaders(headers);
+
+            public static string TestCanonicalizeRequest(
+                Uri endpoint,
+                string resourcePath,
+                string httpMethod,
+                IDictionary<string, string> sortedHeaders,
+                string canonicalQueryString,
+                string precomputedBodyHash,
+                IDictionary<string, string> pathResources,
+                bool doubleEncode)
+                => CanonicalizeRequest(endpoint, resourcePath, httpMethod, sortedHeaders,
+                    canonicalQueryString, precomputedBodyHash, pathResources, doubleEncode);
+
+            public static string TestCanonicalizeQueryParameters(IEnumerable<KeyValuePair<string, string>> parameters)
+                => CanonicalizeQueryParameters(parameters);
         }
     }
 }
-#endif

--- a/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
+++ b/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
@@ -90,6 +90,19 @@ namespace AWSSDK.UnitTests
         [TestMethod]
         [TestCategory("UnitTest")]
         [TestCategory("Util")]
+        [DataRow("  hello world  ", "hello world")]
+        [DataRow("  hello   world  ", "hello world")]
+        [DataRow("hello world", "hello world")]
+        [DataRow("  ", "")]
+        public void CompressSpaces_TrimsLeadingAndTrailing_WhenTrimIsTrue(string inputText, string expected)
+        {
+            var compressed = AWSSDKUtils.CompressSpaces(inputText, trim: true);
+            Assert.AreEqual(expected, compressed);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Util")]
         public void TestIsAbsolutePathBadInput()
         {
             Assert.IsFalse(AWSSDKUtils.IsAbsolutePath(new string(Path.GetInvalidPathChars())));

--- a/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
+++ b/sdk/test/UnitTests/Custom/Util/AWSSDKUtilsTests.cs
@@ -93,6 +93,10 @@ namespace AWSSDK.UnitTests
         [DataRow("  hello world  ", "hello world")]
         [DataRow("  hello   world  ", "hello world")]
         [DataRow("hello world", "hello world")]
+        [DataRow(" A  B  C  ", "A B C")]
+        [DataRow("   A   B \tC D ", "A B C D")]
+        [DataRow("   AB  C D  ", "AB C D")]
+        [DataRow("A  B C  D  ", "A B C D")]
         [DataRow("  ", "")]
         public void CompressSpaces_TrimsLeadingAndTrailing_WhenTrimIsTrue(string inputText, string expected)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Increase unit test coverage on all altered code paths
2. Alter `AWSSDKUtils.CompressSpaces` to support trimming
3. Add XML comment for `ValueStringBuilder.AppendSpan` to avoid method name confusion
4. AWS4Signer
- avoid redundant allocations
- avoid repeated passes through same collections
- avoid repetition of same operations over same data
- simplify `ComposeSigningKey` - lifetime of plaintext secret in memory is not changed as it is passed to method as a `String` and not `SecureString`, creation of intermediate concatenated secret (another immutable string allocated in memory) and then converted to char array doesn't bring any security since the secret is allocated in memory twice, both cases owned by GC. Change drops all extra steps.

CompressSpace benchmark results
<details>

| Method                   | Scenario  | Length | Mean     | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------------- |---------- |------- |---------:|------:|-------:|----------:|------------:|
| **CompressSpaces_Original**  | **compact**   | **30**     | **11.38 ns** |  **1.00** |      **-** |         **-** |          **NA** |
| CompressSpaces_TrimFalse | compact   | 30     | 11.56 ns |  1.02 |      - |         - |          NA |
| CompressSpaces_TrimTrue  | compact   | 30     | 11.96 ns |  1.05 |      - |         - |          NA |
|                          |           |        |          |       |        |           |             |
| **CompressSpaces_Original**  | **compact**   | **100**    | **42.16 ns** |  **1.00** |      **-** |         **-** |          **NA** |
| CompressSpaces_TrimFalse | compact   | 100    | 42.41 ns |  1.01 |      - |         - |          NA |
| CompressSpaces_TrimTrue  | compact   | 100    | 44.94 ns |  1.07 |      - |         - |          NA |
|                          |           |        |          |       |        |           |             |
| **CompressSpaces_Original**  | **run_mid**   | **30**     | **29.50 ns** |  **1.00** | **0.0042** |      **80 B** |        **1.00** |
| CompressSpaces_TrimFalse | run_mid   | 30     | 21.02 ns |  0.71 | 0.0042 |      80 B |        1.00 |
| CompressSpaces_TrimTrue  | run_mid   | 30     | 22.10 ns |  0.75 | 0.0042 |      80 B |        1.00 |
|                          |           |        |          |       |        |           |             |
| **CompressSpaces_Original**  | **run_mid**   | **100**    | **64.65 ns** |  **1.00** | **0.0118** |     **224 B** |        **1.00** |
| CompressSpaces_TrimFalse | run_mid   | 100    | 57.79 ns |  0.89 | 0.0118 |     224 B |        1.00 |
| CompressSpaces_TrimTrue  | run_mid   | 100    | 57.57 ns |  0.89 | 0.0119 |     224 B |        1.00 |
|                          |           |        |          |       |        |           |             |
| **CompressSpaces_Original**  | **run_start** | **30**     | **29.18 ns** |  **1.00** | **0.0042** |      **80 B** |        **1.00** |
| CompressSpaces_TrimFalse | run_start | 30     | 20.48 ns |  0.70 | 0.0042 |      80 B |        1.00 |
| CompressSpaces_TrimTrue  | run_start | 30     | 21.40 ns |  0.73 | 0.0042 |      80 B |        1.00 |
|                          |           |        |          |       |        |           |             |
| **CompressSpaces_Original**  | **run_start** | **100**    | **58.91 ns** |  **1.00** | **0.0118** |     **224 B** |        **1.00** |
| CompressSpaces_TrimFalse | run_start | 100    | 49.98 ns |  0.85 | 0.0119 |     224 B |        1.00 |
| CompressSpaces_TrimTrue  | run_start | 100    | 50.88 ns |  0.86 | 0.0119 |     224 B |        1.00 |

</details>

SignRequest benchmark results
<details>

| Method                   | Scenario  |  Mean     | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------------- |---------- |---------:|------:|-------:|----------:|------------:|
| **SignRequest_Original**  | **TypicalPut**   | **3.668 μs** |  **1.00** |      **0.5646** |         **10.47 KB** |          **1.00** |
| SignRequest_New | TypicalPut   | 3.422 μs |  0.93 | 0.4425 | 8.14 KB |          0.78 |
|                          |           |          |       |        |           |             |
| **SignRequest_Original**  | **GetManyQueryParams**   | **4.941 μs** |  **1.00** |      **0.7324** |         **13.84 KB** |          **1.00** |
| SignRequest_New | GetManyQueryParams   | 4.439 μs |  0.90 | 0.5493 | 10.19 KB |          0.74 |
|                          |           |          |       |        |           |             |
| **SignRequest_Original**  | **ManyHeaders**   | **6.310 μs** |  **1.00** |      **1.0986** |         **20.22 KB** |          **1.00** |
| SignRequest_New | ManyHeaders   | 5.541 μs |  0.88 | 0.7629 | 14.49 KB |          0.72 |

</details>

Request signing gains ~10% cpu improvement and ~20% memory savings.

Benchmark code
<details>

```
public class AWS4SignerSignRequestBenchmarks
{
    // ── Signing credentials (fake; all-ASCII to avoid per-run UTF-8 overhead) ──
    private const string AccessKey = "AKIAIOSFODNN7EXAMPLE";
    private const string SecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
    // ── Shared infrastructure ────────────────────────────────────────────────
    private AWS4Signer _signer = null!;
    private MockClientConfig _config = null!;
    private byte[] _bodyBytes = null!;
    // ── Per-scenario seed data ───────────────────────────────────────────────
    private string[] _manyQueryKeys = null!;
    private string[] _manyQueryValues = null!;
    [GlobalSetup]
    public void Setup()
    {
        _signer = new AWS4Signer(signPayload: true);
        _config = new MockClientConfig
        {
            RegionEndpoint = RegionEndpoint.USEast1,
            AuthenticationServiceName = "s3"
        };
        // Realistic 64-byte request body (e.g., small JSON payload)
        _bodyBytes = Encoding.UTF8.GetBytes("{\"Action\":\"PutObject\",\"Key\":\"prefix/object-key\"}");
        _manyQueryKeys = new string[10];
        _manyQueryValues = new string[10];
        for (int i = 0; i < 10; i++)
        {
            _manyQueryKeys[i] = $"param{i:D2}";
            _manyQueryValues[i] = $"value-{i:D3}";
        }
    }

    // ────────────────────────────────────────────────────────────────────────
    // Helpers
    // ────────────────────────────────────────────────────────────────────────
    /// <summary>
    /// Builds a realistic PUT request representative of an S3 or Bedrock object
    /// upload: path resource substitution, a pre-computed body hash header, and a
    /// typical application header set.
    /// </summary>
    private DefaultRequest BuildPutRequest()
    {
        var request = new DefaultRequest(new BenchmarkWebServiceRequest(), "s3")
        {
            HttpMethod = "PUT",
            Endpoint = new Uri("https://s3.us-east-1.amazonaws.com"),
            ResourcePath = "/{Bucket}/{Key+}",
            OverrideSigningServiceName = "s3",
            UseDoubleEncoding = false,
        };
        request.PathResources.Add("{Bucket}", "my-benchmark-bucket");
        request.PathResources.Add("{Key+}", "prefix/objects/test-object-key.json");
        request.Content = _bodyBytes;
        request.Headers["Content-Type"] = "application/json";
        request.Headers["Content-Length"] = _bodyBytes.Length.ToString();
        request.Headers["x-amz-content-sha256"] = AWS4Signer.EmptyBodySha256;
        request.Headers["x-amz-storage-class"] = "STANDARD";
        return request;
    }

    /// <summary>
    /// Builds a GET request with 10 query-string parameters, representative of
    /// a paginated list or describe call with many filter parameters.
    /// </summary>
    private DefaultRequest BuildGetManyQueryParamsRequest()
    {
        var request = new DefaultRequest(new BenchmarkWebServiceRequest(), "execute-api")
        {
            HttpMethod = "GET",
            Endpoint = new Uri("https://execute-api.us-east-1.amazonaws.com"),
            ResourcePath = "/prod/items",
            OverrideSigningServiceName = "execute-api",
        };
        // UseQueryString=true is triggered by GET (see DefaultRequest.UseQueryString getter)
        for (int i = 0; i < _manyQueryKeys.Length; i++)
            request.Parameters[_manyQueryKeys[i]] = _manyQueryValues[i];
        request.Headers["Content-Type"] = "application/json";
        return request;
    }

    /// <summary>
    /// Builds a POST request with 15 custom headers, representative of a service
    /// that surfaces many per-request control headers (e.g., Bedrock, Kinesis).
    /// Exercises the <c>SortAndPruneHeaders</c> sort and the double
    /// <c>ToLowerInvariant</c> pass in <c>CanonicalizeHeaders</c> /
    /// <c>CanonicalizeHeaderNames</c>.
    /// </summary>
    private DefaultRequest BuildManyHeadersRequest()
    {
        var request = new DefaultRequest(new BenchmarkWebServiceRequest(), "bedrock")
        {
            HttpMethod = "POST",
            Endpoint = new Uri("https://bedrock.us-east-1.amazonaws.com"),
            ResourcePath = "/model/invoke",
            OverrideSigningServiceName = "bedrock",
        };
        request.Content = _bodyBytes;
        request.Headers["Content-Type"] = "application/json";
        request.Headers["Content-Length"] = _bodyBytes.Length.ToString();
        for (int i = 0; i < 15; i++)
            request.Headers[$"X-Custom-Header-{i:D2}"] = $"HeaderValue{i}";
        return request;
    }

    // ────────────────────────────────────────────────────────────────────────
    // Benchmarks
    // ────────────────────────────────────────────────────────────────────────
    /// <summary>
    /// Baseline: typical S3 PUT — path resource substitution, body hash, standard
    /// header set. Representative of the most common SDK signing hot path.
    /// </summary>
    [Benchmark(Baseline = true)]
    public AWS4SigningResult TypicalPut() => _signer.SignRequest(BuildPutRequest(), _config, null, AccessKey, SecretKey);
    /// <summary>
    /// GET with 10 query-string parameters — exercises the double-materialise /
    /// double-sort path in <c>GetParametersToCanonicalize</c> →
    /// <c>CanonicalizeQueryParameters</c>.
    /// </summary>
    [Benchmark]
    public AWS4SigningResult GetManyQueryParams() => _signer.SignRequest(BuildGetManyQueryParamsRequest(), _config, null, AccessKey, SecretKey);
    /// <summary>
    /// POST with 15 custom headers — exercises the <c>SortAndPruneHeaders</c>
    /// red-black tree build and the redundant <c>ToLowerInvariant</c> pair in
    /// <c>CanonicalizeHeaders</c> + <c>CanonicalizeHeaderNames</c>.
    /// </summary>
    [Benchmark]
    public AWS4SigningResult ManyHeaders() => _signer.SignRequest(BuildManyHeadersRequest(), _config, null, AccessKey, SecretKey);
    // ────────────────────────────────────────────────────────────────────────
    // Minimal AmazonWebServiceRequest stub — required by DefaultRequest ctor
    // ────────────────────────────────────────────────────────────────────────
    private sealed class BenchmarkWebServiceRequest : AmazonWebServiceRequest
    {
    }

    // ────────────────────────────────────────────────────────────────────────
    // Minimal ClientConfig stub — mirrors MockClientConfig from unit tests
    // ────────────────────────────────────────────────────────────────────────
    private sealed class MockClientConfig : ClientConfig
    {
        public MockClientConfig() : base(new DefaultConfigProvider())
        {
        }

        public string AuthenticationServiceName { get; set; } = string.Empty;
        public override string RegionEndpointServiceName => AuthenticationServiceName;
        public override string ServiceVersion => "benchmark";
        public override string UserAgent => "benchmark";

        public override Endpoint DetermineServiceOperationEndpoint(ServiceOperationEndpointParameters parameters) => new Endpoint(ServiceURL ?? "https://example.com");
        private sealed class DefaultConfigProvider : IDefaultConfigurationProvider
        {
            public IDefaultConfiguration GetDefaultConfiguration(RegionEndpoint clientRegion, DefaultConfigurationMode? requestedConfigurationMode = null) => new DefaultConfiguration();
        }
    }
}
```

</details>

## Motivation and Context
GC pressure reduction, lowering cpu and memory load

## Testing
23 unit tests were added to cover all affected branches. Tested to pass both before and after the changes were applied to ensure contract wasn't changed.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

Changes are designed to be non-breaking.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement