### PR TITLE
Update RDS and DSQL token generators to force credentials refresh when needed

### DIFF
--- a/generator/.DevConfigs/6c5704cb-97e5-47ce-b930-8733977e2a94.json
+++ b/generator/.DevConfigs/6c5704cb-97e5-47ce-b930-8733977e2a94.json
@@ -1,7 +1,7 @@
 {
   "core": {
     "changeLogMessages": [
-      "Added `RefreshingAWSCredentials.ForceRefresh(TimeSpan)` and `ForceRefreshAsync(TimeSpan)` methods that regenerate credentials when the current credentials would expire within the requested minimum lifetime, and return the existing credentials otherwise."
+      "Added `RefreshingAWSCredentials.GetCredentials(TimeSpan)` and `GetCredentialsAsync(TimeSpan)` methods that regenerate credentials when the current credentials would expire within the requested minimum lifetime, and return the existing credentials otherwise."
     ],
     "type": "patch",
     "updateMinimum": true

--- a/generator/.DevConfigs/6c5704cb-97e5-47ce-b930-8733977e2a94.json
+++ b/generator/.DevConfigs/6c5704cb-97e5-47ce-b930-8733977e2a94.json
@@ -1,0 +1,25 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Added `RefreshingAWSCredentials.ForceRefresh(TimeSpan)` and `ForceRefreshAsync(TimeSpan)` methods that regenerate credentials when the current credentials would expire within the requested minimum lifetime, and return the existing credentials otherwise."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  },
+  "services": [
+    {
+      "serviceName": "RDS",
+      "type": "minor",
+      "changeLogMessages": [
+        "`RDSAuthTokenGenerator` now forces a refresh when the credentials would expire before the generated token, so the token remains valid for its full lifetime. This applies to credential providers deriving from `RefreshingAWSCredentials` (such as `AssumeRoleAWSCredentials` and `AssumeRoleWithWebIdentityCredentials`); EC2 instance profile credentials and static credentials are unaffected. `GenerateAuthToken` may now throw if the credentials refresh fails; previously a token could be returned signed with credentials nearing expiration, which the database could reject."
+      ]
+    },
+    {
+      "serviceName": "DSQL",
+      "type": "minor",
+      "changeLogMessages": [
+        "`DSQLAuthTokenGenerator` now forces a refresh when the credentials would expire before the generated token, so the token remains valid for its full lifetime (or as close to it as the credentials session duration allows). This applies to credential providers deriving from `RefreshingAWSCredentials` (such as `AssumeRoleAWSCredentials` and `AssumeRoleWithWebIdentityCredentials`); EC2 instance profile credentials and static credentials are unaffected. Token generation may now throw if the credentials refresh fails; previously a token could be returned signed with credentials nearing expiration, which the database could reject."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -162,7 +162,7 @@ namespace Amazon.Runtime
         /// <summary>
         /// GetCredentials may refresh credentials if the credentials are in the pre-empt expiration window. This will trigger
         /// a background refresh of the credentials and could force an update to the credentials and to the expiration. Users should
-        /// not rely on the <see cref="Expiration"/> property before calling <see cref="GetCredentials"/> because the <see cref="Expiration"/>
+        /// not rely on the <see cref="Expiration"/> property before calling <see cref="GetCredentials()"/> because the <see cref="Expiration"/>
         /// could be updated.
         /// </summary>
         /// <returns>An instance of ImmutableCredentials</returns>
@@ -234,7 +234,7 @@ namespace Amazon.Runtime
         /// <summary>
         /// GetCredentialsAsync may refresh credentials if the credentials are in the pre-empt expiration window. This will trigger
         /// a background refresh of the credentials and could force an update to the credentials and to the expiration. Users should
-        /// not rely on the <see cref="Expiration"/> property before calling <see cref="GetCredentialsAsync"/> because the <see cref="Expiration"/>
+        /// not rely on the <see cref="Expiration"/> property before calling <see cref="GetCredentialsAsync()"/> because the <see cref="Expiration"/>
         /// could be updated.
         /// </summary>
         /// <returns>A task whose result is an ImmutableCredentials instance.</returns>
@@ -467,7 +467,7 @@ namespace Amazon.Runtime
         /// requested lifetime exceeds the provider's maximum session duration), they are returned anyway and an
         /// informational message is logged. Exceptions thrown while regenerating the credentials propagate to the caller.
         /// </summary>
-        public ImmutableCredentials ForceRefresh(TimeSpan minimumLifetime)
+        public ImmutableCredentials GetCredentials(TimeSpan minimumLifetime)
         {
             if (minimumLifetime < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException("minimumLifetime", "minimumLifetime cannot be negative");
@@ -502,8 +502,8 @@ namespace Amazon.Runtime
             }
         }
 
-        /// <inheritdoc cref="ForceRefresh(TimeSpan)"/>
-        public async Task<ImmutableCredentials> ForceRefreshAsync(TimeSpan minimumLifetime)
+        /// <inheritdoc cref="GetCredentials(TimeSpan)"/>
+        public async Task<ImmutableCredentials> GetCredentialsAsync(TimeSpan minimumLifetime)
         {
             if (minimumLifetime < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException("minimumLifetime", "minimumLifetime cannot be negative");

--- a/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
+++ b/sdk/src/Core/Amazon.Runtime/Credentials/RefreshingAWSCredentials.cs
@@ -459,6 +459,100 @@ namespace Amazon.Runtime
             currentState = null;
         }
 
+        /// <summary>
+        /// Returns credentials that remain valid for at least <paramref name="minimumLifetime"/> when the credential
+        /// provider can supply them, regenerating the current credentials if they would expire sooner. This lets callers
+        /// such as the RDS and DSQL auth-token generators ensure the generated token stays valid for its full lifetime.
+        /// If the regenerated credentials still expire within <paramref name="minimumLifetime"/> (for example, the
+        /// requested lifetime exceeds the provider's maximum session duration), they are returned anyway and an
+        /// informational message is logged. Exceptions thrown while regenerating the credentials propagate to the caller.
+        /// </summary>
+        public ImmutableCredentials ForceRefresh(TimeSpan minimumLifetime)
+        {
+            if (minimumLifetime < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException("minimumLifetime", "minimumLifetime cannot be negative");
+
+            // Lock-free fast path, mirroring GetCredentials: most calls will find credentials
+            // that already satisfy the minimum lifetime.
+            var tempState = currentState;
+            if (tempState != null && !tempState.IsExpiredWithin(minimumLifetime))
+                return tempState.Credentials;
+
+            _updateGeneratedCredentialsSemaphore.Wait();
+            try
+            {
+                // Re-check under the lock in case another thread refreshed first.
+                tempState = currentState;
+                if (tempState != null && !tempState.IsExpiredWithin(minimumLifetime))
+                    return tempState.Credentials;
+
+                var newState = GenerateNewCredentials();
+                ValidateGeneratedCredentials(newState);
+                LogCredentialsBelowMinimumLifetime(newState, minimumLifetime);
+
+                // currentLoadState is intentionally not modified here: if a background refresh is in
+                // flight it must stay Loading so no duplicate background refresh is started, and the
+                // background task resets the flag itself when it completes or fails.
+                currentState = newState;
+                return newState.Credentials;
+            }
+            finally
+            {
+                _updateGeneratedCredentialsSemaphore.Release();
+            }
+        }
+
+        /// <inheritdoc cref="ForceRefresh(TimeSpan)"/>
+        public async Task<ImmutableCredentials> ForceRefreshAsync(TimeSpan minimumLifetime)
+        {
+            if (minimumLifetime < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException("minimumLifetime", "minimumLifetime cannot be negative");
+
+            // Lock-free fast path, mirroring GetCredentialsAsync: most calls will find credentials
+            // that already satisfy the minimum lifetime.
+            var tempState = currentState;
+            if (tempState != null && !tempState.IsExpiredWithin(minimumLifetime))
+                return tempState.Credentials;
+
+            await _updateGeneratedCredentialsSemaphore.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                // Re-check under the lock in case another thread refreshed first.
+                tempState = currentState;
+                if (tempState != null && !tempState.IsExpiredWithin(minimumLifetime))
+                    return tempState.Credentials;
+
+                var newState = await GenerateNewCredentialsAsync().ConfigureAwait(false);
+                ValidateGeneratedCredentials(newState);
+                LogCredentialsBelowMinimumLifetime(newState, minimumLifetime);
+
+                // currentLoadState is intentionally not modified here: if a background refresh is in
+                // flight it must stay Loading so no duplicate background refresh is started, and the
+                // background task resets the flag itself when it completes or fails.
+                currentState = newState;
+                return newState.Credentials;
+            }
+            finally
+            {
+                _updateGeneratedCredentialsSemaphore.Release();
+            }
+        }
+
+        private void LogCredentialsBelowMinimumLifetime(CredentialsRefreshState state, TimeSpan minimumLifetime)
+        {
+            if (!state.IsExpiredWithin(minimumLifetime))
+            {
+                return;
+            }
+
+            _logger.InfoFormat(
+                "Newly generated credentials expire at {0}, which does not satisfy the requested minimum lifetime of {1}. " +
+                "This typically means the requested lifetime exceeds the credential provider's maximum session duration.",
+                state.Expiration.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffK", CultureInfo.InvariantCulture),
+                minimumLifetime
+            );
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
+++ b/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
@@ -177,7 +177,7 @@ namespace Amazon.DSQL.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? refreshing.ForceRefresh(FifteenMinutes)
+                ? refreshing.GetCredentials(FifteenMinutes)
                 : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, FifteenMinutes);
         }
@@ -202,7 +202,7 @@ namespace Amazon.DSQL.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? refreshing.ForceRefresh(expiresIn)
+                ? refreshing.GetCredentials(expiresIn)
                 : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, expiresIn);
         }
@@ -330,7 +330,7 @@ namespace Amazon.DSQL.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? await refreshing.ForceRefreshAsync(FifteenMinutes).ConfigureAwait(false)
+                ? await refreshing.GetCredentialsAsync(FifteenMinutes).ConfigureAwait(false)
                 : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, FifteenMinutes);
         }
@@ -355,7 +355,7 @@ namespace Amazon.DSQL.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? await refreshing.ForceRefreshAsync(expiresIn).ConfigureAwait(false)
+                ? await refreshing.GetCredentialsAsync(expiresIn).ConfigureAwait(false)
                 : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, expiresIn);
         }
