### PR TITLE
Re-implement region fix without imds fallback

### DIFF
--- a/generator/.DevConfigs/27c941d9-aa52-490b-ace5-9091d302d26b.json
+++ b/generator/.DevConfigs/27c941d9-aa52-490b-ace5-9091d302d26b.json
@@ -1,0 +1,8 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+    "[Breaking Change] When service clients are configured with a service URL and the signing region can not be determined from the host name the SDK would incorrectly default to us-east-1. Now the SDK will detect the default region configured for the environment and use that for signing region. If there is no default region the SDK falls back to the previous behavior and defaults to us-east-1."    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Util/Internal/RegionFinder.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/RegionFinder.cs
@@ -102,7 +102,7 @@ namespace Amazon.Util.Internal
             if (endpoint.EndsWith("amazonaws.com") || endpoint.EndsWith("amazon.com"))
                 return _root.RegionEndpoint;
 
-            return FallbackRegionFactory.GetRegionEndpoint() ?? _root.RegionEndpoint;
+            return FallbackRegionFactory.GetRegionEndpoint(false) ?? _root.RegionEndpoint;
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Util/Internal/RegionFinder.cs
+++ b/sdk/src/Core/Amazon.Util/Internal/RegionFinder.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Amazon.Runtime;
 using Amazon.Runtime.Internal.Util;
 
 namespace Amazon.Util.Internal
@@ -95,10 +96,13 @@ namespace Amazon.Util.Internal
                 return fuzzyRegion;
             }
 
-            _logger.InfoFormat($"Unable to find fuzzy matched region in endpoint {endpoint}");
+            _logger.InfoFormat($"Unable to find fuzzy matched region in endpoint {endpoint}, falling back to FallbackRegionFactory logic.");
 
-            // Return the default region
-            return _root.RegionEndpoint;
+            // if no region can be found in the url and it is an aws endpoint, then it is a global endpoint
+            if (endpoint.EndsWith("amazonaws.com") || endpoint.EndsWith("amazon.com"))
+                return _root.RegionEndpoint;
+
+            return FallbackRegionFactory.GetRegionEndpoint() ?? _root.RegionEndpoint;
         }
 
         /// <summary>

