### PR TITLE
Eliminates per node path allocation in XML and AWSQuery response unmarshalling.

### DIFF
--- a/generator/.DevConfigs/4e87e50a-2f32-49c7-8fe7-7eab4c1c9f22.json
+++ b/generator/.DevConfigs/4e87e50a-2f32-49c7-8fe7-7eab4c1c9f22.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Eliminates per node path allocation in XML and AWSQuery response unmarshalling."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/generator/.DevConfigs/d93f07e6-e27a-4638-95dd-6cf18aa93c86.json
+++ b/generator/.DevConfigs/d93f07e6-e27a-4638-95dd-6cf18aa93c86.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Reduce memory allocations in XML primitive unmarshalling."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/SimpleTypeUnmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/SimpleTypeUnmarshaller.cs
@@ -25,12 +25,6 @@ namespace Amazon.Runtime.Internal.Transform
 {
     static class SimpleTypeUnmarshaller<T>
     {
-        public static T Unmarshall(XmlUnmarshallerContext context)
-        {
-            string text = context.ReadText();
-            return (T)Convert.ChangeType(text, typeof(T), CultureInfo.InvariantCulture);
-        }
-
         public static T Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
             context.Read(ref reader);
@@ -66,7 +60,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public int Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<int>.Unmarshall(context);
+            return int.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public int Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -148,7 +142,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public long Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<long>.Unmarshall(context);
+            return long.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public long Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -219,7 +213,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public float Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<float>.Unmarshall(context);
+            return float.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public float Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -295,7 +289,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public double Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<double>.Unmarshall(context);
+            return double.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public double Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -369,7 +363,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public decimal Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<decimal>.Unmarshall(context);
+            return decimal.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public decimal Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -443,7 +437,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public bool Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<bool>.Unmarshall(context);
+            return bool.Parse(context.ReadText());
         }
         public bool Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -517,7 +511,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public string Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<string>.Unmarshall(context);
+            return context.ReadText();
         }
         public string Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -550,7 +544,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public byte Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<byte>.Unmarshall(context);
+            return byte.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public byte Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -681,12 +675,13 @@ namespace Amazon.Runtime.Internal.Transform
 
         public DateTime Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<DateTime>.Unmarshall(context);
+            long milliseconds = long.Parse(context.ReadText(), CultureInfo.InvariantCulture);
+            return Amazon.Util.AWSSDKUtils.EPOCH_START.AddMilliseconds(milliseconds);
         }
         public DateTime Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
-            long millseconds = LongUnmarshaller.Instance.Unmarshall(context, ref reader);
-            var ret = Amazon.Util.AWSSDKUtils.EPOCH_START.AddMilliseconds(millseconds);
+            long milliseconds = LongUnmarshaller.Instance.Unmarshall(context, ref reader);
+            var ret = Amazon.Util.AWSSDKUtils.EPOCH_START.AddMilliseconds(milliseconds);
             return ret;
         }
     }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/SimpleTypeUnmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/SimpleTypeUnmarshaller.cs
@@ -813,7 +813,7 @@ namespace Amazon.Runtime.Internal.Transform
                     if (context.TestExpression("ResponseMetadata/RequestId"))
                         metadata.RequestId = StringUnmarshaller.GetInstance().Unmarshall(context);
                     else
-                        metadata.Metadata.Add(context.CurrentPath.Substring(context.CurrentPath.LastIndexOf('/') + 1), StringUnmarshaller.GetInstance().Unmarshall(context));
+                        metadata.Metadata.Add(context.CurrentElementName, StringUnmarshaller.GetInstance().Unmarshall(context));
                 }
             }
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/UnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/UnmarshallerContext.cs
@@ -169,7 +169,7 @@ namespace Amazon.Runtime.Internal.Transform
         /// <returns>
         ///     True if the expression matches the current position in the document, 
         ///     false otherwise.</returns>
-        public bool TestExpression(string expression)
+        public virtual bool TestExpression(string expression)
         {
             return TestExpression(expression, CurrentPath);
         }
@@ -186,7 +186,7 @@ namespace Amazon.Runtime.Internal.Transform
         /// <returns>
         ///     True if the specified expression matches the current position in
         ///     the XML document, starting from the specified depth. </returns>
-        public bool TestExpression(string expression, int startingStackDepth)
+        public virtual bool TestExpression(string expression, int startingStackDepth)
         {
             return TestExpression(expression, startingStackDepth, CurrentPath, CurrentDepth);
         }

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/XmlUnmarshallerContext.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/XmlUnmarshallerContext.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.Runtime.Internal.Util;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -46,8 +47,8 @@ namespace Amazon.Runtime.Internal.Transform
 
         private StreamReader streamReader;
         private XmlTextReader _xmlTextReader;
-        private Stack<string> stack = new Stack<string>();
-        private string stackString = "";
+        private readonly XmlPathBuffer pathBuffer = new XmlPathBuffer();
+        private string currentAttributeName;
         private Dictionary<string, string> attributeValues;
         private List<string> attributeNames;
         private IEnumerator<string> attributeEnumerator;
@@ -158,7 +159,12 @@ namespace Amazon.Runtime.Internal.Transform
         /// </summary>
         public override string CurrentPath
         {
-            get { return this.stackString; }
+            get
+            {
+                return this.currentAttributeName == null
+                    ? this.pathBuffer.CurrentPath
+                    : this.pathBuffer.BuildAttributePath(this.currentAttributeName);
+            }
         }
 
         /// <summary>
