### PR TITLE
Feature/s3 download directory file request event

### DIFF
--- a/generator/.DevConfigs/d3c19aa1-9757-422f-9bc9-31eaaeb8ed05.json
+++ b/generator/.DevConfigs/d3c19aa1-9757-422f-9bc9-31eaaeb8ed05.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "minor",
+      "changeLogMessages": [
+        "Added `TransferUtilityDownloadDirectoryRequest.DownloadDirectoryFileRequestEvent`, which is raised for each file before it is downloaded and allows subscribers to inspect and modify the individual `TransferUtilityDownloadRequest`. This mirrors the existing `TransferUtilityUploadDirectoryRequest.UploadDirectoryFileRequestEvent`."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/GlobalSuppressions.cs
+++ b/sdk/src/Services/S3/Custom/GlobalSuppressions.cs
@@ -49,6 +49,7 @@ using System.Diagnostics.CodeAnalysis;
 [module: SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Scope = "type", Target = "Amazon.S3.Transfer.DownloadDirectoryProgressArgs")]
 [module: SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Scope = "type", Target = "Amazon.S3.Transfer.UploadDirectoryProgressArgs")]
 [module: SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Scope = "type", Target = "Amazon.S3.Transfer.UploadDirectoryFileRequestArgs")]
+[module: SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Scope = "type", Target = "Amazon.S3.Transfer.DownloadDirectoryFileRequestArgs")]
 // General exception types
 [module: SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Scope = "member", Target = "Amazon.S3.Transfer.Internal.MultipartUploadCommand.#AbortMultipartUpload(System.String)")]
 [module: SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Scope = "member", Target = "Amazon.S3.Transfer.Internal.MultipartUploadCommand.#shutdown(System.String)")]

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
@@ -154,8 +154,6 @@ namespace Amazon.S3.Transfer.Internal
 
             downloadRequest.WriteObjectProgressEvent += downloadedProgressEventCallback;
 
-            _request.RaiseDownloadDirectoryFileRequestEvent(downloadRequest);
-
             return downloadRequest;
         }
 

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/DownloadDirectoryCommand.cs
@@ -154,6 +154,8 @@ namespace Amazon.S3.Transfer.Internal
 
             downloadRequest.WriteObjectProgressEvent += downloadedProgressEventCallback;
 
+            _request.RaiseDownloadDirectoryFileRequestEvent(downloadRequest);
+
             return downloadRequest;
         }
 

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/UploadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/UploadDirectoryCommand.cs
@@ -136,9 +136,6 @@ namespace Amazon.S3.Transfer.Internal
 
             uploadRequest.UploadProgressEvent += new EventHandler<UploadProgressArgs>(UploadProgressEventCallback);
 
-            // Raise event to allow subscribers to modify request
-            _request.RaiseUploadDirectoryFileRequestEvent(uploadRequest);
-
             return uploadRequest;
         }
 

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/DownloadDirectoryCommand.cs
@@ -310,6 +310,9 @@ namespace Amazon.S3.Transfer.Internal
             this._currentFile = s3Object.Key.Substring(prefixLength);
             var downloadRequest = ConstructTransferUtilityDownloadRequest(s3Object, prefixLength);
 
+            // Raise event to allow subscribers to modify request
+            _request.RaiseDownloadDirectoryFileRequestEvent(downloadRequest);
+
             // Create failure callback
             Action<Exception> onFailure = (ex) =>
             {

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/UploadDirectoryCommand.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/_bcl+netstandard/UploadDirectoryCommand.cs
@@ -215,6 +215,9 @@ namespace Amazon.S3.Transfer.Internal
 
             var uploadRequest = ConstructRequest(basePath, filepath, prefix);
 
+            // Raise event to allow subscribers to modify request
+            _request.RaiseUploadDirectoryFileRequestEvent(uploadRequest);
+
             // Create failure callback
             Action<Exception> onFailure = (ex) =>
             {

--- a/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryRequest.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/TransferUtilityDownloadDirectoryRequest.cs
@@ -523,10 +523,25 @@ namespace Amazon.S3.Transfer
         /// </remarks>
         public event EventHandler<DownloadDirectoryProgressArgs> DownloadedDirectoryProgressEvent;
 
+        /// <summary>
+        /// The event for modifying individual TransferUtilityDownloadRequest for each file
+        /// being downloaded.
+        /// </summary>
+        public event EventHandler<DownloadDirectoryFileRequestArgs> DownloadDirectoryFileRequestEvent;
 
         internal void OnRaiseProgressEvent(DownloadDirectoryProgressArgs downloadDirectoryProgress)
         {
             AWSSDKUtils.InvokeInBackground(DownloadedDirectoryProgressEvent, downloadDirectoryProgress, this);
+        }
+
+        internal void RaiseDownloadDirectoryFileRequestEvent(TransferUtilityDownloadRequest request)
+        {
+            var targetEvent = DownloadDirectoryFileRequestEvent;
+            if (targetEvent != null)
+            {
+                var args = new DownloadDirectoryFileRequestArgs(request);
+                targetEvent(this, args);
+            }
         }
     }
 
@@ -691,6 +706,28 @@ namespace Amazon.S3.Transfer
         }
     }
     
+    /// <summary>
+    /// Contains a single TransferUtilityDownloadRequest corresponding
+    /// to a single file about to be downloaded, allowing changes to
+    /// the request before it is executed.
+    /// </summary>
+    public class DownloadDirectoryFileRequestArgs : EventArgs
+    {
+        /// <summary>
+        /// Constructs a new DownloadDirectoryFileRequestArgs instance.
+        /// </summary>
+        /// <param name="request">Request being processed.</param>
+        public DownloadDirectoryFileRequestArgs(TransferUtilityDownloadRequest request)
+        {
+            DownloadRequest = request;
+        }
+
+        /// <summary>
+        /// Gets and sets the DownloadRequest property.
+        /// </summary>
+        public TransferUtilityDownloadRequest DownloadRequest { get; set; }
+    }
+
     /// <summary>
     /// Provides data for <see cref="TransferUtilityDownloadDirectoryRequest.ObjectDownloadFailedEvent"/>
     /// which is raised when an individual object fails to download during a

--- a/sdk/test/Services/S3/UnitTests/Custom/DownloadDirectoryCommandTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/DownloadDirectoryCommandTests.cs
@@ -1124,6 +1124,136 @@ namespace AWSSDK.UnitTests
 
         #endregion
 