--- a/sdk/test/Services/S3/UnitTests/Custom/S3ObjectLambdaTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/S3ObjectLambdaTests.cs
@@ -22,7 +22,7 @@ namespace AWSSDK.UnitTests
     [TestClass]
     public class S3ObjectLambdaTests
     {
-        
+        private static readonly string regionEndpoint = (FallbackRegionFactory.GetRegionEndpoint(includeInstanceMetadata: false) ?? RegionEndpoint.USEast1).SystemName;
         public static IEnumerable<object[]> S3ObjectLambdaBucketFieldInputTestsData()
         {
             var testDataFromSpecMarkDown =
@@ -173,8 +173,7 @@ namespace AWSSDK.UnitTests
 
         [TestMethod]
         [TestCategory("S3")]
-        [DataRow("arn:aws:s3-object-lambda:us-west-2:123456789012:accesspoint/mybanner", "https://my-endpoint.com", true, "mybanner-123456789012.my-endpoint.com")]
-        [DataRow("arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/mybanner", "https://my-endpoint.com", false, "mybanner-123456789012.my-endpoint.com")]
+        [DynamicData(nameof(CustomEndpointUrlTestData))]
         public void CustomEndpointUrlTest(string arnString, string serviceUrl, bool useArnRegion, string expectedEndpointHost)
         {
             var request = new GetObjectRequest
@@ -190,6 +189,12 @@ namespace AWSSDK.UnitTests
             };
             var internalRequest = S3ArnTestUtils.RunMockRequest(request, GetObjectRequestMarshaller.Instance, config);
             Assert.AreEqual(expectedEndpointHost, internalRequest.Endpoint.Host);
+        }
+
+        private static IEnumerable<object[]> CustomEndpointUrlTestData()
+        {
+            yield return new object[] { "arn:aws:s3-object-lambda:us-west-2:123456789012:accesspoint/mybanner", "https://my-endpoint.com", true, "mybanner-123456789012.my-endpoint.com" };
+            yield return new object[] { $"arn:aws:s3-object-lambda:{regionEndpoint}:123456789012:accesspoint/mybanner", "https://my-endpoint.com", false, "mybanner-123456789012.my-endpoint.com" };
         }
 
         [TestMethod]

--- a/sdk/test/Services/S3/UnitTests/Custom/S3VpceTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/S3VpceTests.cs
@@ -37,33 +37,40 @@ namespace AWSSDK.UnitTests
         private const string USWest2 = "us-west-2";
         private const string USEast1 = "us-east-1";
 
+        private static string regionEndpoint = FallbackRegionFactory.GetRegionEndpoint().SystemName;
+
         [Flags]
         public enum Flags { None = 0, Dualstack = 2, Accelerate = 4, PathStyle = 8, UseArnRegion = 16 }
 
         [TestMethod]
-        [DataRow("bucketname", "https://beta.example.com", Flags.None, "https://bucketname.beta.example.com", USEast1, S3)]
-        [DataRow("arn:aws:s3:us-east-1:123456789012:accesspoint:myendpoint", "https://beta.example.com", Flags.None, "https://myendpoint-123456789012.beta.example.com", USEast1, S3)]
-        [DataRow("arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://beta.example.com", Flags.UseArnRegion, "https://myendpoint-123456789012.beta.example.com", USWest2, S3)]
-        [DataRow("bucketname", "https://s3.us-west-2.amazonaws.com", Flags.None, "https://bucketname.s3.us-west-2.amazonaws.com", USWest2, S3)]
-        [DataRow("arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://s3.us-west-2.amazonaws.com", Flags.None, "https://myendpoint-123456789012.s3.us-west-2.amazonaws.com", USWest2, S3)]
-        [DataRow("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myendpoint", "https://s3-outposts.us-west-2.amazonaws.com", Flags.None, "https://myendpoint-123456789012.op-01234567890123456.s3-outposts.us-west-2.amazonaws.com", "*", S3Outposts)]
-        [DataRow("bucketname", "https://bucket.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", Flags.PathStyle, "https://bucket.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com/bucketname/", USWest2, S3)]
-        [DataRow("bucketname", "https://bucket.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", Flags.None, "https://bucketname.bucket.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", USWest2, S3)]
-        [DataRow("arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://accesspoint.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", Flags.None, "https://myendpoint-123456789012.accesspoint.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", USWest2, S3)]
-        [DataRow("arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://accesspoint.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", Flags.UseArnRegion, "https://myendpoint-123456789012.accesspoint.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", USWest2, S3)]
-        [DataRow("arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://accesspoint.vpce-123-abc.s3.eu-west-1.vpce.amazonaws.com", Flags.UseArnRegion, "https://myendpoint-123456789012.accesspoint.vpce-123-abc.s3.eu-west-1.vpce.amazonaws.com", USWest2, S3)] //This will produce a signing error for a real request but are the expected values
+        [DynamicData(nameof(ListObjectsTestData))]
         [TestCategory("S3")]
         public void VpceEndpointTests_ListObjects(string bucketName, string serviceUrl, Flags flags,
             string expectedUri, string expectedRegion, string expectedService)
-        {                        
+        {
             var request = new ListObjectsRequest
             {
                 BucketName = bucketName
             };
 
             RunTestRequest(request, ListObjectsRequestMarshaller.Instance,
-                Arn.IsArn(bucketName), serviceUrl, flags, 
-                expectedUri, expectedRegion, expectedService);                        
+                Arn.IsArn(bucketName), serviceUrl, flags,
+                expectedUri, expectedRegion, expectedService);
+        }
+
+        private static IEnumerable<object[]> ListObjectsTestData()
+        {
+            yield return new object[] { "bucketname", "https://beta.example.com", Flags.None, "https://bucketname.beta.example.com", regionEndpoint, S3 };
+            yield return new object[] { $"arn:aws:s3:{regionEndpoint}:123456789012:accesspoint:myendpoint", "https://beta.example.com", Flags.None, "https://myendpoint-123456789012.beta.example.com", regionEndpoint, S3 };
+            yield return new object[] { "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://beta.example.com", Flags.UseArnRegion, "https://myendpoint-123456789012.beta.example.com", USWest2, S3 };
+            yield return new object[] { "bucketname", "https://s3.us-west-2.amazonaws.com", Flags.None, "https://bucketname.s3.us-west-2.amazonaws.com", USWest2, S3 };
+            yield return new object[] { "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://s3.us-west-2.amazonaws.com", Flags.None, "https://myendpoint-123456789012.s3.us-west-2.amazonaws.com", USWest2, S3 };
+            yield return new object[] { "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myendpoint", "https://s3-outposts.us-west-2.amazonaws.com", Flags.None, "https://myendpoint-123456789012.op-01234567890123456.s3-outposts.us-west-2.amazonaws.com", "*", S3Outposts };
+            yield return new object[] { "bucketname", "https://bucket.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", Flags.PathStyle, "https://bucket.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com/bucketname/", USWest2, S3 };
+            yield return new object[] { "bucketname", "https://bucket.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", Flags.None, "https://bucketname.bucket.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", USWest2, S3 };
+            yield return new object[] { "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://accesspoint.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", Flags.None, "https://myendpoint-123456789012.accesspoint.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", USWest2, S3 };
+            yield return new object[] { "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://accesspoint.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", Flags.UseArnRegion, "https://myendpoint-123456789012.accesspoint.vpce-123-abc.s3.us-west-2.vpce.amazonaws.com", USWest2, S3 };
+            yield return new object[] { "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint", "https://accesspoint.vpce-123-abc.s3.eu-west-1.vpce.amazonaws.com", Flags.UseArnRegion, "https://myendpoint-123456789012.accesspoint.vpce-123-abc.s3.eu-west-1.vpce.amazonaws.com", USWest2, S3 };
         }
 
         [TestMethod]

--- a/sdk/test/Services/S3Control/UnitTests/Custom/S3ControlVpceTests.cs
+++ b/sdk/test/Services/S3Control/UnitTests/Custom/S3ControlVpceTests.cs
@@ -36,15 +36,21 @@ namespace AWSSDK.UnitTests
         private const string S3Outposts = "s3-outposts";
         private const string USWest2 = "us-west-2";
         private const string USEast1 = "us-east-1";
+        private static string FallbackRegion => FallbackRegionFactory.GetRegionEndpoint()?.SystemName;
 
         [Flags]
         public enum Flags { None = 0, Dualstack = 2, UseArnRegion = 4 }
 
+        private static IEnumerable<object[]> GetAccessPointTestCases => new List<object[]>
+        {
+            new object[] { "apname", "https://beta.example.com", Flags.None, "https://123456789012.beta.example.com", FallbackRegion, S3 },
+            new object[] { "apname", "https://s3.us-west-2.amazonaws.com", Flags.None, "https://123456789012.s3.us-west-2.amazonaws.com", USWest2, S3 },
+            new object[] { "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint", "https://s3-outposts.us-west-2.amazonaws.com", Flags.None, "https://s3-outposts.us-west-2.amazonaws.com", USWest2, S3Outposts },
+            new object[] { "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint", "https://s3-outposts.eu-west-1.amazonaws.com", Flags.UseArnRegion, "https://s3-outposts.eu-west-1.amazonaws.com", USWest2, S3Outposts }, //This will produce a signing error for a real request but are the expected values
+        };
+
         [TestMethod]
-        [DataRow("apname", "https://beta.example.com", Flags.None, "https://123456789012.beta.example.com", USEast1, S3)]
-        [DataRow("apname", "https://s3.us-west-2.amazonaws.com", Flags.None, "https://123456789012.s3.us-west-2.amazonaws.com", USWest2, S3)]        
-        [DataRow("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint", "https://s3-outposts.us-west-2.amazonaws.com", Flags.None, "https://s3-outposts.us-west-2.amazonaws.com", USWest2, S3Outposts)]
-        [DataRow("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint", "https://s3-outposts.eu-west-1.amazonaws.com", Flags.UseArnRegion, "https://s3-outposts.eu-west-1.amazonaws.com", USWest2, S3Outposts)] //This will produce a signing error for a real request but are the expected values
+        [DynamicData(nameof(GetAccessPointTestCases))]
         [TestCategory("S3Control")]
         public void VpceEndpointTests_GetAccessPoint(string accessPointName, string serviceUrl, Flags flags,
             string expectedUri, string expectedRegion, string expectedService)
@@ -52,7 +58,7 @@ namespace AWSSDK.UnitTests
             var request = new GetAccessPointRequest
             {
                 AccountId = "123456789012",
-                Name = accessPointName                
+                Name = accessPointName
             };
 
             RunTestRequest(request, GetAccessPointRequestMarshaller.Instance,
@@ -60,9 +66,14 @@ namespace AWSSDK.UnitTests
                 expectedUri, expectedRegion, expectedService);
         }
 
+        private static IEnumerable<object[]> CreateBucketTestCases => new List<object[]>
+        {
+            new object[] { "bucketname", "https://beta.example.com", Flags.None, "https://beta.example.com", FallbackRegion, S3Outposts },
+            new object[] { "bucketname", "https://s3-outposts.us-west-2.amazonaws.com", Flags.None, "https://s3-outposts.us-west-2.amazonaws.com", USWest2, S3Outposts },
+        };
+
         [TestMethod]
-        [DataRow("bucketname", "https://beta.example.com", Flags.None, "https://beta.example.com", USEast1, S3Outposts)]
-        [DataRow("bucketname", "https://s3-outposts.us-west-2.amazonaws.com", Flags.None, "https://s3-outposts.us-west-2.amazonaws.com", USWest2, S3Outposts)]
+        [DynamicData(nameof(CreateBucketTestCases))]
         [TestCategory("S3Control")]
         public void VpceEndpointTests_CreateBucket(string bucketName, string serviceUrl, Flags flags,
             string expectedUri, string expectedRegion, string expectedService)
@@ -78,17 +89,22 @@ namespace AWSSDK.UnitTests
                 expectedUri, expectedRegion, expectedService);
         }
 
+        private static IEnumerable<object[]> GetBucketTestCases => new List<object[]>
+        {
+            new object[] { $"arn:aws:s3-outposts:{FallbackRegion}:123456789012:outpost:op-01234567890123456:bucket:mybucket", "https://beta.example.com", Flags.None, "https://beta.example.com", FallbackRegion, S3Outposts },
+            new object[] { "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:bucket:mybucket", "https://s3-outposts.us-west-2.amazonaws.com", Flags.None, "https://s3-outposts.us-west-2.amazonaws.com", USWest2, S3Outposts },
+            new object[] { "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:bucket:mybucket", "https://s3-outposts.us-west-2.amazonaws.com", Flags.UseArnRegion, "https://s3-outposts.us-west-2.amazonaws.com", USWest2, S3Outposts },
+            new object[] { "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:bucket:mybucket", "https://s3-outposts.eu-west-1.amazonaws.com", Flags.UseArnRegion, "https://s3-outposts.eu-west-1.amazonaws.com", USWest2, S3Outposts }, //This will produce a signing error for a real request but are the expected values
+        };
+
         [TestMethod]