@@ -167,7 +173,16 @@ namespace Amazon.Runtime.Internal.Transform
         /// </summary>
         public override int CurrentDepth
         {
-            get { return stack.Count; }
+            get { return pathBuffer.Count; }
+        }
+
+        /// <summary>
+        /// The local name of the element the parser is currently positioned on (the last path
+        /// segment), or an empty string at the document root.
+        /// </summary>
+        public string CurrentElementName
+        {
+            get { return this.pathBuffer.TopSegment; }
         }
 
         /// <summary>
@@ -192,6 +207,57 @@ namespace Amazon.Runtime.Internal.Transform
         public override bool IsStartOfDocument
         {
             get { return XmlReader.ReadState == ReadState.Initial; }
+        }
+
+        /// <summary>
+        /// Matches an expression against the current path suffix without materializing the path string.
+        /// Result-identical to the base string-based <see cref="UnmarshallerContext.TestExpression(string)"/>.
+        /// </summary>
+        public override bool TestExpression(string expression)
+        {
+            if (expression.Equals("."))
+                return true;
+
+            // Build the comparison span. For an attribute node the effective path is
+            // "{elementPath}/@{attr}", which we never materialize on the element buffer; fall back
+            // to the string path in that (rare) case to keep behavior identical.
+            if (currentAttributeName != null)
+                return CurrentPath.EndsWith(expression, StringComparison.OrdinalIgnoreCase);
+
+            return (pathBuffer.PathSpan.Length == 0 ? "/".AsSpan() : pathBuffer.PathSpan)
+                 .EndsWith(expression.AsSpan(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Matches an expression at a given starting stack depth without materializing the path string.
+        /// Result-identical to the base string-based <see cref="UnmarshallerContext.TestExpression(string, int)"/>.
+        /// </summary>
+        public override bool TestExpression(string expression, int startingStackDepth)
+        {
+            if (expression.Equals("."))
+                return true;
+
+            // Count '/' separators to derive the required depth, matching the base algorithm exactly.
+            int requiredDepth = startingStackDepth;
+            for (int i = expression.IndexOf('/'); i > -1; i = expression.IndexOf('/', i + 1))
+            {
+                // Don't consider attributes a new depth level
+                if (expression[0] != '@')
+                    requiredDepth++;
+            }
+
+            if (requiredDepth != CurrentDepth)
+                return false;
+
+            var path = pathBuffer.PathSpan;
+            if (currentAttributeName != null)
+            {
+                path = CurrentPath.AsSpan();
+            }
+
+            return path.Length > expression.Length
+                && path[path.Length - expression.Length - 1] == '/'
+                && path.EndsWith(expression.AsSpan(), StringComparison.OrdinalIgnoreCase);
         }
 
         #endregion
@@ -237,10 +303,14 @@ namespace Amazon.Runtime.Internal.Transform
             if (attributeEnumerator != null && attributeEnumerator.MoveNext())
             {
                 this.nodeType = XmlNodeType.Attribute;
-                stackString = string.Format(CultureInfo.InvariantCulture, "{0}/@{1}", StackToPath(stack), attributeEnumerator.Current);
+                // Positioned on an attribute: the element path is unchanged; CurrentPath/matching
+                // append "/@{name}" on demand via currentAttributeName.
+                this.currentAttributeName = attributeEnumerator.Current;
             }
             else
             {
+                this.currentAttributeName = null;
+
                 // Skip some nodes
                 if (nodesToSkip.Contains(XmlReader.NodeType))
                     XmlReader.Read();
@@ -248,8 +318,7 @@ namespace Amazon.Runtime.Internal.Transform
                 if (currentlyProcessingEmptyElement)
                 {
                     nodeType = XmlNodeType.EndElement;
-                    stack.Pop();
-                    stackString = StackToPath(stack);
+                    pathBuffer.Pop();
                     XmlReader.Read();
                     currentlyProcessingEmptyElement = false;
                 }
@@ -257,8 +326,7 @@ namespace Amazon.Runtime.Internal.Transform
                 {
                     //This is a shorthand form of an empty element <element /> and we want to allow it
                     nodeType = XmlNodeType.Element;
-                    stack.Push(XmlReader.LocalName);
-                    stackString = StackToPath(stack);
+                    pathBuffer.Push(XmlReader.LocalName);
                     currentlyProcessingEmptyElement = true;
                     nodeContent = String.Empty;
 
@@ -270,14 +338,12 @@ namespace Amazon.Runtime.Internal.Transform
                     {
                         case XmlNodeType.EndElement:
                             this.nodeType = XmlNodeType.EndElement;
-                            stack.Pop();
-                            stackString = StackToPath(stack);
+                            pathBuffer.Pop();
                             XmlReader.Read();
                             break;
                         case XmlNodeType.Element:
                             nodeType = XmlNodeType.Element;
-                            stack.Push(XmlReader.LocalName);
-                            stackString = StackToPath(stack);
+                            pathBuffer.Push(XmlReader.LocalName);
                             this.ReadElement();
                             break;
                         default:
@@ -289,7 +355,6 @@ namespace Amazon.Runtime.Internal.Transform
                             // after advancing the underlying XmlReader past an unhandled node type.
                             nodeType = XmlNodeType.None;
                             nodeContent = string.Empty;
-                            stackString = StackToPath(stack);
                             break;
                     }
                 }
@@ -312,16 +377,6 @@ namespace Amazon.Runtime.Internal.Transform
         #endregion
 
         #region Private Methods
-
-        private static string StackToPath(Stack<string> stack)
-        {
-            string path = null;
-            foreach (string s in stack.ToArray())
-            {
-                path = null == path ? s : string.Format(CultureInfo.InvariantCulture, "{0}/{1}", s, path);
-            }
-            return "/" + path;
-        }
 
         // Move to the next element, cache the attributes collection
         // and attempt to cache the inner text of the element if applicable.
@@ -369,10 +424,111 @@ namespace Amazon.Runtime.Internal.Transform
 #endif
                         _xmlTextReader = null;
                     }
+                    pathBuffer.Dispose();
                 }
                 disposed = true;
             }
             base.Dispose(disposing);
+        }
+
+        private sealed class XmlPathBuffer : IDisposable
+        {
+            // The current path as chars, e.g. "/Root/Child/member". Segments are appended on Push and
+            // trimmed (by moving pathLength back) on Pop. The buffer is reused for the whole document.
+            private char[] pathChars = ArrayPool<char>.Shared.Rent(256);
+            private int pathLength;
+            // Length (including the leading '/') of each pushed segment, enabling O(1) Pop.
+            private readonly Stack<int> segmentLengths = new Stack<int>();
+            private string cached;
+
+            /// <summary>Number of element segments on the path (the current depth).</summary>
+            public int Count
+            {
+                get { return segmentLengths.Count; }
+            }
+
+            /// <summary>
+            /// The full path string, e.g. "/Root/Child". An empty stack yields "/" to match the
+            /// historical StackToPath behavior. Materialized lazily and cached until the next mutation.
+            /// </summary>
+            public string CurrentPath
+            {
+                get
+                {
+                    return this.cached ??= pathLength == 0 ? "/" : new string(pathChars, 0, pathLength);
+                }
+            }
+
+            /// <summary>The path chars without the trailing string allocation, for span matching.</summary>
+            public ReadOnlySpan<char> PathSpan
+            {
+                get { return pathChars.AsSpan(0, pathLength); }
+            }
+
+            public string TopSegment
+            {
+                get
+                {
+                    if (segmentLengths.Count == 0)
+                        return string.Empty;
+
+                    int seg = segmentLengths.Peek();
+                    return new string(pathChars, pathLength - seg + 1, seg - 1);
+                }
+            }
+
+            /// <summary>
+            /// Builds the transient attribute path "{CurrentPath}/@{name}" without mutating the buffer.
+            /// </summary>
+            public string BuildAttributePath(string attributeName)
+            {
+                return string.Concat(CurrentPath, "/@", attributeName);
+            }
+
+            public void Push(string localName)
+            {
+                int seg = localName.Length + 1; // leading '/'
+                EnsureCapacity(seg);
+                pathChars[pathLength++] = '/';
+                localName.CopyTo(0, pathChars, pathLength, localName.Length);
+                pathLength += localName.Length;
+                segmentLengths.Push(seg);
+                cached = null;
+            }
+
+            public void Pop()
+            {
+                if (segmentLengths.Count == 0)
+                    return;
+
+                pathLength -= segmentLengths.Pop();
+                cached = null;
+            }
+
+            private void EnsureCapacity(int additionalChars)
+            {
+                if (pathLength + additionalChars <= pathChars.Length)
+                    return;
+
+                int newSize = Math.Max(pathChars.Length * 2, pathLength + additionalChars);
+                char[] newBuffer = ArrayPool<char>.Shared.Rent(newSize);
+                Array.Copy(pathChars, 0, newBuffer, 0, pathLength);
+                ArrayPool<char>.Shared.Return(pathChars);
+                pathChars = newBuffer;
+            }
+
+            public void Dispose()
+            {
+                if (pathChars != null)
+                {
+                    // Materialize the path string before returning the buffer so that a post-dispose
+                    // CurrentPath read (e.g. AmazonUnmarshallingException diagnostics in an error path)
+                    // returns the last known path instead of dereferencing the returned buffer.
+                    cached ??= pathLength == 0 ? "/" : new string(pathChars, 0, pathLength);
+                    ArrayPool<char>.Shared.Return(pathChars);
+                    pathChars = null;
+                }
+            }
         }
     }
 

