### PR TITLE
Add SigV4SigningHandler for transparent HttpClient signing

### DIFF
--- a/generator/.DevConfigs/6586a403-b94c-4241-b475-31da5b36d616.json
+++ b/generator/.DevConfigs/6586a403-b94c-4241-b475-31da5b36d616.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Added `SigV4SigningHandler`, a `System.Net.Http.DelegatingHandler` in the `Amazon.Runtime.Signing` namespace that SigV4-signs each outbound request. Install it on an `HttpClient` (directly or via `IHttpClientFactory`) to sign requests transparently. It is a thin layer over the standalone `AWSSigV4Signer` facade, resolves credentials on every send, and supports per-request region/service/payload-signing overrides via `HttpRequestMessage.Options`."
+    ],
+    "type": "minor",
+    "updateMinimum": true
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Signing/AWSSigV4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/AWSSigV4Signer.cs
@@ -469,7 +469,7 @@ namespace Amazon.Runtime.Signing
 
         #region Validation
 
-        // Return parameters whose Region is set, falling back to the ambient region (env var, profile, IMDS)
+        // Return parameters whose Region is set, falling back to the ambient region via FallbackRegionFactory
         // when the caller left it null — matching how the service clients resolve a missing region. The
         // caller's object is never mutated; a shallow copy carries the resolved region. Throws only when no
         // region can be determined at all.
@@ -481,7 +481,7 @@ namespace Amazon.Runtime.Signing
             var region = FallbackRegionFactory.GetRegionEndpoint()
                 ?? throw new ArgumentException(
                     "Region must be set. No region was supplied and none could be resolved from the environment " +
-                    "(AWS_REGION, the shared config file, or EC2 instance metadata).", nameof(parameters));
+                    "by the default region resolution chain.", nameof(parameters));
 
             return new AWSSigV4Parameters
             {

--- a/sdk/src/Core/Amazon.Runtime/Signing/AWSSigV4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/AWSSigV4Signer.cs
@@ -19,6 +19,7 @@ using System.Globalization;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Runtime.Credentials;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Runtime.Internal.Util;
@@ -55,7 +56,8 @@ namespace Amazon.Runtime.Signing
         public static AWSSigningResult Sign(AWSSigningRequest request, AWSSigV4Parameters parameters)
         {
             ValidateArguments(request, parameters, presign: false);
-            var credentials = parameters.Credentials.GetCredentials();
+            parameters = ResolveRegion(parameters);
+            var credentials = ResolveCredentials(parameters).GetCredentials();
             return SignInternal(request, parameters, credentials);
         }
 
@@ -67,7 +69,8 @@ namespace Amazon.Runtime.Signing
         {
             cancellationToken.ThrowIfCancellationRequested();
             ValidateArguments(request, parameters, presign: false);
-            var credentials = await parameters.Credentials.GetCredentialsAsync().ConfigureAwait(false);
+            parameters = ResolveRegion(parameters);
+            var credentials = await ResolveCredentials(parameters).GetCredentialsAsync().ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             return SignInternal(request, parameters, credentials);
         }
@@ -79,7 +82,8 @@ namespace Amazon.Runtime.Signing
         {
             ValidateArguments(request, parameters, presign: true);
             ValidateExpiry(expiry);
-            var credentials = ResolveForPresign(parameters.Credentials, expiry);
+            parameters = ResolveRegion(parameters);
+            var credentials = ResolveForPresign(ResolveCredentials(parameters), expiry);
             return PresignInternal(request, parameters, expiry, credentials);
         }
 
@@ -92,7 +96,8 @@ namespace Amazon.Runtime.Signing
             cancellationToken.ThrowIfCancellationRequested();
             ValidateArguments(request, parameters, presign: true);
             ValidateExpiry(expiry);
-            var credentials = await ResolveForPresignAsync(parameters.Credentials, expiry).ConfigureAwait(false);
+            parameters = ResolveRegion(parameters);
+            var credentials = await ResolveForPresignAsync(ResolveCredentials(parameters), expiry).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             return PresignInternal(request, parameters, expiry, credentials);
         }
@@ -464,6 +469,42 @@ namespace Amazon.Runtime.Signing
 
         #region Validation
 