-        [DataRow("arn:aws:s3-outposts:us-east-1:123456789012:outpost:op-01234567890123456:bucket:mybucket", "https://beta.example.com", Flags.None, "https://beta.example.com", USEast1, S3Outposts)]
-        [DataRow("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:bucket:mybucket", "https://s3-outposts.us-west-2.amazonaws.com", Flags.None, "https://s3-outposts.us-west-2.amazonaws.com", USWest2, S3Outposts)]
-        [DataRow("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:bucket:mybucket", "https://s3-outposts.us-west-2.amazonaws.com", Flags.UseArnRegion, "https://s3-outposts.us-west-2.amazonaws.com", USWest2, S3Outposts)]
-        [DataRow("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:bucket:mybucket", "https://s3-outposts.eu-west-1.amazonaws.com", Flags.UseArnRegion, "https://s3-outposts.eu-west-1.amazonaws.com", USWest2, S3Outposts)] //This will produce a signing error for a real request but are the expected values
+        [DynamicData(nameof(GetBucketTestCases))]
         [TestCategory("S3Control")]
         public void VpceEndpointTests_GetBucket(string bucketName, string serviceUrl, Flags flags,
             string expectedUri, string expectedRegion, string expectedService)
         {
             var request = new GetBucketRequest
-            {                
+            {
                 Bucket = bucketName
             };
 
@@ -106,6 +122,7 @@ namespace AWSSDK.UnitTests
                 Name = "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint"
             };
             var config = CreateConfig("https://beta.example.com", Flags.None);
+            config.RegionEndpoint = RegionEndpoint.USEast2;
             Assert.ThrowsExactly<AmazonClientException>(() =>
                 S3ControlArnTestUtils.RunMockRequest(request, GetAccessPointRequestMarshaller.Instance, config));
         }

--- a/sdk/test/UnitTests/Custom/Runtime/SignerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/SignerTests.cs
@@ -1,5 +1,9 @@
 ﻿using Amazon;
 using Amazon.S3;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Internal;