--- a/sdk/test/UnitTests/Custom/Runtime/XmlUnmarshallerContextTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/XmlUnmarshallerContextTests.cs
@@ -1,0 +1,269 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Amazon.Runtime.Internal.Transform;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSSDK.UnitTests
+{
+    [TestClass]
+    [TestCategory("UnitTest")]
+    [TestCategory("Runtime")]
+    public class XmlUnmarshallerContextTests
+    {
+        [TestMethod]
+        public void StartElements_ReportExactPathAndDepth()
+        {
+            var byPath = CollectStartElementDepths(
+                "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+                  "<Name>bucket</Name>" +
+                  "<Contents><Key>1.txt</Key><Size>0</Size></Contents>" +
+                "</ListBucketResult>");
+
+            Assert.AreEqual(1, byPath["/ListBucketResult"]);
+            Assert.AreEqual(2, byPath["/ListBucketResult/Name"]);
+            Assert.AreEqual(2, byPath["/ListBucketResult/Contents"]);
+            Assert.AreEqual(3, byPath["/ListBucketResult/Contents/Key"]);
+            Assert.AreEqual(3, byPath["/ListBucketResult/Contents/Size"]);
+        }
+
+        [TestMethod]
+        public void RepeatedSegmentNames_PushAndPopIndependently()
+        {
+            var byPath = CollectStartElementDepths(
+                "<Root><nested><foo>Foo1</foo><nested><bar>Bar1</bar>" +
+                "<inner><nested><bar>Bar2</bar></nested></inner></nested></nested></Root>");
+
+            Assert.AreEqual(1, byPath["/Root"]);
+            Assert.AreEqual(2, byPath["/Root/nested"]);
+            Assert.AreEqual(3, byPath["/Root/nested/nested"]);
+            Assert.AreEqual(4, byPath["/Root/nested/nested/inner"]);
+            Assert.AreEqual(5, byPath["/Root/nested/nested/inner/nested"]);
+            Assert.AreEqual(6, byPath["/Root/nested/nested/inner/nested/bar"]);
+        }
+
+        [TestMethod]
+        public void IsStartOfDocument_TrueOnlyBeforeFirstRead()
+        {
+            using (var context = CreateContext("<R><A>v</A></R>"))
+            {
+                Assert.IsTrue(context.IsStartOfDocument, "IsStartOfDocument must be true before the first Read().");
+                context.Read();
+                Assert.IsFalse(context.IsStartOfDocument, "IsStartOfDocument must be false once reading has begun.");
+            }
+        }
+
+        [TestMethod]
+        public void AttributeNode_ReportsAttributePathWithoutAddingDepth()
+        {
+            using (var context = CreateContext("<XmlAttributesResponse test=\"v\"><foo>hi</foo></XmlAttributesResponse>"))
+            {
+                var attrPaths = new List<string>();
+                while (context.Read())
+                {
+                    if (context.IsAttribute)
+                    {
+                        attrPaths.Add(context.CurrentPath);
+                        Assert.AreEqual(1, context.CurrentDepth);
+                    }
+                }
+
+                CollectionAssert.Contains(attrPaths, "/XmlAttributesResponse/@test");
+            }
+        }
+
+        [TestMethod]
+        public void AttributeEnumeration_DoesNotCorruptFollowingElementPaths()
+        {
+            var byPath = CollectStartElementDepths(
+                "<Payload test=\"attributeValue\"><foo>Foo</foo><baz>Baz</baz></Payload>");
+
+            Assert.AreEqual(1, byPath["/Payload"]);
+            Assert.AreEqual(2, byPath["/Payload/foo"]);
+            Assert.AreEqual(2, byPath["/Payload/baz"]);
+        }
+
+        [TestMethod]
+        public void CurrentElementName_IsTopSegment_EmptyAtRootBoundaries()
+        {
+            using (var context = CreateContext("<Resp><ResponseMetadata><RequestId>x</RequestId></ResponseMetadata></Resp>"))
+            {
+                var byPath = new Dictionary<string, string>();
+                while (context.Read())
+                {
+                    if (context.IsStartElement)
+                        byPath[context.CurrentPath] = context.CurrentElementName;
+                }
+
+                Assert.AreEqual("Resp", byPath["/Resp"]);
+                Assert.AreEqual("ResponseMetadata", byPath["/Resp/ResponseMetadata"]);
+                Assert.AreEqual("RequestId", byPath["/Resp/ResponseMetadata/RequestId"]);
+
+                Assert.AreEqual(0, context.CurrentDepth);
+                Assert.AreEqual(string.Empty, context.CurrentElementName,
+                    "At the empty-stack (post-EOF) state CurrentElementName must be an empty string.");
+            }
+        }
+
+        [TestMethod]
+        public void SelfClosingAndEmptyElements_ProduceStartThenEndWithBalancedDepth()
+        {
+            using (var context = CreateContext("<R><A/><B></B><C><D/></C></R>"))
+            {
+                int starts = 0, ends = 0, maxDepth = 0;
+                while (context.Read())
+                {
+                    if (context.IsStartElement) starts++;
+                    if (context.IsEndElement) ends++;
+                    if (context.CurrentDepth > maxDepth) maxDepth = context.CurrentDepth;
+                }
+
+                Assert.AreEqual(5, starts, "Every element (incl. self-closing) must report a start.");
+                // Only 4 ends are OBSERVABLE via the loop body: the Read() that processes the root's
+                // </R> EndElement is the same call that reaches EOF and returns false, so the loop exits
+                // before the body observes it. The buffer still pops R (final depth 0 below).
+                Assert.AreEqual(4, ends, "All non-root ends are observable; the root end coincides with EOF.");
+                Assert.AreEqual(3, maxDepth, "/R/C/D is the deepest path (depth 3).");
+                Assert.AreEqual(0, context.CurrentDepth, "Depth must return to 0 after all elements close.");
+            }
+        }
+
+        [TestMethod]
+        public void IsAttribute_TrueOnlyOnAttributeNodes()
+        {
+            using (var context = CreateContext("<R a=\"1\"><B>v</B></R>"))
+            {
+                while (context.Read())
+                {
+                    if (context.IsAttribute)
+                    {
+                        Assert.IsFalse(context.IsStartElement, "A node cannot be both an attribute and a start element.");
+                        Assert.IsFalse(context.IsEndElement, "A node cannot be both an attribute and an end element.");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ReadText_ReturnsElementText()
+        {
+            using (var context = CreateContext("<R><A>hello world</A></R>"))
+            {
+                string text = null;
+                while (context.Read())
+                {
+                    if (context.IsStartElement && context.CurrentPath == "/R/A")
+                        text = context.ReadText();
+                }
+                Assert.AreEqual("hello world", text);
+            }
+        }
+
+        [TestMethod]
+        public void ReadText_OnAttributeNode_ReturnsAttributeValue()
+        {
+            using (var context = CreateContext("<R><A attr1=\"the-value\">body</A></R>"))
+            {
+                string attrValue = null;
+                while (context.Read())
+                {
+                    if (context.IsAttribute && context.CurrentPath == "/R/A/@attr1")
+                        attrValue = context.ReadText();
+                }
+                Assert.AreEqual("the-value", attrValue);
+            }
+        }
+
+        [TestMethod]
+        public void ReadText_ReadsS3ObjectKeyVerbatim_IncludingSpecialChars()
+        {
+            using (var context = CreateContext(
+                "<ListBucketResult><Contents><Key>a &amp; b/c+d .txt</Key></Contents></ListBucketResult>"))
+            {
+                string key = null;
+                while (context.Read())
+                {
+                    if (context.IsStartElement && context.CurrentPath == "/ListBucketResult/Contents/Key")
+                    {
+                        Assert.AreEqual(3, context.CurrentDepth, "'/' inside the key text must not create depth.");
+                        key = context.ReadText();
+                    }
+                }
+                Assert.AreEqual("a & b/c+d .txt", key);
+            }
+        }
+
+        [TestMethod]
+        public void TestExpression_DotAlwaysMatches()
+        {
+            using (var context = CreateContext("<R><A><B>v</B></A></R>"))
+            {
+                while (context.Read())
+                {
+                    Assert.IsTrue(context.TestExpression("."), "\".\" must always match, at every node.");
+                    Assert.IsTrue(context.TestExpression(".", 0), "\".\" must always match regardless of depth arg.");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void TestExpression_BoundaryGuard_RejectsPartialSegmentSuffix()
+        {
+            using (var context = CreateContext("<R><List><member>a</member></List></R>"))
+            {
+                bool checkedMember = false;
+                while (context.Read())
+                {
+                    if (context.IsStartElement && context.CurrentPath == "/R/List/member")
+                    {
+                        checkedMember = true;
+                        Assert.IsTrue(context.TestExpression("member", 3), "Full segment matches at depth 3.");
+                        Assert.IsFalse(context.TestExpression("ember", 3),
+                            "Partial-segment suffix must be rejected by the '/'-boundary guard.");
+                    }
+                }
+                Assert.IsTrue(checkedMember, "Expected to visit /R/List/member.");
+            }
+        }
+
+        /// <summary>
+        /// Reads the whole document and returns a map of every start element's exact CurrentPath to its
+        /// CurrentDepth. Assumes distinct paths.
+        /// </summary>
+        private static Dictionary<string, int> CollectStartElementDepths(string xml)
+        {
+            var byPath = new Dictionary<string, int>();
+            using (var context = CreateContext(xml))
+            {
+                while (context.Read())
+                {
+                    if (context.IsStartElement)
+                        byPath[context.CurrentPath] = context.CurrentDepth;
+                }
+            }
+            return byPath;
+        }
+
+        private static XmlUnmarshallerContext CreateContext(string xml)
+        {
+            var bytes = Encoding.UTF8.GetBytes(xml);
+            var stream = new MemoryStream(bytes);
+            return new XmlUnmarshallerContext(stream, false, null);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

  Eliminates the per-node path-string allocation in the **XML and AWSQuery response unmarshalling** pipeline by replacing the full path-string rebuild on every `Read()` with an incrementally-maintained, pooled character buffer and allocation-free span matching.

  In unmarshalling benchmarks this reduces **time by up to ~66% and allocations by up to ~95%** on large responses (e.g. `awsQuery_GetMetricDataResponse_L`: **304 MB → 14.6 MB allocated, 171.9 ms → 57.6 ms**), and the win survives end-to-end: a full `GetMetricData` round-trip is **53-62% faster and allocates 72–75% less**. See the full before/after tables in [Testing](#testing).

  Previously `XmlUnmarshallerContext` tracked the current element path as a `Stack<string>` plus a `stackString`, and on **every** `Read()` it rebuilt the entire slash-joined path string (`StackToPath` is a `stack.ToArray()` + `string.Format` cascade over every segment). Generated unmarshallers call `context.TestExpression("path/to/element")` once per node, and each call compared against that freshly-rebuilt string. For a document with N nodes at depth D, this allocated a fresh path string per node, producing super-linear (O(N·D)) time and allocation, the source of the ~304 MB / 172 ms on the large response.

This PR mirrors the approach the JSON context already uses. The XML context now maintains a single reusable `char[]` rented from `ArrayPool<char>.Shared`: `Push` appends `/segment` and `Pop` trims it, with the full path string materialized **lazily and cached** only when actually read. The boolean results are **identical** to the previous string path validated by `XmlUnmarshallerContextPathTests` . The buffer returns to the `ArrayPool` when the context is disposed.


<!--- Describe your changes in detail -->

## Motivation and Context
 `DOTNET-8588`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

  - Added `XmlUnmarshallerContextPathTests`.
  
  - Measured using the AWS Query and RestXml serde/service benchmarks. The results below compare the branch **without** this change (`before`) against the branch **with** it (`after`):

  #### Serde benchmarks - AWS Query

  **Before**

  | Method                                 | Mean             | Error           | StdDev          | Max              | P50              | P90              | P95              | Gen0       | Gen1      | Allocated    |
  |--------------------------------------- |-----------------:|----------------:|----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------:|----------:|-------------:|
  | awsQuery_PutMetricDataRequest_Baseline |         385.5 ns |         6.19 ns |         3.24 ns |         390.3 ns |         384.8 ns |         389.1 ns |         389.7 ns |     0.1073 |         - |      1.32 KB |
  | awsQuery_PutMetricDataRequest_L        |     344,353.8 ns |     5,460.08 ns |       844.95 ns |     345,085.8 ns |     344,570.4 ns |     345,014.5 ns |     345,050.2 ns |    20.9961 |    6.3477 |    262.84 KB |
  | awsQuery_GetMetricDataRequest_L        |     258,520.2 ns |     2,590.37 ns |       400.86 ns |     259,106.3 ns |     258,366.5 ns |     258,909.1 ns |     259,007.7 ns |    19.5313 |    5.8594 |    240.43 KB |
  | awsQuery_GetMetricDataResponse_S       |      24,647.0 ns |     1,817.96 ns |     2,093.56 ns |      28,844.2 ns |      24,235.8 ns |      26,979.9 ns |      28,672.8 ns |     4.5166 |    0.2441 |     55.72 KB |
  | awsQuery_GetMetricDataResponse_M       |   1,702,363.8 ns |    34,025.61 ns |     5,265.50 ns |   1,707,707.6 ns |   1,702,728.4 ns |   1,707,100.5 ns |   1,707,404.1 ns |   261.7188 |   31.2500 |   3210.47 KB |
  | awsQuery_GetMetricDataResponse_L       | 171,898,520.4 ns | 3,407,717.75 ns | 3,646,219.82 ns | 179,693,366.7 ns | 172,442,816.7 ns | 175,911,450.0 ns | 177,257,493.3 ns | 25333.3333 | 1000.0000 | 311795.04 KB |

  **After**

  | Method                                 | Mean            | Error           | StdDev        | Max             | P50             | P90             | P95             | Gen0      | Gen1     | Allocated   |
  |--------------------------------------- |----------------:|----------------:|--------------:|----------------:|----------------:|----------------:|----------------:|----------:|---------:|------------:|
  | awsQuery_PutMetricDataRequest_Baseline |        395.7 ns |        19.03 ns |      21.15 ns |        443.9 ns |        390.5 ns |        427.1 ns |        437.4 ns |    0.1073 |        - |     1.32 KB |
  | awsQuery_PutMetricDataRequest_L        |    359,965.8 ns |     8,186.80 ns |   9,427.94 ns |    378,610.1 ns |    355,839.0 ns |    375,768.6 ns |    377,840.2 ns |   20.9961 |   6.3477 |   262.84 KB |
  | awsQuery_GetMetricDataRequest_L        |    262,248.3 ns |     5,151.35 ns |   3,407.30 ns |    270,116.2 ns |    261,416.6 ns |    264,993.3 ns |    267,554.7 ns |   19.5313 |   5.8594 |   240.43 KB |
  | awsQuery_GetMetricDataResponse_S       |      9,027.7 ns |       417.32 ns |     480.59 ns |     10,136.9 ns |      8,820.9 ns |      9,711.0 ns |      9,777.5 ns |    1.4343 |   0.0763 |    17.76 KB |
  | awsQuery_GetMetricDataResponse_M       |    576,731.7 ns |     9,729.86 ns |   3,469.76 ns |    580,381.7 ns |    577,537.0 ns |    579,920.3 ns |    580,151.0 ns |   13.6719 |   0.9766 |   178.04 KB |
  | awsQuery_GetMetricDataResponse_L       | 57,597,468.5 ns | 1,086,302.98 ns | 387,386.11 ns | 58,270,355.6 ns | 57,510,400.0 ns | 58,026,127.8 ns | 58,148,241.7 ns | 1222.2222 | 777.7778 | 14998.38 KB |

  **Response unmarshalling delta (AWS Query):**

  | Method                            | Time before      | Time after      | Δ time  | Alloc before  | Alloc after | Δ alloc         |
  |---------------------------------- |-----------------:|----------------:|--------:|--------------:|------------:|----------------:|
  | awsQuery_GetMetricDataResponse_S  |      24,647 ns    |      9,028 ns   | −63.4%  |    55.72 KB   |   17.76 KB  | −68.1%          |
  | awsQuery_GetMetricDataResponse_M  |   1,702,364 ns    |    576,732 ns   | −66.1%  |  3,210.47 KB  |  178.04 KB  | −94.5% (18.0×)  |
  | awsQuery_GetMetricDataResponse_L  | 171,898,520 ns    | 57,597,469 ns   | −66.5%  | 311,795 KB    | 14,998 KB   | −95.2% (20.8×)  |

  The `…Request_*` marshalling rows are unchanged (byte-identical allocations, timing within noise), confirming this PR touches only the response unmarshalling path. The allocation win grows with response size (18× → 21× as M → L).

  ### Serde benchmarks - RestXml

  **Before**

  | Method                             | Mean         | Error       | StdDev       | Max          | P50          | P90          | P95          | Gen0     | Gen1     | Gen2     | Allocated  |
  |----------------------------------- |-------------:|------------:|-------------:|-------------:|-------------:|-------------:|-------------:|---------:|---------:|---------:|-----------:|
  | restXml_CopyObjectRequest_M        |   1,030.8 ns |    34.67 ns |     38.53 ns |   1,103.6 ns |   1,025.5 ns |   1,092.8 ns |   1,095.0 ns |   0.2632 |   0.0019 |        - |    3.24 KB |
  | restXml_CopyObjectOutput_Baseline  |   1,103.1 ns |    41.85 ns |     46.51 ns |   1,199.9 ns |   1,081.2 ns |   1,191.8 ns |   1,198.9 ns |   1.1368 |   0.0534 |        - |   13.93 KB |
  | restXml_CopyObjectOutput_M         |   3,438.6 ns |   440.29 ns |    507.04 ns |   4,444.4 ns |   3,255.0 ns |   4,289.6 ns |   4,345.5 ns |   1.3237 |   0.0687 |        - |   16.24 KB |
  | restXml_GetObject_M                |  10,637.3 ns |   437.47 ns |    468.09 ns |  11,580.1 ns |  10,560.1 ns |  11,312.5 ns |  11,435.2 ns |  18.4326 |  18.0969 |  18.0969 |  103.95 KB |
  | restXml_GetObject_L                | 144,962.9 ns | 9,359.17 ns | 10,014.20 ns | 167,947.0 ns | 143,444.9 ns | 156,568.6 ns | 158,326.2 ns | 166.9922 | 166.5039 | 166.5039 | 1028.36 KB |

  **After**

  | Method                             | Mean         | Error       | StdDev      | Max          | P50          | P90          | P95          | Gen0     | Gen1     | Gen2     | Allocated |
  |----------------------------------- |-------------:|------------:|------------:|-------------:|-------------:|-------------:|-------------:|---------:|---------:|---------:|----------:|
  | restXml_CopyObjectRequest_M        |   1,059.4 ns |    50.02 ns |    55.59 ns |   1,187.5 ns |   1,042.5 ns |   1,146.0 ns |   1,157.4 ns |   0.2632 |   0.0019 |        - |   3.24 KB |
  | restXml_CopyObjectOutput_Baseline  |   1,072.1 ns |    21.38 ns |    21.96 ns |   1,112.6 ns |   1,069.1 ns |   1,094.5 ns |   1,099.3 ns |   1.1292 |   0.0381 |        - |  13.84 KB |
  | restXml_CopyObjectOutput_M         |   2,340.4 ns |    42.47 ns |    35.47 ns |   2,410.4 ns |   2,334.7 ns |   2,381.5 ns |   2,395.4 ns |   1.2054 |   0.0191 |        - |  14.79 KB |
  | restXml_GetObject_M                |  11,641.1 ns |   605.53 ns |   621.84 ns |  12,911.6 ns |  11,719.8 ns |  12,341.6 ns |  12,518.7 ns |  19.0277 |  18.6920 |  18.6920 |    104 KB |
  | restXml_GetObject_L                | 153,763.4 ns | 3,064.34 ns | 2,392.43 ns | 159,123.8 ns | 153,211.3 ns | 155,663.1 ns | 157,224.6 ns | 164.5508 | 164.0625 | 164.0625 | 1028.4 KB |

  `CopyObjectOutput_M` is **−31.9% time / −8.9% allocation** (3,439 ns → 2,340 ns, 16.24 KB → 14.79 KB). The `GetObject_*`  body is a raw binary blob with essentially no XML element structure, so the cost is the stream copy, not path tracking and they are flat within noise (`GetObject_L` StdDev ≈ 10 µs before).

  #### End-to-end benchmarks - AWS Query

  **Before**

  | Method                       | Mean         | Error      | StdDev     | Max          | P50          | P90          | P95          | Gen0    | Gen1   | Allocated |
  |----------------------------- |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|-------------:|--------:|-------:|----------:|
  | awsQuery_e2e_Healthcheck     |  17,294.0 ns |   252.0 ns |   223.4 ns |  17,646.0 ns |  17,294.7 ns |  17,562.1 ns |  17,602.4 ns |  3.2043 | 1.0681 |  39.34 KB |
  | awsQuery_e2e_PutMetricData_S |  19,479.1 ns |   342.1 ns |   320.0 ns |  20,123.4 ns |  19,419.0 ns |  19,818.3 ns |  19,950.5 ns |  3.3264 | 0.9155 |  41.04 KB |
  | awsQuery_e2e_PutMetricData_M |  30,679.4 ns |   391.5 ns |   326.9 ns |  31,228.7 ns |  30,721.7 ns |  30,977.8 ns |  31,082.4 ns |  4.0283 | 1.3428 |  49.54 KB |
  | awsQuery_e2e_GetMetricData_S |  31,624.0 ns |   535.4 ns |   657.6 ns |  32,794.2 ns |  31,507.4 ns |  32,288.0 ns |  32,605.8 ns |  5.1880 | 1.7090 |   64.2 KB |
  | awsQuery_e2e_GetMetricData_M | 111,192.0 ns | 1,809.3 ns | 1,510.8 ns | 114,892.5 ns | 111,072.7 ns | 112,395.5 ns | 113,436.0 ns | 16.9678 | 3.1738 | 208.57 KB |

  **After**

  | Method                       | Mean        | Error    | StdDev     | Median      | Max         | P50         | P90         | P95         | Gen0   | Gen1   | Allocated |
  |----------------------------- |------------:|---------:|-----------:|------------:|------------:|------------:|------------:|------------:|-------:|-------:|----------:|
  | awsQuery_e2e_Healthcheck     | 17,005.7 ns | 325.4 ns |   348.2 ns | 16,888.6 ns | 17,866.6 ns | 16,888.6 ns | 17,496.9 ns | 17,582.1 ns | 3.1128 | 1.0376 |  38.47 KB |
  | awsQuery_e2e_PutMetricData_S | 19,127.1 ns | 377.3 ns |   660.8 ns | 18,844.1 ns | 21,094.3 ns | 18,844.1 ns | 19,971.0 ns | 20,691.7 ns | 3.2654 | 1.0681 |  40.08 KB |
  | awsQuery_e2e_PutMetricData_M | 32,380.1 ns | 646.2 ns | 1,484.8 ns | 32,054.1 ns | 36,135.0 ns | 32,054.1 ns | 34,259.4 ns | 35,746.6 ns | 3.9368 | 1.3123 |  48.59 KB |
  | awsQuery_e2e_GetMetricData_S | 24,596.0 ns | 609.1 ns | 1,767.1 ns | 24,027.1 ns | 29,120.9 ns | 24,027.1 ns | 27,330.3 ns | 28,149.4 ns | 3.4180 | 1.1292 |  41.97 KB |
  | awsQuery_e2e_GetMetricData_M | 52,403.2 ns | 789.6 ns |   738.6 ns | 52,345.4 ns | 53,825.7 ns | 52,345.4 ns | 53,186.1 ns | 53,411.4 ns | 4.2725 | 1.4038 |  53.08 KB |

The response-heavy operations improve substantially: `GetMetricData_S` 31.6 µs → 24.6 µs (−22%), 64.2 KB → 42.0 KB (−35%); `GetMetricData_M` 111.2 µs → 52.4 µs (−53%), 208.6 KB → 53.1 KB (−75%). The marshal-only operations (`Healthcheck`, `PutMetricData_*`) are flat within noise.

  ### End-to-end benchmarks - RestXml

  **Before**

  | Method                      | Mean           | Error       | StdDev      | Max            | P50            | P90            | P95            | Gen0     | Gen1     | Gen2     | Allocated  |
  |---------------------------- |---------------:|------------:|------------:|---------------:|---------------:|---------------:|---------------:|---------:|---------:|---------:|-----------:|
  | restXml_e2e_GetMetricData_S |    29,650.2 ns |    409.1 ns |    362.7 ns |    30,268.0 ns |    29,536.1 ns |    30,183.2 ns |    30,248.7 ns |   6.1646 |   1.5259 |        - |   75.84 KB |
  | restXml_e2e_GetMetricData_M |    91,386.2 ns |  1,739.4 ns |  1,861.2 ns |    96,302.1 ns |    91,169.9 ns |    93,034.5 ns |    93,582.3 ns |  17.3340 |   2.8076 |        - |  213.43 KB |
  | restXml_e2e_GetObject_M     |    37,518.9 ns |    737.8 ns |  1,540.0 ns |    41,446.2 ns |    37,318.6 ns |    39,865.7 ns |    40,300.6 ns |  25.3296 |  23.1323 |  23.0103 |  128.31 KB |
  | restXml_e2e_PutObject_M     |   272,210.0 ns |  6,351.1 ns | 17,704.4 ns |   316,904.4 ns |   268,200.4 ns |   297,685.4 ns |   312,109.6 ns |   2.4414 |   0.9766 |        - |   30.23 KB |

  **After**

  | Method                      | Mean           | Error       | StdDev      | Median         | Max            | P50            | P90            | P95            | Gen0     | Gen1     | Gen2     | Allocated  |
  |---------------------------- |---------------:|------------:|------------:|---------------:|---------------:|---------------:|---------------:|---------------:|---------:|---------:|---------:|-----------:|
  | restXml_e2e_GetMetricData_S |    21,169.7 ns |    305.1 ns |    238.2 ns |    21,185.5 ns |    21,510.0 ns |    21,185.5 ns |    21,384.4 ns |    21,442.8 ns |   4.4556 |   1.4648 |        - |   54.62 KB |
  | restXml_e2e_GetMetricData_M |    34,453.1 ns |    456.6 ns |    404.8 ns |    34,309.8 ns |    35,048.9 ns |    34,309.8 ns |    34,994.0 ns |    35,029.4 ns |   4.7607 |   1.5869 |        - |   58.96 KB |
  | restXml_e2e_GetObject_M     |    37,582.3 ns |    742.7 ns |  1,358.1 ns |    37,411.7 ns |    41,337.9 ns |    37,411.7 ns |    39,623.6 ns |    39,913.3 ns |  26.3672 |  24.1089 |  23.9868 |  128.89 KB |
  | restXml_e2e_PutObject_M     |   253,140.7 ns |  4,827.5 ns |  6,105.2 ns |   251,656.5 ns |   268,957.5 ns |   251,656.5 ns |   260,418.9 ns |   264,477.1 ns |   2.4414 |   0.9766 |        - |    30.8 KB |

  `GetMetricData_S` 29.7 µs → 21.2 µs (−29%), 75.8 KB → 54.6 KB (−28%); `GetMetricData_M` 91.4 µs → 34.5 µs (−62%), 213.4 KB → 59.0 KB (−72%). The binary-body operations (`GetObject_M`, `PutObject_M`) are flat within noise.

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** af54336a-46cf-434e-a9af-43036d471048
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 1e6192be-574c-4f6a-9a35-2452898153ad
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement



