### PR TITLE
Allow draft PRs to opt into the build with a run-build label

### DIFF
--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -5,11 +5,12 @@ permissions: {}
 
 on:
   pull_request:
-    # No `synchronize` build trigger: pushes do NOT auto-start a build.
-    # A new commit just leaves the new SHA without a passing check, which
-    # blocks merge until you manually re-add the run-build label.
-    # `unlabeled` is included so that removing skip-build re-evaluates and
-    # overwrites the bypass "success" check with a failing one.
+    # We listen broadly, but the gate step (not the job `if`) decides what to do.
+    # A job that is *skipped* via `if` reports its required check as "skipped",
+    # which branch protection treats as PASSING - that would let an unbuilt PR
+    # merge. So the required check is an explicit commit status ("pr-build")
+    # that we post ourselves; merge is blocked whenever that status is absent
+    # or not success on the PR head commit.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     branches:
       - development
@@ -25,56 +26,95 @@ env:
   # constants
   DOWNLOAD_FOLDER: '.build-scripts/'
   SCRIPT_LOCATION: 'workflows/start-pull-request-build/pull-request-build-v1.sh'
+  # The commit-status context that branch protection should require. Merge is
+  # allowed only when this context is "success" on the PR head commit.
+  STATUS_CONTEXT: 'pr-build'
 
 jobs:
   build-sdk-v4:
     name: build-sdk-v4
-    # Forks are excluded because they can't assume the build role. Beyond that,
-    # this job wakes only for events that should (re)compute the check:
-    #   - run-build or skip-build was just ADDED,
-    #   - skip-build was just REMOVED (re-evaluate: overwrite the bypass success
-    #     check with a failing one so the PR is blocked again), or
-    #   - a push/open/reopen/ready while skip-build is present (keep stamping a
-    #     success check on the new head so a bypassed PR stays mergeable).
-    # It deliberately does NOT wake on `unlabeled` of run-build: that is this
-    # job's own post-build cleanup, and re-running would clobber the green check
-    # we just earned. Unrelated labels are ignored for the same reason.
-    if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (
-        (github.event.action == 'labeled' && (github.event.label.name == 'run-build' || github.event.label.name == 'skip-build')) ||
-        (github.event.action == 'unlabeled' && github.event.label.name == 'skip-build') ||
-        (
-          github.event.action != 'labeled' && github.event.action != 'unlabeled' &&
-          contains(github.event.pull_request.labels.*.name, 'skip-build')
-        )
-      )
+    # Only forks are excluded (they can't assume the build role). Same-repo PRs
+    # always enter the job so the gate can run; the gate then decides whether to
+    # build, bypass, re-block, or leave the existing status untouched.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       id-token: write        # request the OIDC token used to assume the AWS IAM role
-      issues: write          # comment on the associated issue / manage PR labels
+      issues: write          # allow the build script to comment on the associated issue
       pull-requests: write   # allow the build script to post build status/comments on the PR
       contents: read         # check out the repository contents
+      statuses: write        # post the required "pr-build" commit status
     env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       HAS_SKIP_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'skip-build') }}
       IS_RUN_BUILD_ADD: ${{ github.event.action == 'labeled' && github.event.label.name == 'run-build' }}
+      IS_SKIP_BUILD_REMOVED: ${{ github.event.action == 'unlabeled' && github.event.label.name == 'skip-build' }}
     steps:
+      # Decide what this run should do. Precedence: skip-build > run-build add >
+      # skip-build removal > no-op.
+      #   build : run-build was just ADDED  -> run the build, status = its result
+      #   skip  : skip-build present        -> post success without building (bypass)
+      #   block : skip-build was just REMOVED (and no build starting) -> post failure
+      #   noop  : anything else (push, open, unrelated label toggle)  -> leave the
+      #           existing status alone. A brand-new commit therefore has no
+      #           success status and stays blocked; an already-built commit keeps
+      #           its green status through unrelated events. Builds never auto-start
+      #           on push - re-add run-build to build a new commit.
       - name: Evaluate build labels
         id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           if [ "$HAS_SKIP_BUILD" = "true" ]; then
             echo "decision=skip" >> "$GITHUB_OUTPUT"
-            echo "::notice::'skip-build' label present - reporting success without building."
           elif [ "$IS_RUN_BUILD_ADD" = "true" ]; then
             echo "decision=build" >> "$GITHUB_OUTPUT"
-            echo "::notice::'run-build' label added - running the build."
+          elif [ "$IS_SKIP_BUILD_REMOVED" = "true" ]; then
+            echo "decision=block" >> "$GITHUB_OUTPUT"
           else
-            # Reached when skip-build was just removed and run-build is not set.
-            # Fail so this run overwrites the prior bypass "success" check with a
-            # failing one, re-blocking the PR until run-build is added.
-            echo "::error::No 'run-build' or 'skip-build' label. Add 'run-build' to build (required to merge) or 'skip-build' to bypass."
-            exit 1
+            echo "decision=noop" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Report bypass (skip-build)
+        if: steps.gate.outputs.decision == 'skip'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "::notice::'skip-build' present - reporting success without building."
+          gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state=success \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Bypassed via skip-build label" \
+            -f target_url="$RUN_URL"
+
+      - name: Report re-block (skip-build removed)
+        if: steps.gate.outputs.decision == 'block'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "::notice::'skip-build' removed - re-blocking; add 'run-build' to build."
+          gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state=failure \
+            -f context="$STATUS_CONTEXT" \
+            -f description="skip-build removed - add run-build to build" \
+            -f target_url="$RUN_URL"
+
+      - name: Mark build pending
+        if: steps.gate.outputs.decision == 'build'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state=pending \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Build running" \
+            -f target_url="$RUN_URL"
+
       - name: Configure AWS Credentials
         if: steps.gate.outputs.decision == 'build'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -83,12 +123,15 @@ jobs:
           role-session-name: PullRequestBuildGitHubAction
           role-duration-seconds: 7200
           aws-region: us-west-2
+
       - name: Download Build Script
         if: steps.gate.outputs.decision == 'build'
         run: |
           aws s3 cp s3://aws-sdk-builds-github-assets-prod-us-west-2/$SCRIPT_LOCATION ./$DOWNLOAD_FOLDER/$SCRIPT_LOCATION --no-progress
           chmod +x ./$DOWNLOAD_FOLDER/$SCRIPT_LOCATION
+
       - name: Build
+        id: build
         if: steps.gate.outputs.decision == 'build'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -103,14 +146,25 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --run-id "$RUN_ID"
         timeout-minutes: 150
-      # One-shot: strip the label whether the build passed or failed, so the next
-      # `add run-build` is always a fresh event (re-adding an already-present
-      # label fires nothing). This must never turn a green build red.
-      - name: Remove run-build label
+
+      # Post the final build result to the head commit. `always()` so a failed or
+      # cancelled build still reports failure (rather than leaving a stale pending).
+      - name: Report build result
         if: always() && steps.gate.outputs.decision == 'build'
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/run-build" || true
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+        run: |
+          if [ "$BUILD_OUTCOME" = "success" ]; then
+            STATE=success
+            DESC="Build passed"
+          else
+            STATE=failure
+            DESC="Build $BUILD_OUTCOME"
+          fi
+          gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="$STATE" \
+            -f context="$STATUS_CONTEXT" \
+            -f description="$DESC" \
+            -f target_url="$RUN_URL"

--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -8,7 +8,9 @@ on:
     # No `synchronize` build trigger: pushes do NOT auto-start a build.
     # A new commit just leaves the new SHA without a passing check, which
     # blocks merge until you manually re-add the run-build label.
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    # `unlabeled` is included so that removing skip-build re-evaluates and
+    # overwrites the bypass "success" check with a failing one.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     branches:
       - development
 
@@ -28,19 +30,24 @@ jobs:
   build-sdk-v4:
     name: build-sdk-v4
     # Forks are excluded because they can't assume the build role. Beyond that,
-    # this job runs only when:
-    #   - the run-build label was just ADDED (manual, one-shot build trigger), or
-    #   - the PR carries skip-build (so pushes keep stamping a success check and
-    #     the PR stays mergeable without building).
-    # A plain push with neither condition does not run, so the new head commit
-    # has no passing check and merge is blocked until run-build is added again.
-    # Because the required check is bound to the head SHA, a stale build can
-    # never be merged onto a newer commit.
+    # this job wakes only for events that should (re)compute the check:
+    #   - run-build or skip-build was just ADDED,
+    #   - skip-build was just REMOVED (re-evaluate: overwrite the bypass success
+    #     check with a failing one so the PR is blocked again), or
+    #   - a push/open/reopen/ready while skip-build is present (keep stamping a
+    #     success check on the new head so a bypassed PR stays mergeable).
+    # It deliberately does NOT wake on `unlabeled` of run-build: that is this
+    # job's own post-build cleanup, and re-running would clobber the green check
+    # we just earned. Unrelated labels are ignored for the same reason.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       (
-        (github.event.action == 'labeled' && github.event.label.name == 'run-build') ||
-        contains(github.event.pull_request.labels.*.name, 'skip-build')
+        (github.event.action == 'labeled' && (github.event.label.name == 'run-build' || github.event.label.name == 'skip-build')) ||
+        (github.event.action == 'unlabeled' && github.event.label.name == 'skip-build') ||
+        (
+          github.event.action != 'labeled' && github.event.action != 'unlabeled' &&
+          contains(github.event.pull_request.labels.*.name, 'skip-build')
+        )
       )
     runs-on: ubuntu-latest
     permissions:
@@ -50,6 +57,7 @@ jobs:
       contents: read         # check out the repository contents
     env:
       HAS_SKIP_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'skip-build') }}
+      IS_RUN_BUILD_ADD: ${{ github.event.action == 'labeled' && github.event.label.name == 'run-build' }}
     steps:
       - name: Evaluate build labels
         id: gate
@@ -57,9 +65,15 @@ jobs:
           if [ "$HAS_SKIP_BUILD" = "true" ]; then
             echo "decision=skip" >> "$GITHUB_OUTPUT"
             echo "::notice::'skip-build' label present - reporting success without building."
-          else
+          elif [ "$IS_RUN_BUILD_ADD" = "true" ]; then
             echo "decision=build" >> "$GITHUB_OUTPUT"
             echo "::notice::'run-build' label added - running the build."
+          else
+            # Reached when skip-build was just removed and run-build is not set.
+            # Fail so this run overwrites the prior bypass "success" check with a
+            # failing one, re-blocking the PR until run-build is added.
+            echo "::error::No 'run-build' or 'skip-build' label. Add 'run-build' to build (required to merge) or 'skip-build' to bypass."
+            exit 1
           fi
       - name: Configure AWS Credentials
         if: steps.gate.outputs.decision == 'build'

--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -21,7 +21,10 @@ env:
 jobs:
   build-sdk-v4:
     name: build-sdk-v4
-    # Only run for PRs from the same repo (forks don't have access to the role), and either:
+    # Only run for PRs from the same repo (forks don't have access to the role).
+    # The "skip-build" label is a global override: if it is present the build never
+    # runs, even for a non-draft PR (and it wins over "run-build").
+    # Otherwise the build runs when either:
     #   - a "run-build" label was just added (opts a draft into building), or
     #   - for any other event, the PR is not a draft, or it is a draft that
     #     already carries the "run-build" label (so labeled drafts keep building
@@ -30,6 +33,7 @@ jobs:
     # unrelated labels from starting a fresh build.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-build') &&
       (
         (github.event.action == 'labeled' && github.event.label.name == 'run-build') ||
         (

--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -5,14 +5,16 @@ permissions: {}
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    # No `synchronize` build trigger: pushes do NOT auto-start a build.
+    # A new commit just leaves the new SHA without a passing check, which
+    # blocks merge until you manually re-add the run-build label.
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches:
       - development
 
 concurrency:
-  # Per-PR group so a cheap gate evaluation never queues behind another PR's
-  # long-running build, and a newer commit cancels the now-stale build for the
-  # same PR (which keeps the required check bound to the latest commit).
+  # Per-PR group so one PR's long build never blocks another, and a newer commit
+  # cancels the now-stale build for the same PR.
   group: build-sdk-v4-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
@@ -24,39 +26,39 @@ env:
 jobs:
   build-sdk-v4:
     name: build-sdk-v4
-    # This job intentionally runs on every same-repo PR event (forks are excluded
-    # because they can't assume the build role). It always produces a definitive
-    # pass/fail check-run on the PR's head commit so it can be used as a required
-    # status check for merging. Which outcome it produces is decided by labels:
-    #   - "skip-build"  -> succeed immediately without building (explicit bypass).
-    #   - "run-build"   -> run the full build; the build's result is the check.
-    #   - neither label -> fail, forcing the author to opt in (or skip) explicitly.
-    # skip-build wins over run-build. Because the required check is bound to the
-    # head SHA, pushing a new commit invalidates a prior pass and (with run-build
-    # still applied) triggers a fresh build, so a stale build can never be merged.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Forks are excluded because they can't assume the build role. Beyond that,
+    # this job runs only when:
+    #   - the run-build label was just ADDED (manual, one-shot build trigger), or
+    #   - the PR carries skip-build (so pushes keep stamping a success check and
+    #     the PR stays mergeable without building).
+    # A plain push with neither condition does not run, so the new head commit
+    # has no passing check and merge is blocked until run-build is added again.
+    # Because the required check is bound to the head SHA, a stale build can
+    # never be merged onto a newer commit.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'run-build') ||
+        contains(github.event.pull_request.labels.*.name, 'skip-build')
+      )
     runs-on: ubuntu-latest
     permissions:
       id-token: write        # request the OIDC token used to assume the AWS IAM role
-      issues: write          # allow the build script to comment on the associated issue
+      issues: write          # comment on the associated issue / manage PR labels
       pull-requests: write   # allow the build script to post build status/comments on the PR
       contents: read         # check out the repository contents
     env:
       HAS_SKIP_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'skip-build') }}
-      HAS_RUN_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'run-build') }}
     steps:
       - name: Evaluate build labels
         id: gate
         run: |
           if [ "$HAS_SKIP_BUILD" = "true" ]; then
             echo "decision=skip" >> "$GITHUB_OUTPUT"
-            echo "::notice::'skip-build' label present - skipping the build and reporting success."
-          elif [ "$HAS_RUN_BUILD" = "true" ]; then
-            echo "decision=build" >> "$GITHUB_OUTPUT"
-            echo "::notice::'run-build' label present - running the build."
+            echo "::notice::'skip-build' label present - reporting success without building."
           else
-            echo "::error::This PR has neither the 'run-build' nor 'skip-build' label. Add 'run-build' to build (required to merge) or 'skip-build' to bypass."
-            exit 1
+            echo "decision=build" >> "$GITHUB_OUTPUT"
+            echo "::notice::'run-build' label added - running the build."
           fi
       - name: Configure AWS Credentials
         if: steps.gate.outputs.decision == 'build'
@@ -86,3 +88,14 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --run-id "$RUN_ID"
         timeout-minutes: 150
+      # One-shot: strip the label whether the build passed or failed, so the next
+      # `add run-build` is always a fresh event (re-adding an already-present
+      # label fires nothing). This must never turn a green build red.
+      - name: Remove run-build label
+        if: always() && steps.gate.outputs.decision == 'build'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/run-build" || true

--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -5,13 +5,16 @@ permissions: {}
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     branches:
       - development
 
 concurrency:
-  group: build-sdk-v4
-  cancel-in-progress: false
+  # Per-PR group so a cheap gate evaluation never queues behind another PR's
+  # long-running build, and a newer commit cancels the now-stale build for the
+  # same PR (which keeps the required check bound to the latest commit).
+  group: build-sdk-v4-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   # constants
@@ -21,37 +24,42 @@ env:
 jobs:
   build-sdk-v4:
     name: build-sdk-v4
-    # Only run for PRs from the same repo (forks don't have access to the role).
-    # The "skip-build" label is a global override: if it is present the build never
-    # runs, even for a non-draft PR (and it wins over "run-build").
-    # Otherwise the build runs when either:
-    #   - a "run-build" label was just added (opts a draft into building), or
-    #   - for any other event, the PR is not a draft, or it is a draft that
-    #     already carries the "run-build" label (so labeled drafts keep building
-    #     on every push / synchronize).
-    # Requiring label.name == 'run-build' on the `labeled` action also prevents
-    # unrelated labels from starting a fresh build.
-    if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-build') &&
-      (
-        (github.event.action == 'labeled' && github.event.label.name == 'run-build') ||
-        (
-          github.event.action != 'labeled' &&
-          (
-            github.event.pull_request.draft == false ||
-            contains(github.event.pull_request.labels.*.name, 'run-build')
-          )
-        )
-      )
+    # This job intentionally runs on every same-repo PR event (forks are excluded
+    # because they can't assume the build role). It always produces a definitive
+    # pass/fail check-run on the PR's head commit so it can be used as a required
+    # status check for merging. Which outcome it produces is decided by labels:
+    #   - "skip-build"  -> succeed immediately without building (explicit bypass).
+    #   - "run-build"   -> run the full build; the build's result is the check.
+    #   - neither label -> fail, forcing the author to opt in (or skip) explicitly.
+    # skip-build wins over run-build. Because the required check is bound to the
+    # head SHA, pushing a new commit invalidates a prior pass and (with run-build
+    # still applied) triggers a fresh build, so a stale build can never be merged.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       id-token: write        # request the OIDC token used to assume the AWS IAM role
       issues: write          # allow the build script to comment on the associated issue
       pull-requests: write   # allow the build script to post build status/comments on the PR
       contents: read         # check out the repository contents
+    env:
+      HAS_SKIP_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'skip-build') }}
+      HAS_RUN_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'run-build') }}
     steps:
+      - name: Evaluate build labels
+        id: gate
+        run: |
+          if [ "$HAS_SKIP_BUILD" = "true" ]; then
+            echo "decision=skip" >> "$GITHUB_OUTPUT"
+            echo "::notice::'skip-build' label present - skipping the build and reporting success."
+          elif [ "$HAS_RUN_BUILD" = "true" ]; then
+            echo "decision=build" >> "$GITHUB_OUTPUT"
+            echo "::notice::'run-build' label present - running the build."
+          else
+            echo "::error::This PR has neither the 'run-build' nor 'skip-build' label. Add 'run-build' to build (required to merge) or 'skip-build' to bypass."
+            exit 1
+          fi
       - name: Configure AWS Credentials
+        if: steps.gate.outputs.decision == 'build'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ vars.BUILD_SYSTEM_ROLE_ARN }}
@@ -59,10 +67,12 @@ jobs:
           role-duration-seconds: 7200
           aws-region: us-west-2
       - name: Download Build Script
+        if: steps.gate.outputs.decision == 'build'
         run: |
           aws s3 cp s3://aws-sdk-builds-github-assets-prod-us-west-2/$SCRIPT_LOCATION ./$DOWNLOAD_FOLDER/$SCRIPT_LOCATION --no-progress
           chmod +x ./$DOWNLOAD_FOLDER/$SCRIPT_LOCATION
       - name: Build
+        if: steps.gate.outputs.decision == 'build'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -13,10 +13,15 @@ on:
       - development
 
 concurrency:
-  # Per-PR group so one PR's long build never blocks another, and a newer commit
-  # cancels the now-stale build for the same PR.
-  group: build-sdk-v4-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Global serial lock: every real build shares one group so only one build runs
+  # at a time across ALL PRs; a second build is held pending until the first
+  # finishes (cancel-in-progress: false = queue, don't cancel). skip-build no-ops
+  # get their own per-PR group so they never sit in the queue behind a real build.
+  # Note: GitHub keeps only one in-progress + one pending run per group, so if a
+  # third build is triggered while one is running and one is queued, the queued
+  # one is superseded (its PR simply needs run-build re-added).
+  group: ${{ contains(github.event.pull_request.labels.*.name, 'skip-build') && format('build-sdk-v4-skip-{0}', github.event.pull_request.number) || 'build-sdk-v4-global' }}
+  cancel-in-progress: false
 
 env:
   # constants

--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -13,15 +13,11 @@ on:
       - development
 
 concurrency:
-  # Global serial lock: every real build shares one group so only one build runs
-  # at a time across ALL PRs; a second build is held pending until the first
-  # finishes (cancel-in-progress: false = queue, don't cancel). skip-build no-ops
-  # get their own per-PR group so they never sit in the queue behind a real build.
-  # Note: GitHub keeps only one in-progress + one pending run per group, so if a
-  # third build is triggered while one is running and one is queued, the queued
-  # one is superseded (its PR simply needs run-build re-added).
-  group: ${{ contains(github.event.pull_request.labels.*.name, 'skip-build') && format('build-sdk-v4-skip-{0}', github.event.pull_request.number) || 'build-sdk-v4-global' }}
-  cancel-in-progress: false
+  # Per-PR group. Cross-PR serialization (one build at a time) is handled by the
+  # build backend, so GitHub concurrency only needs to manage a single PR: a
+  # newer trigger for the same PR cancels its stale in-flight build.
+  group: build-sdk-v4-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   # constants

--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -5,7 +5,7 @@ permissions: {}
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches:
       - development
 
@@ -21,8 +21,25 @@ env:
 jobs:
   build-sdk-v4:
     name: build-sdk-v4
-    # Skip draft PRs and PRs from forked repos (they don't have access)
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    # Only run for PRs from the same repo (forks don't have access to the role), and either:
+    #   - a "run-build" label was just added (opts a draft into building), or
+    #   - for any other event, the PR is not a draft, or it is a draft that
+    #     already carries the "run-build" label (so labeled drafts keep building
+    #     on every push / synchronize).
+    # Requiring label.name == 'run-build' on the `labeled` action also prevents
+    # unrelated labels from starting a fresh build.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'run-build') ||
+        (
+          github.event.action != 'labeled' &&
+          (
+            github.event.pull_request.draft == false ||
+            contains(github.event.pull_request.labels.*.name, 'run-build')
+          )
+        )
+      )
     runs-on: ubuntu-latest
     permissions:
       id-token: write        # request the OIDC token used to assume the AWS IAM role


### PR DESCRIPTION
## Summary

Reworks the Build SDK V4 workflow into a **manually-triggered, one-shot build** whose result is an **explicit `pr-build` commit status** suitable as a required check for merging.

## Why a commit status instead of the job's own check
A required check that is **skipped** (via a job-level `if`) is treated by branch protection as **passing** - which let an unbuilt, no-label PR merge. Instead we post an explicit `pr-build` status to the PR head commit. **Merge is blocked whenever `pr-build` is absent or not `success` on the head SHA** - and absence is the default for any new commit.

## Labels
- **`run-build`** - adding it triggers one build on the current head commit; status = build result.
- **`skip-build`** - bypass: posts `success` without building (and keeps doing so on pushes). Removing it posts `failure` to re-block.

## Behavior

| Action | `pr-build` status | Merge |
|---|---|---|
| No label / new commit | absent | blocked |
| Add `run-build` | pending -> success/failure | per build result |
| Push a new commit | absent on new SHA (no auto-build) | blocked |
| Re-trigger: remove + re-add `run-build` | rebuilds new SHA | per result |
| Add `skip-build` | success (bypass) | allowed |
| Remove `skip-build` | failure | blocked |

## Re-trigger model
No auto-build on push. To build a new commit, **remove then re-add `run-build`** (re-adding an already-present label fires no event). This keeps the check bound to the exact commit and prevents run-then-append-then-merge.

## Changes
- Gate decides build / skip / block / noop in a step (not job `if`), so no-label produces a real blocking state rather than a skip-pass.
- Explicit `pr-build` commit status: pending on start, success/failure on finish (`always()`), success for skip-build bypass, failure when skip-build is removed.
- Per-PR concurrency with `cancel-in-progress`; cross-PR one-at-a-time is enforced by the build backend.

## Follow-up (manual, not in this PR)
1. Create the `run-build` and `skip-build` labels.
2. Add **`pr-build`** to `development` branch protection as a required status check (`strict: false` recommended). This is what actually blocks merge.