### PR TITLE
feat(cloudfront-signers): sign with AWS KMS / external signer via ICloudFrontSigner

### DIFF
--- a/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AmazonCloudFrontCookieSigner.cs
+++ b/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AmazonCloudFrontCookieSigner.cs
@@ -399,6 +399,37 @@ namespace Amazon.CloudFront
         }
 
         /// <summary>
+        /// Returns signed cookies that provide tailored access to private content based on an
+        /// access time window and an ip range, signing the policy with a caller-supplied
+        /// <see cref="ICloudFrontSigner"/>.
+        /// <para>
+        /// Use this when the signature is computed by a custom mechanism rather than by this SDK,
+        /// commonly an AWS KMS asymmetric key so that the private key never leaves KMS. The policy
+        /// document and the cookie encoding are produced exactly as the private-key overloads do;
+        /// only the signature is delegated. See <see cref="ICloudFrontSigner"/> for a KMS example.
+        /// </para>
+        /// </summary>
+        /// <param name="resourceUrlOrPath">The URL or path for resource within a distribution.</param>
+        /// <param name="signer">The signer that produces the CloudFront signature for the policy.</param>
+        /// <param name="keyPairId">Identifier of a public key already configured in a CloudFront trusted key group.</param>
+        /// <param name="expiresOn">The expiration date till which content can be accessed using the generated cookies.</param>
+        /// <param name="activeFrom">The date from which content can be accessed using the generated cookies.</param>
+        /// <param name="ipRange">The allowed IP address range of the client making the GET request, in CIDR form (e.g. 192.168.0.1/24).</param>
+        /// <returns>The signed cookies.</returns>
+        public static CookiesForCustomPolicy GetCookiesForCustomPolicy(string resourceUrlOrPath,
+                                                ICloudFrontSigner signer,
+                                                string keyPairId,
+                                                DateTime expiresOn,
+                                                DateTime activeFrom,
+                                                string ipRange)
+        {
+            if (signer == null) throw new ArgumentNullException(nameof(signer));
+            string policy = PrepareCustomPolicy(resourceUrlOrPath, expiresOn, ipRange, activeFrom, out byte[] policyBytes);
+            var (signatureBytes, usedAlgorithm) = signer.Sign(policyBytes);
+            return BuildCustomCookies(keyPairId, policy, signatureBytes, usedAlgorithm);
+        }
+
+        /// <summary>
         /// Returns signed cookies that provides tailored access to private content based on an access time window and an ip range.
         /// </summary>
         /// <param name="resourceUrlOrPath">

--- a/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AmazonCloudFrontUrlSigner.cs
+++ b/extensions/src/AWSSDK.Extensions.CloudFront.Signers/AmazonCloudFrontUrlSigner.cs
@@ -344,6 +344,29 @@ namespace Amazon.CloudFront
         }
 
         /// <summary>
+        /// Returns a signed URL that grants tailored access to private content based on an access
+        /// time window and an ip range, signing the policy with a caller-supplied
+        /// <see cref="ICloudFrontSigner"/> (commonly an AWS KMS key, whose private key never leaves KMS).
+        /// </summary>
+        /// <param name="url">The URL or path that uniquely identifies a resource within a distribution.</param>
+        /// <param name="signer">The signer that produces the CloudFront signature for the policy.</param>
+        /// <param name="keyPairId">Identifier of a public key already configured in a CloudFront trusted key group.</param>
+        /// <param name="expiresOn">The expiration date of the signed URL</param>
+        /// <param name="activeFrom">The beginning valid date of the signed URL</param>
+        /// <param name="ipRange">The allowed IP address range of the client making the GET request, in CIDR form (e.g. 192.168.0.1/24).</param>
+        /// <returns>The signed URL.</returns>
+        public static string GetCustomSignedURL(string url,
+                                                ICloudFrontSigner signer,
+                                                string keyPairId,
+                                                DateTime expiresOn,
+                                                DateTime activeFrom,
+                                                string ipRange)
+        {
+            string policy = BuildPolicyForSignedUrl(url, expiresOn, ipRange, activeFrom);
+            return SignUrl(url, keyPairId, signer, policy);
+        }
+
+        /// <summary>
         /// Returns a signed URL that provides tailored access to private content based on an access time window and an ip range.
         /// </summary>
         /// <param name="url">The protocol of the URL</param>
@@ -511,6 +534,32 @@ namespace Amazon.CloudFront
         {
             ValidatePolicyInput(resourceUrlOrPath, "resourceUrlOrPath");
             var (signatureBytes, usedAlgorithm) = SignData(Encoding.UTF8.GetBytes(policy), privateKey, algorithm);
+            return BuildSignedUrl(resourceUrlOrPath, keyPairId, MakeStringUrlSafe(policy), signatureBytes, usedAlgorithm);
+        }
+
+        /// <summary>
+        /// Generate a signed URL that allows access to distribution and resource path by applying
+        /// access restrictions specified in a custom policy document, signing the policy with a
+        /// caller-supplied <see cref="ICloudFrontSigner"/>.
+        /// <para>
+        /// Use this when the signature is computed by a custom mechanism rather than by this SDK,
+        /// commonly an AWS KMS asymmetric key so that the private key never leaves KMS. The policy
+        /// document and the url-safe encoding are produced exactly as the private-key overloads do;
+        /// only the signature is delegated. See <see cref="ICloudFrontSigner"/> for a KMS example.
+        /// </para>
+        /// </summary>
+        /// <param name="resourceUrlOrPath">
+        /// The URL or path that uniquely identifies a resource within a distribution.
+        /// </param>
+        /// <param name="keyPairId">Identifier of a public key already configured in a CloudFront trusted key group.</param>
+        /// <param name="signer">The signer that produces the CloudFront signature for the policy.</param>
+        /// <param name="policy">A policy document that describes the access permissions that will be applied by the signed URL.</param>
+        /// <returns>A signed URL that will permit access to distribution and S3 objects as specified in the policy document.</returns>
+        public static string SignUrl(string resourceUrlOrPath, string keyPairId, ICloudFrontSigner signer, string policy)
+        {
+            ValidatePolicyInput(resourceUrlOrPath, "resourceUrlOrPath");
+            if (signer == null) throw new ArgumentNullException(nameof(signer));
+            var (signatureBytes, usedAlgorithm) = signer.Sign(Encoding.UTF8.GetBytes(policy));
             return BuildSignedUrl(resourceUrlOrPath, keyPairId, MakeStringUrlSafe(policy), signatureBytes, usedAlgorithm);
         }
 

--- a/extensions/src/AWSSDK.Extensions.CloudFront.Signers/ICloudFrontSigner.cs
+++ b/extensions/src/AWSSDK.Extensions.CloudFront.Signers/ICloudFrontSigner.cs
@@ -1,0 +1,145 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using System;
+using System.Security.Cryptography;
+
+namespace Amazon.CloudFront
+{
+    /// <summary>
+    /// Provides a custom mechanism for signing a CloudFront policy document. Implement this to
+    /// compute the signature with whatever key material and cryptographic implementation you
+    /// choose, instead of handing a private key to the SDK.
+    /// <para>
+    /// The common scenario is an <b>AWS KMS</b> asymmetric key, so that the private key never
+    /// leaves KMS, but nothing here assumes that: an implementation is free to use an HSM, an
+    /// external key service, or a key the process holds in memory.
+    /// </para>
+    /// <para>
+    /// The <see cref="AmazonCloudFrontUrlSigner"/> and <see cref="AmazonCloudFrontCookieSigner"/>
+    /// overloads that take an <see cref="ICloudFrontSigner"/> build the policy document and the
+    /// url-safe encoding exactly as the private-key overloads do; only the signature computation
+    /// is delegated here. This keeps the extension free of any hard dependency on KMS while still
+    /// enabling it.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// This is signature-algorithm agnostic, so both key types CloudFront accepts work through the
+    /// same seam. The guidance below names the AWS KMS signing algorithms because that is the common
+    /// case, but the requirement on any implementation is the same, per key type:
+    /// <list type="bullet">
+    /// <item><description>
+    /// <b>RSA</b> (2048-bit): sign with KMS <c>RSASSA_PKCS1_V1_5_SHA_256</c> and return
+    /// <see cref="HashAlgorithmName.SHA256"/>. Use PKCS#1 v1.5, <b>not</b> RSASSA-PSS: although KMS
+    /// recommends PSS in general, CloudFront only verifies PKCS#1 v1.5 RSA signatures.
+    /// </description></item>
+    /// <item><description>
+    /// <b>ECDSA</b> (NIST P-256 / <c>ECC_NIST_P256</c>): sign with KMS <c>ECDSA_SHA_256</c> and
+    /// return <see cref="HashAlgorithmName.SHA256"/>. KMS returns the signature DER-encoded
+    /// (ANSI X9.62 / RFC 3279), which is exactly the form CloudFront expects, so no re-encoding
+    /// is needed.
+    /// </description></item>
+    /// </list>
+    /// A CloudFront policy document is well under KMS's 4096-byte <c>Message</c> limit, so signing
+    /// the policy bytes directly with <c>MessageType=RAW</c> is correct; there is no need to
+    /// pre-hash and use <c>MessageType=DIGEST</c>.
+    /// </remarks>
+    /// <example>
+    /// Sign CloudFront cookies with an AWS KMS RSA key (SHA-256), so the private key never leaves
+    /// KMS. CloudFront supports SHA-256 signed URLs/cookies; KMS RSA signing is
+    /// <c>RSASSA_PKCS1_V1_5_SHA_256</c>, which produces exactly the signature CloudFront verifies.
+    /// <code>
+    /// using Amazon.KeyManagementService;
+    /// using Amazon.KeyManagementService.Model;
+    ///
+    /// // A DelegateCloudFrontSigner adapts any "sign these bytes" function into ICloudFrontSigner.
+    /// var kms = new AmazonKeyManagementServiceClient();
+    /// var signer = new DelegateCloudFrontSigner(
+    ///     HashAlgorithmName.SHA256,
+    ///     policyBytes =>
+    ///     {
+    ///         var response = kms.SignAsync(new SignRequest
+    ///         {
+    ///             KeyId = kmsKeyId,
+    ///             Message = new MemoryStream(policyBytes),
+    ///             MessageType = MessageType.RAW,
+    ///             SigningAlgorithm = SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256
+    ///         }).GetAwaiter().GetResult();
+    ///         return response.Signature.ToArray();
+    ///     });
+    ///
+    /// var cookies = AmazonCloudFrontCookieSigner.GetCookiesForCustomPolicy(
+    ///     resourceUrlOrPath, signer, cloudFrontKeyPairId, expiresOn, activeFrom, ipRange);
+    /// </code>
+    /// </example>
+    public interface ICloudFrontSigner
+    {
+        /// <summary>
+        /// Signs the UTF-8 bytes of the CloudFront policy document and returns the raw signature
+        /// together with the hash algorithm used.
+        /// </summary>
+        /// <param name="policyBytes">The UTF-8 encoded CloudFront policy document to sign.</param>
+        /// <returns>
+        /// The raw signature bytes and the hash algorithm used. For RSA the signature must be
+        /// PKCS#1 v1.5; for ECDSA (P-256) it must be a DER-encoded (RFC 3279) signature. The hash
+        /// algorithm is emitted as CloudFront's <c>Hash-Algorithm</c> / <c>CloudFront-Hash-Algorithm</c>
+        /// (only <see cref="HashAlgorithmName.SHA1"/> and <see cref="HashAlgorithmName.SHA256"/> are
+        /// valid for CloudFront; SHA-1 is RSA-only).
+        /// </returns>
+        (byte[] Signature, HashAlgorithmName Algorithm) Sign(byte[] policyBytes);
+    }
+
+    /// <summary>
+    /// An <see cref="ICloudFrontSigner"/> backed by a caller-supplied signing function. Use this to
+    /// plug in a signing mechanism such as AWS KMS, an HSM, or an in-process key, without adding a
+    /// compile-time dependency from this extension on those libraries (see the
+    /// <see cref="ICloudFrontSigner"/> example).
+    /// </summary>
+    public sealed class DelegateCloudFrontSigner : ICloudFrontSigner
+    {
+        private readonly HashAlgorithmName _algorithm;
+        private readonly Func<byte[], byte[]> _sign;
+
+        /// <summary>
+        /// Creates a signer from a function that maps the policy bytes to a raw CloudFront signature.
+        /// </summary>
+        /// <param name="algorithm">
+        /// The hash algorithm the function signs with: <see cref="HashAlgorithmName.SHA256"/>
+        /// (recommended; required for ECDSA) or <see cref="HashAlgorithmName.SHA1"/> (RSA only).
+        /// </param>
+        /// <param name="sign">
+        /// Signs the UTF-8 policy bytes and returns the raw signature (PKCS#1 v1.5 for RSA, or a
+        /// DER-encoded RFC 3279 signature for ECDSA P-256).
+        /// </param>
+        public DelegateCloudFrontSigner(HashAlgorithmName algorithm, Func<byte[], byte[]> sign)
+        {
+            if (algorithm != HashAlgorithmName.SHA1 && algorithm != HashAlgorithmName.SHA256)
+            {
+                throw new ArgumentException(
+                    $"Unsupported hash algorithm for CloudFront: {algorithm}. Use HashAlgorithmName.SHA1 (RSA only) or HashAlgorithmName.SHA256.",
+                    nameof(algorithm));
+            }
+            _algorithm = algorithm;
+            _sign = sign ?? throw new ArgumentNullException(nameof(sign));
+        }
+
+        /// <inheritdoc/>
+        public (byte[] Signature, HashAlgorithmName Algorithm) Sign(byte[] policyBytes)
+        {
+            var signature = _sign(policyBytes)
+                ?? throw new InvalidOperationException("The CloudFront signing delegate returned a null signature.");
+            return (signature, _algorithm);
+        }
+    }
+}

--- a/extensions/test/CloudFront.SignersTests/SignerDelegationTest.cs
+++ b/extensions/test/CloudFront.SignersTests/SignerDelegationTest.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using Amazon.CloudFront;
+using Xunit;
+
+namespace AWSSDK_DotNet.UnitTests
+{
+    /// <summary>
+    /// Tests the <see cref="ICloudFrontSigner"/> delegation seam (used to sign with AWS KMS or
+    /// another custom signing mechanism). The key invariant: signing through an
+    /// <see cref="ICloudFrontSigner"/> must produce byte-for-byte the same policy/signature/cookies
+    /// as the private-key overloads, since only the signature computation is delegated.
+    /// </summary>
+    public class SignerDelegationTest
+    {
+        private static string ReadPrivateKeyPem()
+        {
+            var path = Path.Combine(Environment.CurrentDirectory, "EmbeddedResource", "sample.rsa.private.key.txt");
+            return File.ReadAllText(path);
+        }
+
+        // RSA.ImportFromPem is .NET 5+; these equivalence tests build an RSA key from the PEM to
+        // stand in for an external signer (e.g. KMS), so they compile only where that API exists.
+        // The argument-validation tests below need no key and run on all target frameworks.
+#if NET5_0_OR_GREATER
+        // A DelegateCloudFrontSigner backed by the same RSA key stands in for an external signer
+        // (e.g. KMS RSASSA_PKCS1_V1_5_SHA_256). It must produce identical output to the raw-key path.
+        [Fact]
+        [Trait("Category", "CloudFront")]
+        public void CustomCookies_ViaSigner_MatchPrivateKeyOverload()
+        {
+            var pem = ReadPrivateKeyPem();
+            using var rsa = RSA.Create();
+            rsa.ImportFromPem(pem);
+
+            const string keyPairId = "DelegateKeyPairId";
+            const string resource = "https://awesome.dot.com/private/*";
+            var expiresOn = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var activeFrom = new DateTime(2023, 12, 1, 12, 0, 0, DateTimeKind.Utc);
+
+            var viaKey = AmazonCloudFrontCookieSigner.GetCookiesForCustomPolicy(
+                resource, new StringReader(pem), keyPairId, expiresOn, activeFrom, null, HashAlgorithmName.SHA256);
+
+            var signer = new DelegateCloudFrontSigner(
+                HashAlgorithmName.SHA256,
+                policyBytes => rsa.SignData(policyBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+            var viaSigner = AmazonCloudFrontCookieSigner.GetCookiesForCustomPolicy(
+                resource, signer, keyPairId, expiresOn, activeFrom, null);
+
+            Assert.Equal(viaKey.Policy.Value, viaSigner.Policy.Value);
+            Assert.Equal(viaKey.Signature.Value, viaSigner.Signature.Value);
+            Assert.Equal(viaKey.KeyPairId.Value, viaSigner.KeyPairId.Value);
+            Assert.Equal("SHA256", viaSigner.HashAlgorithm.Value);
+            Assert.Equal(viaKey.HashAlgorithm.Value, viaSigner.HashAlgorithm.Value);
+        }
+
+        [Fact]
+        [Trait("Category", "CloudFront")]
+        public void CustomUrl_ViaSigner_MatchesPrivateKeyOverload()
+        {
+            var pem = ReadPrivateKeyPem();
+            using var rsa = RSA.Create();
+            rsa.ImportFromPem(pem);
+
+            const string keyPairId = "DelegateKeyPairId";
+            const string url = "https://awesome.dot.com/private/file.txt";
+            var expiresOn = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var activeFrom = new DateTime(2023, 12, 1, 12, 0, 0, DateTimeKind.Utc);
+
+            var viaKey = AmazonCloudFrontUrlSigner.GetCustomSignedURL(
+                url, new StringReader(pem), keyPairId, expiresOn, activeFrom, null, HashAlgorithmName.SHA256);
+
+            var signer = new DelegateCloudFrontSigner(
+                HashAlgorithmName.SHA256,
+                policyBytes => rsa.SignData(policyBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+            var viaSigner = AmazonCloudFrontUrlSigner.GetCustomSignedURL(
+                url, signer, keyPairId, expiresOn, activeFrom, null);
+
+            Assert.Equal(viaKey, viaSigner);
+        }
+
+        // ECDSA is non-deterministic, so two signings won't match byte-for-byte; instead prove the
+        // seam passes an ECDSA (P-256, DER) signature through untouched by verifying the emitted
+        // cookie signature with the public key. This mirrors how a KMS ECDSA_SHA_256 signature
+        // (also DER-encoded) would flow through DelegateCloudFrontSigner unchanged.
+        [Fact]
+        [Trait("Category", "CloudFront")]
+        public void CustomCookies_ViaEcdsaSigner_ProduceVerifiableSignature()
+        {
+            using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+            const string keyPairId = "EcdsaKeyPairId";
+            const string resource = "https://awesome.dot.com/private/*";
+            var expiresOn = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var activeFrom = new DateTime(2023, 12, 1, 12, 0, 0, DateTimeKind.Utc);
+
+            var signer = new DelegateCloudFrontSigner(
+                HashAlgorithmName.SHA256,
+                policyBytes => ecdsa.SignData(policyBytes, HashAlgorithmName.SHA256, DSASignatureFormat.Rfc3279DerSequence));
+            var cookies = AmazonCloudFrontCookieSigner.GetCookiesForCustomPolicy(
+                resource, signer, keyPairId, expiresOn, activeFrom, null);
+
+            Assert.Equal("SHA256", cookies.HashAlgorithm.Value);
+
+            // Reverse CloudFront's url-safe base64 (- _ ~  ->  + = /) and verify against the policy.
+            var policyBytes = System.Text.Encoding.UTF8.GetBytes(
+                UrlSafeToBase64Decode(cookies.Policy.Value));
+            var signatureBytes = Convert.FromBase64String(
+                cookies.Signature.Value.Replace('-', '+').Replace('_', '=').Replace('~', '/'));
+
+            Assert.True(ecdsa.VerifyData(
+                policyBytes, signatureBytes, HashAlgorithmName.SHA256, DSASignatureFormat.Rfc3279DerSequence));
+        }
+
+        private static string UrlSafeToBase64Decode(string urlSafe)
+        {
+            var b64 = urlSafe.Replace('-', '+').Replace('_', '=').Replace('~', '/');
+            return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(b64));
+        }
+#endif
+
+        [Fact]
+        [Trait("Category", "CloudFront")]
+        public void DelegateSigner_RejectsUnsupportedAlgorithm()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new DelegateCloudFrontSigner(HashAlgorithmName.SHA512, _ => Array.Empty<byte>()));
+        }
+
+        [Fact]
+        [Trait("Category", "CloudFront")]
+        public void DelegateSigner_RejectsNullDelegate()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DelegateCloudFrontSigner(HashAlgorithmName.SHA256, null));
+        }
+
+        [Fact]
+        [Trait("Category", "CloudFront")]
+        public void SignerOverloads_RejectNullSigner()
+        {
+            var expiresOn = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            Assert.Throws<ArgumentNullException>(() =>
+                AmazonCloudFrontCookieSigner.GetCookiesForCustomPolicy(
+                    "https://awesome.dot.com/private/*", (ICloudFrontSigner)null, "kp", expiresOn, DateTime.MinValue, null));
+        }
+    }
+}