@@ -483,7 +483,7 @@ namespace Amazon.DSQL.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? refreshing.ForceRefresh(FifteenMinutes)
+                ? refreshing.GetCredentials(FifteenMinutes)
                 : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, FifteenMinutes);
         }
@@ -508,7 +508,7 @@ namespace Amazon.DSQL.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? refreshing.ForceRefresh(expiresIn)
+                ? refreshing.GetCredentials(expiresIn)
                 : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, expiresIn);
         }
@@ -636,7 +636,7 @@ namespace Amazon.DSQL.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? await refreshing.ForceRefreshAsync(FifteenMinutes).ConfigureAwait(false)
+                ? await refreshing.GetCredentialsAsync(FifteenMinutes).ConfigureAwait(false)
                 : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, FifteenMinutes);
         }
@@ -661,7 +661,7 @@ namespace Amazon.DSQL.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? await refreshing.ForceRefreshAsync(expiresIn).ConfigureAwait(false)
+                ? await refreshing.GetCredentialsAsync(expiresIn).ConfigureAwait(false)
                 : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, expiresIn);
         }

--- a/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
+++ b/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
@@ -79,7 +79,9 @@ namespace Amazon.DSQL.Util
         /// </remarks>
         /// </summary>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static string GenerateDbConnectAuthToken(string hostname, TimeSpan expiresIn)
         {
@@ -114,7 +116,9 @@ namespace Amazon.DSQL.Util
         /// </summary>
         /// <param name="region">The region of the DSQL database.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static string GenerateDbConnectAuthToken(RegionEndpoint region, string hostname, TimeSpan expiresIn)
         {
@@ -149,7 +153,9 @@ namespace Amazon.DSQL.Util
         /// </summary>
         /// <param name="credentials">The credentials for the token.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static string GenerateDbConnectAuthToken(AWSCredentials credentials, string hostname, TimeSpan expiresIn)
         {
@@ -169,7 +175,10 @@ namespace Amazon.DSQL.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = credentials.GetCredentials();
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? refreshing.ForceRefresh(FifteenMinutes)
+                : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, FifteenMinutes);
         }
 
@@ -179,14 +188,22 @@ namespace Amazon.DSQL.Util
         /// <param name="credentials">The credentials for the token.</param>
         /// <param name="region">The region of the DSQL database.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. If not specified on other overloads, defaults to 15 minutes.</param>
+        /// <param name="expiresIn">The token expiry duration. If not specified on other overloads, defaults to 15 minutes.
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static string GenerateDbConnectAuthToken(AWSCredentials credentials, RegionEndpoint region, string hostname, TimeSpan expiresIn)
         {
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = credentials.GetCredentials();
+            // Validate before the refresh below so an out-of-range expiration cannot trigger a credentials fetch.
+            ValidateExpiresIn(expiresIn);
+
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? refreshing.ForceRefresh(expiresIn)
+                : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, expiresIn);
         }
 