+using Amazon.SecurityToken.Model;
+using Amazon.SecurityToken.Model.Internal.MarshallTransformations;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
@@ -30,6 +34,204 @@ namespace AWSSDK.UnitTests
 
             Assert.IsTrue(context.RequestContext.IsSigned);
             Assert.AreEqual(1, signer.SignCount);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestSignerWithRegionAndCustomServiceURLSetViaEnvVariables()
+        {
+            var savedEndpoint = Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL");
+            var savedRegion = Environment.GetEnvironmentVariable("AWS_REGION");
+            try
+            {
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", "https://non-aws-endpoint.com");
+                Environment.SetEnvironmentVariable("AWS_REGION", "us-east-2");
+                FallbackRegionFactory.Reset();
+
+                var config = new AmazonSecurityTokenServiceConfig();
+
+                var getCallerIdentityRequest = new GetCallerIdentityRequest();
+                var marshaller = new GetCallerIdentityRequestMarshaller();
+                var marshalledRequest = marshaller.Marshall(getCallerIdentityRequest);
+
+                var signer = new AWS4Signer();
+                var requestContext = new RequestContext(true, signer)
+                {
+                    ClientConfig = config,
+                    OriginalRequest = getCallerIdentityRequest,
+                    Request = marshalledRequest,
+                    Identity = new BasicAWSCredentials("accessKey", "secretKey")
+                };
+
+                var executionContext = new ExecutionContext(requestContext, new ResponseContext());
+
+                var pipeline = new RuntimePipeline(new MockHandler());
+                pipeline.AddHandler(new Signer());
+                pipeline.AddHandler(new AmazonSecurityTokenServiceEndpointResolver());
+
+                pipeline.InvokeSync(executionContext);
+
+                var authHeader = executionContext.RequestContext.Request.Headers[HeaderKeys.AuthorizationHeader];
+                // When both region and serviceURL are set via env variables, the region env variable should be respected.
+                Assert.IsTrue(authHeader.Contains("us-east-2/sts/aws4_request"),
+                    $"Expected Authorization header to contain 'us-east-2/sts/aws4_request' but got: {authHeader}");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", savedRegion);
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", savedEndpoint);
+                FallbackRegionFactory.Reset();
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestSignerWithRegionAndAWSServiceURLSetViaEnvVariables()
+        {
+            var savedRegion = Environment.GetEnvironmentVariable("AWS_REGION");
+            var savedEndpoint = Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL");
+            try
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", "us-east-2");
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", "http://s3.amazonaws.com");
+                FallbackRegionFactory.Reset();
+
+                var config = new AmazonSecurityTokenServiceConfig();
+
+                var getCallerIdentityRequest = new GetCallerIdentityRequest();
+                var marshaller = new GetCallerIdentityRequestMarshaller();
+                var marshalledRequest = marshaller.Marshall(getCallerIdentityRequest);
+
+                var signer = new AWS4Signer();
+                var requestContext = new RequestContext(true, signer)
+                {
+                    ClientConfig = config,
+                    OriginalRequest = getCallerIdentityRequest,
+                    Request = marshalledRequest,
+                    Identity = new BasicAWSCredentials("accessKey", "secretKey")
+                };
+
+                var executionContext = new ExecutionContext(requestContext, new ResponseContext());
+
+                var pipeline = new RuntimePipeline(new MockHandler());
+                pipeline.AddHandler(new Signer());
+                pipeline.AddHandler(new AmazonSecurityTokenServiceEndpointResolver());
+
+                pipeline.InvokeSync(executionContext);
+
+                var authHeader = executionContext.RequestContext.Request.Headers[HeaderKeys.AuthorizationHeader];
+                // for aws endpoints, the global region is used as a default, even if one is provided via AWS_REGION 
+                // to preserve backwards compatibility.
+                Assert.IsTrue(authHeader.Contains("us-east-1/sts/aws4_request"),
+                    $"Expected Authorization header to contain 'us-east-1/sts/aws4_request' but got: {authHeader}");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", savedRegion);
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", savedEndpoint);
+                FallbackRegionFactory.Reset();
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestAuthenticationRegionOverridesRegionSetViaEnvVariable()
+        {
+            var savedRegion = Environment.GetEnvironmentVariable("AWS_REGION");
+            var savedEndpoint = Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL");
+            try
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", "http://testEndpoint.com/443");
+                FallbackRegionFactory.Reset();
+
+                var config = new AmazonSecurityTokenServiceConfig();
+                config.AuthenticationRegion = "us-east-2";
+
+                var getCallerIdentityRequest = new GetCallerIdentityRequest();
+                var marshaller = new GetCallerIdentityRequestMarshaller();
+                var marshalledRequest = marshaller.Marshall(getCallerIdentityRequest);
+
+                var signer = new AWS4Signer();
+                var requestContext = new RequestContext(true, signer)
+                {
+                    ClientConfig = config,
+                    OriginalRequest = getCallerIdentityRequest,
+                    Request = marshalledRequest,
+                    Identity = new BasicAWSCredentials("accessKey", "secretKey")
+                };
+
+                var executionContext = new ExecutionContext(requestContext, new ResponseContext());
+
+                var pipeline = new RuntimePipeline(new MockHandler());
+                pipeline.AddHandler(new Signer());
+                pipeline.AddHandler(new AmazonSecurityTokenServiceEndpointResolver());
+
+                pipeline.InvokeSync(executionContext);
+
+                var authHeader = executionContext.RequestContext.Request.Headers[HeaderKeys.AuthorizationHeader];
+                Assert.IsTrue(authHeader.Contains($"us-east-2/sts/aws4_request"),
+                    $"Expected Authorization header to contain 'us-east-2/sts/aws4_request' but got: {authHeader}");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", savedRegion);
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", savedEndpoint);
+                FallbackRegionFactory.Reset();
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestSignerWithNoServiceURLAndNoRegionEnvVariableRespectsClientConfig()
+        {
+            var savedRegion = Environment.GetEnvironmentVariable("AWS_REGION");
+            var savedEndpoint = Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL");
+            try
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", null);
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", null);
+                FallbackRegionFactory.Reset();
+
+                var config = new AmazonSecurityTokenServiceConfig();
+                config.RegionEndpoint = RegionEndpoint.USWest2;
+
+                var getCallerIdentityRequest = new GetCallerIdentityRequest();
+                var marshaller = new GetCallerIdentityRequestMarshaller();
+                var marshalledRequest = marshaller.Marshall(getCallerIdentityRequest);
+
+                var signer = new AWS4Signer();
+                var requestContext = new RequestContext(true, signer)
+                {
+                    ClientConfig = config,
+                    OriginalRequest = getCallerIdentityRequest,
+                    Request = marshalledRequest,
+                    Identity = new BasicAWSCredentials("accessKey", "secretKey")
+                };
+
+                var executionContext = new ExecutionContext(requestContext, new ResponseContext());
+
+                var pipeline = new RuntimePipeline(new MockHandler());
+                pipeline.AddHandler(new Signer());
+                pipeline.AddHandler(new AmazonSecurityTokenServiceEndpointResolver());
+
+                pipeline.InvokeSync(executionContext);
+              
+                var authHeader = executionContext.RequestContext.Request.Headers[HeaderKeys.AuthorizationHeader];
+                // When no region is explicitly set via env var, the SDK falls back to profile/default region
+                Assert.IsTrue(authHeader.Contains($"us-west-2"),
+                    $"Expected Authorization header to contain 'us-west-2/sts/aws4_request' but got: {authHeader}");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AWS_REGION", savedRegion);
+                Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", savedEndpoint);
+                FallbackRegionFactory.Reset();
+            }
         }
 
         [TestMethod][TestCategory("UnitTest")]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Due to https://github.com/aws/aws-sdk-net/issues/4444 and https://github.com/aws/aws-sdk-net/issues/4445. I had to rollback the fix. If a user provides a custom endpoint via AWS_ENDPOINT_URL or serviceURL and that endpoint is not an aws endpoint, the SDK will look to the `FallbackRegionFactory` for the region instead of defaulting to `us-east-1` always. 

This was also pointed out in the latest Localstack release: https://github.com/localstack-dotnet/dotnet-aspire-for-localstack/releases/tag/13.4.0

I did a test with a console app and and made sure it doesn't fallback to IMDS.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the exact scenario in the issue 
```
var lambdaConfig = new AmazonLambdaConfig
{
    ServiceURL = "https://fake-endpoint.com"
};
var creds = new BasicAWSCredentials("test", "test");
using var lambdaClient = new AmazonLambdaClient(creds, lambdaConfig);
try
{
    await lambdaClient.ListFunctionsAsync().ConfigureAwait(continueOnCapturedContext: false);

}
catch (Exception e)
{
    
}
```


### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** cf9ff13b-40e5-4ff4-ba37-5a939f13785d
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** ec778314-b286-4c66-bc0e-a02e90740cec
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement