### PR TITLE
Add IRequest.PrecomputedContentSha256 honored ahead of the body read

### DIFF
--- a/generator/.DevConfigs/fc028646-169e-49db-b3be-08f22e43e919.json
+++ b/generator/.DevConfigs/fc028646-169e-49db-b3be-08f22e43e919.json
@@ -4,9 +4,6 @@
       "Added `IRequest.PrecomputedContentSha256`, a caller-supplied body hash that `AWS4Signer` uses verbatim (when payload signing is enabled) in place of reading the request body."
     ],
     "type": "minor",
-    "updateMinimum": true,
-    "backwardIncompatibilitiesToIgnore": [
-      "Amazon.Runtime.Internal.IRequest/MethodAbstractMethodAdded"
-    ]
+    "updateMinimum": true
   }
 }

--- a/generator/.DevConfigs/fc028646-169e-49db-b3be-08f22e43e919.json
+++ b/generator/.DevConfigs/fc028646-169e-49db-b3be-08f22e43e919.json
@@ -1,0 +1,12 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Added `IRequest.PrecomputedContentSha256`, a caller-supplied body hash that `AWS4Signer` uses verbatim (when payload signing is enabled) in place of reading the request body."
+    ],
+    "type": "minor",
+    "updateMinimum": true,
+    "backwardIncompatibilitiesToIgnore": [
+      "Amazon.Runtime.Internal.IRequest/MethodAbstractMethodAdded"
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -542,6 +542,14 @@ namespace Amazon.Runtime.Internal.Auth
                 }
             }
 
+            // If the caller supplied a precomputed body hash on the request, use it verbatim.
+            // This is honored ahead of the body read (and survives the InitializeHeaders/CleanHeaders
+            // scrub that clears a stale x-amz-content-sha256 header before signing), letting a caller
+            // sign a body the signer must not read (large or non-seekable). The standard service
+            // pipeline never sets this, so its resign/scrub behavior is unaffected.
+            if (!request.UseChunkEncoding && !string.IsNullOrEmpty(request.PrecomputedContentSha256))
+                return SetPayloadSignatureHeader(request, request.PrecomputedContentSha256);
+
             // if the body hash has been precomputed and already placed in the header, just extract and return it
             string computedContentHash;
             var shaHeaderPresent = request.Headers.TryGetValue(HeaderKeys.XAmzContentSha256Header, out computedContentHash);

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -547,6 +547,11 @@ namespace Amazon.Runtime.Internal.Auth
             // scrub that clears a stale x-amz-content-sha256 header before signing), letting a caller
             // sign a body the signer must not read (large or non-seekable). The standard service
             // pipeline never sets this, so its resign/scrub behavior is unaffected.
+            //
+            // This branch is only reachable when payload signing is effectively enabled: the
+            // unsigned-payload gate above (DisablePayloadSigning ?? !signPayload) already returned
+            // UNSIGNED-PAYLOAD otherwise, so PrecomputedContentSha256 cannot override that magic string.
+            // It is likewise ignored for chunk-encoded requests, which carry their own streaming hash.
             if (!request.UseChunkEncoding && !string.IsNullOrEmpty(request.PrecomputedContentSha256))
                 return SetPayloadSignatureHeader(request, request.PrecomputedContentSha256);
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/DefaultRequest.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/DefaultRequest.cs
@@ -395,6 +395,9 @@ namespace Amazon.Runtime.Internal
             return this.contentStreamHash;
         }
 
+        /// <inheritdoc/>
+        public string PrecomputedContentSha256 { get; set; }
+
         /// <summary>
         /// The name of the service to which this request is being sent.
         /// </summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/IRequest.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/IRequest.cs
@@ -214,6 +214,18 @@ namespace Amazon.Runtime.Internal
         string ComputeContentStreamHash();
 
         /// <summary>
+        /// A caller-supplied, precomputed SHA256 hash of the request body (hex-encoded)
+        /// to use as the x-amz-content-sha256 value during signing, in place of the signer
+        /// reading and hashing the body itself. When set (and payload signing is enabled),
+        /// <c>AWS4Signer.SetRequestBodyHash</c> uses this
+        /// value verbatim during signing. This is honored ahead of the body read, so it survives the
+        /// header scrub that clears a stale x-amz-content-sha256 before (re)signing. The standard
+        /// service pipeline never sets this; it exists for standalone signing scenarios where
+        /// the body should not be read (large or non-seekable content).
+        /// </summary>
+        string PrecomputedContentSha256 { get; set; }
+
+        /// <summary>
         /// If the request needs to be signed with a different service name 
         /// than the client config AuthenticationServiceName, set it here to override
         /// the result of DetermineService in AWS4Signer

--- a/sdk/src/Core/Amazon.Runtime/Internal/IRequest.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/IRequest.cs
@@ -214,14 +214,23 @@ namespace Amazon.Runtime.Internal
         string ComputeContentStreamHash();
 
         /// <summary>
-        /// A caller-supplied, precomputed SHA256 hash of the request body (hex-encoded)
-        /// to use as the x-amz-content-sha256 value during signing, in place of the signer
-        /// reading and hashing the body itself. When set (and payload signing is enabled),
-        /// <c>AWS4Signer.SetRequestBodyHash</c> uses this
-        /// value verbatim during signing. This is honored ahead of the body read, so it survives the
-        /// header scrub that clears a stale x-amz-content-sha256 before (re)signing. The standard
-        /// service pipeline never sets this; it exists for standalone signing scenarios where
-        /// the body should not be read (large or non-seekable content).
+        /// A caller-supplied, precomputed SHA256 hash of the request body used as the
+        /// x-amz-content-sha256 value during signing, in place of the signer reading and hashing
+        /// the body itself. The value must be the lowercase hex encoding of the 32-byte SHA256
+        /// digest (64 hex characters); it is used verbatim (no normalization), so it must match the
+        /// body byte-for-byte or the request will fail to authenticate.
+        /// <para>
+        /// When set, <c>AWS4Signer.SetRequestBodyHash</c> uses this value ahead of the body read,
+        /// so it survives the header scrub that clears a stale x-amz-content-sha256 before (re)signing.
+        /// It is only applied when payload signing is effectively enabled: it is ignored when the
+        /// payload is unsigned (<see cref="DisablePayloadSigning"/> is true, or the signer is
+        /// configured not to sign the payload), and when chunk encoding is used, since those paths
+        /// use their own content-hash magic strings.
+        /// </para>
+        /// <para>
+        /// The standard service pipeline never sets this; it exists for standalone signing scenarios
+        /// where the body should not be read (large or non-seekable content).
+        /// </para>
         /// </summary>
         string PrecomputedContentSha256 { get; set; }
 

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/PrecomputedContentSha256Tests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/PrecomputedContentSha256Tests.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.IO;
 using System.Text;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
@@ -41,14 +42,16 @@ namespace AWSSDK.UnitTests.Signing
         // -----------------------------------------------------------------------
 
         [TestMethod]
-        public void SetRequestBodyHash_WithPrecomputedHash_UsesItVerbatim()
+        public void SetRequestBodyHash_WithPrecomputedHash_UsesItVerbatimWithoutReadingBody()
         {
-            // A precomputed hash must be used verbatim as x-amz-content-sha256, even when a body is present
-            // that would otherwise be read and hashed.
+            // A precomputed hash must be used verbatim as x-amz-content-sha256 AND the signer must not
+            // read the body to produce it. We back the request with a stream that throws on any read: if
+            // the signer honors the precomputed hash ahead of the body read, signing succeeds and the
+            // header carries the supplied value; if it fell through to hashing the body, the read would throw.
             var precomputed = new string('a', 64);
             var config = new MockClientConfig { AuthenticationRegion = Region };
             var request = BuildInternalRequest();
-            request.Content = Encoding.UTF8.GetBytes("some body the signer must not read");
+            request.ContentStream = new ThrowOnReadStream(Encoding.UTF8.GetBytes("some body the signer must not read"));
             request.PrecomputedContentSha256 = precomputed;
 
             new AWS4Signer().SignRequest(request, config, new RequestMetrics(), AccessKey, SecretKey);
@@ -91,9 +94,10 @@ namespace AWSSDK.UnitTests.Signing
 
         private static IRequest BuildInternalRequest()
         {
+            // POST is the body-typical verb these scenarios represent (a caller supplying a body hash).
             return new DefaultRequest(new StubRequest(), Service)
             {
-                HttpMethod = "GET",
+                HttpMethod = "POST",
                 Endpoint = new Uri("https://example.amazonaws.com"),
                 ResourcePath = "/",
                 OverrideSigningServiceName = Service,
@@ -102,5 +106,58 @@ namespace AWSSDK.UnitTests.Signing
         }
 
         private class StubRequest : AmazonWebServiceRequest { }
+
+        /// <summary>
+        /// A seekable stream whose length matches the supplied content but which throws on any read
+        /// attempt. Used to prove the signer honors PrecomputedContentSha256 without reading the body:
+        /// if signing touched the body, the read would throw instead of completing.
+        /// </summary>
+        private sealed class ThrowOnReadStream : Stream
+        {
+            private readonly long _length;
+            private long _position;
+
+            public ThrowOnReadStream(byte[] content)
+            {
+                _length = content.Length;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => true;
+            public override bool CanWrite => false;
+            public override long Length => _length;
+
+            public override long Position
+            {
+                get => _position;
+                set => _position = value;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new InvalidOperationException("The signer must not read the request body when PrecomputedContentSha256 is set.");
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                switch (origin)
+                {
+                    case SeekOrigin.Begin:
+                        _position = offset;
+                        break;
+                    case SeekOrigin.Current:
+                        _position += offset;
+                        break;
+                    case SeekOrigin.End:
+                        _position = _length + offset;
+                        break;
+                }
+                return _position;
+            }
+
+            public override void Flush() { }
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
     }
 }

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/PrecomputedContentSha256Tests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/PrecomputedContentSha256Tests.cs
@@ -1,0 +1,106 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Text;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Auth;
+using Amazon.Runtime.Internal.Util;
+using Amazon.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSSDK.UnitTests.Signing
+{
+    [TestClass]
+    [TestCategory("Core")]
+    [TestCategory("Signer")]
+    public class PrecomputedContentSha256Tests
+    {
+        private const string AccessKey = "AKIDEXAMPLE";
+        private const string SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        private const string Region = "us-east-1";
+        private const string Service = "service";
+
+        // -----------------------------------------------------------------------
+        // IRequest.PrecomputedContentSha256 is honored by SetRequestBodyHash ahead of the body read,
+        // so a caller can sign a precomputed body hash without the signer reading the body. Routed
+        // through a request field so the shared resign/scrub path is left untouched.
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public void SetRequestBodyHash_WithPrecomputedHash_UsesItVerbatim()
+        {
+            // A precomputed hash must be used verbatim as x-amz-content-sha256, even when a body is present
+            // that would otherwise be read and hashed.
+            var precomputed = new string('a', 64);
+            var config = new MockClientConfig { AuthenticationRegion = Region };
+            var request = BuildInternalRequest();
+            request.Content = Encoding.UTF8.GetBytes("some body the signer must not read");
+            request.PrecomputedContentSha256 = precomputed;
+
+            new AWS4Signer().SignRequest(request, config, new RequestMetrics(), AccessKey, SecretKey);
+
+            Assert.AreEqual(precomputed, request.Headers[HeaderKeys.XAmzContentSha256Header]);
+        }
+
+        [TestMethod]
+        public void SetRequestBodyHash_WithPrecomputedHash_SurvivesStaleHeaderScrub()
+        {
+            // The precomputed value is honored ahead of the body read, so it must survive the
+            // InitializeHeaders/CleanHeaders scrub that clears a stale x-amz-content-sha256 before signing.
+            var precomputed = new string('b', 64);
+            var config = new MockClientConfig { AuthenticationRegion = Region };
+            var request = BuildInternalRequest();
+            // Inject a stale header value as though from a prior signing pass.
+            request.Headers[HeaderKeys.XAmzContentSha256Header] = new string('c', 64);
+            request.PrecomputedContentSha256 = precomputed;
+
+            new AWS4Signer().SignRequest(request, config, new RequestMetrics(), AccessKey, SecretKey);
+
+            Assert.AreEqual(precomputed, request.Headers[HeaderKeys.XAmzContentSha256Header]);
+        }
+
+        [TestMethod]
+        public void SetRequestBodyHash_WithoutPrecomputedHash_StillScrubsStaleContentHash()
+        {
+            // Guards that the standard signer path (no PrecomputedContentSha256 set) is unaffected: it must
+            // still recompute x-amz-content-sha256 rather than trusting a stale header value.
+            var config = new MockClientConfig { AuthenticationRegion = Region };
+            var request = BuildInternalRequest();
+            // Inject a stale hash as though from a prior signing pass; leave PrecomputedContentSha256 unset.
+            request.Headers[HeaderKeys.XAmzContentSha256Header] = new string('d', 64);
+
+            new AWS4Signer().SignRequest(request, config, new RequestMetrics(), AccessKey, SecretKey);
+
+            // Empty body → the signer should have replaced the stale value with the empty-body SHA.
+            Assert.AreEqual(AWS4Signer.EmptyBodySha256, request.Headers[HeaderKeys.XAmzContentSha256Header]);
+        }
+
+        private static IRequest BuildInternalRequest()
+        {
+            return new DefaultRequest(new StubRequest(), Service)
+            {
+                HttpMethod = "GET",
+                Endpoint = new Uri("https://example.amazonaws.com"),
+                ResourcePath = "/",
+                OverrideSigningServiceName = Service,
+                AuthenticationRegion = Region,
+            };
+        }
+
+        private class StubRequest : AmazonWebServiceRequest { }
+    }
+}

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/PrecomputedContentSha256Tests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/PrecomputedContentSha256Tests.cs
@@ -92,6 +92,30 @@ namespace AWSSDK.UnitTests.Signing
             Assert.AreEqual(AWS4Signer.EmptyBodySha256, request.Headers[HeaderKeys.XAmzContentSha256Header]);
         }
 
+        [TestMethod]
+        [DataRow(true,  true,  false, AWS4Signer.UnsignedPayload)]
+        [DataRow(false, false, false, AWS4Signer.UnsignedPayload)]
+        [DataRow(false, true,  true,  AWS4Signer.StreamingBodySha256)]
+        public void SetRequestBodyHash_WithPrecomputedHash_IgnoredWhenNotEffectivelySigningBody(bool disablePayloadSigning, bool signerSignsPayload, bool useChunkEncoding, string expectedHash)
+        {
+            // PrecomputedContentSha256 must only take effect when payload signing is effectively enabled
+            // and the request isn't chunk-encoded. When the unsigned-payload gate applies (DisablePayloadSigning,
+            // or a signer constructed with signPayload:false) the magic string wins; a chunk-encoded request
+            // carries its own streaming hash. In all these cases the precomputed value must be ignored.
+            var config = new MockClientConfig { AuthenticationRegion = Region };
+            var request = BuildInternalRequest();
+            request.UseChunkEncoding = useChunkEncoding;
+            request.PrecomputedContentSha256 = new string('a', 64);
+
+            if (disablePayloadSigning)
+            {
+                request.DisablePayloadSigning = true;
+            }
+
+            new AWS4Signer(signPayload: signerSignsPayload).SignRequest(request, config, new RequestMetrics(), AccessKey, SecretKey);
+            Assert.AreEqual(expectedHash, request.Headers[HeaderKeys.XAmzContentSha256Header]);
+        }
+
         private static IRequest BuildInternalRequest()
         {
             // POST is the body-typical verb these scenarios represent (a caller supplying a body hash).


### PR DESCRIPTION
## Description


Adds `IRequest.PrecomputedContentSha256` so a caller can supply a hex-encoded SHA256 of the request body and have `AWS4Signer.SetRequestBodyHash` use it verbatim as `x-amz-content-sha256` — without the signer reading and hashing the body itself. This is what lets a caller sign large or non-seekable content.

## What's included

- `IRequest.PrecomputedContentSha256` (+ `DefaultRequest` implementation).
- `AWS4Signer.SetRequestBodyHash` honors it **ahead of the body read**, so it survives the `InitializeHeaders`/`CleanHeaders` scrub that clears a stale `x-amz-content-sha256` before (re)signing.

## Design note

The value is routed through a **request field** rather than teaching `CleanHeaders` to preserve the header, specifically so the shared resign/scrub path is left untouched. The standard service pipeline never sets this field, so its resign behavior is unaffected.

## Testing

- New `PrecomputedContentSha256Tests`: verbatim use, survival of a stale-header scrub, and a regression test proving the standard path (field unset) **still** scrubs a stale hash.
- `AWSSDK.Core` builds clean; new tests pass.

## Dry-run

Basic chained dry-run (`catapult-net`, product `dotnetv4`, stage `prod`, source `origin:sigv4-precomputed-content-sha256`):

| Product | Build ID |
|---|---|
| .NET (`dotnetv4`) | `0abed65d-116f-446b-920e-ef2c6c77b7bc` |
| PowerShell (`powershell5`) | `8cf8129f-7b56-4ce2-9830-797a29ece4c4` |

