### PR TITLE
Add time-accepting SignRequest overloads for deterministic SigV4 signing

### DIFF
--- a/generator/.DevConfigs/d2e5c577-2c4e-4bfc-9681-725f3f6728b1.json
+++ b/generator/.DevConfigs/d2e5c577-2c4e-4bfc-9681-725f3f6728b1.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Added time-accepting overloads of `AWS4Signer.SignRequest` and `AWS4PreSignedUrlSigner.SignRequest` that take an explicit `signedAt`, enabling deterministic signing. Existing overloads are unchanged and delegate to these with the previously computed default time."
+    ],
+    "type": "minor",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -168,7 +168,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// <remarks>
         /// Parameters passed as part of the resource path should be uri-encoded prior to
         /// entry to the signer. Parameters passed in the request.Parameters collection should
-        /// be not be encoded; encoding will be done for these parameters as part of the 
+        /// not be encoded; encoding will be done for these parameters as part of the
         /// construction of the canonical request.
         /// </remarks>
         public AWS4SigningResult SignRequest(IRequest request,
@@ -177,6 +177,9 @@ namespace Amazon.Runtime.Internal.Auth
                                              string awsAccessKeyId,
                                              string awsSecretAccessKey)
         {
+            // Validate before touching request.Endpoint so that the validation behavior (and any
+            // resulting exception) is unchanged from the pre-refactor flow, which validated first.
+            ValidateRequest(request);
             return SignRequest(request, clientConfig, metrics, awsAccessKeyId, awsSecretAccessKey,
                                CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString()));
         }
@@ -213,7 +216,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// <remarks>
         /// Parameters passed as part of the resource path should be uri-encoded prior to
         /// entry to the signer. Parameters passed in the request.Parameters collection should
-        /// be not be encoded; encoding will be done for these parameters as part of the
+        /// not be encoded; encoding will be done for these parameters as part of the
         /// construction of the canonical request.
         /// </remarks>
         public AWS4SigningResult SignRequest(IRequest request,
@@ -1159,7 +1162,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// <remarks>
         /// Parameters passed as part of the resource path should be uri-encoded prior to
         /// entry to the signer. Parameters passed in the request.Parameters collection should
-        /// be not be encoded; encoding will be done for these parameters as part of the 
+        /// not be encoded; encoding will be done for these parameters as part of the
         /// construction of the canonical request.
         /// </remarks>
         public new AWS4SigningResult SignRequest(IRequest request,
@@ -1207,7 +1210,7 @@ namespace Amazon.Runtime.Internal.Auth
         /// <remarks>
         /// Parameters passed as part of the resource path should be uri-encoded prior to
         /// entry to the signer. Parameters passed in the request.Parameters collection should
-        /// be not be encoded; encoding will be done for these parameters as part of the 
+        /// not be encoded; encoding will be done for these parameters as part of the
         /// construction of the canonical request.
         ///
         /// The X-Amz-Content-SHA256 is cleared out of the request.

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -177,11 +177,57 @@ namespace Amazon.Runtime.Internal.Auth
                                              string awsAccessKeyId,
                                              string awsSecretAccessKey)
         {
+            return SignRequest(request, clientConfig, metrics, awsAccessKeyId, awsSecretAccessKey,
+                               CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString()));
+        }
+
+        /// <summary>
+        /// Calculates and signs the specified request using the AWS4 signing protocol by using the
+        /// AWS account credentials given in the method parameters, at the caller-supplied signing time.
+        /// </summary>
+        /// <param name="request">
+        /// The request to compute the signature for. Additional headers mandated by the AWS4 protocol
+        /// ('host' and 'x-amz-date') will be added to the request before signing.
+        /// </param>
+        /// <param name="clientConfig">
+        /// Client configuration data encompassing the service call (notably authentication
+        /// region, endpoint and service name).
+        /// </param>
+        /// <param name="metrics">
+        /// Metrics for the request.
+        /// </param>
+        /// <param name="awsAccessKeyId">
+        /// The AWS public key for the account making the service call.
+        /// </param>
+        /// <param name="awsSecretAccessKey">
+        /// The AWS secret key for the account making the call, in clear text.
+        /// </param>
+        /// <param name="signedAt">
+        /// The date and time to use for the signature. Callers who need a deterministic signing time
+        /// (e.g. offline signing or test-vector reproduction) supply it here; the parameterless-time
+        /// overload defaults it to the clock-skew-corrected UTC now for the request endpoint.
+        /// </param>
+        /// <exception cref="Amazon.Runtime.SignatureException">
+        /// If any problems are encountered while signing the request.
+        /// </exception>
+        /// <remarks>
+        /// Parameters passed as part of the resource path should be uri-encoded prior to
+        /// entry to the signer. Parameters passed in the request.Parameters collection should
+        /// be not be encoded; encoding will be done for these parameters as part of the
+        /// construction of the canonical request.
+        /// </remarks>
+        public AWS4SigningResult SignRequest(IRequest request,
+                                             IClientConfig clientConfig,
+                                             RequestMetrics metrics,
+                                             string awsAccessKeyId,
+                                             string awsSecretAccessKey,
+                                             DateTime signedAt)
+        {
             ValidateRequest(request);
-            var signedAt = InitializeHeaders(request.Headers, request.Endpoint);
-            
-            var serviceSigningName = !string.IsNullOrEmpty(request.OverrideSigningServiceName) 
-                ? request.OverrideSigningServiceName 
+            signedAt = InitializeHeaders(request.Headers, request.Endpoint, signedAt);
+
+            var serviceSigningName = !string.IsNullOrEmpty(request.OverrideSigningServiceName)
+                ? request.OverrideSigningServiceName
                 : DetermineService(clientConfig, request);
 
             if (serviceSigningName == "s3")
@@ -1176,6 +1222,55 @@ namespace Amazon.Runtime.Internal.Auth
                                                  string service,
                                                  string overrideSigningRegion)
         {
+            return SignRequest(request, clientConfig, metrics, awsAccessKeyId, awsSecretAccessKey, service, overrideSigningRegion,
+                               CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString()));
+        }
+
+        /// <summary>
+        /// Calculates the AWS4 signature for a presigned url, at the caller-supplied signing time.
+        /// </summary>
+        /// <param name="request">
+        /// The request to compute the signature for. Additional headers mandated by the AWS4 protocol
+        /// ('host' and 'x-amz-date') will be added to the request before signing. If the Expires parameter
+        /// is present, it is renamed to 'X-Amz-Expires' before signing.
+        /// </param>
+        /// <param name="clientConfig">
+        /// Adding supporting data for the service call required by the signer (notably authentication
+        /// region, endpoint and service name). May be null when <paramref name="overrideSigningRegion"/>
+        /// is supplied, since the region is then not derived from the config.
+        /// </param>
+        /// <param name="metrics">
+        /// Metrics for the request
+        /// </param>
+        /// <param name="awsAccessKeyId">
+        /// The AWS public key for the account making the service call.
+        /// </param>
+        /// <param name="awsSecretAccessKey">
+        /// The AWS secret key for the account making the call, in clear text
+        /// </param>
+        /// <param name="service">
+        /// The service to sign for
+        /// </param>
+        /// <param name="overrideSigningRegion">
+        /// The region to sign to, if null then the region the client is configured for will be used.
+        /// </param>
+        /// <param name="signedAt">
+        /// The date and time to use for the signature. Callers who need a deterministic signing time
+        /// supply it here; the parameterless-time overload defaults it to the clock-skew-corrected UTC
+        /// now for the request endpoint.
+        /// </param>
+        /// <exception cref="Amazon.Runtime.SignatureException">
+        /// If any problems are encountered while signing the request.
+        /// </exception>
+        public static AWS4SigningResult SignRequest(IRequest request,
+                                                 IClientConfig clientConfig,
+                                                 RequestMetrics metrics,
+                                                 string awsAccessKeyId,
+                                                 string awsSecretAccessKey,
+                                                 string service,
+                                                 string overrideSigningRegion,
+                                                 DateTime signedAt)
+        {
             if (service == "s3" || service == "s3express")
             {
                 // Older versions of the S3 package can be used with newer versions of Core, this guarantees no double encoding will be used.
@@ -1193,7 +1288,6 @@ namespace Amazon.Runtime.Internal.Auth
                 request.Headers.Add(HeaderKeys.HostHeader, hostHeader);
             }
 
-            var signedAt = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString());
             request.SignedAt = signedAt;
             var region = overrideSigningRegion ?? DetermineSigningRegion(clientConfig, clientConfig.RegionEndpointServiceName, request.AlternateEndpoint, request);
 

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/AWS4SignerExplicitTimeTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/AWS4SignerExplicitTimeTests.cs
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Auth;
+using Amazon.Runtime.Internal.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSSDK.UnitTests.Signing
+{
+    [TestClass]
+    [TestCategory("Core")]
+    [TestCategory("Signer")]
+    public class AWS4SignerExplicitTimeTests
+    {
+        private const string AccessKey = "AKIDEXAMPLE";
+        private const string SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        private const string Region = "us-east-1";
+        private const string Service = "service";
+
+        // -----------------------------------------------------------------------
+        // Time-accepting overloads: the parameterless-time overloads must delegate to the
+        // time-accepting ones with the previously-computed default, so existing callers are unchanged.
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public void SignRequest_DefaultTime_MatchesExplicitTimeWithSameInstant()
+        {
+            // The original 5-arg SignRequest computed its signing time via
+            // CorrectClockSkew.GetCorrectedUtcNowForEndpoint and used it. The refactor moved the logic into a
+            // 6-arg time-accepting overload and made the 5-arg delegate with that same computed default. This
+            // test invokes BOTH overloads and asserts they produce byte-identical output when the explicit
+            // time is the value the default-time overload would compute — so a broken delegation (wrong
+            // default, double header init, dropped reassignment) would fail here.
+            var config = new MockClientConfig { AuthenticationRegion = Region };
+            var endpoint = new Uri("https://example.amazonaws.com");
+            var computedDefault = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(endpoint.ToString());
+
+            var defaultResult = new AWS4Signer().SignRequest(
+                BuildInternalRequest(), config, new RequestMetrics(), AccessKey, SecretKey);
+            var explicitResult = new AWS4Signer().SignRequest(
+                BuildInternalRequest(), config, new RequestMetrics(), AccessKey, SecretKey, computedDefault);
+
+            // Scope (date) and signed headers are the deterministic-instant-dependent portions of the result;
+            // both overloads resolve to the same corrected-now here, so both must match.
+            Assert.AreEqual(explicitResult.Scope, defaultResult.Scope);
+            Assert.AreEqual(explicitResult.SignedHeaders, defaultResult.SignedHeaders);
+        }
+
+        [TestMethod]
+        public void SignRequest_ExplicitTime_IsDeterministic()
+        {
+            // A fixed signing instant must produce a fixed signature: signing the same request twice with the
+            // same explicit time yields identical authorization output.
+            var config = new MockClientConfig { AuthenticationRegion = Region };
+            var signedAt = new DateTime(2015, 8, 30, 12, 36, 0, DateTimeKind.Utc);
+
+            var first = new AWS4Signer().SignRequest(
+                BuildInternalRequest(), config, new RequestMetrics(), AccessKey, SecretKey, signedAt);
+            var second = new AWS4Signer().SignRequest(
+                BuildInternalRequest(), config, new RequestMetrics(), AccessKey, SecretKey, signedAt);
+
+            Assert.AreEqual(first.ForAuthorizationHeader, second.ForAuthorizationHeader);
+            // The scope carries the signing date; a fixed instant pins it.
+            StringAssert.Contains(first.Scope, "20150830");
+        }
+
+        [TestMethod]
+        public void PresignRequest_ExplicitTime_IsDeterministic()
+        {
+            // The presigner's time-accepting overload must likewise pin the signature to the supplied instant.
+            var config = new MockClientConfig { AuthenticationRegion = Region };
+            var signedAt = new DateTime(2015, 8, 30, 12, 36, 0, DateTimeKind.Utc);
+
+            var first = AWS4PreSignedUrlSigner.SignRequest(
+                BuildInternalRequest(), config, new RequestMetrics(), AccessKey, SecretKey, Service, Region, signedAt);
+            var second = AWS4PreSignedUrlSigner.SignRequest(
+                BuildInternalRequest(), config, new RequestMetrics(), AccessKey, SecretKey, Service, Region, signedAt);
+
+            Assert.AreEqual(first.ForQueryParameters, second.ForQueryParameters);
+            StringAssert.Contains(first.Scope, "20150830");
+        }
+
+        private static IRequest BuildInternalRequest()
+        {
+            return new DefaultRequest(new StubRequest(), Service)
+            {
+                HttpMethod = "GET",
+                Endpoint = new Uri("https://example.amazonaws.com"),
+                ResourcePath = "/",
+                OverrideSigningServiceName = Service,
+                AuthenticationRegion = Region,
+            };
+        }
+
+        private class StubRequest : AmazonWebServiceRequest { }
+    }
+}

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/AWS4SignerExplicitTimeTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/AWS4SignerExplicitTimeTests.cs
@@ -42,23 +42,24 @@ namespace AWSSDK.UnitTests.Signing
         {
             // The original 5-arg SignRequest computed its signing time via
             // CorrectClockSkew.GetCorrectedUtcNowForEndpoint and used it. The refactor moved the logic into a
-            // 6-arg time-accepting overload and made the 5-arg delegate with that same computed default. This
-            // test invokes BOTH overloads and asserts they produce byte-identical output when the explicit
-            // time is the value the default-time overload would compute — so a broken delegation (wrong
-            // default, double header init, dropped reassignment) would fail here.
+            // 6-arg time-accepting overload and made the 5-arg delegate with that same computed default.
+            //
+            // We can't independently recompute the default instant and expect a match, since the default
+            // overload computes its own corrected-now that would differ from ours by the wall-clock elapsed
+            // between the two calls. Instead we capture the exact instant the default path actually used
+            // (surfaced on the result as DateTime), then re-sign with the explicit overload using that same
+            // instant and compare a time-sensitive output. A broken delegation (wrong default, double header
+            // init, dropped reassignment) would make ForAuthorizationHeader diverge here.
             var config = new MockClientConfig { AuthenticationRegion = Region };
-            var endpoint = new Uri("https://example.amazonaws.com");
-            var computedDefault = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(endpoint.ToString());
 
             var defaultResult = new AWS4Signer().SignRequest(
                 BuildInternalRequest(), config, new RequestMetrics(), AccessKey, SecretKey);
             var explicitResult = new AWS4Signer().SignRequest(
-                BuildInternalRequest(), config, new RequestMetrics(), AccessKey, SecretKey, computedDefault);
+                BuildInternalRequest(), config, new RequestMetrics(), AccessKey, SecretKey, defaultResult.DateTime);
 
