### PR TITLE
fix: Handle zero-byte objects in TransferUtility RANGE multipart download

### DIFF
--- a/generator/.DevConfigs/a6947522-0d0b-4bfb-80cd-67f65f65d9cb.json
+++ b/generator/.DevConfigs/a6947522-0d0b-4bfb-80cd-67f65f65d9cb.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fixed `TransferUtility` multipart download in RANGE mode failing on zero-byte objects. The initial ranged GET (`bytes=0-{partSize-1}`) returns `416 Range Not Satisfiable` for an empty object; the RANGE strategy now detects the 416, probes with a `partNumber=1` GET, and completes as an empty file, matching the PART strategy's behavior."
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
@@ -866,7 +866,7 @@ namespace Amazon.S3.Transfer.Internal
 
                 var partProbeResponse = await _s3Client.GetObjectAsync(partProbeRequest, cancellationToken).ConfigureAwait(false);
 
-                if (partProbeResponse != null && partProbeResponse.ContentLength == 0)
+                if (partProbeResponse != null && partProbeResponse.ContentLength == 0 && partProbeResponse.ContentRange == null)
                 {
                     // Confirmed empty. This response has no ContentRange, so the caller's ContentRange == null
                     // branch treats it as a single empty part and completes with a 0-byte file.

--- a/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
+++ b/sdk/src/Services/S3/Custom/Transfer/Internal/MultipartDownloadManager.cs
@@ -24,6 +24,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Runtime;
@@ -733,11 +734,6 @@ namespace Amazon.S3.Transfer.Internal
             // Get target part size for RANGE strategy (already set in config from request or default)
             var targetPartSize = _config.TargetPartSizeBytes;
             
-            // SEP Ranged GET Step 1: "create a new GetObject request copying all fields in the original request. 
-            // Set range value to bytes=0-{targetPartSizeBytes-1} to request the first part."
-            var firstRangeRequest = CreateGetObjectRequest();
-            firstRangeRequest.ByteRange = new ByteRange(0, targetPartSize - 1);
-            
             // Wait for both capacity types before making HTTP request (consistent with background parts)
             _logger.DebugFormat("MultipartDownloadManager: [Part 1 Discovery] Waiting for buffer capacity");
             await _dataHandler.WaitForCapacityAsync(cancellationToken).ConfigureAwait(false);
@@ -746,16 +742,18 @@ namespace Amazon.S3.Transfer.Internal
             await _httpConcurrencySlots.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             GetObjectResponse firstRangeResponse = null;
-            
+
             // NOTE: Semaphore is NOT released here - it will be released in StartDownloadsAsync
             // after Part 1 is processed. This ensures the semaphore controls both network download
             // AND disk write for Part 1, consistent with Parts 2+ (see CreateDownloadTaskAsync)
-            
+
             try
             {
-                // SEP Ranged GET Step 2: "send the request and wait for the response in a non-blocking fashion"
-                firstRangeResponse = await _s3Client.GetObjectAsync(firstRangeRequest, cancellationToken).ConfigureAwait(false);
-                
+                // SEP Ranged GET Steps 1-2: build and send the first ranged GET (bytes=0-{targetPartSize-1}) and
+                // wait for the response. This helper also transparently handles the empty-object edge case where
+                // S3 rejects the ranged GET with 416 (Range Not Satisfiable); see the helper for details.
+                firstRangeResponse = await SendFirstRangeRequestWithEmptyObjectFallbackAsync(targetPartSize, cancellationToken).ConfigureAwait(false);
+
                 // Defensive null check
                 if (firstRangeResponse == null)
                     throw new InvalidOperationException("Failed to retrieve object from S3");
@@ -830,6 +828,61 @@ namespace Amazon.S3.Transfer.Internal
                 _httpConcurrencySlots.Release();
                 firstRangeResponse?.Dispose();
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Sends the first ranged GET (bytes=0-{targetPartSize-1}) for RANGE-strategy discovery, transparently
+        /// handling the empty-object edge case.
+        /// <para>
+        /// S3 rejects a ranged GET against a zero-byte object with 416 (Range Not Satisfiable) because there is
+        /// no byte 0 to satisfy. A <c>partNumber=1</c> GET, by contrast, succeeds on an empty object. So on a 416
+        /// we probe with a <c>partNumber=1</c> GET: if it confirms the object is empty (ContentLength == 0) we
+        /// return that response (which has no ContentRange, so the caller treats it as a single empty part). If
+        /// the probe instead shows a non-empty object, the object was replaced server-side between our ranged GET
+        /// and the probe; we surface that as an error so the caller can retry the whole download, consistent with
+        /// how the IfMatch (ETag) guard fails subsequent parts when an object changes mid-download.
+        /// </para>
+        /// </summary>
+        private async Task<GetObjectResponse> SendFirstRangeRequestWithEmptyObjectFallbackAsync(long targetPartSize, CancellationToken cancellationToken)
+        {
+            // SEP Ranged GET Step 1: "create a new GetObject request copying all fields in the original request.
+            // Set range value to bytes=0-{targetPartSizeBytes-1} to request the first part."
+            var firstRangeRequest = CreateGetObjectRequest();
+            firstRangeRequest.ByteRange = new ByteRange(0, targetPartSize - 1);
+
+            try
+            {
+                // SEP Ranged GET Step 2: "send the request and wait for the response in a non-blocking fashion"
+                return await _s3Client.GetObjectAsync(firstRangeRequest, cancellationToken).ConfigureAwait(false);
+            }
+            catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable)
+            {
+                _logger.DebugFormat("MultipartDownloadManager: [Part 1 Discovery] Received 416 Range Not Satisfiable on the ranged GET; " +
+                    "probing with a partNumber=1 GET to confirm the object is empty.");
+
+                var partProbeRequest = CreateGetObjectRequest();
+                partProbeRequest.PartNumber = 1;
+
+                var partProbeResponse = await _s3Client.GetObjectAsync(partProbeRequest, cancellationToken).ConfigureAwait(false);
+
+                if (partProbeResponse != null && partProbeResponse.ContentLength == 0)
+                {
+                    // Confirmed empty. This response has no ContentRange, so the caller's ContentRange == null
+                    // branch treats it as a single empty part and completes with a 0-byte file.
+                    return partProbeResponse;
+                }
+
+                // The object is no longer empty: it must have been replaced server-side between our ranged GET
+                // and this probe. Surface it as an error rather than silently re-discovering; the caller can
+                // retry the whole download.
+                partProbeResponse?.Dispose();
+
+                throw new InvalidOperationException(
+                    "Multipart RANGE download discovery failed because the object changed during discovery: the ranged GET returned " +
+                    "416 Range Not Satisfiable (empty object) but a subsequent partNumber=1 probe returned a non-empty object. " +
+                    "Retry the download.",
+                    ex);
             }
         }
 

--- a/sdk/test/Services/S3/IntegrationTests/TransferUtility/TransferUtilityDownloadWithResponseTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/TransferUtility/TransferUtilityDownloadWithResponseTests.cs
@@ -175,6 +175,43 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
         }
 
         [Fact]
+        public async Task DownloadWithResponse_RangeStrategy_EmptyObject()
+        {
+            // S3 rejects a ranged GET (bytes=0-{partSize-1}) against a zero-byte object with
+            // 416 Range Not Satisfiable. The RANGE strategy must detect the 416, probe with a
+            // partNumber=1 GET, and complete as an empty file instead of failing.
+            var key = UtilityMethods.GenerateName("range-empty-object");
+            await _client.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = _bucketName,
+                Key = key,
+                ContentBody = ""
+            });
+            var downloadPath = Path.Combine(_basePath, key);
+
+            var downloadRequest = new TransferUtilityDownloadRequest
+            {
+                BucketName = _bucketName,
+                Key = key,
+                FilePath = downloadPath,
+                MultipartDownloadType = MultipartDownloadType.RANGE,
+                PartSize = 8 * MB
+            };
+
+            var response = await _transfer.DownloadWithResponseAsync(downloadRequest);
+
+            Assert.NotNull(response);
+            Assert.Equal(0, response.Headers.ContentLength);
+            Assert.Null(response.ContentRange);
+
+            Assert.True(File.Exists(downloadPath));
+            var fileInfo = new FileInfo(downloadPath);
+            Assert.Equal(0, fileInfo.Length);
+
+            VerifyNoTempFilesExist(downloadPath);
+        }
+
+        [Fact]
         public async Task DownloadWithResponse_Multipart_RangeDownload()
         {
             var objectSize = 17 * MB;

--- a/sdk/test/Services/S3/UnitTests/Custom/MultipartDownloadManagerTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/MultipartDownloadManagerTests.cs
@@ -518,6 +518,7 @@ namespace AWSSDK.UnitTests
                 }
 
                 // partNumber=1 probe sees the replaced, non-empty object.
+                Assert.AreEqual(1, req.PartNumber, "Fallback probe should use partNumber=1.");
                 partProbeCount++;
                 return Task.FromResult(nonEmptyProbeResponse);
             });

--- a/sdk/test/Services/S3/UnitTests/Custom/MultipartDownloadManagerTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/MultipartDownloadManagerTests.cs
@@ -436,6 +436,105 @@ namespace AWSSDK.UnitTests
             Assert.IsNotNull(result.InitialResponse);
         }
 
+        [TestMethod]
+        public async Task DiscoverUsingRangeStrategy_EmptyObject_FallsBackToPartNumberGet()
+        {
+            // Arrange
+            // S3 rejects a ranged GET (bytes=0-{partSize-1}) against a zero-byte object with
+            // 416 Range Not Satisfiable. The RANGE strategy must treat a 416 on the discovery request
+            // as a signal to probe with a partNumber=1 GET, which succeeds on an empty object, so the
+            // download completes as an empty file (matching the PART strategy's behavior).
+            var partProbeCount = 0;
+
+            var emptyObjectResponse = MultipartDownloadTestHelpers.CreateMockGetObjectResponse(
+                contentLength: 0,
+                partsCount: null,
+                contentRange: null,  // partNumber=1 GET on an empty object has no ContentRange
+                eTag: "empty-object-etag");
+
+            var mockClient = MultipartDownloadTestHelpers.CreateMockS3Client((req, ct) =>
+            {
+                if (req.ByteRange != null)
+                {
+                    // The initial ranged discovery request against the empty object.
+                    throw new AmazonS3Exception("The requested range is not satisfiable")
+                    {
+                        StatusCode = System.Net.HttpStatusCode.RequestedRangeNotSatisfiable,
+                        ErrorCode = "InvalidRange"
+                    };
+                }
+
+                // The partNumber=1 probe.
+                Assert.AreEqual(1, req.PartNumber, "Fallback probe should use partNumber=1.");
+                partProbeCount++;
+                return Task.FromResult(emptyObjectResponse);
+            });
+
+            var request = MultipartDownloadTestHelpers.CreateOpenStreamRequest(
+                downloadType: MultipartDownloadType.RANGE);
+            var config = MultipartDownloadTestHelpers.CreateBufferedDownloadConfiguration();
+            var coordinator = new MultipartDownloadManager(mockClient.Object, request, config, CreateMockDataHandler().Object);
+
+            // Act
+            var result = await coordinator.StartDownloadAsync(null, CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(1, result.TotalParts);
+            Assert.AreEqual(0, result.ObjectSize);
+            Assert.IsNotNull(result.InitialResponse);
+            Assert.AreEqual(1, partProbeCount, "Expected exactly one partNumber=1 probe after the 416.");
+        }
+
+        [TestMethod]
+        public async Task DiscoverUsingRangeStrategy_ObjectReplacedAfter416_Throws()
+        {
+            // Arrange
+            // Simulate a race: the ranged GET 416s (empty object), but by the time the partNumber=1
+            // probe runs the object has been replaced server-side with a non-empty object. The probe
+            // reports ContentLength > 0, so discovery cannot safely treat it as empty and must surface
+            // an error (the caller can retry the whole download), consistent with how the IfMatch guard
+            // fails subsequent parts when an object changes mid-download.
+            var totalObjectSize = 50 * 1024 * 1024; // 50MB new object
+            var partSize = 8 * 1024 * 1024;         // 8MB parts
+            var partProbeCount = 0;
+
+            // partNumber=1 probe reports the (new) object is no longer empty.
+            var nonEmptyProbeResponse = MultipartDownloadTestHelpers.CreateMockGetObjectResponse(
+                contentLength: partSize,
+                partsCount: null,
+                contentRange: $"bytes 0-{partSize - 1}/{totalObjectSize}",
+                eTag: "new-object-etag");
+
+            var mockClient = MultipartDownloadTestHelpers.CreateMockS3Client((req, ct) =>
+            {
+                if (req.ByteRange != null)
+                {
+                    // Ranged GET: object was still empty -> 416.
+                    throw new AmazonS3Exception("The requested range is not satisfiable")
+                    {
+                        StatusCode = System.Net.HttpStatusCode.RequestedRangeNotSatisfiable,
+                        ErrorCode = "InvalidRange"
+                    };
+                }
+
+                // partNumber=1 probe sees the replaced, non-empty object.
+                partProbeCount++;
+                return Task.FromResult(nonEmptyProbeResponse);
+            });
+
+            var request = MultipartDownloadTestHelpers.CreateOpenStreamRequest(
+                partSize: partSize,
+                downloadType: MultipartDownloadType.RANGE);
+            var config = MultipartDownloadTestHelpers.CreateBufferedDownloadConfiguration();
+            var coordinator = new MultipartDownloadManager(mockClient.Object, request, config, CreateMockDataHandler().Object);
+
+            // Act & Assert
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
+                await coordinator.StartDownloadAsync(null, CancellationToken.None));
+
+            Assert.AreEqual(1, partProbeCount, "Expected exactly one partNumber=1 probe.");
+        }
+
         #endregion
 
         #region Discovery - RANGE Strategy - Single Part from Range Tests


### PR DESCRIPTION
## Description

Fixes a bug where `TransferUtility` multipart download in **RANGE** mode fails on zero-byte (empty) objects.

The RANGE strategy's discovery request issues a ranged GET (`bytes=0-{partSize-1}`) as its very first request. For a zero-byte object, S3 returns **416 Range Not Satisfiable** (there is no byte 0 to satisfy), which previously propagated and failed the entire download. The default **PART** strategy is unaffected because it discovers with `partNumber=1` (which succeeds on empty objects).

## Fix

In `MultipartDownloadManager.DiscoverUsingRangeStrategyAsync`, the initial ranged GET is now sent via a helper that:

1. Sends the ranged GET (normal path for objects with data).
2. On **416**, probes with a `partNumber=1` GET to disambiguate.
3. If the probe confirms the object is empty (`ContentLength == 0`), returns it — the response has no `ContentRange`, so the existing single-part branch completes the download as a 0-byte file.
4. If the probe returns a **non-empty** object (the object was replaced server-side between the ranged GET and the probe), throws an `InvalidOperationException` so the caller can retry the whole download. This is intentionally *not* retried internally, consistent with how the IfMatch/ETag guard already fails subsequent parts on mid-download mutation.

This aligns with the AWS SDK for Java v2, whose range-based (presigned-URL) downloader handles the same 416-on-empty-object case explicitly.

## Testing

- **Unit** (`MultipartDownloadManagerTests`):
  - `DiscoverUsingRangeStrategy_EmptyObject_FallsBackToPartNumberGet` — 416 → `partNumber=1` probe → single 0-byte part.
  - `DiscoverUsingRangeStrategy_ObjectReplacedAfter416_Throws` — 416 → probe returns non-empty → throws.
  - Full `MultipartDownloadManager` suite: **109/109 pass**.
- **Integration** (`TransferUtilityDownloadWithResponseTests`):
  - `DownloadWithResponse_RangeStrategy_EmptyObject` — verified against real S3; passes with the fix (fails without it). Fills a coverage gap where the only prior empty-object test used the PART strategy.

## Dry-run builds

Chained Catapult dry-run (prod stage, source `origin:transfer-util-range-empty-object-fallback`):

- **.NET (dotnetv4):** `c2cf323a-f8df-48e3-8ec7-b998763ba3ca`
- **PowerShell (powershell5):** `590100a1-fb60-4d92-9835-88be951865aa`
