### PR TITLE
[C2J to Smithy] Add int member support to the JSON marshaller/unmarshaller writers

### DIFF
--- a/generator/.DevConfigs/07f207d1-fb91-4458-b15d-375555a0cd80.json
+++ b/generator/.DevConfigs/07f207d1-fb91-4458-b15d-375555a0cd80.json
@@ -1,0 +1,8 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "[C2J to Smithy] Add int member support to the JSON marshaller/unmarshaller writers"    ],
+    "type": "patch",
+    "updateMinimum": true
+  }
+}

--- a/generator/SmithyDotNet/SmithyDotNet.Generator.Tests/Writers/IntMemberMarshallingTests.cs
+++ b/generator/SmithyDotNet/SmithyDotNet.Generator.Tests/Writers/IntMemberMarshallingTests.cs
@@ -1,0 +1,177 @@
+using System.Text.Json;
+using SmithyDotNet.Generator.Generation;
+using SmithyDotNet.Generator.Model;
+using SmithyDotNet.Generator.Model.Shapes;
+using SmithyDotNet.Generator.Writers;
+using Xunit;
+
+namespace SmithyDotNet.Generator.Tests.Writers;
+
+/// <summary>
+/// Exercises int? (Smithy integer) support across the four JSON marshalling writers. The shared
+/// CloudTrailData fixture is all-string, so these tests synthesize structures/operations carrying
+/// integer members and assert the emitted marshal/unmarshal code matches the existing SDK's
+/// patterns (WriteNumberValue with .Value, NullableIntUnmarshaller, StringUtils.FromInt).
+/// </summary>
+[Collection(nameof(CloudTrailModelCollection))]
+public class IntMemberMarshallingTests
+{
+    private const string ModelFileName = "cloudtrail-data-2021-08-11.normal.json";
+    private const string Namespace = "com.amazonaws.cloudtraildata";
+
+    private readonly GenerationContext _context;
+
+    public IntMemberMarshallingTests(CloudTrailModelFixture fixture)
+    {
+        _context = fixture.Context;
+    }
+
+    [Fact]
+    public void StructureMarshaller_IntMember_WritesNumberValueWithDotValue()
+    {
+        var structure = StructureWith(("count", Integer(), false));
+        var output = new JsonStructureMarshallerWriter(_context, ModelFileName)
+            .Write(structure, ShapeId.Parse($"{Namespace}#Widget"), TestContext.Current.CancellationToken);
+
+        Assert.Contains("if (requestObject.IsSetCount())", output);
+        Assert.Contains("context.Writer.WritePropertyName(\"count\");", output);
+        Assert.Contains("context.Writer.WriteNumberValue(requestObject.Count.Value);", output);
+    }
+
+    [Fact]
+    public void StructureUnmarshaller_IntMember_UsesNullableIntUnmarshaller()
+    {
+        var structure = StructureWith(("count", Integer(), false));
+        var output = new JsonStructureUnmarshallerWriter(_context, ModelFileName)
+            .Write(structure, ShapeId.Parse($"{Namespace}#Widget"), TestContext.Current.CancellationToken);
+
+        Assert.Contains("if (context.TestExpression(\"count\", targetDepth, ref reader))", output);
+        Assert.Contains("var unmarshaller = NullableIntUnmarshaller.Instance;", output);
+        Assert.Contains("unmarshalledObject.Count = unmarshaller.Unmarshall(context, ref reader);", output);
+    }
+
+    [Fact]
+    public void ResponseUnmarshaller_IntMember_UsesNullableIntUnmarshaller()
+    {
+        var operation = OperationWith(output: StructureWith(("count", Integer(), false)));
+        var source = new JsonResponseUnmarshallerWriter(_context, ModelFileName)
+            .Write(operation, TestContext.Current.CancellationToken);
+
+        Assert.Contains("if (context.TestExpression(\"count\", targetDepth, ref reader))", source);
+        Assert.Contains("var unmarshaller = NullableIntUnmarshaller.Instance;", source);
+        Assert.Contains("response.Count = unmarshaller.Unmarshall(context, ref reader);", source);
+    }
+
+    [Fact]
+    public void RequestMarshaller_IntBodyMember_WritesNumberValueWithDotValue()
+    {
+        var operation = OperationWith(input: StructureWith(("count", Integer(), false)));
+        var source = WriteRequest(operation);
+
+        Assert.Contains("if (publicRequest.IsSetCount())", source);
+        Assert.Contains("context.Writer.WritePropertyName(\"count\");", source);
+        Assert.Contains("context.Writer.WriteNumberValue(publicRequest.Count.Value);", source);
+    }
+
+    [Fact]
+    public void RequestMarshaller_IntQueryMember_UsesFromIntWithoutDotValue()
+    {
+        var member = Integer(("smithy.api#httpQuery", "maxResults"));
+        var operation = OperationWith(input: StructureWith(("maxResults", member, false)));
+        var source = WriteRequest(operation);
+
+        Assert.Contains("if (publicRequest.IsSetMaxResults())", source);
+        Assert.Contains("request.Parameters.Add(\"maxResults\", StringUtils.FromInt(publicRequest.MaxResults));", source);
+        Assert.DoesNotContain("publicRequest.MaxResults.Value", source);
+    }
+
+    [Fact]
+    public void RequestMarshaller_RequiredIntQueryMember_GuardsWithIsSetNotIsNullOrEmpty()
+    {
+        var member = Integer(("smithy.api#httpQuery", "maxResults"), ("smithy.api#required", null));
+        var operation = OperationWith(input: StructureWith(("maxResults", member, true)));
+        var source = WriteRequest(operation);
+
+        Assert.Contains("if (!publicRequest.IsSetMaxResults())", source);
+        Assert.DoesNotContain("string.IsNullOrEmpty(publicRequest.MaxResults)", source);
+        Assert.Contains("Request object does not have required field MaxResults set", source);
+    }
+
+    [Fact]
+    public void RequestMarshaller_IntHeaderMember_ConvertsThroughFromInt()
+    {
+        var member = Integer(("smithy.api#httpHeader", "Max-Results"));
+        var operation = OperationWith(input: StructureWith(("maxResults", member, false)));
+        var source = WriteRequest(operation);
+
+        Assert.Contains("if (publicRequest.IsSetMaxResults())", source);
+        Assert.Contains("request.Headers[\"Max-Results\"] = StringUtils.FromInt(publicRequest.MaxResults);", source);
+    }
+
+    [Fact]
+    public void RequestMarshaller_IntLabelMember_UsesFromIntInPathResource()
+    {
+        var member = Integer(("smithy.api#httpLabel", null));
+        var operation = OperationWith(
+            input: StructureWith(("id", member, true)),
+            uri: "/widgets/{id}");
+        var source = WriteRequest(operation);
+
+        Assert.Contains("if (!publicRequest.IsSetId())", source);
+        Assert.Contains("request.AddPathResource(\"{id}\", StringUtils.FromInt(publicRequest.Id));", source);
+    }
+
+    private string WriteRequest(Operation operation) =>
+        new JsonRequestMarshallerWriter(_context, ModelFileName)
+            .Write(operation, TestContext.Current.CancellationToken);
+
+    // --- Synthetic model builders ------------------------------------------------------------
+
+    private static readonly JsonSerializerOptions Options = CloudTrailModelFixture.Options;
+
+    // An integer member shape targeting the smithy.api#Integer prelude shape, carrying the given
+    // traits (value null -> annotation trait "{}", otherwise a JSON string value).
+    private static MemberShape Integer(params (string Trait, string? Value)[] traits)
+    {
+        var traitJson = string.Join(", ", traits.Select(t =>
+            t.Value is null ? $"\"{t.Trait}\": {{}}" : $"\"{t.Trait}\": \"{t.Value}\""));
+        var json = $$"""{ "target": "smithy.api#Integer", "traits": { {{traitJson}} } }""";
+        return Deserialize<MemberShape>(json);
+    }
+
+    private static StructureShape StructureWith(params (string Name, MemberShape Member, bool Required)[] members)
+    {
+        var structure = new StructureShape();
+        foreach (var (name, member, required) in members)
+        {
+            structure.Members[name] = required ? WithRequired(member) : member;
+        }
+
+        return structure;
+    }
+
+    // @required lives on the structure member reference, not the target; re-emit the member with the
+    // trait added so IsRequired() and the AWSProperty resolution see it.
+    private static MemberShape WithRequired(MemberShape member)
+    {
+        var traits = new Dictionary<string, JsonElement>(member.Traits)
+        {
+            ["smithy.api#required"] = JsonDocument.Parse("{}").RootElement,
+        };
+        return member with { Traits = traits };
+    }
+
+    private Operation OperationWith(StructureShape? input = null, StructureShape? output = null, string uri = "/widgets")
+    {
+        var http = Deserialize<OperationShape>(
+            $$"""{ "type": "operation", "traits": { "smithy.api#http": { "method": "POST", "uri": "{{uri}}", "code": 200 } } }""");
+        return new Operation("DoThing", http, input ?? new StructureShape(), output ?? new StructureShape(), []);
+    }
+
+    // Deserialize the concrete T directly, not via Shape: ShapeConverter dispatches on a "type"
+    // field, which member shapes (target + traits, no type) don't carry. The converter matches only
+    // typeof(Shape), so a concrete T bypasses it and uses reflection-based deserialization.
+    private static T Deserialize<T>(string json) where T : Shape =>
+        JsonSerializer.Deserialize<T>(json, Options)
+        ?? throw new InvalidOperationException($"'{json}' deserialized to null.");
+}

--- a/generator/SmithyDotNet/SmithyDotNet.Generator.Tests/Writers/TypeMapperTests.cs
+++ b/generator/SmithyDotNet/SmithyDotNet.Generator.Tests/Writers/TypeMapperTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using SmithyDotNet.Generator.Model;
 using SmithyDotNet.Generator.Model.Shapes;
 using SmithyDotNet.Generator.Writers;
 using Xunit;
@@ -143,4 +144,38 @@ public class TypeMapperTests
         Assert.Contains("Min=2", result);
         Assert.Contains("Max=8", result);
     }
+
+    [Fact]
+    public void MapType_Integer_ReturnsNullableInt()
+    {
+        // Disabling Cannot convert null literal to non-nullable reference type, since we don't really
+        // need the context here and it isn't used anywhere in this class.
+#pragma warning disable CS8625 
+        Assert.Equal("int?", TypeMapper.MapType(ShapeId.Parse("smithy.api#Integer"), new IntegerShape(), context: null));
+#pragma warning restore CS8625
+    }
+
+    [Fact]
+    public void IsSetExpression_NullableValueType_UsesHasValue()
+    {
+        Assert.Equal("this.Count.HasValue", SimpleScalarMember("Count", "int?").IsSetExpression);
+    }
+
+    [Fact]
+    public void IsSetExpression_ReferenceType_UsesNullCheck()
+    {
+        Assert.Equal("this.Plain != null", SimpleScalarMember("Plain", "string").IsSetExpression);
+    }
+
+    private static Member SimpleScalarMember(string propertyName, string dotNetType) => new(
+        PropertyName: propertyName,
+        DotNetType: dotNetType,
+        IsCollection: false,
+        IsStructure: false,
+        IsRequired: false,
+        IsElementStructure: false,
+        AwsProperty: null,
+        Obsolete: null,
+        Documentation: string.Empty,
+        ModeledName: propertyName);
 }

