### PR TITLE
Use TryGetValue for header lookups in AWSSigV4Signer

### DIFF
--- a/sdk/src/Core/Amazon.Runtime/Signing/AWSSigV4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/AWSSigV4Signer.cs
@@ -262,14 +262,17 @@ namespace Amazon.Runtime.Signing
 
             // Copy caller headers into the request. A caller-supplied x-amz-content-sha256 is routed to
             // PrecomputedContentSha256 (below) rather than left on the header, so the signer honors it
-            // instead of scrubbing it during InitializeHeaders/CleanHeaders.
-            string precomputedHash = null;
+            // instead of scrubbing it during InitializeHeaders/CleanHeaders. internalRequest.Headers is a
+            // case-insensitive dictionary, so the pulled-out hash header is found and removed regardless of
+            // the caller's casing.
             foreach (var header in request.Headers)
+                internalRequest.Headers[header.Key] = header.Value;
+
+            string precomputedHash = null;
+            if (internalRequest.Headers.TryGetValue(HeaderKeys.XAmzContentSha256Header, out var callerHash))
             {
-                if (string.Equals(header.Key, HeaderKeys.XAmzContentSha256Header, StringComparison.OrdinalIgnoreCase))
-                    precomputedHash = header.Value;
-                else
-                    internalRequest.Headers[header.Key] = header.Value;
+                precomputedHash = callerHash;
+                internalRequest.Headers.Remove(HeaderKeys.XAmzContentSha256Header);
             }
 
             // Parse any query string on the URI into the request's parameter collection. Query components
@@ -577,23 +580,20 @@ namespace Amazon.Runtime.Signing
             if (headers == null)
                 return false;
 
-            foreach (var header in headers)
-            {
-                if (string.Equals(header.Key, HeaderKeys.XAmzContentSha256Header, StringComparison.OrdinalIgnoreCase))
-                {
-                    // A blank (empty or whitespace-only) value is treated as "not supplied", matching how
-                    // BuildRequest routes the header to PrecomputedContentSha256 and how the downstream signer
-                    // (its own IsNullOrEmpty check) ignores such a value. Without this, ValidateArguments would
-                    // reject a blank header for presign and SignPayload = false even though it has no effect.
-                    if (string.IsNullOrWhiteSpace(header.Value))
-                        return false;
+            // AWSSigningRequest.Headers is a case-insensitive (OrdinalIgnoreCase) dictionary, so the lookup
+            // resolves the header regardless of the caller's casing without scanning every entry.
+            if (!headers.TryGetValue(HeaderKeys.XAmzContentSha256Header, out var headerValue))
+                return false;
 
-                    value = header.Value;
-                    return true;
-                }
-            }
+            // A blank (empty or whitespace-only) value is treated as "not supplied", matching how
+            // BuildRequest routes the header to PrecomputedContentSha256 and how the downstream signer
+            // (its own IsNullOrEmpty check) ignores such a value. Without this, ValidateArguments would
+            // reject a blank header for presign and SignPayload = false even though it has no effect.
+            if (string.IsNullOrWhiteSpace(headerValue))
+                return false;
 
-            return false;
+            value = headerValue;
+            return true;
         }
 
         #endregion

--- a/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -216,7 +217,7 @@ namespace Amazon.Runtime.Signing
             return parameters.SignPayload && !HasContentSha256Header(request) && request.Content != null;
         }
 
-        private static AWSSigningRequest NewSigningRequest(HttpRequestMessage request, byte[] body)
+        private static AWSSigningRequest NewSigningRequest(HttpRequestMessage request, string precomputedContentSha256)
         {
             // Drop a security-token header left over from an earlier signing pass before collecting headers.
             // On a re-signed retry the credentials may have changed from short-term to long-term; if the stale
@@ -229,47 +230,79 @@ namespace Amazon.Runtime.Signing
             {
                 HttpMethod = request.Method,
                 RequestUri = request.RequestUri,
-                Content = body,
             };
             CollectHeaders(request, signingRequest.Headers);
+
+            // The body is hashed here (off the buffered content stream) rather than handed to the signer as a
+            // byte[] so the signer does not re-materialize the whole payload to hash it. The hash is supplied as
+            // the precomputed x-amz-content-sha256, which the signer honors instead of reading a body. When the
+            // body must not be hashed (UNSIGNED-PAYLOAD, or a caller-supplied hash) this is null and no header
+            // is added, leaving the signer's existing behavior unchanged.
+            if (precomputedContentSha256 != null)
+                signingRequest.Headers[HeaderKeys.XAmzContentSha256Header] = precomputedContentSha256;
+
             return signingRequest;
+        }
+
+        // Buffer the content once (so a one-shot body survives a retry resend, just as before) and hash it
+        // incrementally off the resulting re-readable stream. This avoids the second full-size allocation that
+        // ReadAsByteArrayAsync makes on top of the internal buffer: for a large body that removed copy is a
+        // Large Object Heap allocation that existed only to feed the hasher. ComputeSHA256Hash(Stream) reads in
+        // small chunks, so the peak footprint is one buffer rather than two.
+        private static async Task<string> HashBodyAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            // LoadIntoBufferAsync has no CancellationToken overload (its argument is a max buffer size), so the
+            // cancellation check above covers the buffering step; the stream read below honors the token where
+            // the overload accepts one.
+            await request.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+            var stream = await request.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#else
+            var stream = await request.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#endif
+            return HashStream(stream);
+        }
+
+        private static string HashStream(Stream stream)
+        {
+            var hashBytes = CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(stream);
+
+            // The stream is owned by the HttpContent (a re-readable in-memory buffer after LoadIntoBuffer), so it
+            // is not disposed here — disposing it would break the subsequent wire send and any retry that reads
+            // the same content. Hashing read it to the end, so rewind it: the wire send, an inner handler, or a
+            // retry that re-enters this handler must read the body from the start, not from EOF.
+            if (stream.CanSeek)
+                stream.Position = 0;
+
+            return AWSSDKUtils.ToHex(hashBytes, true);
         }
 
         private static async Task<AWSSigningRequest> BuildSigningRequestAsync(HttpRequestMessage request, AWSSigV4Parameters parameters, CancellationToken cancellationToken)
         {
-            byte[] body = null;
+            string precomputedContentSha256 = null;
             if (MustHashBody(request, parameters))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                // Reading the content here to hash it also buffers it internally: HttpContent loads its body
-                // into an in-memory buffer on the first read, so the same message can be re-serialized on a
-                // retry resend without re-reading (or exhausting) a one-shot stream. No explicit rebuffering is
-                // needed to make the body survive a resend.
-#if NET5_0_OR_GREATER
-                body = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
-#else
-                body = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
-#endif
-            }
+                precomputedContentSha256 = await HashBodyAsync(request, cancellationToken).ConfigureAwait(false);
 
-            return NewSigningRequest(request, body);
+            return NewSigningRequest(request, precomputedContentSha256);
         }
 
 #if NET5_0_OR_GREATER
         private static AWSSigningRequest BuildSigningRequest(HttpRequestMessage request, AWSSigV4Parameters parameters, CancellationToken cancellationToken)
         {
-            byte[] body = null;
+            string precomputedContentSha256 = null;
             if (MustHashBody(request, parameters))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                // ReadAsByteArrayAsync buffers the content in memory (so it survives a retry resend) and, once
-                // buffered, completes synchronously — the same read the async path uses. The BCL exposes no
-                // fully synchronous buffering primitive, so block on it here to keep the sync send genuinely
-                // synchronous end to end.
-                body = request.Content.ReadAsByteArrayAsync(cancellationToken).GetAwaiter().GetResult();
+                // LoadIntoBufferAsync buffers the content in memory (so it survives a retry resend) and, once
+                // buffered, the stream read completes synchronously. The BCL exposes no fully synchronous
+                // buffering primitive, so block on it here to keep the sync send genuinely synchronous end to
+                // end, then hash off the buffered stream (see HashBodyAsync for why we hash the stream).
+                request.Content.LoadIntoBufferAsync().GetAwaiter().GetResult();
+                precomputedContentSha256 = HashStream(request.Content.ReadAsStream(cancellationToken));
             }
 
-            return NewSigningRequest(request, body);
+            return NewSigningRequest(request, precomputedContentSha256);
         }
 #endif
 

--- a/sdk/test/IntegrationTests/Tests/SigV4SigningHandlerIntegrationTests.cs
+++ b/sdk/test/IntegrationTests/Tests/SigV4SigningHandlerIntegrationTests.cs
@@ -101,6 +101,31 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
 
         [Fact]
         [Trait("Category", "SigV4Signer")]
+        public async Task Post_WithLargeBody_SucceedsAgainstSts()
+        {
+            // A body larger than the LOH threshold exercises the handler's streamed body hashing end to end:
+            // the handler hashes the buffered content stream in chunks rather than a materialized byte[], and
+            // STS recomputes the body hash and rejects the signature if the streamed hash is wrong. The extra
+            // ignored form field pads the body past 85 KB while keeping GetCallerIdentity the requested action.
+            using (var client = NewSignedClient())
+            {
+                var padding = new string('a', 200 * 1024);
+                var content = new StringContent(
+                    "Action=GetCallerIdentity&Version=2011-06-15&Padding=" + padding,
+                    Encoding.UTF8,
+                    "application/x-www-form-urlencoded");
+
+                using (var response = await client.PostAsync(StsEndpoint(), content))
+                {
+                    var body = await response.Content.ReadAsStringAsync();
+                    Assert.True(response.StatusCode == HttpStatusCode.OK, $"STS returned {(int)response.StatusCode}: {body}");
+                    Assert.Contains("<Arn>", body);
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "SigV4Signer")]
         public async Task Post_WithSameHeaderOnRequestAndContent_SucceedsAgainstSts()
         {
             // A header set on both the request and the content goes on the wire as two lines (request value

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
@@ -106,6 +106,58 @@ namespace AWSSDK.UnitTests.Signing
         }
 
         [TestMethod]
+        public async Task Send_WithLargeBody_SignsStreamedHashMatchingByteArrayHash()
+        {
+            // The handler hashes the body off the buffered content stream rather than a materialized byte[].
+            // A body larger than the LOH threshold (and larger than the hasher's internal read chunk) proves
+            // the streamed hash spans many reads correctly and matches the byte[] hash the signer would compute
+            // over the same bytes. Non-repeating content guards against a chunk-boundary bug being masked by
+            // uniform bytes.
+            var bytes = new byte[200 * 1024];
+            for (int i = 0; i < bytes.Length; i++)
+                bytes[i] = (byte)(i * 31 + 7);
+
+            var handler = NewHandler(out var inner);
+            inner.CaptureBody = true;
+            using (var client = NewClient(handler))
+            {
+                var content = new ByteArrayContent(bytes);
+                await client.PostAsync("https://example.execute-api.us-east-1.amazonaws.com/items", content);
+            }
+
+            var sent = inner.LastRequest;
+            var expectedHash = AWSSDKUtils.ToHex(CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(bytes), true);
+            var actualHash = sent.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single();
+            Assert.AreEqual(expectedHash, actualHash);
+        }
+
+        [TestMethod]
+        public async Task Send_ReSigningLargeBody_ResendsAndReHashesBody()
+        {
+            // Buffering the large body (rather than reading it into a one-shot byte[]) must still leave it
+            // re-readable, so a retry resends the same bytes and recomputes the same hash.
+            var bytes = new byte[200 * 1024];
+            for (int i = 0; i < bytes.Length; i++)
+                bytes[i] = (byte)(i * 17 + 3);
+            var expectedHash = AWSSDKUtils.ToHex(CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(bytes), true);
+
+            var handler = NewHandler(out var inner);
+            var invoker = new HttpMessageInvoker(handler);
+            var message = new HttpRequestMessage(HttpMethod.Post, "https://example.execute-api.us-east-1.amazonaws.com/items")
+            {
+                Content = new ByteArrayContent(bytes),
+            };
+
+            await invoker.SendAsync(message, CancellationToken.None);
+            Assert.AreEqual(expectedHash, inner.LastRequest.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single());
+
+            // Retry: same message re-enters the handler; the buffered body must still be readable and re-hashed.
+            await invoker.SendAsync(message, CancellationToken.None);
+            Assert.AreEqual(expectedHash, inner.LastRequest.Headers.GetValues(HeaderKeys.XAmzContentSha256Header).Single());
+            Assert.AreEqual(1, message.Headers.GetValues(HeaderKeys.AuthorizationHeader).Count());
+        }
+
+        [TestMethod]
         public async Task Send_WithSessionCredentials_AddsSecurityTokenHeader()
         {
             var handler = NewHandler(new SessionAWSCredentials(AccessKey, SecretKey, "the-session-token"), out var inner);


### PR DESCRIPTION
## Summary
- Replace manual `foreach` iteration with `Dictionary.TryGetValue` in `TryGetContentSha256Header` — the dictionary already uses `OrdinalIgnoreCase`, so `TryGetValue` gives the same case-insensitive match without scanning every entry.
- Simplify the header-copy loop in `BuildRequest` to copy all headers first, then extract and remove the `x-amz-content-sha256` header via `TryGetValue` + `Remove` instead of branching inside the loop.

Addresses review feedback from @JanHyka on #4482 (comments on lines 267 and 580).