@@ -215,7 +232,9 @@ namespace Amazon.DSQL.Util
         /// </remarks>
         /// </summary>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static async System.Threading.Tasks.Task<string> GenerateDbConnectAuthTokenAsync(string hostname, TimeSpan expiresIn)
         {
@@ -250,7 +269,9 @@ namespace Amazon.DSQL.Util
         /// </summary>
         /// <param name="region">The region of the DSQL database.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static async System.Threading.Tasks.Task<string> GenerateDbConnectAuthTokenAsync(RegionEndpoint region, string hostname, TimeSpan expiresIn)
         {
@@ -285,7 +306,9 @@ namespace Amazon.DSQL.Util
         /// </summary>
         /// <param name="credentials">The credentials for the token.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static async System.Threading.Tasks.Task<string> GenerateDbConnectAuthTokenAsync(AWSCredentials credentials, string hostname, TimeSpan expiresIn)
         {
@@ -305,7 +328,10 @@ namespace Amazon.DSQL.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? await refreshing.ForceRefreshAsync(FifteenMinutes).ConfigureAwait(false)
+                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, FifteenMinutes);
         }
 
@@ -315,14 +341,22 @@ namespace Amazon.DSQL.Util
         /// <param name="credentials">The credentials for the token.</param>
         /// <param name="region">The region of the DSQL database.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. If not specified on other overloads, defaults to 15 minutes.</param>
+        /// <param name="expiresIn">The token expiry duration. If not specified on other overloads, defaults to 15 minutes.
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static async System.Threading.Tasks.Task<string> GenerateDbConnectAuthTokenAsync(AWSCredentials credentials, RegionEndpoint region, string hostname, TimeSpan expiresIn)
         {
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            // Validate before the refresh below so an out-of-range expiration cannot trigger a credentials fetch.
+            ValidateExpiresIn(expiresIn);
+
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? await refreshing.ForceRefreshAsync(expiresIn).ConfigureAwait(false)
+                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, expiresIn);
         }
 
@@ -351,7 +385,9 @@ namespace Amazon.DSQL.Util
         /// </remarks>
         /// </summary>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static string GenerateDbConnectAdminAuthToken(string hostname, TimeSpan expiresIn)
         {
@@ -386,7 +422,9 @@ namespace Amazon.DSQL.Util
         /// </summary>
         /// <param name="region">The region of the DSQL database.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static string GenerateDbConnectAdminAuthToken(RegionEndpoint region, string hostname, TimeSpan expiresIn)
         {
@@ -421,7 +459,9 @@ namespace Amazon.DSQL.Util
         /// </summary>
         /// <param name="credentials">The credentials for the token.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static string GenerateDbConnectAdminAuthToken(AWSCredentials credentials, string hostname, TimeSpan expiresIn)
         {
@@ -441,7 +481,10 @@ namespace Amazon.DSQL.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = credentials.GetCredentials();
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? refreshing.ForceRefresh(FifteenMinutes)
+                : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, FifteenMinutes);
         }
 
@@ -451,14 +494,22 @@ namespace Amazon.DSQL.Util
         /// <param name="credentials">The credentials for the token.</param>
         /// <param name="region">The region of the DSQL database.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. If not specified on other overloads, defaults to 15 minutes.</param>
+        /// <param name="expiresIn">The token expiry duration. If not specified on other overloads, defaults to 15 minutes.
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static string GenerateDbConnectAdminAuthToken(AWSCredentials credentials, RegionEndpoint region, string hostname, TimeSpan expiresIn)
         {
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = credentials.GetCredentials();
+            // Validate before the refresh below so an out-of-range expiration cannot trigger a credentials fetch.
+            ValidateExpiresIn(expiresIn);
+
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? refreshing.ForceRefresh(expiresIn)
+                : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, expiresIn);
         }
 