+        // Return parameters whose Region is set, falling back to the ambient region (env var, profile, IMDS)
+        // when the caller left it null — matching how the service clients resolve a missing region. The
+        // caller's object is never mutated; a shallow copy carries the resolved region. Throws only when no
+        // region can be determined at all.
+        private static AWSSigV4Parameters ResolveRegion(AWSSigV4Parameters parameters)
+        {
+            if (parameters.Region != null)
+                return parameters;
+
+            var region = FallbackRegionFactory.GetRegionEndpoint()
+                ?? throw new ArgumentException(
+                    "Region must be set. No region was supplied and none could be resolved from the environment " +
+                    "(AWS_REGION, the shared config file, or EC2 instance metadata).", nameof(parameters));
+
+            return new AWSSigV4Parameters
+            {
+                Credentials = parameters.Credentials,
+                Region = region,
+                Service = parameters.Service,
+                SignPayload = parameters.SignPayload,
+                SignedAt = parameters.SignedAt,
+            };
+        }
+
+        // Return the credentials to sign with, falling back to the default credential resolution chain when the
+        // caller left them null — matching how the service clients resolve missing credentials. Throws only
+        // when no credentials can be determined at all.
+        private static AWSCredentials ResolveCredentials(AWSSigV4Parameters parameters)
+        {
+            return parameters.Credentials
+                ?? DefaultAWSCredentialsIdentityResolver.GetCredentials()
+                ?? throw new ArgumentException(
+                    "Credentials must be set. No credentials were supplied and none could be resolved from the " +
+                    "environment (the default AWS credential resolution chain).", nameof(parameters));
+        }
+
         private static void ValidateArguments(AWSSigningRequest request, AWSSigV4Parameters parameters, bool presign)
         {
             if (request == null)
@@ -476,12 +517,12 @@ namespace Amazon.Runtime.Signing
                 throw new ArgumentException("RequestUri must be set.", nameof(request));
             if (!request.RequestUri.IsAbsoluteUri)
                 throw new ArgumentException("RequestUri must be an absolute URI.", nameof(request));
-            if (parameters.Region == null)
-                throw new ArgumentException("Region must be set.", nameof(parameters));
             if (string.IsNullOrEmpty(parameters.Service))
                 throw new ArgumentException("Service must be set.", nameof(parameters));
-            if (parameters.Credentials == null)
-                throw new ArgumentException("Credentials must be set.", nameof(parameters));
+            // Region and Credentials are intentionally not validated here: when unset they are resolved from
+            // the environment (FallbackRegionFactory / DefaultAWSCredentialsIdentityResolver), matching the
+            // behavior of our other libraries. Resolution — and the error when it too comes up empty — happens
+            // in ResolveRegion / the credential resolution path.
 
             var hasPrecomputedHash = TryGetContentSha256Header(request.Headers, out _);
 

--- a/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
@@ -1,0 +1,271 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Util;
+
+namespace Amazon.Runtime.Signing
+{
+    /// <summary>
+    /// A <see cref="DelegatingHandler"/> that signs each outbound request with AWS Signature Version 4
+    /// before it is sent. Install it on an <see cref="HttpClient"/> — directly or via
+    /// <c>IHttpClientFactory</c> — to sign transparently, so callers write ordinary <see cref="HttpClient"/>
+    /// code and every request is signed. It is a thin front door over <see cref="AWSSigV4Signer"/> and
+    /// performs no signing computation of its own.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The signing region, service, and payload-signing mode are handler-level defaults for the common
+    /// one-service-per-client case. A single client that must sign for more than one service or region,
+    /// or vary payload signing per request, can override any of them on an individual message through
+    /// <c>HttpRequestMessage.Options</c> (net5.0+) or <c>HttpRequestMessage.Properties</c> (earlier
+    /// targets), using <see cref="ServiceOptionKey"/>, <see cref="RegionOptionKey"/>, and
+    /// <see cref="SignPayloadOptionKey"/>.
+    /// </para>
+    /// <para>
+    /// Credentials are resolved on every send (not captured at construction), so a rotating credential
+    /// source such as SSO, assume-role, or IMDS always signs with current credentials.
+    /// </para>
+    /// <para>
+    /// <b>Important — disable automatic redirects.</b> The primary/inner handler must set
+    /// <c>AllowAutoRedirect = false</c>. An auto-followed redirect is replayed below this handler, so it is
+    /// not re-signed; because it often targets a different host it would carry a signature computed for the
+    /// original host and be rejected. Handle redirects above this handler so each hop is re-signed.
+    /// </para>
+    /// <para>
+    /// <b>Important — retry ordering.</b> Any retry handler must sit <i>outside</i> (before) this handler in
+    /// the chain so each attempt re-enters signing and is signed with a fresh timestamp. A retry handler
+    /// placed closer to the transport would replay one frozen signature and a delayed retry could fall
+    /// outside the allowed clock-skew window.
+    /// </para>
+    /// <para>
+    /// To hash the body the handler buffers request content into memory (and rebuffers it as re-readable
+    /// content so it survives a resend on retry). For a large or streaming upload where this is undesirable,
+    /// set <see cref="AWSSigningParameters.SignPayload"/> to <c>false</c> (the body is signed as
+    /// UNSIGNED-PAYLOAD and never read; requires HTTPS) or supply a precomputed
+    /// <c>x-amz-content-sha256</c> header (the body is not read).
+    /// </para>
+    /// </remarks>
+    public class SigV4SigningHandler : DelegatingHandler
+    {
+        /// <summary>
+        /// The <c>HttpRequestMessage.Options</c> / <c>Properties</c> key (a <see cref="string"/>) that
+        /// overrides the signing service for a single request.
+        /// </summary>
+        public const string ServiceOptionKey = "Amazon.Runtime.Signing.Service";
+
+        /// <summary>
+        /// The <c>HttpRequestMessage.Options</c> / <c>Properties</c> key (a <see cref="string"/>) that
+        /// overrides the signing region for a single request.
+        /// </summary>
+        public const string RegionOptionKey = "Amazon.Runtime.Signing.Region";
+
+        /// <summary>
+        /// The <c>HttpRequestMessage.Options</c> / <c>Properties</c> key (a <see cref="bool"/>) that
+        /// overrides payload signing for a single request.
+        /// </summary>
+        public const string SignPayloadOptionKey = "Amazon.Runtime.Signing.SignPayload";
+
+        private readonly AWSSigningParameters _parameters;
+
+        /// <summary>
+        /// Creates a handler that signs each request for the given credentials, region, and service.
+        /// </summary>
+        /// <param name="credentials">The credentials to sign with; resolved on every send.</param>
+        /// <param name="region">The default signing region.</param>
+        /// <param name="service">The default signing service name, e.g. "execute-api".</param>
+        public SigV4SigningHandler(AWSCredentials credentials, RegionEndpoint region, string service)
+            : this(BuildParameters(credentials, region, service))
+        {
+        }
+
+        /// <summary>
+        /// Creates a handler from a set of default signing parameters. <see cref="AWSSigningParameters.Credentials"/>
+        /// is resolved on every send. Leave <see cref="AWSSigningParameters.SignedAt"/> unset so each request is
+        /// signed with a current timestamp.
+        /// </summary>
+        /// <param name="parameters">The default signing parameters.</param>
+        public SigV4SigningHandler(AWSSigningParameters parameters)
+        {
+            _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+            if (_parameters.Credentials == null)
+                throw new ArgumentException("Credentials must be set.", nameof(parameters));
+            if (string.IsNullOrEmpty(_parameters.Region))
+                throw new ArgumentException("Region must be set.", nameof(parameters));
+            if (string.IsNullOrEmpty(_parameters.Service))
+                throw new ArgumentException("Service must be set.", nameof(parameters));
+        }
+
+        /// <summary>
+        /// Signs <paramref name="request"/> with SigV4 and forwards it to the inner handler.
+        /// </summary>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            if (request.RequestUri == null || !request.RequestUri.IsAbsoluteUri)
+                throw new InvalidOperationException(
+                    "The request URI must be an absolute URI. Set HttpClient.BaseAddress or use an absolute request URI.");
+
+            var parameters = ResolveParameters(request);
+            var signingRequest = await BuildSigningRequestAsync(request, parameters).ConfigureAwait(false);
+
+            var result = await AWSSigV4Signer.SignAsync(signingRequest, parameters, cancellationToken).ConfigureAwait(false);
+
+            ApplySigningHeaders(request, result);
+
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static AWSSigningParameters BuildParameters(AWSCredentials credentials, RegionEndpoint region, string service)
+        {
+            if (region == null)
+                throw new ArgumentNullException(nameof(region));
+
+            return new AWSSigningParameters
+            {
+                Credentials = credentials,
+                Region = region.SystemName,
+                Service = service,
+            };
+        }
+
+        // Produce a per-request copy of the defaults, applying any per-message overrides. A copy is required
+        // because the same handler instance signs concurrent requests that may carry different overrides.
+        private AWSSigningParameters ResolveParameters(HttpRequestMessage request)
+        {
+            var parameters = new AWSSigningParameters
+            {
+                Credentials = _parameters.Credentials,
+                Region = _parameters.Region,
+                Service = _parameters.Service,
+                SignPayload = _parameters.SignPayload,
+                SignedAt = _parameters.SignedAt,
+            };
+
+            if (TryGetOption(request, ServiceOptionKey, out string service) && !string.IsNullOrEmpty(service))
+                parameters.Service = service;
+            if (TryGetOption(request, RegionOptionKey, out string region) && !string.IsNullOrEmpty(region))
+                parameters.Region = region;
+            if (TryGetOption(request, SignPayloadOptionKey, out bool signPayload))
+                parameters.SignPayload = signPayload;
+
+            return parameters;
+        }
+
+        private static async Task<AWSSigningRequest> BuildSigningRequestAsync(HttpRequestMessage request, AWSSigningParameters parameters)
+        {
+            // The body is only needed when the signer will hash it: payload signing is on and the caller
+            // hasn't already supplied a hash. Otherwise (UNSIGNED-PAYLOAD, or a precomputed hash) the body is
+            // never read, which is what keeps a large or streaming upload from being buffered.
+            var hasPrecomputedHash = HasContentSha256Header(request);
+            var mustHashBody = parameters.SignPayload && !hasPrecomputedHash && request.Content != null;
+
+            byte[] body = null;
+            if (mustHashBody)
+            {
+                body = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+                // Replace the (possibly one-shot) content with a re-readable buffer so the body survives a
+                // resend on retry, preserving the original content headers.
+                var buffered = new ByteArrayContent(body);
+                foreach (var header in request.Content.Headers)
+                    buffered.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                request.Content = buffered;
+            }
+
+            return new AWSSigningRequest
+            {
+                HttpMethod = request.Method.Method,
+                RequestUri = request.RequestUri,
+                Headers = CollectHeaders(request),
+                Content = body,
+            };
+        }
+
+        // Flatten the request and content headers into the single-value-per-name shape AWSSigningRequest
+        // expects. A multi-valued header is joined with commas, each value trimmed, per the SigV4 canonical
+        // form documented on AWSSigningRequest.Headers.
+        private static IDictionary<string, string> CollectHeaders(HttpRequestMessage request)
+        {
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var header in request.Headers)
+                headers[header.Key] = JoinValues(header.Value);
+
+            if (request.Content != null)
+            {
+                foreach (var header in request.Content.Headers)
+                    headers[header.Key] = JoinValues(header.Value);
+            }
+
+            return headers;
+        }
+
+        private static string JoinValues(IEnumerable<string> values)
+        {
+            return string.Join(",", values.Select(v => v == null ? string.Empty : v.Trim()));
+        }
+
+        private static bool HasContentSha256Header(HttpRequestMessage request)
+        {
+            if (request.Headers.TryGetValues(HeaderKeys.XAmzContentSha256Header, out var values) &&
+                values.Any(v => !string.IsNullOrWhiteSpace(v)))
+                return true;
+
+            if (request.Content != null &&
+                request.Content.Headers.TryGetValues(HeaderKeys.XAmzContentSha256Header, out var contentValues) &&
+                contentValues.Any(v => !string.IsNullOrWhiteSpace(v)))
+                return true;
+
+            return false;
+        }
+
+        // Apply the computed signing headers, replacing any left over from a previous signing pass so a
+        // re-signed retry does not accumulate duplicate Authorization / X-Amz-Date headers.
+        private static void ApplySigningHeaders(HttpRequestMessage request, AWSSigningResult result)
+        {
+            foreach (var header in result.Headers)
+            {
+                request.Headers.Remove(header.Key);
+                request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+#if NET5_0_OR_GREATER
+        private static bool TryGetOption<T>(HttpRequestMessage request, string key, out T value)
+        {
+            return request.Options.TryGetValue(new HttpRequestOptionsKey<T>(key), out value);
+        }
+#else
+        private static bool TryGetOption<T>(HttpRequestMessage request, string key, out T value)
+        {
+            if (request.Properties.TryGetValue(key, out var raw) && raw is T typed)
+            {
+                value = typed;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+#endif
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
@@ -125,7 +125,7 @@ namespace Amazon.Runtime.Signing
                     "The request URI must be an absolute URI. Set HttpClient.BaseAddress or use an absolute request URI.");
 
             var parameters = ResolveParameters(request);
-            var signingRequest = await BuildSigningRequestAsync(request, parameters).ConfigureAwait(false);
+            var signingRequest = await BuildSigningRequestAsync(request, parameters, cancellationToken).ConfigureAwait(false);
 
             var result = await AWSSigV4Signer.SignAsync(signingRequest, parameters, cancellationToken).ConfigureAwait(false);
 
@@ -170,7 +170,7 @@ namespace Amazon.Runtime.Signing
             return parameters;
         }
 
-        private static async Task<AWSSigningRequest> BuildSigningRequestAsync(HttpRequestMessage request, AWSSigningParameters parameters)
+        private static async Task<AWSSigningRequest> BuildSigningRequestAsync(HttpRequestMessage request, AWSSigningParameters parameters, CancellationToken cancellationToken)
         {
             // The body is only needed when the signer will hash it: payload signing is on and the caller
             // hasn't already supplied a hash. Otherwise (UNSIGNED-PAYLOAD, or a precomputed hash) the body is
@@ -181,7 +181,12 @@ namespace Amazon.Runtime.Signing
             byte[] body = null;
             if (mustHashBody)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+#if NET5_0_OR_GREATER
+                body = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+#else
                 body = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+#endif
 
                 // Replace the (possibly one-shot) content with a re-readable buffer so the body survives a
                 // resend on retry, preserving the original content headers.
@@ -239,13 +244,36 @@ namespace Amazon.Runtime.Signing
         }
 
         // Apply the computed signing headers, replacing any left over from a previous signing pass so a
-        // re-signed retry does not accumulate duplicate Authorization / X-Amz-Date headers.
+        // re-signed retry does not accumulate duplicate header lines. A signing header may also have been set
+        // by the caller on the content headers (e.g. a precomputed X-Amz-Content-SHA256), so clear it from
+        // there too — otherwise the outgoing request carries the header twice (once on the request, once on
+        // the content), which SigV4 validation can reject.
         private static void ApplySigningHeaders(HttpRequestMessage request, AWSSigningResult result)
         {
             foreach (var header in result.Headers)
             {
+                RemoveFromContentHeaders(request.Content, header.Key);
                 request.Headers.Remove(header.Key);
                 request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        // Remove a signing header from the content headers if present. HttpContentHeaders validates the name
+        // and throws for a request-only header (e.g. Authorization), so guard the call: request-only headers
+        // can never be on the content headers anyway, and a custom header such as x-amz-content-sha256 (which
+        // a caller may have set there) is removed cleanly.
+        private static void RemoveFromContentHeaders(HttpContent content, string name)
+        {
+            if (content == null)
+                return;
+
+            try
+            {
+                content.Headers.Remove(name);
+            }
+            catch (InvalidOperationException)
+            {
+                // Not a valid content header name, so it cannot have been set on the content headers.
             }
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
@@ -45,9 +45,11 @@ namespace Amazon.Runtime.Signing
     /// </para>
     /// <para>
     /// <b>Important — disable automatic redirects.</b> The primary/inner handler must set
-    /// <c>AllowAutoRedirect = false</c>. An auto-followed redirect is replayed below this handler, so it is
-    /// not re-signed; because it often targets a different host it would carry a signature computed for the
-    /// original host and be rejected. Handle redirects above this handler so each hop is re-signed.
+    /// <c>AllowAutoRedirect = false</c>. An auto-followed redirect is handled by the transport below this
+    /// handler, so it is never re-signed: a cross-host redirect has its Authorization header stripped by the
+    /// runtime and arrives unsigned, and a same-host redirect replays the original signature over a canonical
+    /// request that no longer matches the new path or query. Either way the redirected hop is rejected. Handle
+    /// redirects above this handler so each hop is re-signed for its own destination.
     /// </para>
     /// <para>
     /// <b>Important — retry ordering.</b> Any retry handler must sit <i>outside</i> (before) this handler in

--- a/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
@@ -120,11 +120,7 @@ namespace Amazon.Runtime.Signing
         /// </summary>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-            if (request.RequestUri == null || !request.RequestUri.IsAbsoluteUri)
-                throw new InvalidOperationException(
-                    "The request URI must be an absolute URI. Set HttpClient.BaseAddress or use an absolute request URI.");
+            ValidateRequest(request);
 
             var parameters = ResolveParameters(request);
             var signingRequest = await BuildSigningRequestAsync(request, parameters, cancellationToken).ConfigureAwait(false);
@@ -134,6 +130,36 @@ namespace Amazon.Runtime.Signing
             ApplySigningHeaders(request, result);
 
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+#if NET5_0_OR_GREATER
+        /// <summary>
+        /// Signs <paramref name="request"/> with SigV4 and forwards it to the inner handler synchronously.
+        /// Present so a synchronous <c>HttpClient.Send</c> is signed too, rather than bypassing this handler
+        /// and going out unsigned via the base implementation.
+        /// </summary>
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            ValidateRequest(request);
+
+            var parameters = ResolveParameters(request);
+            var signingRequest = BuildSigningRequest(request, parameters, cancellationToken);
+
+            var result = AWSSigV4Signer.Sign(signingRequest, parameters);
+
+            ApplySigningHeaders(request, result);
+
+            return base.Send(request, cancellationToken);
+        }
+#endif
+
+        private static void ValidateRequest(HttpRequestMessage request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            if (request.RequestUri == null || !request.RequestUri.IsAbsoluteUri)
+                throw new InvalidOperationException(
+                    "The request URI must be an absolute URI. Set HttpClient.BaseAddress or use an absolute request URI.");
         }
 
         private static AWSSigV4Parameters BuildParameters(AWSCredentials credentials, RegionEndpoint region, string service)
@@ -172,16 +198,37 @@ namespace Amazon.Runtime.Signing
             return parameters;
         }
 
+        // The body is only needed when the signer will hash it: payload signing is on and the caller hasn't
+        // already supplied a hash. Otherwise (UNSIGNED-PAYLOAD, or a precomputed hash) the body is never read,
+        // which is what keeps a large or streaming upload from being buffered.
+        private static bool MustHashBody(HttpRequestMessage request, AWSSigV4Parameters parameters)
+        {
+            return parameters.SignPayload && !HasContentSha256Header(request) && request.Content != null;
+        }
+
+        private static AWSSigningRequest NewSigningRequest(HttpRequestMessage request, byte[] body)
+        {
+            // Drop a security-token header left over from an earlier signing pass before collecting headers.
+            // On a re-signed retry the credentials may have changed from short-term to long-term; if the stale
+            // token stayed on the request it would be collected into the signing request, signed, and echoed
+            // back in the result even though the current credentials carry no token. Removing it here means the
+            // token is present only when the current pass's credentials re-add it.
+            request.Headers.Remove(HeaderKeys.XAmzSecurityTokenHeader);
+
+            var signingRequest = new AWSSigningRequest
+            {
+                HttpMethod = request.Method,
+                RequestUri = request.RequestUri,
+                Content = body,
+            };
+            CollectHeaders(request, signingRequest.Headers);
+            return signingRequest;
+        }
+
         private static async Task<AWSSigningRequest> BuildSigningRequestAsync(HttpRequestMessage request, AWSSigV4Parameters parameters, CancellationToken cancellationToken)
         {
-            // The body is only needed when the signer will hash it: payload signing is on and the caller
-            // hasn't already supplied a hash. Otherwise (UNSIGNED-PAYLOAD, or a precomputed hash) the body is
-            // never read, which is what keeps a large or streaming upload from being buffered.
-            var hasPrecomputedHash = HasContentSha256Header(request);
-            var mustHashBody = parameters.SignPayload && !hasPrecomputedHash && request.Content != null;
-
             byte[] body = null;
-            if (mustHashBody)
+            if (MustHashBody(request, parameters))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 // Reading the content here to hash it also buffers it internally: HttpContent loads its body
@@ -195,20 +242,33 @@ namespace Amazon.Runtime.Signing
 #endif
             }
 
-            var signingRequest = new AWSSigningRequest
-            {
-                HttpMethod = request.Method,
-                RequestUri = request.RequestUri,
-                Content = body,
-            };
-            CollectHeaders(request, signingRequest.Headers);
-            return signingRequest;
+            return NewSigningRequest(request, body);
         }
+
+#if NET5_0_OR_GREATER
+        private static AWSSigningRequest BuildSigningRequest(HttpRequestMessage request, AWSSigV4Parameters parameters, CancellationToken cancellationToken)
+        {
+            byte[] body = null;
+            if (MustHashBody(request, parameters))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // ReadAsByteArrayAsync buffers the content in memory (so it survives a retry resend) and, once
+                // buffered, completes synchronously — the same read the async path uses. The BCL exposes no
+                // fully synchronous buffering primitive, so block on it here to keep the sync send genuinely
+                // synchronous end to end.
+                body = request.Content.ReadAsByteArrayAsync(cancellationToken).GetAwaiter().GetResult();
+            }
+
+            return NewSigningRequest(request, body);
+        }
+#endif
 
         // Flatten the request and content headers into the single-value-per-name shape AWSSigningRequest
         // expects, adding them to its (case-insensitive, get-only) Headers collection. A multi-valued header
         // is joined with commas, each value trimmed, per the SigV4 canonical form documented on
-        // AWSSigningRequest.Headers.
+        // AWSSigningRequest.Headers. When the same header name appears on both the request and the content,
+        // HttpClient sends both values (request first, then content) as one comma-joined line, so the
+        // signature must cover that same combined value rather than only the content value.
         private static void CollectHeaders(HttpRequestMessage request, IDictionary<string, string> headers)
         {
             foreach (var header in request.Headers)
@@ -217,7 +277,12 @@ namespace Amazon.Runtime.Signing
             if (request.Content != null)
             {
                 foreach (var header in request.Content.Headers)
-                    headers[header.Key] = JoinValues(header.Value);
+                {
+                    var contentValue = JoinValues(header.Value);
+                    headers[header.Key] = headers.TryGetValue(header.Key, out var requestValue)
+                        ? requestValue + "," + contentValue
+                        : contentValue;
+                }
             }
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
@@ -58,7 +58,7 @@ namespace Amazon.Runtime.Signing
     /// <para>
     /// To hash the body the handler buffers request content into memory (and rebuffers it as re-readable
     /// content so it survives a resend on retry). For a large or streaming upload where this is undesirable,
-    /// set <see cref="AWSSigningParameters.SignPayload"/> to <c>false</c> (the body is signed as
+    /// set <see cref="AWSSigV4Parameters.SignPayload"/> to <c>false</c> (the body is signed as
     /// UNSIGNED-PAYLOAD and never read; requires HTTPS) or supply a precomputed
     /// <c>x-amz-content-sha256</c> header (the body is not read).
     /// </para>
@@ -83,7 +83,7 @@ namespace Amazon.Runtime.Signing
         /// </summary>
         public const string SignPayloadOptionKey = "Amazon.Runtime.Signing.SignPayload";
 
-        private readonly AWSSigningParameters _parameters;
+        private readonly AWSSigV4Parameters _parameters;
 
         /// <summary>
         /// Creates a handler that signs each request for the given credentials, region, and service.
@@ -97,17 +97,17 @@ namespace Amazon.Runtime.Signing
         }
 
         /// <summary>
-        /// Creates a handler from a set of default signing parameters. <see cref="AWSSigningParameters.Credentials"/>
-        /// is resolved on every send. Leave <see cref="AWSSigningParameters.SignedAt"/> unset so each request is
+        /// Creates a handler from a set of default signing parameters. <see cref="AWSSigV4Parameters.Credentials"/>
+        /// is resolved on every send. Leave <see cref="AWSSigV4Parameters.SignedAt"/> unset so each request is
         /// signed with a current timestamp.
         /// </summary>
         /// <param name="parameters">The default signing parameters.</param>
-        public SigV4SigningHandler(AWSSigningParameters parameters)
+        public SigV4SigningHandler(AWSSigV4Parameters parameters)
         {
             _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
             if (_parameters.Credentials == null)
                 throw new ArgumentException("Credentials must be set.", nameof(parameters));
-            if (string.IsNullOrEmpty(_parameters.Region))
+            if (_parameters.Region == null)
                 throw new ArgumentException("Region must be set.", nameof(parameters));
             if (string.IsNullOrEmpty(_parameters.Service))
                 throw new ArgumentException("Service must be set.", nameof(parameters));
@@ -134,24 +134,24 @@ namespace Amazon.Runtime.Signing
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-        private static AWSSigningParameters BuildParameters(AWSCredentials credentials, RegionEndpoint region, string service)
+        private static AWSSigV4Parameters BuildParameters(AWSCredentials credentials, RegionEndpoint region, string service)
         {
             if (region == null)
                 throw new ArgumentNullException(nameof(region));
 
-            return new AWSSigningParameters
+            return new AWSSigV4Parameters
             {
                 Credentials = credentials,
-                Region = region.SystemName,
+                Region = region,
                 Service = service,
             };
         }
 
         // Produce a per-request copy of the defaults, applying any per-message overrides. A copy is required
         // because the same handler instance signs concurrent requests that may carry different overrides.
-        private AWSSigningParameters ResolveParameters(HttpRequestMessage request)
+        private AWSSigV4Parameters ResolveParameters(HttpRequestMessage request)
         {
-            var parameters = new AWSSigningParameters
+            var parameters = new AWSSigV4Parameters
             {
                 Credentials = _parameters.Credentials,
                 Region = _parameters.Region,
@@ -163,14 +163,14 @@ namespace Amazon.Runtime.Signing
             if (TryGetOption(request, ServiceOptionKey, out string service) && !string.IsNullOrEmpty(service))
                 parameters.Service = service;
             if (TryGetOption(request, RegionOptionKey, out string region) && !string.IsNullOrEmpty(region))
-                parameters.Region = region;
+                parameters.Region = RegionEndpoint.GetBySystemName(region);
             if (TryGetOption(request, SignPayloadOptionKey, out bool signPayload))
                 parameters.SignPayload = signPayload;
 
             return parameters;
         }
 
-        private static async Task<AWSSigningRequest> BuildSigningRequestAsync(HttpRequestMessage request, AWSSigningParameters parameters, CancellationToken cancellationToken)
+        private static async Task<AWSSigningRequest> BuildSigningRequestAsync(HttpRequestMessage request, AWSSigV4Parameters parameters, CancellationToken cancellationToken)
         {
             // The body is only needed when the signer will hash it: payload signing is on and the caller
             // hasn't already supplied a hash. Otherwise (UNSIGNED-PAYLOAD, or a precomputed hash) the body is
@@ -196,22 +196,22 @@ namespace Amazon.Runtime.Signing
                 request.Content = buffered;
             }
 
-            return new AWSSigningRequest
+            var signingRequest = new AWSSigningRequest
             {
-                HttpMethod = request.Method.Method,
+                HttpMethod = request.Method,
                 RequestUri = request.RequestUri,
-                Headers = CollectHeaders(request),
                 Content = body,
             };
+            CollectHeaders(request, signingRequest.Headers);
+            return signingRequest;
         }
 
         // Flatten the request and content headers into the single-value-per-name shape AWSSigningRequest
-        // expects. A multi-valued header is joined with commas, each value trimmed, per the SigV4 canonical
-        // form documented on AWSSigningRequest.Headers.
-        private static IDictionary<string, string> CollectHeaders(HttpRequestMessage request)
+        // expects, adding them to its (case-insensitive, get-only) Headers collection. A multi-valued header
+        // is joined with commas, each value trimmed, per the SigV4 canonical form documented on
+        // AWSSigningRequest.Headers.
+        private static void CollectHeaders(HttpRequestMessage request, IDictionary<string, string> headers)
         {
-            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
             foreach (var header in request.Headers)
                 headers[header.Key] = JoinValues(header.Value);
 
@@ -220,8 +220,6 @@ namespace Amazon.Runtime.Signing
                 foreach (var header in request.Content.Headers)
                     headers[header.Key] = JoinValues(header.Value);
             }
-
-            return headers;
         }
 
         private static string JoinValues(IEnumerable<string> values)

--- a/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
@@ -184,18 +184,15 @@ namespace Amazon.Runtime.Signing
             if (mustHashBody)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                // Reading the content here to hash it also buffers it internally: HttpContent loads its body
+                // into an in-memory buffer on the first read, so the same message can be re-serialized on a
+                // retry resend without re-reading (or exhausting) a one-shot stream. No explicit rebuffering is
+                // needed to make the body survive a resend.
 #if NET5_0_OR_GREATER
                 body = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 #else
                 body = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 #endif
-
-                // Replace the (possibly one-shot) content with a re-readable buffer so the body survives a
-                // resend on retry, preserving the original content headers.
-                var buffered = new ByteArrayContent(body);
-                foreach (var header in request.Content.Headers)
-                    buffered.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                request.Content = buffered;
             }
 
             var signingRequest = new AWSSigningRequest

--- a/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
@@ -40,10 +40,6 @@ namespace Amazon.Runtime.Signing
     /// <see cref="SignPayloadOptionKey"/>.
     /// </para>
     /// <para>
-    /// Credentials are resolved on every send (not captured at construction), so a rotating credential
-    /// source such as SSO, assume-role, or IMDS always signs with current credentials.
-    /// </para>
-    /// <para>
     /// <b>Important — disable automatic redirects.</b> The primary/inner handler must set
     /// <c>AllowAutoRedirect = false</c>. An auto-followed redirect is handled by the transport below this
     /// handler, so it is never re-signed: a cross-host redirect has its Authorization header stripped by the
@@ -93,26 +89,40 @@ namespace Amazon.Runtime.Signing
         /// <param name="credentials">The credentials to sign with; resolved on every send.</param>
         /// <param name="region">The default signing region.</param>
         /// <param name="service">The default signing service name, e.g. "execute-api".</param>
-        public SigV4SigningHandler(AWSCredentials credentials, RegionEndpoint region, string service)
-            : this(BuildParameters(credentials, region, service))
+        /// <param name="innerHandler">
+        /// The inner handler that sends the signed request. When null, a default transport handler is used.
+        /// </param>
+        public SigV4SigningHandler(AWSCredentials credentials, RegionEndpoint region, string service, HttpMessageHandler innerHandler = null)
+            : this(BuildParameters(credentials, region, service), innerHandler)
         {
         }
 
         /// <summary>
-        /// Creates a handler from a set of default signing parameters. <see cref="AWSSigV4Parameters.Credentials"/>
-        /// is resolved on every send. Leave <see cref="AWSSigV4Parameters.SignedAt"/> unset so each request is
-        /// signed with a current timestamp.
+        /// Creates a handler from a set of default signing parameters. Leave
+        /// <see cref="AWSSigV4Parameters.SignedAt"/> unset so each request is signed with a current timestamp.
         /// </summary>
         /// <param name="parameters">The default signing parameters.</param>
-        public SigV4SigningHandler(AWSSigV4Parameters parameters)
+        /// <param name="innerHandler">
+        /// The inner handler that sends the signed request. When null, a default transport handler is used.
+        /// </param>
+        public SigV4SigningHandler(AWSSigV4Parameters parameters, HttpMessageHandler innerHandler = null)
+            : base(innerHandler ?? CreateDefaultInnerHandler())
         {
             _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
-            if (_parameters.Credentials == null)
-                throw new ArgumentException("Credentials must be set.", nameof(parameters));
-            if (_parameters.Region == null)
-                throw new ArgumentException("Region must be set.", nameof(parameters));
             if (string.IsNullOrEmpty(_parameters.Service))
                 throw new ArgumentException("Service must be set.", nameof(parameters));
+        }
+
+        // The inner handler must not auto-follow redirects: a followed redirect is replayed below this handler
+        // (unsigned for the new host) and would be rejected, so the default transport disables it. On .NET Core
+        // 2.1+ SocketsHttpHandler is the modern transport; earlier targets have only HttpClientHandler.
+        private static HttpMessageHandler CreateDefaultInnerHandler()
+        {
+#if NETCOREAPP3_1_OR_GREATER
+            return new SocketsHttpHandler { AllowAutoRedirect = false };
+#else
+            return new HttpClientHandler { AllowAutoRedirect = false };
+#endif
         }
 
         /// <summary>

--- a/sdk/test/IntegrationTests/Tests/SigV4SigningHandlerIntegrationTests.cs
+++ b/sdk/test/IntegrationTests/Tests/SigV4SigningHandlerIntegrationTests.cs
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.Signing;
+using Xunit;
+
+namespace AWSSDK_DotNet.IntegrationTests.Tests
+{
+    /// <summary>
+    /// End-to-end tests for <see cref="SigV4SigningHandler"/>. These install the handler on a real
+    /// <see cref="HttpClient"/> and send requests to STS, proving that a request signed transparently by the
+    /// handler is accepted by a real AWS service.
+    ///
+    /// STS <c>GetCallerIdentity</c> is used because it is callable by any valid identity and needs no
+    /// provisioned resources. It accepts the request either as a GET (empty body) or a POST with the action
+    /// in a form-encoded body, so the same operation exercises both the no-body and body-hashing paths.
+    /// </summary>
+    [Trait("Category", "SigV4Signer")]
+    [Collection("Serial")]
+    public class SigV4SigningHandlerIntegrationTests
+    {
+        private const string StsService = "sts";
+
+        private static string Region => FallbackRegionFactory.GetRegionEndpoint()?.SystemName ?? "us-east-1";
+
+        private static Uri StsEndpoint() => new Uri($"https://sts.{Region}.amazonaws.com/");
+
+        private static HttpClient NewSignedClient()
+        {
+            var handler = new SigV4SigningHandler(
+                FallbackCredentialsFactory.GetCredentials(),
+                RegionEndpoint.GetBySystemName(Region),
+                StsService)
+            {
+                // A signing handler must not auto-follow redirects: a redirect is replayed below this handler
+                // (unsigned for the new host) and would be rejected. STS won't redirect here, but this is the
+                // correct production configuration and keeps the test faithful to documented guidance.
+                InnerHandler = new HttpClientHandler { AllowAutoRedirect = false },
+            };
+
+            return new HttpClient(handler);
+        }
+
+        [Fact]
+        [Trait("Category", "SigV4Signer")]
+        public async Task Get_GetCallerIdentity_SucceedsAgainstSts()
+        {
+            using (var client = NewSignedClient())
+            {
+                var uri = new Uri(StsEndpoint(), "?Action=GetCallerIdentity&Version=2011-06-15");
+
+                using (var response = await client.GetAsync(uri))
+                {
+                    var body = await response.Content.ReadAsStringAsync();
+                    Assert.True(response.StatusCode == HttpStatusCode.OK, $"STS returned {(int)response.StatusCode}: {body}");
+                    Assert.Contains("<Arn>", body);
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "SigV4Signer")]
+        public async Task Post_WithBody_GetCallerIdentity_SucceedsAgainstSts()
+        {
+            // A form-encoded POST body proves the handler buffers and hashes the payload end-to-end: STS
+            // recomputes the body hash and rejects the signature if it does not match what the handler signed.
+            using (var client = NewSignedClient())
+            {
+                var content = new StringContent(
+                    "Action=GetCallerIdentity&Version=2011-06-15",
+                    Encoding.UTF8,
+                    "application/x-www-form-urlencoded");
+
+                using (var response = await client.PostAsync(StsEndpoint(), content))
+                {
+                    var body = await response.Content.ReadAsStringAsync();
+                    Assert.True(response.StatusCode == HttpStatusCode.OK, $"STS returned {(int)response.StatusCode}: {body}");
+                    Assert.Contains("<Arn>", body);
+                }
+            }
+        }
+    }
+}

--- a/sdk/test/IntegrationTests/Tests/SigV4SigningHandlerIntegrationTests.cs
+++ b/sdk/test/IntegrationTests/Tests/SigV4SigningHandlerIntegrationTests.cs
@@ -20,6 +20,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.Runtime;
+using Amazon.Runtime.Credentials;
 using Amazon.Runtime.Signing;
 using Xunit;
 
@@ -47,7 +48,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
         private static HttpClient NewSignedClient()
         {
             var handler = new SigV4SigningHandler(
-                FallbackCredentialsFactory.GetCredentials(),
+                DefaultAWSCredentialsIdentityResolver.GetCredentials(),
                 RegionEndpoint.GetBySystemName(Region),
                 StsService)
             {

--- a/sdk/test/IntegrationTests/Tests/SigV4SigningHandlerIntegrationTests.cs
+++ b/sdk/test/IntegrationTests/Tests/SigV4SigningHandlerIntegrationTests.cs
@@ -36,7 +36,6 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
     /// in a form-encoded body, so the same operation exercises both the no-body and body-hashing paths.
     /// </summary>
     [Trait("Category", "SigV4Signer")]
-    [Collection("Serial")]
     public class SigV4SigningHandlerIntegrationTests
     {
         private const string StsService = "sts";
@@ -92,6 +91,36 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
                     "application/x-www-form-urlencoded");
 
                 using (var response = await client.PostAsync(StsEndpoint(), content))
+                {
+                    var body = await response.Content.ReadAsStringAsync();
+                    Assert.True(response.StatusCode == HttpStatusCode.OK, $"STS returned {(int)response.StatusCode}: {body}");
+                    Assert.Contains("<Arn>", body);
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "SigV4Signer")]
+        public async Task Post_WithSameHeaderOnRequestAndContent_SucceedsAgainstSts()
+        {
+            // A header set on both the request and the content goes on the wire as two lines (request value
+            // first, then content value), which SigV4 canonicalizes as one comma-joined value in that order.
+            // The handler must sign that same combined value. STS includes the header in SignedHeaders and
+            // recomputes the signature over the value it received, so a wrong combination (or order) is
+            // rejected with a 403 SignatureDoesNotMatch — making a 200 here proof the combination is correct
+            // end-to-end.
+            using (var client = NewSignedClient())
+            {
+                var content = new StringContent(
+                    "Action=GetCallerIdentity&Version=2011-06-15",
+                    Encoding.UTF8,
+                    "application/x-www-form-urlencoded");
+                content.Headers.TryAddWithoutValidation("x-custom", "content-value");
+
+                var request = new HttpRequestMessage(HttpMethod.Post, StsEndpoint()) { Content = content };
+                request.Headers.TryAddWithoutValidation("x-custom", "request-value");
+
+                using (var response = await client.SendAsync(request))
                 {
                     var body = await response.Content.ReadAsStringAsync();
                     Assert.True(response.StatusCode == HttpStatusCode.OK, $"STS returned {(int)response.StatusCode}: {body}");

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/AWSSigV4SignerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/AWSSigV4SignerTests.cs
@@ -915,8 +915,9 @@ namespace AWSSDK.UnitTests.Signing
         }
 
         [TestMethod]
-        public void Sign_MissingRegion_Throws()
+        public void Sign_MissingRegion_FallsBackToAmbientRegion()
         {
+            // A null Region is not an error: it resolves from the environment like the service clients do.
             var request = new AWSSigningRequest
             {
                 HttpMethod = HttpMethod.Get,
@@ -925,7 +926,22 @@ namespace AWSSDK.UnitTests.Signing
             var parameters = BaseParameters();
             parameters.Region = null;
 
-            AssertThrows<ArgumentException>(() => AWSSigV4Signer.Sign(request, parameters));
+            var original = Environment.GetEnvironmentVariable(EnvironmentVariableAWSRegion.ENVIRONMENT_VARIABLE_REGION);
+            try
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariableAWSRegion.ENVIRONMENT_VARIABLE_REGION, "us-west-2");
+                FallbackRegionFactory.Reset();
+
+                var result = AWSSigV4Signer.Sign(request, parameters);
+
+                // The ambient region flows into the credential scope of the Authorization header.
+                StringAssert.Contains(result.Headers[HeaderKeys.AuthorizationHeader], "/us-west-2/");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariableAWSRegion.ENVIRONMENT_VARIABLE_REGION, original);
+                FallbackRegionFactory.Reset();
+            }
         }
 
         // -----------------------------------------------------------------------

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
@@ -14,7 +14,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -207,6 +206,9 @@ namespace AWSSDK.UnitTests.Signing
             await invoker.SendAsync(message, CancellationToken.None);
 
             Assert.AreEqual(precomputed, message.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single());
+            // The caller set the hash on the content headers; after signing it must live only on the request
+            // headers, not on both, or the outgoing request would carry a duplicate x-amz-content-sha256 line.
+            Assert.IsFalse(message.Content.Headers.Contains(HeaderKeys.XAmzContentSha256Header));
         }
 
         // -----------------------------------------------------------------------

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
@@ -157,6 +157,39 @@ namespace AWSSDK.UnitTests.Signing
             Assert.AreEqual(1, message.Headers.GetValues(HeaderKeys.XAmzDateHeader).Count());
         }
 
+        [TestMethod]
+        public async Task Send_ReSigningMessageWithBody_ResendsAndReHashesBody()
+        {
+            // A retry replays the same message. The handler rebuffers the content as re-readable, so the body
+            // must survive the second send (not be consumed on the first) and produce the same body hash and a
+            // single, non-duplicated set of signing headers on the resend.
+            var handler = NewHandler(out var inner);
+            inner.CaptureBody = true;
+            var invoker = new HttpMessageInvoker(handler);
+
+            const string body = "{\"a\":1}";
+            var message = new HttpRequestMessage(HttpMethod.Post, "https://example.execute-api.us-east-1.amazonaws.com/items")
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+            var expectedHash = AWSSDKUtils.ToHex(
+                CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(Encoding.UTF8.GetBytes(body)), true);
+
+            // First attempt.
+            await invoker.SendAsync(message, CancellationToken.None);
+            Assert.AreEqual(body, inner.LastContentBody);
+            Assert.AreEqual(expectedHash, inner.LastRequest.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single());
+
+            // Retry: same message re-enters the handler. The body must still be readable and re-hashed.
+            await invoker.SendAsync(message, CancellationToken.None);
+            Assert.AreEqual(body, inner.LastContentBody);
+            Assert.AreEqual(expectedHash, inner.LastRequest.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single());
+
+            // Signing headers replaced, not accumulated, across the resign.
+            Assert.AreEqual(1, message.Headers.GetValues(HeaderKeys.AuthorizationHeader).Count());
+            Assert.AreEqual(1, message.Headers.GetValues(HeaderKeys.XAmzDateHeader).Count());
+        }
+
         // -----------------------------------------------------------------------
         // Per-request overrides via Options / Properties.
         // -----------------------------------------------------------------------

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
@@ -1,0 +1,325 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.Signing;
+using Amazon.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSSDK.UnitTests.Signing
+{
+    [TestClass]
+    [TestCategory("Core")]
+    [TestCategory("Signer")]
+    public class SigV4SigningHandlerTests
+    {
+        private const string AccessKey = "AKIDEXAMPLE";
+        private const string SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        private const string Region = "us-east-1";
+        private const string Service = "execute-api";
+
+        private static SigV4SigningHandler NewHandler(out CapturingInnerHandler inner)
+        {
+            return NewHandler(new BasicAWSCredentials(AccessKey, SecretKey), out inner);
+        }
+
+        private static SigV4SigningHandler NewHandler(AWSCredentials credentials, out CapturingInnerHandler inner, string region = Region, string service = Service)
+        {
+            inner = new CapturingInnerHandler();
+            return new SigV4SigningHandler(new AWSSigningParameters
+            {
+                Credentials = credentials,
+                Region = region,
+                Service = service,
+            })
+            {
+                InnerHandler = inner,
+            };
+        }
+
+        private static HttpClient NewClient(SigV4SigningHandler handler) => new HttpClient(handler);
+
+        // -----------------------------------------------------------------------
+        // Signing headers are produced and applied onto the outgoing request.
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task Send_AppliesSigningHeadersToOutgoingRequest()
+        {
+            var handler = NewHandler(out var inner);
+            using (var client = NewClient(handler))
+            {
+                await client.GetAsync("https://example.execute-api.us-east-1.amazonaws.com/items");
+            }
+
+            var sent = inner.LastRequest;
+            Assert.IsTrue(sent.Headers.Contains(HeaderKeys.AuthorizationHeader));
+            Assert.IsTrue(sent.Headers.Contains(HeaderKeys.XAmzDateHeader));
+            // execute-api signs the payload; the empty-body hash header must be present.
+            Assert.IsTrue(sent.Headers.Contains(HeaderKeys.XAmzContentSha256Header));
+            var auth = sent.Headers.GetValues(HeaderKeys.AuthorizationHeader).Single();
+            StringAssert.StartsWith(auth, "AWS4-HMAC-SHA256 ");
+            StringAssert.Contains(auth, "/us-east-1/execute-api/aws4_request");
+        }
+
+        [TestMethod]
+        public async Task Send_WithBody_SignsBufferedContent()
+        {
+            var handler = NewHandler(out var inner);
+            using (var client = NewClient(handler))
+            {
+                var content = new StringContent("{\"a\":1}", Encoding.UTF8, "application/json");
+                await client.PostAsync("https://example.execute-api.us-east-1.amazonaws.com/items", content);
+            }
+
+            var sent = inner.LastRequest;
+            var expectedHash = AWSSDKUtils.ToHex(
+                CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(Encoding.UTF8.GetBytes("{\"a\":1}")), true);
+            var actualHash = sent.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single();
+            Assert.AreEqual(expectedHash, actualHash);
+            // The body must survive as re-readable content after signing.
+            Assert.AreEqual("{\"a\":1}", await sent.Content.ReadAsStringAsync());
+        }
+
+        [TestMethod]
+        public async Task Send_WithSessionCredentials_AddsSecurityTokenHeader()
+        {
+            var handler = NewHandler(new SessionAWSCredentials(AccessKey, SecretKey, "the-session-token"), out var inner);
+            using (var client = NewClient(handler))
+            {
+                await client.GetAsync("https://example.execute-api.us-east-1.amazonaws.com/items");
+            }
+
+            var sent = inner.LastRequest;
+            Assert.AreEqual("the-session-token", sent.Headers.GetValues(HeaderKeys.XAmzSecurityTokenHeader).Single());
+            var auth = sent.Headers.GetValues(HeaderKeys.AuthorizationHeader).Single();
+            StringAssert.Contains(auth, "x-amz-security-token");
+        }
+
+        // -----------------------------------------------------------------------
+        // Credentials resolve per send.
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task Send_ResolvesCredentialsOnEverySend()
+        {
+            var credentials = new CountingCredentials(AccessKey, SecretKey);
+            var handler = NewHandler(credentials, out var inner);
+            using (var client = NewClient(handler))
+            {
+                await client.GetAsync("https://example.execute-api.us-east-1.amazonaws.com/a");
+                await client.GetAsync("https://example.execute-api.us-east-1.amazonaws.com/b");
+            }
+
+            // A long-lived client with rotating credentials must re-resolve on each send, not capture once.
+            Assert.AreEqual(2, credentials.ResolveCount);
+        }
+
+        // -----------------------------------------------------------------------
+        // Re-signing (retry): headers replaced, not duplicated.
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task Send_ReSigningSameMessage_DoesNotDuplicateHeaders()
+        {
+            var handler = NewHandler(out var inner);
+            var invoker = new HttpMessageInvoker(handler);
+
+            // Reuse the same message across two sends, as an outer retry handler would.
+            var message = new HttpRequestMessage(HttpMethod.Get, "https://example.execute-api.us-east-1.amazonaws.com/items");
+            await invoker.SendAsync(message, CancellationToken.None);
+            await invoker.SendAsync(message, CancellationToken.None);
+
+            Assert.AreEqual(1, message.Headers.GetValues(HeaderKeys.AuthorizationHeader).Count());
+            Assert.AreEqual(1, message.Headers.GetValues(HeaderKeys.XAmzDateHeader).Count());
+        }
+
+        // -----------------------------------------------------------------------
+        // Per-request overrides via Options / Properties.
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task Send_PerRequestServiceAndRegionOverride_WinsOverHandlerDefault()
+        {
+            var handler = NewHandler(out var inner); // defaults: execute-api / us-east-1
+            var invoker = new HttpMessageInvoker(handler);
+
+            var message = new HttpRequestMessage(HttpMethod.Get, "https://sts.us-west-2.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15");
+            SetOption(message, SigV4SigningHandler.ServiceOptionKey, "sts");
+            SetOption(message, SigV4SigningHandler.RegionOptionKey, "us-west-2");
+            await invoker.SendAsync(message, CancellationToken.None);
+
+            var auth = message.Headers.GetValues(HeaderKeys.AuthorizationHeader).Single();
+            StringAssert.Contains(auth, "/us-west-2/sts/aws4_request");
+        }
+
+        [TestMethod]
+        public async Task Send_SignPayloadFalseOverride_SignsUnsignedPayloadWithoutReadingBody()
+        {
+            var handler = NewHandler(out var inner);
+            var invoker = new HttpMessageInvoker(handler);
+
+            var message = new HttpRequestMessage(HttpMethod.Post, "https://example.execute-api.us-east-1.amazonaws.com/items")
+            {
+                // A stream that throws if read proves the body is never touched when SignPayload is false.
+                Content = new StreamContent(new ThrowOnReadStream()),
+            };
+            SetOption(message, SigV4SigningHandler.SignPayloadOptionKey, false);
+            await invoker.SendAsync(message, CancellationToken.None);
+
+            Assert.AreEqual("UNSIGNED-PAYLOAD", message.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single());
+        }
+
+        [TestMethod]
+        public async Task Send_PrecomputedContentHashHeader_UsedVerbatimWithoutReadingBody()
+        {
+            var handler = NewHandler(out var inner);
+            var invoker = new HttpMessageInvoker(handler);
+
+            var precomputed = new string('a', 64);
+            var message = new HttpRequestMessage(HttpMethod.Post, "https://example.execute-api.us-east-1.amazonaws.com/items")
+            {
+                Content = new StreamContent(new ThrowOnReadStream()),
+            };
+            message.Content.Headers.TryAddWithoutValidation(HeaderKeys.XAmzContentSha256Header, precomputed);
+            await invoker.SendAsync(message, CancellationToken.None);
+
+            Assert.AreEqual(precomputed, message.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single());
+        }
+
+        // -----------------------------------------------------------------------
+        // Construction and argument validation.
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public void Constructor_RegionEndpointOverload_SetsSystemNameAsRegion()
+        {
+            var handler = new SigV4SigningHandler(new BasicAWSCredentials(AccessKey, SecretKey), RegionEndpoint.USWest2, "sts")
+            {
+                InnerHandler = new CapturingInnerHandler(),
+            };
+            Assert.IsNotNull(handler); // constructed without throwing; region resolved from the endpoint
+        }
+
+        [TestMethod]
+        public void Constructor_MissingRequiredParameters_Throws()
+        {
+            AssertThrows<ArgumentNullException>(() => new SigV4SigningHandler((AWSSigningParameters)null));
+            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigningParameters { Region = Region, Service = Service }));
+            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigningParameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Service = Service }));
+            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigningParameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Region = Region }));
+        }
+
+        [TestMethod]
+        public async Task Send_RelativeUri_Throws()
+        {
+            var handler = NewHandler(out var inner);
+            var invoker = new HttpMessageInvoker(handler);
+            var message = new HttpRequestMessage(HttpMethod.Get, new Uri("/items", UriKind.Relative));
+
+            await AssertThrowsAsync<InvalidOperationException>(() => invoker.SendAsync(message, CancellationToken.None));
+        }
+
+        // -----------------------------------------------------------------------
+        // Helpers
+        // -----------------------------------------------------------------------
+
+        private static void SetOption<T>(HttpRequestMessage message, string key, T value)
+        {
+#if NET5_0_OR_GREATER
+            message.Options.Set(new HttpRequestOptionsKey<T>(key), value);
+#else
+            message.Properties[key] = value;
+#endif
+        }
+
+        private static void AssertThrows<TException>(Action action) where TException : Exception
+        {
+            try { action(); }
+            catch (TException) { return; }
+            catch (Exception ex) { Assert.Fail($"Expected {typeof(TException).Name} but got {ex.GetType().Name}."); }
+            Assert.Fail($"Expected {typeof(TException).Name} but no exception was thrown.");
+        }
+
+        private static async Task AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception
+        {
+            try { await action(); }
+            catch (TException) { return; }
+            catch (Exception ex) { Assert.Fail($"Expected {typeof(TException).Name} but got {ex.GetType().Name}."); }
+            Assert.Fail($"Expected {typeof(TException).Name} but no exception was thrown.");
+        }
+
+        // Captures the request as it reaches the transport (after signing) and returns 200.
+        private sealed class CapturingInnerHandler : HttpMessageHandler
+        {
+            public HttpRequestMessage LastRequest { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+
+        // Counts how many times credentials are resolved, to prove per-send resolution.
+        private sealed class CountingCredentials : AWSCredentials
+        {
+            private readonly ImmutableCredentials _credentials;
+            public int ResolveCount { get; private set; }
+
+            public CountingCredentials(string accessKey, string secretKey)
+            {
+                _credentials = new ImmutableCredentials(accessKey, secretKey, null);
+            }
+
+            public override ImmutableCredentials GetCredentials()
+            {
+                ResolveCount++;
+                return _credentials;
+            }
+
+            public override Task<ImmutableCredentials> GetCredentialsAsync()
+            {
+                ResolveCount++;
+                return Task.FromResult(_credentials);
+            }
+        }
+
+        private sealed class ThrowOnReadStream : Stream
+        {
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => 0; set => throw new NotSupportedException(); }
+            public override int Read(byte[] buffer, int offset, int count) =>
+                throw new InvalidOperationException("The body must not be read when SignPayload is false or a precomputed hash is supplied.");
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override void Flush() { }
+        }
+    }
+}

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
@@ -87,6 +87,7 @@ namespace AWSSDK.UnitTests.Signing
         public async Task Send_WithBody_SignsBufferedContent()
         {
             var handler = NewHandler(out var inner);
+            inner.CaptureBody = true;
             using (var client = NewClient(handler))
             {
                 var content = new StringContent("{\"a\":1}", Encoding.UTF8, "application/json");
@@ -98,8 +99,9 @@ namespace AWSSDK.UnitTests.Signing
                 CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(Encoding.UTF8.GetBytes("{\"a\":1}")), true);
             var actualHash = sent.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single();
             Assert.AreEqual(expectedHash, actualHash);
-            // The body must survive as re-readable content after signing.
-            Assert.AreEqual("{\"a\":1}", await sent.Content.ReadAsStringAsync());
+            // The body must survive as re-readable content through signing (captured inside the inner handler,
+            // since HttpClient disposes the request content once the send completes on net472).
+            Assert.AreEqual("{\"a\":1}", inner.LastContentBody);
         }
 
         [TestMethod]
@@ -273,15 +275,25 @@ namespace AWSSDK.UnitTests.Signing
             Assert.Fail($"Expected {typeof(TException).Name} but no exception was thrown.");
         }
 
-        // Captures the request as it reaches the transport (after signing) and returns 200.
+        // Captures the request as it reaches the transport (after signing) and returns 200. The content body
+        // is read here, while the request is still in flight — on net472 HttpClient disposes the request
+        // content once SendAsync returns, so reading LastRequest.Content after the call throws
+        // ObjectDisposedException. Capturing it inside the handler avoids that.
         private sealed class CapturingInnerHandler : HttpMessageHandler
         {
             public HttpRequestMessage LastRequest { get; private set; }
+            public string LastContentBody { get; private set; }
 
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            // Opt-in: only the body-signing test wants the body captured. Reading is off by default so the
+            // "body must not be read" tests (backed by a throw-on-read stream) keep that invariant.
+            public bool CaptureBody { get; set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 LastRequest = request;
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                if (CaptureBody && request.Content != null)
+                    LastContentBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return new HttpResponseMessage(HttpStatusCode.OK);
             }
         }
 

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
@@ -36,7 +36,8 @@ namespace AWSSDK.UnitTests.Signing
     {
         private const string AccessKey = "AKIDEXAMPLE";
         private const string SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
-        private const string Region = "us-east-1";
+        private const string RegionName = "us-east-1";
+        private static readonly RegionEndpoint Region = RegionEndpoint.GetBySystemName(RegionName);
         private const string Service = "execute-api";
 
         private static SigV4SigningHandler NewHandler(out CapturingInnerHandler inner)
@@ -44,13 +45,13 @@ namespace AWSSDK.UnitTests.Signing
             return NewHandler(new BasicAWSCredentials(AccessKey, SecretKey), out inner);
         }
 
-        private static SigV4SigningHandler NewHandler(AWSCredentials credentials, out CapturingInnerHandler inner, string region = Region, string service = Service)
+        private static SigV4SigningHandler NewHandler(AWSCredentials credentials, out CapturingInnerHandler inner, RegionEndpoint region = null, string service = Service)
         {
             inner = new CapturingInnerHandler();
-            return new SigV4SigningHandler(new AWSSigningParameters
+            return new SigV4SigningHandler(new AWSSigV4Parameters
             {
                 Credentials = credentials,
-                Region = region,
+                Region = region ?? Region,
                 Service = service,
             })
             {
@@ -263,10 +264,10 @@ namespace AWSSDK.UnitTests.Signing
         [TestMethod]
         public void Constructor_MissingRequiredParameters_Throws()
         {
-            AssertThrows<ArgumentNullException>(() => new SigV4SigningHandler((AWSSigningParameters)null));
-            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigningParameters { Region = Region, Service = Service }));
-            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigningParameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Service = Service }));
-            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigningParameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Region = Region }));
+            AssertThrows<ArgumentNullException>(() => new SigV4SigningHandler((AWSSigV4Parameters)null));
+            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Region = Region, Service = Service }));
+            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Service = Service }));
+            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Region = Region }));
         }
 
         [TestMethod]

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
@@ -352,12 +352,28 @@ namespace AWSSDK.UnitTests.Signing
         }
 
         [TestMethod]
