### PR TITLE
Reduce memory allocations in XML primitive unmarshalling.

### DIFF
--- a/generator/.DevConfigs/d93f07e6-e27a-4638-95dd-6cf18aa93c86.json
+++ b/generator/.DevConfigs/d93f07e6-e27a-4638-95dd-6cf18aa93c86.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Reduce memory allocations in XML primitive unmarshalling."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Transform/SimpleTypeUnmarshaller.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Transform/SimpleTypeUnmarshaller.cs
@@ -25,12 +25,6 @@ namespace Amazon.Runtime.Internal.Transform
 {
     static class SimpleTypeUnmarshaller<T>
     {
-        public static T Unmarshall(XmlUnmarshallerContext context)
-        {
-            string text = context.ReadText();
-            return (T)Convert.ChangeType(text, typeof(T), CultureInfo.InvariantCulture);
-        }
-
         public static T Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
             context.Read(ref reader);
@@ -66,7 +60,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public int Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<int>.Unmarshall(context);
+            return int.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public int Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -148,7 +142,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public long Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<long>.Unmarshall(context);
+            return long.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public long Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -219,7 +213,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public float Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<float>.Unmarshall(context);
+            return float.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public float Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -295,7 +289,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public double Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<double>.Unmarshall(context);
+            return double.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public double Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -369,7 +363,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public decimal Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<decimal>.Unmarshall(context);
+            return decimal.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public decimal Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -443,7 +437,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public bool Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<bool>.Unmarshall(context);
+            return bool.Parse(context.ReadText());
         }
         public bool Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -517,7 +511,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public string Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<string>.Unmarshall(context);
+            return context.ReadText();
         }
         public string Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -550,7 +544,7 @@ namespace Amazon.Runtime.Internal.Transform
 
         public byte Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<byte>.Unmarshall(context);
+            return byte.Parse(context.ReadText(), CultureInfo.InvariantCulture);
         }
         public byte Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
@@ -681,12 +675,13 @@ namespace Amazon.Runtime.Internal.Transform
 
         public DateTime Unmarshall(XmlUnmarshallerContext context)
         {
-            return SimpleTypeUnmarshaller<DateTime>.Unmarshall(context);
+            long milliseconds = long.Parse(context.ReadText(), CultureInfo.InvariantCulture);
+            return Amazon.Util.AWSSDKUtils.EPOCH_START.AddMilliseconds(milliseconds);
         }
         public DateTime Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
         {
-            long millseconds = LongUnmarshaller.Instance.Unmarshall(context, ref reader);
-            var ret = Amazon.Util.AWSSDKUtils.EPOCH_START.AddMilliseconds(millseconds);
+            long milliseconds = LongUnmarshaller.Instance.Unmarshall(context, ref reader);
+            var ret = Amazon.Util.AWSSDKUtils.EPOCH_START.AddMilliseconds(milliseconds);
             return ret;
         }
     }


### PR DESCRIPTION
# Reduce memory allocations in XML primitive unmarshalling.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes per-value boxing from the XML primitive unmarshallers in `SimpleTypeUnmarshaller.cs`, which run for every scalar element/attribute value in every XML/AWS Query/EC2/REST-XML response.

The XML `Unmarshall` overloads for `Int`, `Long`, `Float`, `Double`, `Decimal`, `Bool`, `Byte`, `String`, and `DateTimeEpochLongMilliseconds` previously routed through the generic `SimpleTypeUnmarshaller<T>.Unmarshall(XmlUnmarshallerContext)` helper, which called `Convert.ChangeType(text, typeof(T), CultureInfo.InvariantCulture)`. `Convert.ChangeType` returns `object`, so **every non-string value type was boxed on the heap** (then immediately unboxed by the `(T)` cast) and dispatched through `IConvertible`/`TypeCode` rather than a direct typed `Parse`.

Each XML unmarshaller now parses directly to its target type (`int.Parse`, `long.Parse`, `double.Parse`, …) — exactly the pattern the corresponding `Nullable*` unmarshallers in the same file already use. `String` returns `context.ReadText()` directly (the old path ran a string→string identity conversion through `Convert.ChangeType`), and the now-unused generic `SimpleTypeUnmarshaller<T>.Unmarshall(XmlUnmarshallerContext)` overload is removed.

