### PR TITLE
CPU and memory improvements on XmlUnmarshallerContext

### DIFF
--- a/generator/.DevConfigs/b30eb62d-e999-414e-912e-ce7d636193e9.json
+++ b/generator/.DevConfigs/b30eb62d-e999-414e-912e-ce7d636193e9.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "CPU and memory improvements on XmlUnmarshallerContext"
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/XmlUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/XmlUnmarshallerContext.cs
@@ -1,12 +1,11 @@
 ﻿using Amazon.Runtime.Internal.Util;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 
 namespace Amazon.Runtime.Internal.Transform
 {
@@ -34,7 +33,7 @@ namespace Amazon.Runtime.Internal.Transform
     {
         #region Private members
 
-        private static HashSet<XmlNodeType> nodesToSkip = new HashSet<XmlNodeType>
+        private static readonly HashSet<XmlNodeType> nodesToSkipInternal = new HashSet<XmlNodeType>
         {
             XmlNodeType.None,
             XmlNodeType.XmlDeclaration,
@@ -44,10 +43,20 @@ namespace Amazon.Runtime.Internal.Transform
             XmlNodeType.Whitespace
         };
 
+#if NET8_0_OR_GREATER
+        private static readonly FrozenSet<XmlNodeType> nodesToSkip = nodesToSkipInternal.ToFrozenSet();
+#else
+        private static readonly HashSet<XmlNodeType> nodesToSkip = nodesToSkipInternal;
+#endif
+
         private StreamReader streamReader;
         private XmlTextReader _xmlTextReader;
-        private Stack<string> stack = new Stack<string>();
+        // Stack of full element paths (e.g. "/root/child") built incrementally on push,
+        // so the current path never needs to be recomputed by walking the stack.
+        private readonly Stack<string> stack = new Stack<string>();
         private string stackString = "";
+        private string lastPoppedPath;
+        private int lastPoppedDepth = -1;
         private Dictionary<string, string> attributeValues;
         private List<string> attributeNames;
         private IEnumerator<string> attributeEnumerator;
@@ -76,15 +85,17 @@ namespace Amazon.Runtime.Internal.Transform
             {
                 if (_xmlTextReader == null)
                 {
-                    _xmlTextReader = new XmlTextReader(streamReader);
-                    _xmlTextReader.WhitespaceHandling = WhitespaceHandling.All;
-                    _xmlTextReader.DtdProcessing = DtdProcessing.Ignore;
+                    _xmlTextReader = new XmlTextReader(streamReader)
+                    {
+                        WhitespaceHandling = WhitespaceHandling.All,
+                        DtdProcessing = DtdProcessing.Ignore
+                    };
                 }
                 return _xmlTextReader;
             }
         }
 
-        #endregion
+#endregion
 
         #region Constructors
 
@@ -126,8 +137,7 @@ namespace Amazon.Runtime.Internal.Transform
             // If the unmarshaller context is being called internally without there being a http response then the response data would be null
             if (responseData != null)
             {
-                long contentLength;
-                bool parsedContentLengthHeader = long.TryParse(responseData.GetHeaderValue("Content-Length"), out contentLength);
+                bool parsedContentLengthHeader = long.TryParse(responseData.GetHeaderValue("Content-Length"), out long contentLength);
 
                 if (parsedContentLengthHeader && contentLength == 0)
                 {
@@ -237,7 +247,7 @@ namespace Amazon.Runtime.Internal.Transform
             if (attributeEnumerator != null && attributeEnumerator.MoveNext())
             {
                 this.nodeType = XmlNodeType.Attribute;
-                stackString = string.Format(CultureInfo.InvariantCulture, "{0}/@{1}", StackToPath(stack), attributeEnumerator.Current);
+                stackString = string.Concat(stack.Peek(), "/@", attributeEnumerator.Current);
             }
             else
             {
@@ -248,8 +258,7 @@ namespace Amazon.Runtime.Internal.Transform
                 if (currentlyProcessingEmptyElement)
                 {
                     nodeType = XmlNodeType.EndElement;
-                    stack.Pop();
-                    stackString = StackToPath(stack);
+                    PopElementPath();
                     XmlReader.Read();
                     currentlyProcessingEmptyElement = false;
                 }
@@ -257,8 +266,7 @@ namespace Amazon.Runtime.Internal.Transform
                 {
                     //This is a shorthand form of an empty element <element /> and we want to allow it
                     nodeType = XmlNodeType.Element;
-                    stack.Push(XmlReader.LocalName);
-                    stackString = StackToPath(stack);
+                    PushElementPath(XmlReader.LocalName);
                     currentlyProcessingEmptyElement = true;
                     nodeContent = String.Empty;
 
@@ -270,14 +278,12 @@ namespace Amazon.Runtime.Internal.Transform
                     {
                         case XmlNodeType.EndElement:
                             this.nodeType = XmlNodeType.EndElement;
-                            stack.Pop();
-                            stackString = StackToPath(stack);
+                            PopElementPath();
                             XmlReader.Read();
                             break;
                         case XmlNodeType.Element:
                             nodeType = XmlNodeType.Element;
-                            stack.Push(XmlReader.LocalName);
-                            stackString = StackToPath(stack);
+                            PushElementPath(XmlReader.LocalName);
                             this.ReadElement();
                             break;
                         default:
@@ -289,7 +295,7 @@ namespace Amazon.Runtime.Internal.Transform
                             // after advancing the underlying XmlReader past an unhandled node type.
                             nodeType = XmlNodeType.None;
                             nodeContent = string.Empty;
-                            stackString = StackToPath(stack);
+                            stackString = stack.Count > 0 ? stack.Peek() : "/";
                             break;
                     }
                 }
@@ -313,14 +319,35 @@ namespace Amazon.Runtime.Internal.Transform
 
         #region Private Methods
 
-        private static string StackToPath(Stack<string> stack)
+        private void PushElementPath(string name)
         {
-            string path = null;
-            foreach (string s in stack.ToArray())
+            string parentPath = stack.Count > 0 ? stack.Peek() : string.Empty;
+            string path;
+            // Reuse the previously popped path when re-entering an element with the same name at
+            // the same depth (common for repeated list elements, e.g. <member>), avoiding a new
+            // string allocation per sibling. The parent path is guaranteed unchanged because any
+            // intermediate pop would have overwritten lastPoppedPath/lastPoppedDepth.
+            string reusable = lastPoppedPath;
+            if (reusable != null &&
+                stack.Count == lastPoppedDepth &&
+                reusable.Length == parentPath.Length + name.Length + 1 &&
+                string.CompareOrdinal(reusable, parentPath.Length + 1, name, 0, name.Length) == 0)
             {
-                path = null == path ? s : string.Format(CultureInfo.InvariantCulture, "{0}/{1}", s, path);
+                path = reusable;
             }
-            return "/" + path;
+            else
+            {
+                path = string.Concat(parentPath, "/", name);
+            }
+            stack.Push(path);
+            stackString = path;
+        }
+
+        private void PopElementPath()
+        {
+            lastPoppedPath = stack.Pop();
+            lastPoppedDepth = stack.Count;
+            stackString = stack.Count > 0 ? stack.Peek() : "/";
         }
 
         // Move to the next element, cache the attributes collection

--- a/sdk/test/UnitTests/Custom/Runtime/XmlUnmarshallerContextTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/XmlUnmarshallerContextTests.cs
@@ -154,8 +154,7 @@ namespace AWSSDK.UnitTests
             // TODO: ASK THE TEAM: Should attributes on self-closing elements be surfaced?
             // attributes on a self-closing element are never surfaced because the
             // IsEmptyElement branch in Read() skips ReadElement(). This test asserts the
-            // expected behavior; run it against the base commit to confirm the same
-            // misbehavior existed prior to this branch.
+            // expected behavior, not the observed one.
             var xml = "<Root><Something id=\"111\" /></Root>";
 
             CollectionAssert.AreEqual(new[]

--- a/sdk/test/UnitTests/Custom/Runtime/XmlUnmarshallerContextTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/XmlUnmarshallerContextTests.cs
@@ -1,0 +1,278 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using Amazon.Runtime.Internal.Transform;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace AWSSDK.UnitTests
+{
+    [TestClass]
+    public class XmlUnmarshallerContextTests
+    {
+        private static XmlUnmarshallerContext CreateContext(string xml)
+        {
+            return new XmlUnmarshallerContext(new MemoryStream(Encoding.UTF8.GetBytes(xml)), false, null);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CurrentPath_TracksElementsAttributesAndEndElements()
+        {
+            var xml = "<Root><Item id=\"1\"><Name>foo</Name></Item><Item id=\"2\"><Name>bar</Name></Item><Empty/></Root>";
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "S:/Root=",
+                "S:/Root/Item=",
+                "A:/Root/Item/@id=1",
+                "S:/Root/Item/Name=foo",
+                "E:/Root/Item",
+                "E:/Root",
+                "S:/Root/Item=",
+                "A:/Root/Item/@id=2",
+                "S:/Root/Item/Name=bar",
+                "E:/Root/Item",
+                "E:/Root",
+                "S:/Root/Empty=",
+                "E:/Root"
+            }, ReadEvents(xml));
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CurrentDepth_MatchesElementNesting()
+        {
+            var xml = "<Root><Child><GrandChild>x</GrandChild></Child></Root>";
+
+            using (var context = CreateContext(xml))
+            {
+                var maxDepth = 0;
+                while (context.Read())
+                {
+                    if (context.IsStartElement && context.CurrentDepth > maxDepth)
+                        maxDepth = context.CurrentDepth;
+
+                    if (context.IsStartElement && context.CurrentDepth == 3)
+                    {
+                        Assert.AreEqual("/Root/Child/GrandChild", context.CurrentPath);
+                        Assert.AreEqual("x", context.ReadText());
+                    }
+                }
+
+                Assert.AreEqual(3, maxDepth);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void TestExpression_MatchesGeneratedMarshallerPatterns()
+        {
+            var xml = "<Response><Values><member>a</member><member>b</member></Values></Response>";
+
+            var memberValues = new List<string>();
+            using (var context = CreateContext(xml))
+            {
+                while (context.Read())
+                {
+                    if (context.IsStartElement)
+                    {
+                        // Mirrors the pseudo-XPath matching emitted by the generated unmarshallers.
+                        if (context.TestExpression("Values/member", 2))
+                        {
+                            memberValues.Add(StringUnmarshaller.Instance.Unmarshall(context));
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            CollectionAssert.AreEqual(new[] { "a", "b" }, memberValues);
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CurrentPath_EmptyElementsPushAndPopCorrectly()
+        {
+            var xml = "<Root><A/><B><C/></B></Root>";
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "S:/Root=",
+                "S:/Root/A=",
+                "E:/Root",
+                "S:/Root/B=",
+                "S:/Root/B/C=",
+                "E:/Root/B",
+                "E:/Root"
+            }, ReadEvents(xml));
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CurrentPath_EmptyElementWithAttributes()
+        {
+            // Self-closing element carrying attributes: the path tracking must remain
+            // consistent. Note: the context does not surface attributes on empty
+            // (self-closing) elements; this documents the current behavior.
+            var xml = "<Root><Something id=\"111\" /><After>x</After></Root>";
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "S:/Root=",
+                "S:/Root/Something=",
+                "E:/Root",
+                "S:/Root/After=x",
+                "E:/Root"
+            }, ReadEvents(xml));
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void EmptyElement_AttributesAreSurfaced()
+        {
+            // NOTE: THIS IS EXPECTED TO FAIL. Current base version fails this test!
+            // TODO: ASK THE TEAM: Should attributes on self-closing elements be surfaced?
+            // attributes on a self-closing element are never surfaced because the
+            // IsEmptyElement branch in Read() skips ReadElement(). This test asserts the
+            // expected behavior; run it against the base commit to confirm the same
+            // misbehavior existed prior to this branch.
+            var xml = "<Root><Something id=\"111\" /></Root>";
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "S:/Root=",
+                "S:/Root/Something=",
+                "A:/Root/Something/@id=111",
+                "E:/Root"
+            }, ReadEvents(xml));
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CurrentPath_SameLengthSiblingNamesAreNotConfused()
+        {
+            // Sibling elements with equal-length names must not reuse each other's path.
+            var xml = "<Root><AB>1</AB><CD>2</CD></Root>";
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "S:/Root=",
+                "S:/Root/AB=1",
+                "E:/Root",
+                "S:/Root/CD=2",
+                "E:/Root"
+            }, ReadEvents(xml));
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CurrentPath_SameNameAtDifferentDepthIsNotReused()
+        {
+            // <B/> is first popped at depth 2 (/R/A/B), then /R/A is popped; a new <B>
+            // at depth 1 must get /R/B, not a stale reused path.
+            var xml = "<R><A><B/></A><B>y</B></R>";
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "S:/R=",
+                "S:/R/A=",
+                "S:/R/A/B=",
+                "E:/R/A",
+                "E:/R",
+                "S:/R/B=y",
+                "E:/R"
+            }, ReadEvents(xml));
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CurrentPath_NestedSameNameElements()
+        {
+            var xml = "<A><A>x</A></A>";
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "S:/A=",
+                "S:/A/A=x",
+                "E:/A"
+            }, ReadEvents(xml));
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CurrentPath_MultipleAttributesOnOneElement()
+        {
+            var xml = "<Root><Item a=\"1\" b=\"2\">t</Item></Root>";
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "S:/Root=",
+                "S:/Root/Item=t",
+                "A:/Root/Item/@a=1",
+                "A:/Root/Item/@b=2",
+                "E:/Root"
+            }, ReadEvents(xml));
+        }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void CurrentPath_TextBetweenSiblingElementsIsSkipped()
+        {
+            // Stray text between siblings exercises the default branch in Read(),
+            // which must advance the reader and keep CurrentPath pointing at the parent.
+            var xml = "<Root><A>1</A>stray<B>2</B></Root>";
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "S:/Root=",
+                "S:/Root/A=1",
+                "E:/Root",
+                "S:/Root/B=2",
+                "E:/Root"
+            }, ReadEvents(xml));
+        }
+
+        private static List<string> ReadEvents(string xml)
+        {
+            var events = new List<string>();
+            using (var context = CreateContext(xml))
+            {
+                while (context.Read())
+                {
+                    if (context.IsStartElement)
+                        events.Add("S:" + context.CurrentPath + "=" + context.ReadText());
+                    else if (context.IsAttribute)
+                        events.Add("A:" + context.CurrentPath + "=" + context.ReadText());
+                    else if (context.IsEndElement)
+                        events.Add("E:" + context.CurrentPath);
+                }
+            }
+            return events;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactor XmlUnmarshallerDevConfig, build path stack as ancestor path and avoid repeated string rematerializations.

## Motivation and Context
Lower cpu and gc pressure on xml unmarshaller.

### Benchmark
Before:

| Method        | Shape | ItemCount | Mean      | Gen0    | Gen1   | Allocated |
|-------------- |------ |---------- |----------:|--------:|-------:|----------:|
| **ParseDocument** | **empty** | **10**        |  **8.597 μs** |  **2.1362** | **0.1221** |  **40.29 KB** |
| **ParseDocument** | **empty** | **100**       | **71.417 μs** | **13.6719** | **0.4883** | **252.64 KB** |
| **ParseDocument** | **text**  | **10**        | **11.156 μs** |  **2.6855** | **0.1221** |  **49.98 KB** |
| **ParseDocument** | **text**  | **100**       | **97.764 μs** | **18.5547** | **0.9766** | **349.51 KB** |

After:

| Method        | Shape | ItemCount | Mean      | Gen0   | Gen1   | Allocated |
|-------------- |------ |---------- |----------:|-------:|-------:|----------:|
| **ParseDocument** | **empty** | **10**        |  **3.274 μs** | **0.9766** |      **-** |  **18.76 KB** |
| **ParseDocument** | **empty** | **100**       | **18.776 μs** | **2.1973** |      **-** |  **44.85 KB** |
| **ParseDocument** | **text**  | **10**        |  **4.707 μs** | **1.3428** | **0.0610** |  **24.85 KB** |
| **ParseDocument** | **text**  | **100**       | **36.416 μs** | **5.3711** |      **-** | **104.94 KB** |

After the modification the pass is, based on scenario 2.3-3.8x faster while consuming less than 50% memory.

Benchmark code
<details>

```

public class XmlUnmarshallerContextBenchmarks
{
    private byte[] _payload = null!;

    [Params("text", "empty")]
    public string Shape { get; set; } = null!;

    /// <summary>Number of repeated <c>member</c> entries in the list payload.</summary>
    [Params(10, 100)]
    public int ItemCount { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        var sb = new StringBuilder();
        sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
        sb.Append("<ListResponse xmlns=\"http://example.com/doc/2010-05-08/\">");
        sb.Append("<ListResult>");
        for (var i = 0; i < ItemCount; i++)
        {
            if (Shape == "empty")
            {
                sb.Append("<member><Name/><Value/><Marker attr=\"a\"/></member>");
            }
            else
            {
                sb.Append("<member><Name>item-name-").Append(i)
                  .Append("</Name><Value>some-value-payload-").Append(i)
                  .Append("</Value><Marker attr=\"a\">m</Marker></member>");
            }
        }
        sb.Append("</ListResult>");
        sb.Append("<ResponseMetadata><RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId></ResponseMetadata>");
        sb.Append("</ListResponse>");
        _payload = Encoding.UTF8.GetBytes(sb.ToString());
    }

    [Benchmark]
    public int ParseDocument()
    {
        using var stream = new MemoryStream(_payload);
        var context = new XmlUnmarshallerContext(stream, maintainResponseBody: false, responseData: null);

        var matched = 0;
        // full consuming parse with dummy logic
        while (context.Read())
        {
            if (context.TestExpression("ListResponse/ListResult/member/Name")
                || context.TestExpression("ListResponse/ListResult/member/Value")
                || context.TestExpression("ListResponse/ResponseMetadata/RequestId"))
            {
                _ = context.ReadText();
                matched++;
            }
        }
        return matched;
    }
}

```

</details>

## Testing
I have started by adding unit tests for the original implementation. Then refactored the class and made sure both versions pass in a same way.
*During adding the tests the scenario `<Root><Something id="111" /></Root>` failed with original implementation, the attribute is not surfaced. I have kept the behavior for refactored version same but please advise whether this is desired as it seems highly suspicious*

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

This is refactor on purely private parts of the class, no behavioral or breaking changes are desired.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed - nope, see Testing section for details and advise pls

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement