### PR TITLE
fix: Refill adaptive token bucket per ObtainCapacity and classify IDPCommunicationError as retryable for all STS operations

### DIFF
--- a/generator/.DevConfigs/70b8db63-48ee-4e67-a24b-f8af6c8fdc6b.json
+++ b/generator/.DevConfigs/70b8db63-48ee-4e67-a24b-f8af6c8fdc6b.json
@@ -1,0 +1,18 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Refill adaptive token bucket per ObtainCapacity when using NewRetries2026."
+    ],
+    "type": "patch",
+    "updateMinimum": true
+  },
+  "services": [
+    {
+      "serviceName": "SecurityToken",
+      "type": "patch",
+      "changeLogMessages": [
+        "Classify IDPCommunicationError as retryable for all STS operations."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Core/Amazon.Runtime/TokenBucket.cs
+++ b/sdk/src/Core/Amazon.Runtime/TokenBucket.cs
@@ -216,6 +216,13 @@ namespace Amazon.Runtime.Internal
             double fillRate;
             lock (_bucketLock)
             {
+                //New-retries (AWS_NEW_RETRIES_2026) refills the bucket each iteration so a blocked
+                //caller sees tokens replenish; the legacy path refills only once, in SetupAcquireToken.
+                if (Amazon.Runtime.RetryPolicy.UseNewRetries2026)
+                {
+                    TokenBucketRefill();
+                }
+
                 if (amount <= CurrentCapacity)
                 {
                     CurrentCapacity -= amount;

--- a/sdk/src/Services/SecurityToken/Custom/SecurityTokenServiceRetryPolicy.cs
+++ b/sdk/src/Services/SecurityToken/Custom/SecurityTokenServiceRetryPolicy.cs
@@ -23,10 +23,14 @@ namespace Amazon.SecurityToken
 {
     /// <summary>
     /// An implementation of the <see cref="DefaultRetryPolicy"/> that retries certain additional
-    /// STS errors when doing AssumeRoleWithWebIdentity requests.
+    /// STS errors. IDPCommunicationError is treated as a transient error and retried for all
+    /// STS operations, while InvalidIdentityToken is retried only for AssumeRoleWithWebIdentity
+    /// requests.
     /// </summary>
     public class SecurityTokenServiceRetryPolicy : DefaultRetryPolicy
     {
+        private const string IDPCommunicationErrorCode = "IDPCommunicationError";
+
         /// <summary>
         /// Constructor for SecurityTokenServiceRetryPolicy.
         /// </summary>
@@ -34,12 +38,30 @@ namespace Amazon.SecurityToken
         {
         }
 
+        internal static bool ShouldRetryException(IExecutionContext executionContext, Exception exception)
+        {
+            if (exception is IDPCommunicationErrorException ||
+                (exception is AmazonServiceException amazonServiceException &&
+                string.Equals(amazonServiceException.ErrorCode, IDPCommunicationErrorCode, StringComparison.Ordinal)))
+            {
+                return true;
+            }
+
+            if (executionContext.RequestContext.OriginalRequest is AssumeRoleWithWebIdentityRequest &&
+                exception is InvalidIdentityTokenException)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Returns true if the request should be retried.
         /// </summary>
         public override bool RetryForException(IExecutionContext executionContext, Exception exception)
         {
-            if (executionContext.RequestContext.OriginalRequest is AssumeRoleWithWebIdentityRequest && (exception is IDPCommunicationErrorException || exception is InvalidIdentityTokenException))
+            if (ShouldRetryException(executionContext, exception))
             {
                 return true;
             }
@@ -52,7 +74,7 @@ namespace Amazon.SecurityToken
         /// </summary>
         public override Task<bool> RetryForExceptionAsync(IExecutionContext executionContext, Exception exception)
         {
-            if (executionContext.RequestContext.OriginalRequest is AssumeRoleWithWebIdentityRequest && (exception is IDPCommunicationErrorException || exception is InvalidIdentityTokenException))
+            if (ShouldRetryException(executionContext, exception))
             {
                 return Task.FromResult(true);
             }
@@ -64,7 +86,9 @@ namespace Amazon.SecurityToken
 
     /// <summary>
     /// An implementation of the <see cref="StandardRetryPolicy"/> that retries certain additional
-    /// STS errors when doing AssumeRoleWithWebIdentity requests.
+    /// STS errors. IDPCommunicationError is treated as a transient error and retried for all
+    /// STS operations, while InvalidIdentityToken is retried only for AssumeRoleWithWebIdentity
+    /// requests.
     /// </summary>
     public class SecurityTokenServiceStandardRetryPolicy : StandardRetryPolicy
     {
@@ -80,7 +104,7 @@ namespace Amazon.SecurityToken
         /// </summary>
         public override bool RetryForException(IExecutionContext executionContext, Exception exception)
         {
-            if (executionContext.RequestContext.OriginalRequest is AssumeRoleWithWebIdentityRequest && (exception is IDPCommunicationErrorException || exception is InvalidIdentityTokenException))
+            if (SecurityTokenServiceRetryPolicy.ShouldRetryException(executionContext, exception))
             {
                 return true;
             }
@@ -93,7 +117,7 @@ namespace Amazon.SecurityToken
         /// </summary>
         public override Task<bool> RetryForExceptionAsync(IExecutionContext executionContext, Exception exception)
         {
-            if (executionContext.RequestContext.OriginalRequest is AssumeRoleWithWebIdentityRequest && (exception is IDPCommunicationErrorException || exception is InvalidIdentityTokenException))
+            if (SecurityTokenServiceRetryPolicy.ShouldRetryException(executionContext, exception))
             {
                 return Task.FromResult(true);
             }
@@ -105,7 +129,9 @@ namespace Amazon.SecurityToken
 
     /// <summary>
     /// An implementation of the <see cref="AdaptiveRetryPolicy"/> that retries certain additional
-    /// STS errors when doing AssumeRoleWithWebIdentity requests.
+    /// STS errors. IDPCommunicationError is treated as a transient error and retried for all
+    /// STS operations, while InvalidIdentityToken is retried only for AssumeRoleWithWebIdentity
+    /// requests.
     /// </summary>
     public class SecurityTokenServiceAdaptiveRetryPolicy : AdaptiveRetryPolicy
     {
@@ -121,7 +147,7 @@ namespace Amazon.SecurityToken
         /// </summary>
         public override bool RetryForException(IExecutionContext executionContext, Exception exception)
         {
-            if (executionContext.RequestContext.OriginalRequest is AssumeRoleWithWebIdentityRequest && (exception is IDPCommunicationErrorException || exception is InvalidIdentityTokenException))
+            if (SecurityTokenServiceRetryPolicy.ShouldRetryException(executionContext, exception))
             {
                 return true;
             }
@@ -134,7 +160,7 @@ namespace Amazon.SecurityToken
         /// </summary>
         public override Task<bool> RetryForExceptionAsync(IExecutionContext executionContext, Exception exception)
         {
-            if (executionContext.RequestContext.OriginalRequest is AssumeRoleWithWebIdentityRequest && (exception is IDPCommunicationErrorException || exception is InvalidIdentityTokenException))
+            if (SecurityTokenServiceRetryPolicy.ShouldRetryException(executionContext, exception))
             {
                 return Task.FromResult(true);
             }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
**TokenBucket:** The SEP models the adaptive rate limiter as a continuously-refilling token bucket, the bucket must refill on every acquire pass so a blocked caller sees tokens accrue at the fill rate. 
In the .NET SDK the acquire loop refilled only once before looping, so blocked workers re-evaluated stale capacity and the bucket collapsed under immediate throttling. Now refills each iteration when `UseNewRetries2026` is on.

**SecurityTokenServiceRetryPolicy:** `IDPCommunicationError` was only retried for `AssumeRoleWithWebIdentity`, however the SEP requires it as a baseline transient retry for all STS ops. New shared `ShouldRetryException` helper matches the typed exception and `ErrorCode == "IDPCommunicationError"`.

## Motivation and Context
`DOTNET-8736`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
Ran the internal tests and made sure they passed after the new changes.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** 79661386-919c-4ca9-a1f4-bfdc783f9a20
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 5bbaee76-ccee-4eaf-851c-ef71bd824123
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement


