### PR TITLE
S3 - Handle round-trip of empty filters for lifecycle rules

### DIFF
--- a/generator/.DevConfigs/668aaa91-104a-482c-94b7-bc3834c48969.json
+++ b/generator/.DevConfigs/668aaa91-104a-482c-94b7-bc3834c48969.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "S3",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fix round-trip of empty filters for lifecycle configurations (https://github.com/aws/aws-sdk-net/issues/4480)"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/LifecycleRuleUnmarshaller.cs
+++ b/sdk/src/Services/S3/Custom/Model/Internal/MarshallTransformations/LifecycleRuleUnmarshaller.cs
@@ -20,8 +20,12 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         private static void FilterCustomUnmarshall(XmlUnmarshallerContext context, LifecycleRule rule)
         {
             var predicateList = LifecycleFilterPredicateListUnmarshaller.Instance.Unmarshall(context);
-
-            if (predicateList.Count == 1)
+            if (predicateList.Count == 0)
+            {
+                // Preserve an empty <Filter/> so a Get/Put round-trip doesn't drop it (https://github.com/aws/aws-sdk-net/issues/4480).
+                rule.Filter = new LifecycleFilter();
+            }
+            else if (predicateList.Count == 1)
             {
                 rule.Filter = new LifecycleFilter()
                 {

--- a/sdk/test/Services/S3/IntegrationTests/LifecycleTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/LifecycleTests.cs
@@ -80,11 +80,33 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 return res.Configuration?.Rules?.Any(r => r.Id == "Empty-filter-test") == true ? res.Configuration : null;
             });
 
-            Assert.Equal(configuration.Rules.First().Id, "Empty-filter-test");
-            Assert.Equal(configuration.Rules.First().Expiration.Days, 30);
+            var rule = configuration.Rules.First();
+            Assert.NotNull(rule);
+            Assert.Equal(rule.Id, "Empty-filter-test");
+            Assert.Equal(rule.Expiration.Days, 30);
+            // Issue #4480: an empty <Filter/> must deserialize to a non-null Filter. If it is null,
+            // the element is dropped when the rule is re-submitted and S3 rejects it with MalformedXML.
+            Assert.NotNull(rule.Filter);
+
+            configuration.Rules.Add(new LifecycleRule
+            {
+                Id = "extra-rule",
+                Status = LifecycleRuleStatus.Enabled,
+                Filter = new LifecycleFilter
+                {
+                    LifecycleFilterPredicate = new LifecyclePrefixPredicate { Prefix = "logs/" }
+                },
+                Expiration = new LifecycleRuleExpiration { Days = 30 }
+            });
+
+            await _client.PutLifecycleConfigurationAsync(new PutLifecycleConfigurationRequest
+            {
+                BucketName = _bucketName,
+                Configuration = configuration
+            });
         }
 
-        // even if a user explicitly sets status to null we should set it to disabled so the 
+        // even if a user explicitly sets status to null we should set it to disabled so the
         // request succeeds
         [Fact]
         public async Task LifecycleNullStatusTest()


### PR DESCRIPTION
Fixes #4480 - an existing bug where empty filters could not be round-tripped to S3 (we actually had an existing test for it, but it only performed a `PUT` -> `GET`, and the issue was if the lifecycle rule was sent back to S3 again)

## Testing
In addition to dry-runs below, also created a simple reproduction app and confirmed the failure doesn't happen on this branch (while failing for both V3 and V4):

<details>
<summary>Test application</summary>

```csharp
using System;
using System.Collections.Generic;
using System.Net.Http;
using System.Threading;
using System.Threading.Tasks;
using Amazon;
using Amazon.Runtime;
using Amazon.S3;
using Amazon.S3.Model;

// Reproduces https://github.com/aws/aws-sdk-net/issues/4480
// Empty <Filter/> on a lifecycle rule deserializes to null; on re-submit the
// Filter element is dropped and S3 rejects the PUT with MalformedXML.
//
// Uses the default credential profile. Creates its own bucket and deletes it at the end.
// The LoggingHandler prints each request's XML body so we can see the dropped <Filter>.

var region = RegionEndpoint.USEast1;
var bucket = "repro-4480-" + Guid.NewGuid().ToString("N").Substring(0, 12);

var config = new AmazonS3Config
{
    RegionEndpoint = region,
    HttpClientFactory = new CustomHttpClientFactory(),
};

using var s3 = new AmazonS3Client(config);

Console.WriteLine($"SDK version: {typeof(AmazonS3Client).Assembly.GetName().Version}");
Console.WriteLine($"Creating bucket {bucket} in {region.SystemName}...");
await s3.PutBucketAsync(new PutBucketRequest { BucketName = bucket });

try
{
    // 1. Seed a lifecycle config with an empty filter (applies to all objects).
    var seed = new PutLifecycleConfigurationRequest
    {
        BucketName = bucket,
        Configuration = new LifecycleConfiguration
        {
            Rules = new List<LifecycleRule>
            {
                new LifecycleRule
                {
                    Id = "DEFAULT-DeleteOldVersions",
                    Status = LifecycleRuleStatus.Enabled,
                    // Truly empty filter (applies to all objects) -> serializes as <Filter></Filter>.
                    Filter = new LifecycleFilter(),
                    NoncurrentVersionExpiration = new LifecycleRuleNoncurrentVersionExpiration
                    {
                        NoncurrentDays = 8
                    }
                }
            }
        }
    };
    await s3.PutLifecycleConfigurationAsync(seed);
    Console.WriteLine("Seeded lifecycle configuration with empty filter.");

    // 2. GET it back.
    var got = await s3.GetLifecycleConfigurationAsync(new GetLifecycleConfigurationRequest { BucketName = bucket });
    var rule = got.Configuration.Rules[0];
    Console.WriteLine($"After GET: rule.Filter == null -> {rule.Filter == null}");
    Console.WriteLine($"After GET: rule.Prefix -> '{rule.Prefix ?? "(null)"}'");

    // 3. Add a new rule and PUT the modified configuration back (as in the issue).
    got.Configuration.Rules.Add(new LifecycleRule
    {
        Id = "extra-rule",
        Status = LifecycleRuleStatus.Enabled,
        Filter = new LifecycleFilter
        {
            LifecycleFilterPredicate = new LifecyclePrefixPredicate { Prefix = "logs/" }
        },
        Expiration = new LifecycleRuleExpiration { Days = 30 }
    });

    try
    {
        await s3.PutLifecycleConfigurationAsync(new PutLifecycleConfigurationRequest
        {
            BucketName = bucket,
            Configuration = got.Configuration
        });
        Console.WriteLine("RESULT: PUT succeeded (bug NOT reproduced).");
    }
    catch (AmazonS3Exception ex)
    {
        Console.WriteLine($"RESULT: PUT failed -> {ex.ErrorCode} / HTTP {(int)ex.StatusCode}: {ex.Message}");
        Console.WriteLine("Bug reproduced.");
    }
}
finally
{
    try { await s3.DeleteBucketAsync(new DeleteBucketRequest { BucketName = bucket }); Console.WriteLine($"Deleted bucket {bucket}."); }
    catch (Exception ex) { Console.WriteLine($"Cleanup warning: {ex.Message}"); }
}

class CustomHttpClientFactory : HttpClientFactory
{
    public override HttpClient CreateHttpClient(IClientConfig clientConfig)
        => new(new LoggingHandler(new HttpClientHandler()));
}

class LoggingHandler : DelegatingHandler
{
    public LoggingHandler(HttpMessageHandler innerHandler) : base(innerHandler) { }

    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
    {
        if (request.Content != null && request.RequestUri.Query.Contains("lifecycle"))
        {
            Console.WriteLine("====================== Request body (" + request.Method + " " + request.RequestUri.PathAndQuery + ")");
            Console.WriteLine(await request.Content.ReadAsStringAsync(cancellationToken));
            Console.WriteLine("======================");
        }

        return await base.SendAsync(request, cancellationToken);
    }
}
```
</details>

### Dry-runs
- **DotNet Dry-run ID:** `DRY_RUN-03ff0a54-f586-48c4-86fb-13b278545b12`
  - [X] Completed successfully
- **PowerShell Dry-run ID:** `DRY_RUN-3c44912a-d56a-40c0-b929-44e2d3f33f0f`
  - [X] Completed successfully

## Breaking Changes Assessment
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license