+        #region DownloadDirectoryFileRequestEvent Tests
+
+        [TestMethod]
+        public async Task ExecuteAsync_FileRequestEvent_FiresForEachFile()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadFilesConcurrently = false;
+
+            var files = new Dictionary<string, long>
+            {
+                { "file1.txt", 512 },
+                { "file2.txt", 1024 },
+                { "file3.txt", 2048 }
+            };
+
+            var keys = new List<string>();
+            var eventLock = new object();
+            request.DownloadDirectoryFileRequestEvent += (sender, args) =>
+            {
+                lock (eventLock)
+                {
+                    keys.Add(args.DownloadRequest.Key);
+                }
+            };
+
+            SetupMultipleFilesDirectoryListing(files);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(files.Count, response.ObjectsDownloaded);
+            Assert.AreEqual(files.Count, keys.Count, "Event should fire once per file downloaded");
+            foreach (var file in files)
+            {
+                Assert.IsTrue(keys.Contains($"prefix/{file.Key}"),
+                    $"Event should have fired for prefix/{file.Key}");
+            }
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_FileRequestEvent_ReceivesPopulatedRequest()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            DownloadDirectoryFileRequestArgs capturedArgs = null;
+            request.DownloadDirectoryFileRequestEvent += (sender, args) =>
+            {
+                capturedArgs = args;
+            };
+
+            SetupSingleFileDirectoryListing("test-file.txt", 1024);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(capturedArgs, "Event should have fired");
+            Assert.IsNotNull(capturedArgs.DownloadRequest, "DownloadRequest should be populated");
+            Assert.AreEqual("test-bucket", capturedArgs.DownloadRequest.BucketName);
+            Assert.AreEqual("prefix/test-file.txt", capturedArgs.DownloadRequest.Key);
+            Assert.AreEqual(
+                Path.Combine(_testDirectory, "test-file.txt"),
+                capturedArgs.DownloadRequest.FilePath);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_FileRequestEvent_ModificationsPropagateToGetObjectRequest()
+        {
+            // Arrange
+            var request = CreateDownloadDirectoryRequest();
+            request.DownloadDirectoryFileRequestEvent += (sender, args) =>
+            {
+                args.DownloadRequest.RequestPayer = RequestPayer.Requester;
+            };
+
+            var capturedRequests = new List<GetObjectRequest>();
+            _mockS3Client.Setup(c => c.ListObjectsAsync(
+                It.IsAny<ListObjectsRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(CreateListObjectsResponse(new Dictionary<string, long> { { "test-file.txt", 1024 } }));
+
+            _mockS3Client.Setup(c => c.GetObjectAsync(
+                It.IsAny<GetObjectRequest>(),
+                It.IsAny<CancellationToken>()))
+                .Returns((GetObjectRequest req, CancellationToken ct) =>
+                {
+                    capturedRequests.Add(req);
+                    var data = MultipartDownloadTestHelpers.GenerateTestData(1024, 0);
+                    return Task.FromResult(new GetObjectResponse
+                    {
+                        BucketName = req.BucketName,
+                        Key = req.Key,
+                        ContentLength = 1024,
+                        ResponseStream = new MemoryStream(data),
+                        ETag = "\"test-etag\""
+                    });
+                });
+
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(1, capturedRequests.Count, "Should have issued one GetObject request");
+            Assert.AreEqual(RequestPayer.Requester, capturedRequests[0].RequestPayer,
+                "Modification made in the file request event handler should propagate to the GetObjectRequest");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_WithoutFileRequestEventSubscriber_DownloadsSuccessfully()
+        {
+            // Arrange - no subscriber attached to DownloadDirectoryFileRequestEvent
+            var request = CreateDownloadDirectoryRequest();
+            SetupSingleFileDirectoryListing("test-file.txt", 1024);
+            var command = new DownloadDirectoryCommand(_mockS3Client.Object, request, _config, useMultipartDownload: false);
+
+            // Act
+            var response = await command.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(1, response.ObjectsDownloaded);
+        }
+
+        #endregion
+
         #region Helper Methods
 
         private TransferUtilityDownloadDirectoryRequest CreateDownloadDirectoryRequest(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds `TransferUtilityDownloadDirectoryRequest.DownloadDirectoryFileRequestEvent`, raised for each file before it is downloaded, allowing subscribers to inspect and modify the individual `TransferUtilityDownloadRequest` before it executes. This mirrors the existing `TransferUtilityUploadDirectoryRequest.UploadDirectoryFileRequestEvent` so the download-directory API has parity with the upload-directory API.

## Motivation and Context
`UploadDirectory` already lets callers customize each per-file request via `UploadDirectoryFileRequestEvent`, but `DownloadDirectory` had no equivalent hook. This adds the symmetric capability for downloads (e.g. setting `RequestPayer`, custom headers, or SSE-C settings per file). My personal motivation for this change is being able to handle S3 to Windows file path conversions when uploading (already supported) and downloading directories. Without this event, we have no way of "fixing" an invalid filepath before `TransferUtility` throws an exception at us.

## Testing
Added 4 unit tests to `DownloadDirectoryCommandTests` covering: the event firing once per file, the args carrying a fully-populated request, handler mutations propagating through to the underlying `GetObjectRequest`, and the no-subscriber path. All 38 tests in the class pass (`net8.0`). No integration tests were run (they require AWS credentials).

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment
No breaking changes. The change is purely additive (a new public event and a new `DownloadDirectoryFileRequestArgs : EventArgs` type). No existing signatures or behavior change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
  - I am unsure of this.
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
  - Could not run integration tests.

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

## AI Disclosure
Generated by AI tools, and reviewed by breadswonders. I drove, Claude helped.