@@ -487,7 +538,9 @@ namespace Amazon.DSQL.Util
         /// </remarks>
         /// </summary>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static async System.Threading.Tasks.Task<string> GenerateDbConnectAdminAuthTokenAsync(string hostname, TimeSpan expiresIn)
         {
@@ -522,7 +575,9 @@ namespace Amazon.DSQL.Util
         /// </summary>
         /// <param name="region">The region of the DSQL database.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static async System.Threading.Tasks.Task<string> GenerateDbConnectAdminAuthTokenAsync(RegionEndpoint region, string hostname, TimeSpan expiresIn)
         {
@@ -557,7 +612,9 @@ namespace Amazon.DSQL.Util
         /// </summary>
         /// <param name="credentials">The credentials for the token.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).</param>
+        /// <param name="expiresIn">The token expiry duration. Must be between 0 (exclusive) and 7 days (inclusive).
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static async System.Threading.Tasks.Task<string> GenerateDbConnectAdminAuthTokenAsync(AWSCredentials credentials, string hostname, TimeSpan expiresIn)
         {
@@ -577,7 +634,10 @@ namespace Amazon.DSQL.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? await refreshing.ForceRefreshAsync(FifteenMinutes).ConfigureAwait(false)
+                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, FifteenMinutes);
         }
 
@@ -587,15 +647,29 @@ namespace Amazon.DSQL.Util
         /// <param name="credentials">The credentials for the token.</param>
         /// <param name="region">The region of the DSQL database.</param>
         /// <param name="hostname">Hostname of the DSQL database.</param>
-        /// <param name="expiresIn">The token expiry duration. If not specified on other overloads, defaults to 15 minutes.</param>
+        /// <param name="expiresIn">The token expiry duration. If not specified on other overloads, defaults to 15 minutes.
+        /// A token signed with temporary credentials becomes invalid when the credentials session expires, even if this duration is longer;
+        /// durations beyond the credentials session lifetime require long-term credentials.</param>
         /// <returns></returns>
         public static async System.Threading.Tasks.Task<string> GenerateDbConnectAdminAuthTokenAsync(AWSCredentials credentials, RegionEndpoint region, string hostname, TimeSpan expiresIn)
         {
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            // Validate before the refresh below so an out-of-range expiration cannot trigger a credentials fetch.
+            ValidateExpiresIn(expiresIn);
+
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? await refreshing.ForceRefreshAsync(expiresIn).ConfigureAwait(false)
+                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, expiresIn);
+        }
+
+        private static void ValidateExpiresIn(TimeSpan expiresIn)
+        {
+            if (expiresIn <= TimeSpan.Zero || expiresIn > MaxExpiresIn)
+                throw new ArgumentOutOfRangeException("expiresIn", "ExpiresIn must be between 0 (exclusive) and 7 days (inclusive).");
         }
 
         private static string GenerateAuthToken(ImmutableCredentials immutableCredentials, RegionEndpoint region, string hostname, string actionValue, TimeSpan expiresIn)
@@ -610,8 +684,7 @@ namespace Amazon.DSQL.Util
             if (string.IsNullOrEmpty(hostname))
                 throw new ArgumentException("Hostname must not be null or empty.");
 
-            if (expiresIn <= TimeSpan.Zero || expiresIn > MaxExpiresIn)
-                throw new ArgumentOutOfRangeException("expiresIn", "ExpiresIn must be between 0 (exclusive) and 7 days (inclusive).");
+            ValidateExpiresIn(expiresIn);
 
             GenerateDSQLAuthTokenRequest authTokenRequest = new GenerateDSQLAuthTokenRequest();
             IRequest request = new DefaultRequest(authTokenRequest, DSQLServiceName);

--- a/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
+++ b/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
@@ -175,10 +175,7 @@ namespace Amazon.DSQL.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
-            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? refreshing.GetCredentials(FifteenMinutes)
-                : credentials.GetCredentials();
+            var immutableCredentials = ResolveCredentials(credentials, FifteenMinutes);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, FifteenMinutes);
         }
 
@@ -200,10 +197,7 @@ namespace Amazon.DSQL.Util
             // Validate before the refresh below so an out-of-range expiration cannot trigger a credentials fetch.
             ValidateExpiresIn(expiresIn);
 
-            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
-            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? refreshing.GetCredentials(expiresIn)
-                : credentials.GetCredentials();
+            var immutableCredentials = ResolveCredentials(credentials, expiresIn);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, expiresIn);
         }
 
@@ -328,10 +322,7 @@ namespace Amazon.DSQL.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
-            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? await refreshing.GetCredentialsAsync(FifteenMinutes).ConfigureAwait(false)
-                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            var immutableCredentials = await ResolveCredentialsAsync(credentials, FifteenMinutes).ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, FifteenMinutes);
         }
 
@@ -353,10 +344,7 @@ namespace Amazon.DSQL.Util
             // Validate before the refresh below so an out-of-range expiration cannot trigger a credentials fetch.
             ValidateExpiresIn(expiresIn);
 
-            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
-            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? await refreshing.GetCredentialsAsync(expiresIn).ConfigureAwait(false)
-                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            var immutableCredentials = await ResolveCredentialsAsync(credentials, expiresIn).ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectActionValue, expiresIn);
         }
 
@@ -481,10 +469,7 @@ namespace Amazon.DSQL.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
-            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? refreshing.GetCredentials(FifteenMinutes)
-                : credentials.GetCredentials();
+            var immutableCredentials = ResolveCredentials(credentials, FifteenMinutes);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, FifteenMinutes);
         }
 