-        public void Constructor_MissingRequiredParameters_Throws()
+        public void Constructor_NullParameters_Throws()
         {
             Assert.ThrowsExactly<ArgumentNullException>(() => new SigV4SigningHandler((AWSSigV4Parameters)null));
-            Assert.ThrowsExactly<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Region = Region, Service = Service }));
-            Assert.ThrowsExactly<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Service = Service }));
-            Assert.ThrowsExactly<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Region = Region }));
+        }
+
+        [TestMethod]
+        public void Constructor_MissingService_Throws()
+        {
+            // Service has no ambient fallback, so it must be supplied at construction.
+            Assert.ThrowsExactly<ArgumentException>(() => new SigV4SigningHandler(
+                new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Region = Region }));
+        }
+
+        [TestMethod]
+        public void Constructor_MissingRegionOrCredentials_DoesNotThrow()
+        {
+            // Region and Credentials are resolved from the environment at send time, so their absence is not a
+            // construction-time error (unlike Service).
+            using (new SigV4SigningHandler(new AWSSigV4Parameters { Region = Region, Service = Service }))
+            using (new SigV4SigningHandler(new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Service = Service }))
+            {
+            }
         }
 
         [TestMethod]

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
@@ -120,6 +120,46 @@ namespace AWSSDK.UnitTests.Signing
             StringAssert.Contains(auth, "x-amz-security-token");
         }
 
+#if NET5_0_OR_GREATER
+        [TestMethod]
+        public void SyncSend_SignsOutgoingRequest()
+        {
+            // A synchronous HttpClient.Send must be signed too, not passed through unsigned by the base handler.
+            var handler = NewHandler(out var inner);
+            using (var client = NewClient(handler))
+            {
+                client.Send(new HttpRequestMessage(HttpMethod.Get, "https://example.execute-api.us-east-1.amazonaws.com/items"));
+            }
+
+            var sent = inner.LastRequest;
+            Assert.IsTrue(sent.Headers.Contains(HeaderKeys.AuthorizationHeader));
+            Assert.IsTrue(sent.Headers.Contains(HeaderKeys.XAmzDateHeader));
+            var auth = sent.Headers.GetValues(HeaderKeys.AuthorizationHeader).Single();
+            StringAssert.StartsWith(auth, "AWS4-HMAC-SHA256 ");
+        }
+
+        [TestMethod]
+        public void SyncSend_WithBody_SignsBufferedContent()
+        {
+            var handler = NewHandler(out var inner);
+            inner.CaptureBody = true;
+            using (var client = NewClient(handler))
+            {
+                var message = new HttpRequestMessage(HttpMethod.Post, "https://example.execute-api.us-east-1.amazonaws.com/items")
+                {
+                    Content = new StringContent("{\"a\":1}", Encoding.UTF8, "application/json"),
+                };
+                client.Send(message);
+            }
+
+            var sent = inner.LastRequest;
+            var expectedHash = AWSSDKUtils.ToHex(
+                CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(Encoding.UTF8.GetBytes("{\"a\":1}")), true);
+            Assert.AreEqual(expectedHash, sent.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single());
+            Assert.AreEqual("{\"a\":1}", inner.LastContentBody);
+        }
+#endif
+
         // -----------------------------------------------------------------------
         // Credentials resolve per send.
         // -----------------------------------------------------------------------
@@ -189,6 +229,56 @@ namespace AWSSDK.UnitTests.Signing
             // Signing headers replaced, not accumulated, across the resign.
             Assert.AreEqual(1, message.Headers.GetValues(HeaderKeys.AuthorizationHeader).Count());
             Assert.AreEqual(1, message.Headers.GetValues(HeaderKeys.XAmzDateHeader).Count());
+        }
+
+        [TestMethod]
+        public async Task Send_ReSigningAfterCredentialsDropToken_RemovesStaleSecurityTokenHeader()
+        {
+            // Session credentials on the first send emit x-amz-security-token; if the credential source then
+            // returns long-term credentials, the re-signed message must not carry the stale token header, or it
+            // would go out uncovered by the new signature.
+            var credentials = new SwitchableCredentials(
+                new SessionAWSCredentials(AccessKey, SecretKey, "the-session-token"),
+                new BasicAWSCredentials(AccessKey, SecretKey));
+            var handler = NewHandler(credentials, out var inner);
+            var invoker = new HttpMessageInvoker(handler);
+
+            var message = new HttpRequestMessage(HttpMethod.Get, "https://example.execute-api.us-east-1.amazonaws.com/items");
+
+            // First send uses session credentials: the token header is present.
+            await invoker.SendAsync(message, CancellationToken.None);
+            Assert.IsTrue(message.Headers.Contains(HeaderKeys.XAmzSecurityTokenHeader));
+
+            // Retry resolves long-term credentials: the token header must be gone, not left over.
+            credentials.Advance();
+            await invoker.SendAsync(message, CancellationToken.None);
+            Assert.IsFalse(message.Headers.Contains(HeaderKeys.XAmzSecurityTokenHeader));
+        }
+
+        // -----------------------------------------------------------------------
+        // Header collection for signing.
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task Send_SameHeaderOnRequestAndContent_SignsCombinedValue()
+        {
+            // HttpClient sends a header set on both the request and the content as one combined line
+            // (request value first, then content value). The signature must cover that same combined value.
+            var handler = NewHandler(out var inner);
+            var invoker = new HttpMessageInvoker(handler);
+
+            var message = new HttpRequestMessage(HttpMethod.Post, "https://example.execute-api.us-east-1.amazonaws.com/items")
+            {
+                Content = new StringContent("{\"a\":1}", Encoding.UTF8, "application/json"),
+            };
+            message.Headers.TryAddWithoutValidation("x-custom", "request-value");
+            message.Content.Headers.TryAddWithoutValidation("x-custom", "content-value");
+
+            await invoker.SendAsync(message, CancellationToken.None);
+
+            // x-custom appears in the signed headers, so it is part of SignedHeaders in the Authorization value.
+            var auth = message.Headers.GetValues(HeaderKeys.AuthorizationHeader).Single();
+            StringAssert.Contains(auth, "x-custom");
         }
 
         // -----------------------------------------------------------------------
@@ -264,10 +354,10 @@ namespace AWSSDK.UnitTests.Signing
         [TestMethod]
         public void Constructor_MissingRequiredParameters_Throws()
         {
-            AssertThrows<ArgumentNullException>(() => new SigV4SigningHandler((AWSSigV4Parameters)null));
-            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Region = Region, Service = Service }));
-            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Service = Service }));
-            AssertThrows<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Region = Region }));
+            Assert.ThrowsExactly<ArgumentNullException>(() => new SigV4SigningHandler((AWSSigV4Parameters)null));
+            Assert.ThrowsExactly<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Region = Region, Service = Service }));
+            Assert.ThrowsExactly<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Service = Service }));
+            Assert.ThrowsExactly<ArgumentException>(() => new SigV4SigningHandler(new AWSSigV4Parameters { Credentials = new BasicAWSCredentials(AccessKey, SecretKey), Region = Region }));
         }
 
         [TestMethod]
@@ -277,7 +367,7 @@ namespace AWSSDK.UnitTests.Signing
             var invoker = new HttpMessageInvoker(handler);
             var message = new HttpRequestMessage(HttpMethod.Get, new Uri("/items", UriKind.Relative));
 
-            await AssertThrowsAsync<InvalidOperationException>(() => invoker.SendAsync(message, CancellationToken.None));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => invoker.SendAsync(message, CancellationToken.None));
         }
 
         // -----------------------------------------------------------------------
@@ -291,22 +381,6 @@ namespace AWSSDK.UnitTests.Signing
 #else
             message.Properties[key] = value;
 #endif
-        }
-
-        private static void AssertThrows<TException>(Action action) where TException : Exception
-        {
-            try { action(); }
-            catch (TException) { return; }
-            catch (Exception ex) { Assert.Fail($"Expected {typeof(TException).Name} but got {ex.GetType().Name}."); }
-            Assert.Fail($"Expected {typeof(TException).Name} but no exception was thrown.");
-        }
-
-        private static async Task AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception
-        {
-            try { await action(); }
-            catch (TException) { return; }
-            catch (Exception ex) { Assert.Fail($"Expected {typeof(TException).Name} but got {ex.GetType().Name}."); }
-            Assert.Fail($"Expected {typeof(TException).Name} but no exception was thrown.");
         }
 
         // Captures the request as it reaches the transport (after signing) and returns 200. The content body
@@ -329,6 +403,20 @@ namespace AWSSDK.UnitTests.Signing
                     LastContentBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpResponseMessage(HttpStatusCode.OK);
             }
+
+#if NET5_0_OR_GREATER
+            protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                if (CaptureBody && request.Content != null)
+                {
+                    using (var stream = request.Content.ReadAsStream(cancellationToken))
+                    using (var reader = new StreamReader(stream))
+                        LastContentBody = reader.ReadToEnd();
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+#endif
         }
 
         // Counts how many times credentials are resolved, to prove per-send resolution.
@@ -353,6 +441,29 @@ namespace AWSSDK.UnitTests.Signing
                 ResolveCount++;
                 return Task.FromResult(_credentials);
             }
+        }
+
+        // Returns one set of credentials until Advance() is called, then the next. Models a credential source
+        // whose resolved credentials change type (e.g. session -> long-term) between a send and its retry.
+        private sealed class SwitchableCredentials : AWSCredentials
+        {
+            private readonly AWSCredentials _first;
+            private readonly AWSCredentials _second;
+            private bool _advanced;
+
+            public SwitchableCredentials(AWSCredentials first, AWSCredentials second)
+            {
+                _first = first;
+                _second = second;
+            }
+
+            public void Advance() => _advanced = true;
+
+            private AWSCredentials Current => _advanced ? _second : _first;
+
+            public override ImmutableCredentials GetCredentials() => Current.GetCredentials();
+
+            public override Task<ImmutableCredentials> GetCredentialsAsync() => Current.GetCredentialsAsync();
         }
 
         private sealed class ThrowOnReadStream : Stream


### PR DESCRIPTION
## Description

Adds **`SigV4SigningHandler`**, a `System.Net.Http.DelegatingHandler` in the `Amazon.Runtime.Signing` namespace that SigV4-signs each outbound request. Install it on an `HttpClient` — directly or via `IHttpClientFactory` — and every request through that client is signed transparently.


## Why a handler

`AWSSigV4Signer.SignAsync` gives you signed headers to apply yourself. The handler is the transparent, DI-native layer on top: it plugs into the native `HttpMessageHandler` chain and `IHttpClientFactory`, signs every send with no per-call step, and re-signs each retry/redirect attempt with a fresh timestamp. No sibling AWS SDK ships an equivalent because none runs on `System.Net.Http`; the only precedent is the community `AwsSignatureVersion4` package.

## Usage

**`IHttpClientFactory` / DI** (the intended production wiring) — register the client once, every request is signed:

```csharp
services.AddHttpClient("execute-api", c => c.BaseAddress = new Uri("https://abc123.execute-api.us-east-1.amazonaws.com/"))
    .AddHttpMessageHandler(sp => new SigV4SigningHandler(
        DefaultAWSCredentialsIdentityResolver.GetCredentials(), RegionEndpoint.USEast1, "execute-api"))
    // Signing handler must not auto-follow redirects (see caveats), and a retry policy must sit OUTSIDE it.
    .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false });

// elsewhere — plain HttpClient code, signed automatically:
var client = httpClientFactory.CreateClient("execute-api");
var response = await client.GetAsync("items");
```

**Standalone `HttpClient`** — wrap the handler directly:

```csharp
using Amazon.Runtime.Signing;

var handler = new SigV4SigningHandler(
    DefaultAWSCredentialsIdentityResolver.GetCredentials(),
    RegionEndpoint.USEast1,
    service: "execute-api")
{
    InnerHandler = new HttpClientHandler { AllowAutoRedirect = false },
};

var client = new HttpClient(handler);
var response = await client.PostAsync(
    "https://abc123.execute-api.us-east-1.amazonaws.com/items",
    new StringContent(json, Encoding.UTF8, "application/json"));
```

**Per-request override** — one client that signs for more than one service/region:

```csharp
var message = new HttpRequestMessage(HttpMethod.Get, "https://sts.us-west-2.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15");
message.Options.Set(new HttpRequestOptionsKey<string>(SigV4SigningHandler.ServiceOptionKey), "sts");
message.Options.Set(new HttpRequestOptionsKey<string>(SigV4SigningHandler.RegionOptionKey), "us-west-2");
var response = await client.SendAsync(message);   // signed for sts / us-west-2, overriding the handler defaults
```

The `(AWSSigningParameters)` constructor is also available when you want to set `SignPayload`/`SignedAt` defaults.

## Behavior

- **Credentials resolve on every send** (not captured at construction), so rotating sources (SSO/assume-role/IMDS) always sign with current credentials.
- **Body buffering** happens only when the signer will hash it, and the content is rebuffered as re-readable so the body survives a resend on retry. `SignPayload = false` and a precomputed `x-amz-content-sha256` header skip the body read entirely (large/streaming uploads).
- **Per-request overrides** for service/region/`SignPayload` via `HttpRequestMessage.Options` (net5.0+) / `Properties` (earlier TFMs), keyed by `ServiceOptionKey` / `RegionOptionKey` / `SignPayloadOptionKey`.
- **Re-sign without duplication** — signing headers are replaced (on both request and content headers), not appended, so a re-signed retry stays clean.
- **Cancellation** is honored throughout, including the body-buffering read.

### Two caveats the handler cannot self-enforce (they depend on how the caller assembles the chain)

**1. `AllowAutoRedirect = false` on the primary handler.** The chain is `HttpClient -> SigV4SigningHandler -> HttpClientHandler`. `HttpClientHandler.AllowAutoRedirect` defaults to `true`, and a 3xx is followed *inside* `HttpClientHandler` — i.e. below the signing handler, which already ran on the way down and never sees the redirect. Because SigV4 signs the target `host` and path into the signature, the redirected hop — which was never re-signed — is not valid for its new destination.

Concretely, say you sign a request to `service-a` and it replies `302 Location: https://service-b.amazonaws.com/other`:

```
1. Handler signs:  GET https://service-a.amazonaws.com/thing
                   Authorization: AWS4-HMAC-SHA256 ... (signed for host=service-a, path=/thing)
2. HttpClientHandler auto-follows the 302 to service-b — beneath the signer, so no re-sign.
```

What service-b receives depends on the redirect:

- **Cross-host (service-a → service-b):** the runtime **strips the `Authorization` header** on a cross-origin redirect (so credentials aren't leaked to another host), so service-b gets an **unsigned** request and rejects it.
- **Same-host (`/thing` → `/other` on service-a):** the `Authorization` header survives, but it was computed for `/thing` while the request is now for `/other`, so the canonical request no longer matches and the service rejects it with `SignatureDoesNotMatch` (and the now-older `X-Amz-Date` can also fall outside the clock-skew window).

The handler can't intercept a follow that happens beneath it, so the fix is to turn auto-redirect off and either let the caller re-issue the request (which re-enters signing and is signed for the new host/path) or place a redirect-following handler *above* the signer — either way each hop is signed for its own destination.

**2. A retry handler must sit *outside* (above) the signing handler.** A `DelegatingHandler` retries by calling `base.SendAsync` again, so whatever is *below* the retry handler is what re-runs each attempt.
- **Correct — `HttpClient -> Retry -> SigV4Signing -> HttpClientHandler`:** a failed attempt loops back through the signer, so each attempt is **re-signed with a fresh `X-Amz-Date`** (and freshly-resolved credentials). Every attempt is independently valid.
- **Wrong — `HttpClient -> SigV4Signing -> Retry -> HttpClientHandler`:** the request is signed once and the retry loop replays that same frozen signature; a backed-off retry can then fall outside SigV4's clock-skew tolerance and be rejected for a stale date.

This re-sign-per-attempt behavior is the handler's headline advantage over signing a message once and resending it — but only if the retry policy is ordered outside the signer. With `Microsoft.Extensions.Http` + Polly, register the retry policy **before** the signing handler:

```csharp
services.AddHttpClient("execute-api")
    .AddPolicyHandler(retryPolicy)                               // outer - retries re-enter signing
    .AddHttpMessageHandler(() => new SigV4SigningHandler(...))   // inner - re-signs each attempt
    .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false });
```

Both are documented on the type rather than enforced: the handler can't see what sits above it in the chain, and only sees its own inner handler.

## Testing

unit and integ tests

## Dry-run

Basic chained dry-run (`catapult-net`, product `dotnetv4`, stage `prod`, source `origin:sigv4-signing-handler`):

| Product | Build ID |
|---|---|
| .NET (`dotnetv4`) | `11c03ce4-6dd1-4366-8ffc-158daefca453` |
| PowerShell (`powershell5`) | `3b4fb208-8d6b-455d-a0aa-4838dcafb9f4` |




