### PR TITLE
feat: support strict tool use in Bedrock MEAI BedrockChatClient

### DIFF
--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
@@ -1061,6 +1061,12 @@ internal sealed partial class BedrockChatClient : IChatClient
                 }
             }
 
+            // Opt-in strict tool use: callers request it per-tool via a boolean "strict"
+            // entry on the AIFunction's AdditionalProperties (mirrors the CachePoint pattern).
+            bool strict =
+                f.AdditionalProperties?.TryGetValue("strict", out object? maybeStrict) == true &&
+                maybeStrict is true;
+
             Dictionary<string, Document> schemaDictionary = new()
             {
                 ["type"] = new Document("object"),
@@ -1076,6 +1082,12 @@ internal sealed partial class BedrockChatClient : IChatClient
                 schemaDictionary["required"] = new Document(required);
             }
 
+            if (strict)
+            {
+                // Bedrock strict tool use requires the input schema to forbid extra properties.
+                schemaDictionary["additionalProperties"] = new Document(false);
+            }
+
             toolConfig ??= new();
             toolConfig.Tools ??= [];
             toolConfig.Tools.Add(new()
@@ -1088,6 +1100,7 @@ internal sealed partial class BedrockChatClient : IChatClient
                     {
                         Json = new(schemaDictionary)
                     },
+                    Strict = strict ? true : null,
                 },
             });
         }

--- a/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
+++ b/extensions/src/AWSSDK.Extensions.Bedrock.MEAI/BedrockChatClient.cs
@@ -1061,10 +1061,8 @@ internal sealed partial class BedrockChatClient : IChatClient
                 }
             }
 
-            // Opt-in strict tool use: callers request it per-tool via a boolean "strict"
-            // entry on the AIFunction's AdditionalProperties (mirrors the CachePoint pattern).
             bool strict =
-                f.AdditionalProperties?.TryGetValue("strict", out object? maybeStrict) == true &&
+                f.AdditionalProperties?.TryGetValue(nameof(ToolSpecification.Strict), out object? maybeStrict) == true &&
                 maybeStrict is true;
 
             Dictionary<string, Document> schemaDictionary = new()

--- a/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
+++ b/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
@@ -667,7 +667,7 @@ public class BedrockChatClientTests
             "get_weather",
             "Get the weather",
             schema,
-            new Dictionary<string, object> { ["strict"] = true });
+            new Dictionary<string, object> { ["Strict"] = true });
 
         var options = new ChatOptions { Tools = new[] { tool } };
 

--- a/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
+++ b/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
@@ -677,8 +677,7 @@ public class BedrockChatClientTests
         // Assert
         Assert.NotNull(capturedRequest);
         var toolSpec = capturedRequest.ToolConfig.Tools[0].ToolSpec;
-        Assert.True(toolSpec.Strict);
-
+        Assert.True(toolSpec.Strict is true);
         var schemaDict = toolSpec.InputSchema.Json.AsDictionary();
         Assert.True(schemaDict.ContainsKey("additionalProperties"));
         Assert.False(schemaDict["additionalProperties"].AsBool());

--- a/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
+++ b/extensions/test/BedrockMEAITests/BedrockChatClientTests.cs
@@ -18,16 +18,22 @@ namespace Amazon.BedrockRuntime;
 // Simple test implementation of AIFunctionDeclaration
 internal sealed class TestAIFunction : AIFunctionDeclaration
 {
-    public TestAIFunction(string name, string description, JsonElement jsonSchema)
+    public TestAIFunction(
+        string name,
+        string description,
+        JsonElement jsonSchema,
+        IReadOnlyDictionary<string, object> additionalProperties = null)
     {
         Name = name;
         Description = description;
         JsonSchema = jsonSchema;
+        AdditionalProperties = additionalProperties;
     }
 
     public override string Name { get; }
     public override string Description { get; }
     public override JsonElement JsonSchema { get; }
+    public override IReadOnlyDictionary<string, object> AdditionalProperties { get; }
 }
 
 public class BedrockChatClientTests
@@ -603,6 +609,79 @@ public class BedrockChatClientTests
         // Structured output requested via OutputConfig.
         Assert.NotNull(capturedRequest.OutputConfig);
         Assert.Equal(OutputFormatType.Json_schema, capturedRequest.OutputConfig.TextFormat.Type);
+    }
+
+    [Fact]
+    [Trait("UnitTest", "BedrockRuntime")]
+    public async Task Tool_WithoutStrictOptIn_LeavesStrictNull_AndNoAdditionalProperties()
+    {
+        // Arrange
+        var mockRuntime = new Mock<IAmazonBedrockRuntime>();
+        ConverseRequest capturedRequest = null;
+
+        mockRuntime
+            .Setup(x => x.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ConverseRequest, CancellationToken>((req, ct) => capturedRequest = req)
+            .ReturnsAsync(CreateResponse("ok"));
+
+        var client = mockRuntime.Object.AsIChatClient("claude-3");
+        var messages = new[] { new ChatMessage(ChatRole.User, "Test") };
+
+        var schema = JsonDocument.Parse(
+            """{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}""").RootElement;
+        var tool = new TestAIFunction("get_weather", "Get the weather", schema);
+
+        var options = new ChatOptions { Tools = new[] { tool } };
+
+        // Act
+        await client.GetResponseAsync(messages, options);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        var toolSpec = capturedRequest.ToolConfig.Tools[0].ToolSpec;
+        Assert.Null(toolSpec.Strict);
+
+        var schemaDict = toolSpec.InputSchema.Json.AsDictionary();
+        Assert.False(schemaDict.ContainsKey("additionalProperties"));
+    }
+
+    [Fact]
+    [Trait("UnitTest", "BedrockRuntime")]
+    public async Task Tool_WithStrictOptIn_SetsStrictTrue_AndAdditionalPropertiesFalse()
+    {
+        // Arrange
+        var mockRuntime = new Mock<IAmazonBedrockRuntime>();
+        ConverseRequest capturedRequest = null;
+
+        mockRuntime
+            .Setup(x => x.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ConverseRequest, CancellationToken>((req, ct) => capturedRequest = req)
+            .ReturnsAsync(CreateResponse("ok"));
+
+        var client = mockRuntime.Object.AsIChatClient("claude-3");
+        var messages = new[] { new ChatMessage(ChatRole.User, "Test") };
+
+        var schema = JsonDocument.Parse(
+            """{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}""").RootElement;
+        var tool = new TestAIFunction(
+            "get_weather",
+            "Get the weather",
+            schema,
+            new Dictionary<string, object> { ["strict"] = true });
+
+        var options = new ChatOptions { Tools = new[] { tool } };
+
+        // Act
+        await client.GetResponseAsync(messages, options);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        var toolSpec = capturedRequest.ToolConfig.Tools[0].ToolSpec;
+        Assert.True(toolSpec.Strict);
+
+        var schemaDict = toolSpec.InputSchema.Json.AsDictionary();
+        Assert.True(schemaDict.ContainsKey("additionalProperties"));
+        Assert.False(schemaDict["additionalProperties"].AsBool());
     }
 
     [Fact]

--- a/generator/.DevConfigs/4eb32687-1d28-4664-b924-286e2564bce4.json
+++ b/generator/.DevConfigs/4eb32687-1d28-4664-b924-286e2564bce4.json
@@ -1,0 +1,11 @@
+{
+  "extensions": [
+    {
+      "extensionName": "Extensions.Bedrock.MEAI",
+      "type": "patch",
+      "changeLogMessages": [
+        "Surface strict tool use (ToolSpecification.Strict) through BedrockChatClient"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds opt-in support for **strict tool use** to `BedrockChatClient` in `AWSSDK.Extensions.Bedrock.MEAI`.

`Amazon.BedrockRuntime.Model.ToolSpecification` already exposes a `Strict` property that marshals to `"strict"` on the wire, but `BedrockChatClient.AddUserTools` never sets it - every tool is built with only `Name`/`Description`/`InputSchema`. The method also rebuilds the input schema from scratch using only `type`/`properties`/`required`, dropping any `additionalProperties` the caller's schema declared, which strict mode requires.

This PR lets a caller opt a tool into strict mode via a boolean `"strict"` entry on the `AIFunction`'s `AdditionalProperties` (mirroring the existing `CachePoint` pattern used elsewhere in this file). When set:
- `schemaDictionary["additionalProperties"]` is added as `false`.
- `ToolSpecification.Strict` is set to `true`.

When the flag is absent (the default), behavior is unchanged: `Strict` stays `null` (the generated marshaller omits a null `Strict`, so no new field appears on the wire) and no `additionalProperties` is added to the schema.

## Motivation and Context

Fixes #4458 

## Testing

Added two unit tests to `extensions/test/BedrockMEAITests/BedrockChatClientTests.cs`, following the existing patterns in that file for constructing the client and asserting on the built `ConverseRequest`/`ToolConfiguration`:

- `Tool_WithoutStrictOptIn_LeavesStrictNull_AndNoAdditionalProperties` — confirms unchanged behavior for tools that don't opt in (`Strict == null`, no `additionalProperties` in the emitted schema).
- `Tool_WithStrictOptIn_SetsStrictTrue_AndAdditionalPropertiesFalse` — confirms `Strict == true` and `additionalProperties: false` when the tool's `AdditionalProperties["strict"]` is `true`.

Ran the full `BedrockMEAITests` project locally (`dotnet test`)

## Breaking Changes Assessment

No breaking changes

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

<!--- This PR was drafted with AI assistance and reviewed by Dimo Terziev before submission, per CONTRIBUTING.md's Automated Tools guidance. -->