@@ -506,10 +491,7 @@ namespace Amazon.DSQL.Util
             // Validate before the refresh below so an out-of-range expiration cannot trigger a credentials fetch.
             ValidateExpiresIn(expiresIn);
 
-            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
-            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? refreshing.GetCredentials(expiresIn)
-                : credentials.GetCredentials();
+            var immutableCredentials = ResolveCredentials(credentials, expiresIn);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, expiresIn);
         }
 
@@ -634,10 +616,7 @@ namespace Amazon.DSQL.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
-            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? await refreshing.GetCredentialsAsync(FifteenMinutes).ConfigureAwait(false)
-                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            var immutableCredentials = await ResolveCredentialsAsync(credentials, FifteenMinutes).ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, FifteenMinutes);
         }
 
@@ -659,11 +638,34 @@ namespace Amazon.DSQL.Util
             // Validate before the refresh below so an out-of-range expiration cannot trigger a credentials fetch.
             ValidateExpiresIn(expiresIn);
 
-            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
-            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? await refreshing.GetCredentialsAsync(expiresIn).ConfigureAwait(false)
-                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            var immutableCredentials = await ResolveCredentialsAsync(credentials, expiresIn).ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, DBConnectAdminActionValue, expiresIn);
+        }
+
+        /// <summary>
+        /// Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+        /// If someone requests a 30-minute token, we ensure the underlying credentials will last at least that long.
+        /// The floor of 15 minutes prevents very short token lifetimes from accepting nearly-expired credentials.
+        /// </summary>
+        private static ImmutableCredentials ResolveCredentials(AWSCredentials credentials, TimeSpan tokenLifetime)
+        {
+            var minimumCredentialLifetime = tokenLifetime > FifteenMinutes ? tokenLifetime : FifteenMinutes;
+            return credentials is RefreshingAWSCredentials refreshing
+                ? refreshing.GetCredentials(minimumCredentialLifetime)
+                : credentials.GetCredentials();
+        }
+
+        /// <summary>
+        /// Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+        /// If someone requests a 30-minute token, we ensure the underlying credentials will last at least that long.
+        /// The floor of 15 minutes prevents very short token lifetimes from accepting nearly-expired credentials.
+        /// </summary>
+        private static async System.Threading.Tasks.Task<ImmutableCredentials> ResolveCredentialsAsync(AWSCredentials credentials, TimeSpan tokenLifetime)
+        {
+            var minimumCredentialLifetime = tokenLifetime > FifteenMinutes ? tokenLifetime : FifteenMinutes;
+            return credentials is RefreshingAWSCredentials refreshing
+                ? await refreshing.GetCredentialsAsync(minimumCredentialLifetime).ConfigureAwait(false)
+                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
         }
 
         private static void ValidateExpiresIn(TimeSpan expiresIn)

--- a/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
+++ b/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
@@ -122,7 +122,10 @@ namespace Amazon.RDS.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = credentials.GetCredentials();
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? refreshing.ForceRefresh(FifteenMinutes)
+                : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, port, dbUser);
         }
 
@@ -196,7 +199,10 @@ namespace Amazon.RDS.Util
             if (credentials == null)
                 throw new ArgumentNullException("credentials");
 
-            var immutableCredentials = await credentials.GetCredentialsAsync().ConfigureAwait(false);
+            // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
+            var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
+                ? await refreshing.ForceRefreshAsync(FifteenMinutes).ConfigureAwait(false)
+                : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, port, dbUser);
         }
 

--- a/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
+++ b/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
@@ -124,7 +124,7 @@ namespace Amazon.RDS.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? refreshing.ForceRefresh(FifteenMinutes)
+                ? refreshing.GetCredentials(FifteenMinutes)
                 : credentials.GetCredentials();
             return GenerateAuthToken(immutableCredentials, region, hostname, port, dbUser);
         }
@@ -201,7 +201,7 @@ namespace Amazon.RDS.Util
 
             // Force a refresh if the credentials would expire before the token does, so the token stays valid for its full lifetime.
             var immutableCredentials = credentials is RefreshingAWSCredentials refreshing
-                ? await refreshing.ForceRefreshAsync(FifteenMinutes).ConfigureAwait(false)
+                ? await refreshing.GetCredentialsAsync(FifteenMinutes).ConfigureAwait(false)
                 : await credentials.GetCredentialsAsync().ConfigureAwait(false);
             return GenerateAuthToken(immutableCredentials, region, hostname, port, dbUser);
         }

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/RefreshingAWSCredentialsTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/RefreshingAWSCredentialsTests.cs
@@ -207,7 +207,7 @@ namespace AWSSDK.UnitTests
         [DataRow(0)]
         [DataRow(30)]
         [DataRow(44)] // Exactly minimumLifetime remaining is not considered expired-within.
-        public void ForceRefreshReturnsCurrentCredentialsWhenMinimumLifetimeIsSatisfied(double instantInMinutes)
+        public void GetCredentialsReturnsCurrentCredentialsWhenMinimumLifetimeIsSatisfied(double instantInMinutes)
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
 
@@ -215,7 +215,7 @@ namespace AWSSDK.UnitTests
             var initialCreds = mockCredentials.GetCredentials();
 
             _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(instantInMinutes);
-            var creds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
+            var creds = mockCredentials.GetCredentials(TimeSpan.FromMinutes(15));
 
             Assert.AreEqual(initialCreds, creds);
             Assert.AreEqual(1, mockCredentials.GeneratedTokenCount);
@@ -225,7 +225,7 @@ namespace AWSSDK.UnitTests
         [DataRow(0)]
         [DataRow(30)]
         [DataRow(44)] // Exactly minimumLifetime remaining is not considered expired-within.