-            // Scope (date) and signed headers are the deterministic-instant-dependent portions of the result;
-            // both overloads resolve to the same corrected-now here, so both must match.
-            Assert.AreEqual(explicitResult.Scope, defaultResult.Scope);
-            Assert.AreEqual(explicitResult.SignedHeaders, defaultResult.SignedHeaders);
+            // ForAuthorizationHeader folds in the full signature (down to the second via the credential scope
+            // date and x-amz-date), so it only matches if both paths signed at the identical instant.
+            Assert.AreEqual(explicitResult.ForAuthorizationHeader, defaultResult.ForAuthorizationHeader);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description

Part 1 of splitting #4470 (standalone SigV4 signing) into small, independently reviewable PRs that land on the `feature/sigv4-standalone-signer` integration branch.

Adds explicit-`signedAt` overloads of `AWS4Signer.SignRequest` and `AWS4PreSignedUrlSigner.SignRequest` so callers that need a **deterministic** signing time (offline signing, test-vector reproduction) can supply it directly.

## What's included

- New 6-arg `AWS4Signer.SignRequest(..., DateTime signedAt)` overload.
- New 8-arg `AWS4PreSignedUrlSigner.SignRequest(..., DateTime signedAt)` overload.
- The existing parameterless-time overloads now **delegate** to these, passing the previously-computed default (`CorrectClockSkew.GetCorrectedUtcNowForEndpoint(...)`), so existing callers are byte-for-byte unchanged.

## Why

Pure, behavior-preserving refactor. It's the foundation the standalone signer facade builds on, but it's valuable on its own and safe to review in isolation.

## Testing

- New `AWS4SignerExplicitTimeTests`: proves the default-time overload matches the explicit-time overload for the same instant, and that an explicit time produces deterministic output for both the header and presign paths.
- `AWSSDK.Core` builds clean; new tests pass.

## Stacking

This PR is the base of the stack:
- **PR 1 (this):** time-accepting overloads → `feature/sigv4-standalone-signer`
- PR 2: `IRequest.PrecomputedContentSha256` → this branch
- Later PRs: the `AWSSigV4Signer` facade + presign + `HttpRequestMessage` helper

Splits out of #4470.

## Dry-run

Basic chained dry-run (`catapult-net`, product `dotnetv4`, stage `prod`, source `origin:sigv4-signrequest-explicit-time`):

| Product | Build ID |
|---|---|
| .NET (`dotnetv4`) | `b93a16c8-dc9e-4130-a655-52dfc8c547ff` |
| PowerShell (`powershell5`) | `ad5a3b5a-5a9e-4012-925e-ca4f35422ee9` |