While removing the boxing, the XML overload of `DateTimeEpochLongMillisecondsUnmarshaller` was also found to be inconsistent with the rest of the class: it parsed the element text as a **date string** via `Convert.ChangeType(text, typeof(DateTime))`, whereas the class is meant to interpret the value as **epoch milliseconds**  which is what its own JSON overload and its `NullableDateTimeEpochLongMillisecondsUnmarshaller` sibling (both XML and JSON) already do. The XML overload now parses epoch milliseconds directly (`long.Parse` + `EPOCH_START.AddMilliseconds`), matching the rest of the class. 
This is a **bug fix**, but it is safe: nothing in the SDK selects this unmarshaller for XML, the code generator never emits it and there are no references to it anywhere in the repo, so no shipped service is affected.

Because the box is eliminated, the allocation win scales with the number of numeric values in a response. On a large `GetMetricData` response (100 results × 1,000 `Values` doubles = ~100,000 numeric values) the response unmarshalling allocation drops by ~15.6% — the 100,000 boxed doubles (24 bytes each on 64-bit ≈ 2,344 KB) are no longer allocated.
These improvements stacks over #4467.

<!--- Describe your changes in detail -->

## Motivation and Context
 `DOTNET-8588`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing

Ran the `SerdeBenchmarks` AWS Query unmarshalling benchmarks (`awsQuery_GetMetricDataResponse_*`) before and after the change.

Before this change
| Method                           | Mean            | Error          | StdDev         | Max             | P50             | P90             | P95             | Gen0      | Gen1     | Allocated  |
|--------------------------------- |----------------:|---------------:|---------------:|----------------:|----------------:|----------------:|----------------:|----------:|---------:|-----------:|
| awsQuery_GetMetricDataResponse_S |     11,390.3 ns |       826.8 ns |       952.1 ns |     13,322.9 ns |     11,284.9 ns |     12,669.4 ns |     12,745.4 ns |    1.3428 |        - |   17.79 KB |
| awsQuery_GetMetricDataResponse_M |    634,659.0 ns |    28,578.9 ns |    32,911.6 ns |    708,318.4 ns |    634,144.7 ns |    675,783.8 ns |    684,314.2 ns |   13.6719 |   0.9766 |  178.07 KB |
| awsQuery_GetMetricDataResponse_L | 60,675,292.5 ns | 1,174,000.3 ns | 1,098,160.6 ns | 62,296,112.5 ns | 60,512,062.5 ns | 62,063,620.0 ns | 62,188,233.8 ns | 1125.0000 | 875.0000 | 14998.6 KB |

After this change
| Method                           | Mean            | Error          | StdDev         | Max             | P50             | P90             | P95             | Gen0      | Gen1     | Allocated   |
|--------------------------------- |----------------:|---------------:|---------------:|----------------:|----------------:|----------------:|----------------:|----------:|---------:|------------:|
| awsQuery_GetMetricDataResponse_S |     11,013.4 ns |       476.4 ns |       509.8 ns |     12,496.0 ns |     10,925.9 ns |     11,564.6 ns |     11,749.4 ns |    1.3428 |        - |    17.55 KB |
| awsQuery_GetMetricDataResponse_M |    629,508.3 ns |    27,002.3 ns |    31,095.9 ns |    693,925.3 ns |    637,180.2 ns |    663,149.1 ns |    677,518.9 ns |   11.7188 |   0.9766 |   154.63 KB |
| awsQuery_GetMetricDataResponse_L | 59,178,287.7 ns | 2,568,676.4 ns | 2,855,077.0 ns | 64,787,433.3 ns | 57,830,633.3 ns | 63,484,173.3 ns | 64,201,523.3 ns | 1000.0000 | 888.8889 |  12654.8 KB |

Allocation drops ~1.4% (S), ~13.2% (M), and ~15.6% (L, 14,998.6 KB → 12,654.8 KB). Time is within run-to-run variance.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 31a85a47-5a06-40fa-8ade-f5b74743f97d
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 8f058b59-2172-4078-af94-4f062af896f8
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