--- a/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/JsonRequestMarshallerWriter.cs
+++ b/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/JsonRequestMarshallerWriter.cs
@@ -8,8 +8,8 @@ namespace SmithyDotNet.Generator.Writers;
 /// Emits the C# source for a JSON request marshaller matching the public API surface
 /// of the existing AWS SDK for .NET.
 /// <para />
-/// Phase 1 scope: restJson1 operations whose body members are lists of structures or strings,
-/// and whose query-string members are strings. Other member types throw a
+/// Phase 1 scope: restJson1 operations whose body members are lists of structures, strings, or
+/// int?, and whose query-string members are strings or int?. Other member types throw a
 /// <see cref="GeneratorException"/>.
 /// </summary>
 public sealed class JsonRequestMarshallerWriter(GenerationContext context, string modelFileName)
@@ -100,14 +100,13 @@ public sealed class JsonRequestMarshallerWriter(GenerationContext context, strin
     {
         foreach (var (member, queryName) in queryMembers)
         {
-            if (member.DotNetType != "string")
-            {
-                throw new GeneratorException($"Only string query members are handled currently (member: {member.PropertyName}).");
-            }
-
             if (member.IsRequired)
             {
-                writer.OpenBlock($"if (string.IsNullOrEmpty(publicRequest.{member.PropertyName}))", () =>
+                var condition = member.DotNetType == "string"
+                    ? $"string.IsNullOrEmpty(publicRequest.{member.PropertyName})"
+                    : $"!publicRequest.IsSet{member.PropertyName}()";
+
+                writer.OpenBlock($"if ({condition})", () =>
                 {
                     writer.WriteLine($"throw new Amazon{context.ServiceName}Exception(\"Request object does not have required field {member.PropertyName} set\");");
                 });
@@ -116,7 +115,7 @@ public sealed class JsonRequestMarshallerWriter(GenerationContext context, strin
 
             writer.OpenBlock($"if (publicRequest.IsSet{member.PropertyName}())", () =>
             {
-                writer.WriteLine($"request.Parameters.Add(\"{queryName}\", StringUtils.FromString(publicRequest.{member.PropertyName}));");
+                writer.WriteLine($"request.Parameters.Add(\"{queryName}\", {ScalarToStringUtils(member, "query")});");
             });
             writer.WriteLine("");
         }
@@ -127,13 +126,14 @@ public sealed class JsonRequestMarshallerWriter(GenerationContext context, strin
     {
         foreach (var (member, headerName) in headerMembers)
         {
-            if (member.DotNetType != "string")
-            {
-                throw new GeneratorException($"Only string header members are handled currently (member: {member.PropertyName}).");
-            }
+            // A header value is already a string, other scalars convert through StringUtils first.
+            var value = member.DotNetType == "string"
+                ? $"publicRequest.{member.PropertyName}"
+                : ScalarToStringUtils(member, "header");
+
             writer.OpenBlock($"if (publicRequest.IsSet{member.PropertyName}())", () =>
             {
-                writer.WriteLine($"request.Headers[\"{headerName}\"] = publicRequest.{member.PropertyName};");
+                writer.WriteLine($"request.Headers[\"{headerName}\"] = {value};");
             });
             writer.WriteLine("");
         }
@@ -144,19 +144,23 @@ public sealed class JsonRequestMarshallerWriter(GenerationContext context, strin
     {
         foreach (var member in labelMembers)
         {
-            if (member.DotNetType != "string")
-            {
-                throw new GeneratorException($"Only string label members are handled currently (member: {member.PropertyName}).");
-            }
+            var value = ScalarToStringUtils(member, "label");
             writer.OpenBlock($"if (!publicRequest.IsSet{member.PropertyName}())", () =>
             {
                 writer.WriteLine($"throw new Amazon{context.ServiceName}Exception(\"Request object does not have required field {member.PropertyName} set\");");
             });
-            writer.WriteLine($"request.AddPathResource(\"{{{member.ModeledName}}}\", StringUtils.FromString(publicRequest.{member.PropertyName}));");
+            writer.WriteLine($"request.AddPathResource(\"{{{member.ModeledName}}}\", {value});");
             writer.WriteLine("");
         }
         writer.WriteLine($"request.ResourcePath = \"{httpTrait.Uri}\";");
     }
+
+    private string ScalarToStringUtils(Member member, string binding) => member.DotNetType switch
+    {
+        "string" => $"StringUtils.FromString(publicRequest.{member.PropertyName})",
+        "int?" => $"StringUtils.FromInt(publicRequest.{member.PropertyName})",
+        _ => throw new GeneratorException($"Only string and int? {binding} members are handled currently (member: {member.PropertyName}, type: {member.DotNetType})."),
+    };
 
     private void WriteBodySerialization(CodeWriter writer, List<Member> bodyMembers)
     {
@@ -185,35 +189,35 @@ public sealed class JsonRequestMarshallerWriter(GenerationContext context, strin
 
     private void WriteBodyMember(CodeWriter writer, Member member)
     {
-        if (member.DotNetType == "string")
+        writer.OpenBlock($"if (publicRequest.IsSet{member.PropertyName}())", () =>
         {
-            writer.OpenBlock($"if (publicRequest.IsSet{member.PropertyName}())", () =>
+            writer.WriteLine($"context.Writer.WritePropertyName(\"{member.JsonName ?? member.ModeledName}\");");
+            if (member.DotNetType == "string")
             {
-                writer.WriteLine($"context.Writer.WritePropertyName(\"{member.JsonName ?? member.ModeledName}\");");
                 writer.WriteLine($"context.Writer.WriteStringValue(publicRequest.{member.PropertyName});");
-            });
-        }
-        else if (member.DotNetType.StartsWith("List<", StringComparison.Ordinal))
-        {
-            if (string.IsNullOrEmpty(member.ElementType))
-            {
-                throw new GeneratorException("A List's element type must be populated.");
             }
-            writer.OpenBlock($"if (publicRequest.IsSet{member.PropertyName}())", () =>
+            else if (member.DotNetType == "int?")
             {
-                writer.WriteLine($"context.Writer.WritePropertyName(\"{member.JsonName ?? member.ModeledName}\");");
+                writer.WriteLine($"context.Writer.WriteNumberValue(publicRequest.{member.PropertyName}.Value);");
+            }
+            else if (member.DotNetType.StartsWith("List<", StringComparison.Ordinal))
+            {
+                if (string.IsNullOrEmpty(member.ElementType))
+                {
+                    throw new GeneratorException("A List's element type must be populated.");
+                }
                 writer.WriteLine("context.Writer.WriteStartArray();");
                 writer.OpenBlock($"foreach (var publicRequest{member.PropertyName}ListValue in publicRequest.{member.PropertyName})", () =>
                 {
                     WriteListElement(writer, member);
                 });
                 writer.WriteLine("context.Writer.WriteEndArray();");
-            });
-        }
-        else
-        {
-            throw new GeneratorException($"Only string and List<T> body members are handled currently (member: {member.PropertyName}, type: {member.DotNetType}).");
-        }
+            }
+            else
+            {
+                throw new GeneratorException($"Only string, int?, and List<T> body members are handled currently (member: {member.PropertyName}, type: {member.DotNetType}).");
+            }
+        });
     }
 
     private void WriteListElement(CodeWriter writer, Member member)

--- a/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/JsonResponseUnmarshallerWriter.cs
+++ b/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/JsonResponseUnmarshallerWriter.cs
@@ -98,25 +98,28 @@ public sealed class JsonResponseUnmarshallerWriter(GenerationContext context, st
         if (member.DotNetType == "string")
         {
             writer.WriteLine("var unmarshaller = StringUnmarshaller.Instance;");
-            writer.WriteLine($"response.{member.PropertyName} = unmarshaller.Unmarshall(context, ref reader);");
+        }
+        else if (member.DotNetType == "int?")
+        {
+            writer.WriteLine("var unmarshaller = NullableIntUnmarshaller.Instance;");
         }
         else if (member.IsCollection && member.IsElementStructure)
         {
             var elementType = member.ElementType ?? throw new GeneratorException($"List member '{member.PropertyName}' has no element type.");
             var unmarshallerType = $"{elementType}Unmarshaller";
             writer.WriteLine($"var unmarshaller = new JsonListUnmarshaller<{elementType}, {unmarshallerType}>({unmarshallerType}.Instance);");
-            writer.WriteLine($"response.{member.PropertyName} = unmarshaller.Unmarshall(context, ref reader);");
         }
         else if (member.IsStructure)
         {
             var unmarshallerType = $"{member.DotNetType}Unmarshaller";
             writer.WriteLine($"var unmarshaller = {unmarshallerType}.Instance;");
-            writer.WriteLine($"response.{member.PropertyName} = unmarshaller.Unmarshall(context, ref reader);");
         }
         else
         {
             throw new GeneratorException($"Unsupported response member type '{member.DotNetType}' for member '{member.PropertyName}'.");
         }
+
+        writer.WriteLine($"response.{member.PropertyName} = unmarshaller.Unmarshall(context, ref reader);");
     }
 
     private void WriteUnmarshallExceptionMethod(CodeWriter writer, Operation operation)

--- a/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/JsonStructureMarshallerWriter.cs
+++ b/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/JsonStructureMarshallerWriter.cs
@@ -8,7 +8,7 @@ namespace SmithyDotNet.Generator.Writers;
 /// Emits the C# source for a JSON structure marshaller matching the public API surface
 /// of the existing AWS SDK for .Net.
 /// <para />
-/// Phase 1 scope: Structures whose members all resolve to <c>string</c>. Any other member type
+/// Phase 1 scope: Structures whose members all resolve to <c>string</c> or <c>int?</c>. Any other member type
 /// throws a <see cref="GeneratorException"/>. 
 /// </summary>
 /// <param name="context"></param>
@@ -72,9 +72,17 @@ public sealed class JsonStructureMarshallerWriter(GenerationContext context, str
                     writer.WriteLine($"context.Writer.WriteStringValue(requestObject.{members[i].PropertyName});");
                 });
             }
+            else if (members[i].DotNetType == "int?")
+            {
+                writer.OpenBlock($"if (requestObject.IsSet{members[i].PropertyName}())", () =>
+                {
+                    writer.WriteLine($"context.Writer.WritePropertyName(\"{members[i].JsonName ?? members[i].ModeledName}\");");
+                    writer.WriteLine($"context.Writer.WriteNumberValue(requestObject.{members[i].PropertyName}.Value);");
+                });
+            }
             else
             {
-                throw new GeneratorException("Only string members are handled currently");
+                throw new GeneratorException("Only string and int? members are handled currently");
             }
             if (i < members.Count - 1)
             {

--- a/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/JsonStructureUnmarshallerWriter.cs
+++ b/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/JsonStructureUnmarshallerWriter.cs
@@ -8,8 +8,8 @@ namespace SmithyDotNet.Generator.Writers;
 /// Emits the C# source for a JSON structure unmarshaller matching the public API surface
 /// of the existing AWS SDK for .NET.
 /// <para />
-/// Phase 1 scope: Structures whose members all resolve to <c>string</c>. Any other member type
-/// throws a <see cref="GeneratorException"/>.
+/// Phase 1 scope: Structures whose members all resolve to <c>string</c> or <c>int?</c>. Any other
+/// member type throws a <see cref="GeneratorException"/>.
 /// </summary>
 public sealed class JsonStructureUnmarshallerWriter(GenerationContext context, string modelFileName)
 {
@@ -78,15 +78,12 @@ public sealed class JsonStructureUnmarshallerWriter(GenerationContext context, s
     {
         for (int i = 0; i < members.Count; i++)
         {
-            if (members[i].DotNetType != "string")
-            {
-                throw new GeneratorException($"Only string members are handled currently. Member '{members[i].ModeledName}' resolved to '{members[i].DotNetType}'.");
-            }
+            var unmarshaller = ScalarUnmarshaller(members[i]);
 
             var wireName = members[i].JsonName ?? members[i].ModeledName;
             writer.OpenBlock($"if (context.TestExpression(\"{wireName}\", targetDepth, ref reader))", () =>
             {
-                writer.WriteLine("var unmarshaller = StringUnmarshaller.Instance;");
+                writer.WriteLine($"var unmarshaller = {unmarshaller};");
                 writer.WriteLine($"unmarshalledObject.{members[i].PropertyName} = unmarshaller.Unmarshall(context, ref reader);");
                 writer.WriteLine("continue;");
             });
@@ -97,6 +94,13 @@ public sealed class JsonStructureUnmarshallerWriter(GenerationContext context, s
             }
         }
     }
+
+    private static string ScalarUnmarshaller(Member member) => member.DotNetType switch
+    {
+        "string" => "StringUnmarshaller.Instance",
+        "int?" => "NullableIntUnmarshaller.Instance",
+        _ => throw new GeneratorException($"Only string and int? members are handled currently. Member '{member.ModeledName}' resolved to '{member.DotNetType}'."),
+    };
 
     private static void WriteSingleton(CodeWriter writer, string className)
     {

--- a/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/TypeMapper.cs
+++ b/generator/SmithyDotNet/SmithyDotNet.Generator/Writers/TypeMapper.cs
@@ -38,13 +38,29 @@ public sealed record Member(
     /// <summary>
     /// Body expression for the internal <c>IsSet{Property}()</c> method. Collections honor
     /// <c>AWSConfigs.InitializeCollections</c>: an empty list is "set" only when the
-    /// V4-default null mode is active.
+    /// V4-default null mode is active. Nullable value types (<c>int?</c>, and later
+    /// <c>bool?</c>/<c>long?</c>/<c>DateTime?</c>) test <c>.HasValue</c>; everything else is a
+    /// reference type tested against null. A trailing <c>?</c> in the .NET type is the discriminator:
+    /// only nullable value types carry one.
     /// </summary>
-    // TODO: when nullable value types land (int?, bool?, DateTime?) IsSet should use .HasValue;
-    // Document has its own .IsSet().
-    public string IsSetExpression => IsCollection
-        ? $"this.{PropertyName} != null && (this.{PropertyName}.Count > 0 || !AWSConfigs.InitializeCollections)"
-        : $"this.{PropertyName} != null";
+    public string IsSetExpression
+    {
+        get
+        {
+            if (IsCollection)
+            {
+                return $"this.{PropertyName} != null && (this.{PropertyName}.Count > 0 || !AWSConfigs.InitializeCollections)";
+            }
+            else if (DotNetType.EndsWith('?'))
+            {
+                return $"this.{PropertyName}.HasValue";
+            }
+            else
+            {
+                return $"this.{PropertyName} != null";
+            }
+        }
+    }
 }
 
 /// <summary>
@@ -100,6 +116,11 @@ public static class TypeMapper
         if (target is StringShape)
         {
             return "string";
+        }
+
+        if (target is IntegerShape)
+        {
+            return "int?";
         }
 
         if (target is ListShape list)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Extends the Smithy generator's four JSON marshalling writers to handle integer members, mapping them to int? and emitting marshal/unmarshal code that matches the existing AWS SDK for .NET's output. 

## Motivation and Context
`DOTNET-8749`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
`IntMemberMarshallingTests `
This test class synthesizes structures/operations carrying integer members rather than loading a real service model, and is intentionally temporary. The shared test fixture (CloudTrail Data) is all-string, and every real AWS service model that contains integer members also contains other types the generator doesn't support yet (booleans, doubles, timestamps, maps, enums, blobs), so those models can't be run through the writers until that type coverage exists. There's no real model that isolates int? cleanly, hence the synthetic approach for now.

Follow-up: once the remaining scalar/aggregate types are supported, I'll rework this into broader coverage driven by a real service model (loaded through the normal ShapeConverter → ServiceIndex → GenerationContext pipeline, like the existing CloudTrail-based tests) and retire the synthetic builders.


<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Dry-runs
<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** a9b85345-0efd-4e78-98aa-f6bf8ab524bd
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:** 1bab02f7-6001-4080-b10d-3f0ca92f6fa3
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