--- a/generator/.DevConfigs/ac51c45f-b8c9-43fa-936f-1c4cea3806c8.json
+++ b/generator/.DevConfigs/ac51c45f-b8c9-43fa-936f-1c4cea3806c8.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "Extensions.CloudFront.Signers",
+      "type": "minor",
+      "changeLogMessages": [
+        "Added ICloudFrontSigner and DelegateCloudFrontSigner, plus overloads of AmazonCloudFrontUrlSigner.SignUrl/GetCustomSignedURL and AmazonCloudFrontCookieSigner.GetCookiesForCustomPolicy that accept an ICloudFrontSigner, so policies can be signed with AWS KMS or another external signer (RSA or ECDSA P-256) without holding the private key in the process."
+      ]
+    }
+  ]
+}

--- a/generator/.DevConfigs/ac51c45f-b8c9-43fa-936f-1c4cea3806c8.json
+++ b/generator/.DevConfigs/ac51c45f-b8c9-43fa-936f-1c4cea3806c8.json
@@ -1,7 +1,7 @@
 {
-  "services": [
+  "extensions": [
     {
-      "serviceName": "Extensions.CloudFront.Signers",
+      "extensionName": "Extensions.CloudFront.Signers",
       "type": "minor",
       "changeLogMessages": [
         "Added ICloudFrontSigner and DelegateCloudFrontSigner, plus overloads of AmazonCloudFrontUrlSigner.SignUrl/GetCustomSignedURL and AmazonCloudFrontCookieSigner.GetCookiesForCustomPolicy that accept an ICloudFrontSigner, so policies can be signed with AWS KMS or another external signer (RSA or ECDSA P-256) without holding the private key in the process."


### PR DESCRIPTION
Today `AWSSDK.Extensions.CloudFront.Signers` can only sign from a raw private-key PEM held in the process. There is no way to keep the CloudFront signing key in **AWS KMS** (or an HSM) and have the SDK produce the signed URL/cookies — callers must reimplement the policy JSON, url-safe base64, and cookie assembly by hand.

This PR adds a signing seam:

- `ICloudFrontSigner` — `Sign(byte[] policyBytes) -> (byte[] signature, HashAlgorithmName)`.
- `DelegateCloudFrontSigner` — wraps a `Func<byte[], byte[]>` so a caller can plug in `kms:Sign` (or anything) in a couple of lines, with no new dependency added to the package.
- `ICloudFrontSigner` overloads of `SignUrl`, `GetCustomSignedURL`, and `GetCookiesForCustomPolicy`, routing through the existing policy/encoding/cookie builders.

The seam is algorithm-agnostic and works with **both** key types CloudFront accepts, no code change between them:

- **RSA 2048** → KMS `RSASSA_PKCS1_V1_5_SHA_256` (PKCS#1 v1.5 — CloudFront doesn't verify PSS).
- **ECDSA P-256** → KMS `ECDSA_SHA_256`; KMS returns a DER (RFC 3279) signature, exactly what CloudFront expects, so no re-encoding.

A CloudFront policy is well under KMS's 4096-byte `Message` limit, so `MessageType=RAW` is correct. Tests assert the RSA overloads produce byte-identical output to the private-key overloads, and that an ECDSA-signed cookie verifies against the P-256 public key.

No new package dependency (KMS stays in caller code). Existing overloads and downstream logic are unchanged. Includes the required DevConfig (`Extensions.CloudFront.Signers`, minor).

_Generated by AI tools, and reviewed by James Brown._