-        public async Task ForceRefreshReturnsCurrentCredentialsWhenMinimumLifetimeIsSatisfiedAsync(double instantInMinutes)
+        public async Task GetCredentialsReturnsCurrentCredentialsWhenMinimumLifetimeIsSatisfiedAsync(double instantInMinutes)
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
 
@@ -233,7 +233,7 @@ namespace AWSSDK.UnitTests
             var initialCreds = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
 
             _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(instantInMinutes);
-            var creds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+            var creds = await mockCredentials.GetCredentialsAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
 
             Assert.AreEqual(initialCreds, creds);
             Assert.AreEqual(1, mockCredentials.GeneratedTokenCount);
@@ -243,7 +243,7 @@ namespace AWSSDK.UnitTests
         [DataRow(44.5)] // Credentials expire within the minimum lifetime.
         [DataRow(58)]   // Credentials are close to expiration.
         [DataRow(75)]   // Credentials are fully expired.
-        public void ForceRefreshRegeneratesCredentialsExpiringWithinMinimumLifetime(double instantInMinutes)
+        public void GetCredentialsRegeneratesCredentialsExpiringWithinMinimumLifetime(double instantInMinutes)
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
 
@@ -251,7 +251,7 @@ namespace AWSSDK.UnitTests
             var initialCreds = mockCredentials.GetCredentials();
 
             _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(instantInMinutes);
-            var creds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
+            var creds = mockCredentials.GetCredentials(TimeSpan.FromMinutes(15));
 
             Assert.AreNotEqual(initialCreds, creds);
             Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
@@ -262,7 +262,7 @@ namespace AWSSDK.UnitTests
         [DataRow(44.5)] // Credentials expire within the minimum lifetime.
         [DataRow(58)]   // Credentials are close to expiration.
         [DataRow(75)]   // Credentials are fully expired.
-        public async Task ForceRefreshRegeneratesCredentialsExpiringWithinMinimumLifetimeAsync(double instantInMinutes)
+        public async Task GetCredentialsRegeneratesCredentialsExpiringWithinMinimumLifetimeAsync(double instantInMinutes)
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
 
@@ -270,7 +270,7 @@ namespace AWSSDK.UnitTests
             var initialCreds = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
 
             _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(instantInMinutes);
-            var creds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+            var creds = await mockCredentials.GetCredentialsAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
 
             Assert.AreNotEqual(initialCreds, creds);
             Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
@@ -278,61 +278,61 @@ namespace AWSSDK.UnitTests
         }
 
         [TestMethod]
-        public void ForceRefreshGeneratesCredentialsWhenNoneExist()
+        public void GetCredentialsGeneratesCredentialsWhenNoneExist()
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
 
             _mockProvider.CorrectedUtcNow = _baseTimeUtc;
-            var creds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
+            var creds = mockCredentials.GetCredentials(TimeSpan.FromMinutes(15));
 
             Assert.IsNotNull(creds);
             Assert.AreEqual(1, mockCredentials.GeneratedTokenCount);
         }
 
         [TestMethod]
-        public async Task ForceRefreshGeneratesCredentialsWhenNoneExistAsync()
+        public async Task GetCredentialsGeneratesCredentialsWhenNoneExistAsync()
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
 
             _mockProvider.CorrectedUtcNow = _baseTimeUtc;
-            var creds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+            var creds = await mockCredentials.GetCredentialsAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
 
             Assert.IsNotNull(creds);
             Assert.AreEqual(1, mockCredentials.GeneratedTokenCount);
         }
 
         [TestMethod]
-        public void ForceRefreshRegeneratesOnEveryCallWhenMinimumLifetimeExceedsSessionDuration()
+        public void GetCredentialsRegeneratesOnEveryCallWhenMinimumLifetimeExceedsSessionDuration()
         {
             // A provider whose sessions are shorter than the requested minimum lifetime can never
-            // satisfy it; ForceRefresh still returns the freshest credentials available on every call.
+            // satisfy it; GetCredentials still returns the freshest credentials available on every call.
             var mockCredentials = new MockRefreshingAWSCredentials(TimeSpan.FromMinutes(10), _mockProvider);
 
             _mockProvider.CorrectedUtcNow = _baseTimeUtc;
-            var firstCreds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
-            var secondCreds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
+            var firstCreds = mockCredentials.GetCredentials(TimeSpan.FromMinutes(15));
+            var secondCreds = mockCredentials.GetCredentials(TimeSpan.FromMinutes(15));
 
             Assert.AreNotEqual(firstCreds, secondCreds);
             Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
         }
 
         [TestMethod]
-        public async Task ForceRefreshRegeneratesOnEveryCallWhenMinimumLifetimeExceedsSessionDurationAsync()
+        public async Task GetCredentialsRegeneratesOnEveryCallWhenMinimumLifetimeExceedsSessionDurationAsync()
         {
             // A provider whose sessions are shorter than the requested minimum lifetime can never
-            // satisfy it; ForceRefresh still returns the freshest credentials available on every call.
+            // satisfy it; GetCredentials still returns the freshest credentials available on every call.
             var mockCredentials = new MockRefreshingAWSCredentials(TimeSpan.FromMinutes(10), _mockProvider);
 
             _mockProvider.CorrectedUtcNow = _baseTimeUtc;
-            var firstCreds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
-            var secondCreds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+            var firstCreds = await mockCredentials.GetCredentialsAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+            var secondCreds = await mockCredentials.GetCredentialsAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
 
             Assert.AreNotEqual(firstCreds, secondCreds);
             Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
         }
 
         [TestMethod]
-        public void ConcurrentCallsToForceRefreshOnlyGeneratesNewCredentialsOnce()
+        public void ConcurrentCallsToGetCredentialsOnlyGeneratesNewCredentialsOnce()
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
 
@@ -342,7 +342,7 @@ namespace AWSSDK.UnitTests
             _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(50);
             mockCredentials.CloseGenerateCredentialsGate();
             var concurrentCredentialTasks = Task.WhenAll(
-                Enumerable.Range(1, 5).Select(i => Task.Run(() => mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15))))
+                Enumerable.Range(1, 5).Select(i => Task.Run(() => mockCredentials.GetCredentials(TimeSpan.FromMinutes(15))))
             );
 
             mockCredentials.OpenGenerateCredentialsGate();
@@ -357,7 +357,7 @@ namespace AWSSDK.UnitTests
         }
 
         [TestMethod]
-        public async Task ConcurrentCallsToForceRefreshOnlyGeneratesNewCredentialsOnceAsync()
+        public async Task ConcurrentCallsToGetCredentialsOnlyGeneratesNewCredentialsOnceAsync()
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
 
@@ -367,7 +367,7 @@ namespace AWSSDK.UnitTests
             _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(50);
             mockCredentials.CloseGenerateCredentialsGate();
             var concurrentCredentialTasks = Task.WhenAll(
-                Enumerable.Range(1, 5).Select(i => mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)))
+                Enumerable.Range(1, 5).Select(i => mockCredentials.GetCredentialsAsync(TimeSpan.FromMinutes(15)))
             );
 
             mockCredentials.OpenGenerateCredentialsGate();
@@ -382,17 +382,17 @@ namespace AWSSDK.UnitTests
         }
 
         [TestMethod]
-        public void ForceRefreshRejectsNegativeMinimumLifetime()
+        public void GetCredentialsRejectsNegativeMinimumLifetime()
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => mockCredentials.ForceRefresh(TimeSpan.FromMinutes(-1)));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => mockCredentials.GetCredentials(TimeSpan.FromMinutes(-1)));
         }
 
         [TestMethod]
-        public async Task ForceRefreshRejectsNegativeMinimumLifetimeAsync()
+        public async Task GetCredentialsRejectsNegativeMinimumLifetimeAsync()
         {
             var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
-            await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(() => mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(-1)));
+            await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(() => mockCredentials.GetCredentialsAsync(TimeSpan.FromMinutes(-1)));
         }
 
         private void AssertCredentialsWereRefreshedAtCurrentTime(MockRefreshingAWSCredentials mockCredentials)

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/RefreshingAWSCredentialsTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/RefreshingAWSCredentialsTests.cs
@@ -144,7 +144,7 @@ namespace AWSSDK.UnitTests
 
             var credsAfterRefresh = mockCredentials.GetCredentials();
             Assert.AreNotEqual(credsAfterRefresh, credsDuringPreemptExpiry);
-            Assert.AreEqual(_mockProvider.CorrectedUtcNow + _lifetime - mockCredentials.ExpirationBuffer, mockCredentials.CurrentState.Expiration);
+            AssertCredentialsWereRefreshedAtCurrentTime(mockCredentials);
             Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
         }
 
@@ -171,7 +171,7 @@ namespace AWSSDK.UnitTests
 
             var credsAfterRefresh = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
             Assert.AreNotEqual(credsAfterRefresh, credsDuringPreemptExpiry);
-            Assert.AreEqual(_mockProvider.CorrectedUtcNow + _lifetime - mockCredentials.ExpirationBuffer, mockCredentials.CurrentState.Expiration);
+            AssertCredentialsWereRefreshedAtCurrentTime(mockCredentials);
             Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
         }
 
@@ -201,6 +201,203 @@ namespace AWSSDK.UnitTests
             var credsAfterRefresh = mockCredentials.GetCredentials();
             Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
             Assert.AreNotEqual(initialCreds, credsAfterRefresh);
+        }
+
+        [TestMethod]
+        [DataRow(0)]
+        [DataRow(30)]
+        [DataRow(44)] // Exactly minimumLifetime remaining is not considered expired-within.
+        public void ForceRefreshReturnsCurrentCredentialsWhenMinimumLifetimeIsSatisfied(double instantInMinutes)
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var initialCreds = mockCredentials.GetCredentials();
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(instantInMinutes);
+            var creds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
+
+            Assert.AreEqual(initialCreds, creds);
+            Assert.AreEqual(1, mockCredentials.GeneratedTokenCount);
+        }
+
+        [TestMethod]
+        [DataRow(0)]
+        [DataRow(30)]
+        [DataRow(44)] // Exactly minimumLifetime remaining is not considered expired-within.
+        public async Task ForceRefreshReturnsCurrentCredentialsWhenMinimumLifetimeIsSatisfiedAsync(double instantInMinutes)
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var initialCreds = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(instantInMinutes);
+            var creds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+
+            Assert.AreEqual(initialCreds, creds);
+            Assert.AreEqual(1, mockCredentials.GeneratedTokenCount);
+        }
+
+        [TestMethod]
+        [DataRow(44.5)] // Credentials expire within the minimum lifetime.
+        [DataRow(58)]   // Credentials are close to expiration.
+        [DataRow(75)]   // Credentials are fully expired.
+        public void ForceRefreshRegeneratesCredentialsExpiringWithinMinimumLifetime(double instantInMinutes)
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var initialCreds = mockCredentials.GetCredentials();
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(instantInMinutes);
+            var creds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
+
+            Assert.AreNotEqual(initialCreds, creds);
+            Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
+            AssertCredentialsWereRefreshedAtCurrentTime(mockCredentials);
+        }
+
+        [TestMethod]
+        [DataRow(44.5)] // Credentials expire within the minimum lifetime.
+        [DataRow(58)]   // Credentials are close to expiration.
+        [DataRow(75)]   // Credentials are fully expired.
+        public async Task ForceRefreshRegeneratesCredentialsExpiringWithinMinimumLifetimeAsync(double instantInMinutes)
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var initialCreds = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(instantInMinutes);
+            var creds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+
+            Assert.AreNotEqual(initialCreds, creds);
+            Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
+            AssertCredentialsWereRefreshedAtCurrentTime(mockCredentials);
+        }
+
+        [TestMethod]
+        public void ForceRefreshGeneratesCredentialsWhenNoneExist()
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var creds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
+
+            Assert.IsNotNull(creds);
+            Assert.AreEqual(1, mockCredentials.GeneratedTokenCount);
+        }
+
+        [TestMethod]
+        public async Task ForceRefreshGeneratesCredentialsWhenNoneExistAsync()
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var creds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+
+            Assert.IsNotNull(creds);
+            Assert.AreEqual(1, mockCredentials.GeneratedTokenCount);
+        }
+
+        [TestMethod]
+        public void ForceRefreshRegeneratesOnEveryCallWhenMinimumLifetimeExceedsSessionDuration()
+        {
+            // A provider whose sessions are shorter than the requested minimum lifetime can never
+            // satisfy it; ForceRefresh still returns the freshest credentials available on every call.
+            var mockCredentials = new MockRefreshingAWSCredentials(TimeSpan.FromMinutes(10), _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var firstCreds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
+            var secondCreds = mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15));
+
+            Assert.AreNotEqual(firstCreds, secondCreds);
+            Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
+        }
+
+        [TestMethod]
+        public async Task ForceRefreshRegeneratesOnEveryCallWhenMinimumLifetimeExceedsSessionDurationAsync()
+        {
+            // A provider whose sessions are shorter than the requested minimum lifetime can never
+            // satisfy it; ForceRefresh still returns the freshest credentials available on every call.
+            var mockCredentials = new MockRefreshingAWSCredentials(TimeSpan.FromMinutes(10), _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var firstCreds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+            var secondCreds = await mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)).ConfigureAwait(false);
+
+            Assert.AreNotEqual(firstCreds, secondCreds);
+            Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
+        }
+
+        [TestMethod]
+        public void ConcurrentCallsToForceRefreshOnlyGeneratesNewCredentialsOnce()
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var initialCreds = mockCredentials.GetCredentials();
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(50);
+            mockCredentials.CloseGenerateCredentialsGate();
+            var concurrentCredentialTasks = Task.WhenAll(
+                Enumerable.Range(1, 5).Select(i => Task.Run(() => mockCredentials.ForceRefresh(TimeSpan.FromMinutes(15))))
+            );
+
+            mockCredentials.OpenGenerateCredentialsGate();
+            var allCreds = concurrentCredentialTasks.Result;
+
+            Assert.AreNotEqual(initialCreds, allCreds[0]);
+            Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
+            for (var i = 1; i < allCreds.Length; i++)
+            {
+                Assert.AreEqual(allCreds[0], allCreds[i]);
+            }
+        }
+
+        [TestMethod]
+        public async Task ConcurrentCallsToForceRefreshOnlyGeneratesNewCredentialsOnceAsync()
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc;
+            var initialCreds = await mockCredentials.GetCredentialsAsync().ConfigureAwait(false);
+
+            _mockProvider.CorrectedUtcNow = _baseTimeUtc + TimeSpan.FromMinutes(50);
+            mockCredentials.CloseGenerateCredentialsGate();
+            var concurrentCredentialTasks = Task.WhenAll(
+                Enumerable.Range(1, 5).Select(i => mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(15)))
+            );
+
+            mockCredentials.OpenGenerateCredentialsGate();
+            var allCreds = await concurrentCredentialTasks;
+
+            Assert.AreNotEqual(initialCreds, allCreds[0]);
+            Assert.AreEqual(2, mockCredentials.GeneratedTokenCount);
+            for (var i = 1; i < allCreds.Length; i++)
+            {
+                Assert.AreEqual(allCreds[0], allCreds[i]);
+            }
+        }
+
+        [TestMethod]
+        public void ForceRefreshRejectsNegativeMinimumLifetime()
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => mockCredentials.ForceRefresh(TimeSpan.FromMinutes(-1)));
+        }
+
+        [TestMethod]
+        public async Task ForceRefreshRejectsNegativeMinimumLifetimeAsync()
+        {
+            var mockCredentials = new MockRefreshingAWSCredentials(_lifetime, _mockProvider);
+            await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(() => mockCredentials.ForceRefreshAsync(TimeSpan.FromMinutes(-1)));
+        }
+
+        private void AssertCredentialsWereRefreshedAtCurrentTime(MockRefreshingAWSCredentials mockCredentials)
+        {
+            Assert.AreEqual(_mockProvider.CorrectedUtcNow + _lifetime - mockCredentials.ExpirationBuffer, mockCredentials.CurrentState.Expiration);
         }
 
         private class MockTimeProvider : ITimeProvider


### PR DESCRIPTION
Fix for #4433: A `ForceRefresh` method was added to the `RefreshingAWSCredentials` provider, and it's called from the RDS / DSQL token generators to guarantee the credentials used for signing can outlive the token (in most scenarios, see DSQL comments for limitations with longer expirations).

### Dry-runs
- **DotNet Dry-run ID:** `DRY_RUN-c34e8386-fedd-42aa-ad0c-a32f186b5cd1`
- **PowerShell Dry-run ID:** `DRY_RUN-92251ca3-000c-4c1d-a423-d15bb8a958fc`

## Breaking Changes Assessment
There's a small behavior change when the refresh fails, I called it out in the DevConfig: `Token generation may now throw if the credentials refresh fails; previously a token could be returned signed with credentials nearing expiration, which the database could reject.`

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
