### PR TITLE
Simplify RDS and DSQL auth token generators onto the public SigV4 facade

### DIFF
--- a/generator/.DevConfigs/84e8637a-2004-4c28-8a91-f01b388b9b45.json
+++ b/generator/.DevConfigs/84e8637a-2004-4c28-8a91-f01b388b9b45.json
@@ -1,0 +1,18 @@
+{
+  "services": [
+    {
+      "serviceName": "RDS",
+      "type": "patch",
+      "changeLogMessages": [
+        "Internal refactor of the RDS IAM auth token generator to build its presigned token via the public `Amazon.Runtime.Signing.AWSSigV4Signer` facade. Token output is unchanged. The .NET Framework target now references `System.Net.Http`."
+      ]
+    },
+    {
+      "serviceName": "DSQL",
+      "type": "patch",
+      "changeLogMessages": [
+        "Internal refactor of the DSQL auth token generator to build its presigned token via the public `Amazon.Runtime.Signing.AWSSigV4Signer` facade. Token output is unchanged. The .NET Framework target now references `System.Net.Http`."
+      ]
+    }
+  ]
+}

--- a/generator/ServiceClientGeneratorLib/GenerationManifest.cs
+++ b/generator/ServiceClientGeneratorLib/GenerationManifest.cs
@@ -393,7 +393,9 @@ namespace ServiceClientGenerator
                         {
                             Name = item[ModelsSectionKeys.DependencyNameKey].ToString(),
                             Version = item.PropertyNames.Contains(ModelsSectionKeys.DependencyVersionKey) ? item[ModelsSectionKeys.DependencyVersionKey].ToString() : "0.0.0.0",
-                            HintPath = item[ModelsSectionKeys.DependencyHintPathKey].ToString(),
+                            // hint-path is optional: framework references (e.g. "System.Net.Http" for net472)
+                            // don't need one — the template only emits <HintPath> when it is set.
+                            HintPath = item.PropertyNames.Contains(ModelsSectionKeys.DependencyHintPathKey) ? item[ModelsSectionKeys.DependencyHintPathKey].ToString() : null,
                         };
                         platformDependencies.Add(platformDependency);
                     }

--- a/generator/ServiceClientGeneratorLib/ProjectFileCreator.cs
+++ b/generator/ServiceClientGeneratorLib/ProjectFileCreator.cs
@@ -290,7 +290,20 @@ namespace ServiceClientGenerator
                 toExclude.Add("UnitTests");
             }
             projectProperties.FrameworkPathOverride = projectFileConfiguration.FrameworkPathOverride;
-            projectProperties.ReferenceDependencies = projectFileConfiguration.DllReferences;
+
+            // Framework references come from two sources:
+            //   1) project-type-wide (frameworkReferences in _manifest.json), applied to every service; and
+            //   2) per-service (reference-dependencies in the service's metadata.json), applied only to that
+            //      service. The per-service list is additive so a service can pull in a framework assembly it
+            //      needs without forcing every other service to reference it too (e.g. System.Net.Http for the
+            //      RDS/DSQL auth-token generators, which build AWSSigningRequest instances).
+            var referenceDependencies = projectFileConfiguration.DllReferences ?? Enumerable.Empty<Dependency>();
+            if (serviceConfiguration.ReferenceDependencies != null &&
+                serviceConfiguration.ReferenceDependencies.TryGetValue(projectFileConfiguration.Name, out var perServiceRefs))
+            {
+                referenceDependencies = referenceDependencies.Concat(perServiceRefs);
+            }
+            projectProperties.ReferenceDependencies = referenceDependencies;
             projectProperties.SupressWarnings       = "CA1822";
             projectProperties.SignBinaries          = true;
             projectProperties.PackageReferences = projectFileConfiguration.PackageReferences;

--- a/generator/ServiceModels/dsql/metadata.json
+++ b/generator/ServiceModels/dsql/metadata.json
@@ -1,5 +1,10 @@
 {
   "active": true,
   "synopsis": "Add new API operations for Amazon Aurora DSQL. Amazon Aurora DSQL is a serverless, distributed SQL database with virtually unlimited scale, highest availability, and zero infrastructure management.",
-  "generate-client-constructors": true
+  "generate-client-constructors": true,
+  "reference-dependencies": {
+    "NetFramework": [
+      { "name": "System.Net.Http" }
+    ]
+  }
 }

--- a/generator/ServiceModels/rds/metadata.json
+++ b/generator/ServiceModels/rds/metadata.json
@@ -1,5 +1,10 @@
 {
   "active": true,
   "synopsis": "Amazon Relational Database Service (Amazon RDS) is a web service that makes it easy to set up, operate, and scale a relational database in the cloud. It provides cost-efficient and resizable capacity while managing time-consuming database management tasks, freeing you up to focus on your applications and business.",
-  "legacy-service-id": "RDS"
+  "legacy-service-id": "RDS",
+  "reference-dependencies": {
+    "NetFramework": [
+      { "name": "System.Net.Http" }
+    ]
+  }
 }

--- a/sdk/src/Services/DSQL/AWSSDK.DSQL.NetFramework.csproj
+++ b/sdk/src/Services/DSQL/AWSSDK.DSQL.NetFramework.csproj
@@ -76,6 +76,7 @@
 
   <ItemGroup>
     <Reference Include="System.Configuration"/>
+    <Reference Include="System.Net.Http"/>
   </ItemGroup>
 
 

--- a/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
+++ b/sdk/src/Services/DSQL/Custom/Util/DSQLAuthTokenGenerator.cs
@@ -15,12 +15,10 @@
 
 using Amazon.Runtime;
 using Amazon.Runtime.Credentials.Internal;
-using Amazon.Runtime.Internal;
-using Amazon.Runtime.Internal.Auth;
-using Amazon.Runtime.Internal.Transform;
-using Amazon.Runtime.Internal.Util;
+using Amazon.Runtime.Signing;
 using System;
 using System.Globalization;
+using System.Net.Http;
 
 namespace Amazon.DSQL.Util
 {
@@ -30,29 +28,13 @@ namespace Amazon.DSQL.Util
     public static class DSQLAuthTokenGenerator
     {
         private const string DSQLServiceName = "dsql";
-        private const string HTTPGet = "GET";
         private const string HTTPS = "https";
         private const string URISchemeDelimiter = "://";
         private const string ActionKey = "Action";
         private const string DBConnectActionValue = "DbConnect";
         private const string DBConnectAdminActionValue = "DbConnectAdmin";
-        private const string XAmzExpires = "X-Amz-Expires";
-        private const string XAmzSecurityToken = "X-Amz-Security-Token";
         private static readonly TimeSpan FifteenMinutes = TimeSpan.FromMinutes(15);
         private static readonly TimeSpan MaxExpiresIn = TimeSpan.FromDays(7);
-
-        /// <summary>
-        /// AWS4PreSignedUrlSigner is built around operation request objects.
-        /// This request type will only be used to generate the signed token.
-        /// It will never be used to make an actual request to DSQL.
-        /// </summary>
-        private class GenerateDSQLAuthTokenRequest : AmazonWebServiceRequest
-        {
-            public GenerateDSQLAuthTokenRequest()
-            {
-                ((IAmazonWebServiceRequest)this).SignatureVersion = SignatureVersion.SigV4;
-            }
-        }
 
         /// <summary>
         /// Generate a token for IAM authentication to a DSQL database cluster for the DbConnect action.
@@ -688,28 +670,38 @@ namespace Amazon.DSQL.Util
 
             ValidateExpiresIn(expiresIn);
 
-            GenerateDSQLAuthTokenRequest authTokenRequest = new GenerateDSQLAuthTokenRequest();
-            IRequest request = new DefaultRequest(authTokenRequest, DSQLServiceName);
-
-            request.UseQueryString = true;
-            request.HttpMethod = HTTPGet;
-            request.Parameters.Add(XAmzExpires, ((int)expiresIn.TotalSeconds).ToString(CultureInfo.InvariantCulture));
-            request.Parameters.Add(ActionKey, actionValue);
-            request.Endpoint = new UriBuilder(HTTPS, hostname).Uri;
-
-            if (immutableCredentials.UseToken)
+            // Build a neutral signing request against the public facade. Credentials have already been
+            // resolved (with the 15-min floor above), so wrap them in a non-refreshing AWSCredentials so the
+            // facade's own presign-window refresh is a no-op and doesn't re-resolve them.
+            var signingRequest = new AWSSigningRequest
             {
-                request.Parameters[XAmzSecurityToken] = immutableCredentials.Token;
-            }
+                HttpMethod = HttpMethod.Get,
+                RequestUri = new Uri(string.Format(CultureInfo.InvariantCulture,
+                    "{0}://{1}/?{2}={3}",
+                    HTTPS, hostname, ActionKey, actionValue)),
+            };
 
-            var signingResult = AWS4PreSignedUrlSigner.SignRequest(request, null, new RequestMetrics(), immutableCredentials.AccessKey,
-                immutableCredentials.SecretKey, DSQLServiceName, region.SystemName);
+            var parameters = new AWSSigV4Parameters
+            {
+                Credentials = WrapResolved(immutableCredentials),
+                Region = region,
+                Service = DSQLServiceName,
+            };
 
-            var authorization = "&" + signingResult.ForQueryParameters;
-            var url = AmazonServiceClient.ComposeUrl(request);
+            var presign = AWSSigV4Signer.Presign(signingRequest, parameters, expiresIn);
 
-            // remove the https:// and append the authorization
-            return url.AbsoluteUri.Substring(HTTPS.Length + URISchemeDelimiter.Length) + authorization;
+            // The token is the presigned URL with the scheme stripped: "hostname/?..."
+            return presign.Uri.AbsoluteUri.Substring(HTTPS.Length + URISchemeDelimiter.Length);
+        }
+
+        // Wraps already-resolved credentials as a non-refreshing AWSCredentials for the facade. Since neither
+        // BasicAWSCredentials nor SessionAWSCredentials is a RefreshingAWSCredentials, the facade's presign-window
+        // refresh degrades to a plain GetCredentials() and returns these same values back.
+        private static AWSCredentials WrapResolved(ImmutableCredentials creds)
+        {
+            return creds.UseToken
+                ? (AWSCredentials)new SessionAWSCredentials(creds.AccessKey, creds.SecretKey, creds.Token)
+                : new BasicAWSCredentials(creds.AccessKey, creds.SecretKey);
         }
     }
 }

--- a/sdk/src/Services/RDS/AWSSDK.RDS.NetFramework.csproj
+++ b/sdk/src/Services/RDS/AWSSDK.RDS.NetFramework.csproj
@@ -76,6 +76,7 @@
 
   <ItemGroup>
     <Reference Include="System.Configuration"/>
+    <Reference Include="System.Net.Http"/>
   </ItemGroup>
 
 

--- a/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
+++ b/sdk/src/Services/RDS/Custom/Util/RDSAuthTokenGenerator.cs
@@ -14,12 +14,11 @@
  */
 
 using Amazon.Runtime;
-using Amazon.Runtime.Internal;
-using Amazon.Runtime.Internal.Auth;
-using Amazon.Runtime.Internal.Util;
 using Amazon.Runtime.Credentials.Internal;
+using Amazon.Runtime.Signing;
 using System;
 using System.Globalization;
+using System.Net.Http;
 
 namespace Amazon.RDS.Util
 {
@@ -29,28 +28,12 @@ namespace Amazon.RDS.Util
     public static class RDSAuthTokenGenerator
     {
         private const string RDSServiceName = "rds-db";
-        private const string HTTPGet = "GET";
         private const string HTTPS = "https";
         private const string URISchemeDelimiter = "://";
         private const string ActionKey = "Action";
         private const string ActionValue = "connect";
         private const string DBUserKey = "DBUser";
-        private const string XAmzExpires = "X-Amz-Expires";
-        private const string XAmzSecurityToken = "X-Amz-Security-Token";
         private static readonly TimeSpan FifteenMinutes = TimeSpan.FromMinutes(15);
-
-        /// <summary>
-        /// AWS4PreSignedUrlSigner is built around operation request objects.
-        /// This request type will only be used to generate the signed token.
-        /// It will never be used to make an actual request to RDS.
-        /// </summary>
-        private class GenerateRDSAuthTokenRequest : AmazonWebServiceRequest
-        {
-            public GenerateRDSAuthTokenRequest()
-            {
-                ((IAmazonWebServiceRequest)this).SignatureVersion = SignatureVersion.SigV4;
-            }
-        }
 
         /// <summary>
         /// Generate a token for IAM authentication to an RDS database.
@@ -225,29 +208,38 @@ namespace Amazon.RDS.Util
             if (string.IsNullOrEmpty(dbUser))
                 throw new ArgumentException("DBUser must not be null or empty.");
 
-            GenerateRDSAuthTokenRequest authTokenRequest = new GenerateRDSAuthTokenRequest();
-            IRequest request = new DefaultRequest(authTokenRequest, RDSServiceName);
-
-            request.UseQueryString = true;
-            request.HttpMethod = HTTPGet;
-            request.Parameters.Add(XAmzExpires, FifteenMinutes.TotalSeconds.ToString(CultureInfo.InvariantCulture));
-            request.Parameters.Add(DBUserKey, dbUser);
-            request.Parameters.Add(ActionKey, ActionValue);
-            request.Endpoint = new UriBuilder(HTTPS, hostname, port).Uri;
-
-            if (immutableCredentials.UseToken)
+            // Build a neutral signing request against the public facade. Credentials have already been
+            // resolved (with the refresh above), so wrap them in a non-refreshing AWSCredentials so the
+            // facade's own presign-window refresh is a no-op and doesn't re-resolve them.
+            var signingRequest = new AWSSigningRequest
             {
-                request.Parameters[XAmzSecurityToken] = immutableCredentials.Token;
-            }
+                HttpMethod = HttpMethod.Get,
+                RequestUri = new Uri(string.Format(CultureInfo.InvariantCulture,
+                    "{0}://{1}:{2}/?{3}={4}&{5}={6}",
+                    HTTPS, hostname, port, ActionKey, ActionValue, DBUserKey, Uri.EscapeDataString(dbUser))),
+            };
 
-            var signingResult = AWS4PreSignedUrlSigner.SignRequest(request, null, new RequestMetrics(), immutableCredentials.AccessKey,
-                immutableCredentials.SecretKey, RDSServiceName, region.SystemName);
+            var parameters = new AWSSigV4Parameters
+            {
+                Credentials = WrapResolved(immutableCredentials),
+                Region = region,
+                Service = RDSServiceName,
+            };
 
-            var authorization = "&" + signingResult.ForQueryParameters;
-            var url = AmazonServiceClient.ComposeUrl(request);
+            var presign = AWSSigV4Signer.Presign(signingRequest, parameters, FifteenMinutes);
 
-            // remove the https:// and append the authorization
-            return url.AbsoluteUri.Substring(HTTPS.Length + URISchemeDelimiter.Length) + authorization;
+            // The token is the presigned URL with the scheme stripped: "hostname:port/?..."
+            return presign.Uri.AbsoluteUri.Substring(HTTPS.Length + URISchemeDelimiter.Length);
+        }
+
+        // Wraps already-resolved credentials as a non-refreshing AWSCredentials for the facade. Since neither
+        // BasicAWSCredentials nor SessionAWSCredentials is a RefreshingAWSCredentials, the facade's presign-window
+        // refresh degrades to a plain GetCredentials() and returns these same values back.
+        private static AWSCredentials WrapResolved(ImmutableCredentials creds)
+        {
+            return creds.UseToken
+                ? (AWSCredentials)new SessionAWSCredentials(creds.AccessKey, creds.SecretKey, creds.Token)
+                : new BasicAWSCredentials(creds.AccessKey, creds.SecretKey);
         }
     }
 }

--- a/sdk/test/Services/RDS/UnitTests/Custom/RDSAuthTokenGeneratorTest.cs
+++ b/sdk/test/Services/RDS/UnitTests/Custom/RDSAuthTokenGeneratorTest.cs
@@ -213,6 +213,22 @@ namespace AWSSDK.UnitTests.RDS
             }, typeof(ArgumentException));
         }
 
+        [TestMethod]
+        [TestCategory("RDS")]
+        public void GenerateAuthTokenDBUserRequiringEncoding()
+        {
+            // DBUser is a user-controlled query parameter. It must be URL-encoded exactly once so that
+            // decoding the DBUser value out of the token yields the original string. This guards against a
+            // regression where the value is double-encoded (e.g. '@' -> %40 -> %2540).
+            const string specialUser = "db user+admin@corp";
+            var token = RDSAuthTokenGenerator.GenerateAuthToken(BasicCredentials, AWSRegion, DBHost, DBPort, specialUser);
+
+            var match = Regex.Match(token, "[?&]DBUser=([^&]*)");
+            Assert.IsTrue(match.Success, "DBUser parameter not found in token: " + token);
+            Assert.AreEqual(specialUser, Uri.UnescapeDataString(match.Groups[1].Value),
+                "DBUser should be single-encoded so it decodes back to the original value. Token: " + token);
+        }
+
         private void AssertAuthToken(string token, string accessKey, RegionEndpoint region)
         {
             AssertAuthToken(token, accessKey, region, false);


### PR DESCRIPTION
## Description

Task 8 follow-up from the standalone SigV4 signing work: simplify the RDS and DSQL IAM auth-token generators by building their presigned tokens through the public `AWSSigV4Signer.Presign` facade instead of the internal signing types. Also dogfoods the new public signing API.

## What changed

- Both generators now call `AWSSigV4Signer.Presign(...)` over a neutral `AWSSigningRequest`, dropping the hand-built `DefaultRequest`, private request subclass, `RequestMetrics`, `AWS4PreSignedUrlSigner`, `ComposeUrl`, manual query splicing, and `https://`-stripping.
- Output tokens are byte-identical and public method signatures are unchanged (internal refactor only).
- Existing credential-refresh behavior is preserved, including DSQL's 15-minute credential-lifetime floor.
- On net472, `System.Net.Http` is now referenced by the RDS/DSQL projects (needed because `AWSSigningRequest.HttpMethod` is `System.Net.Http.HttpMethod`). Added per-service `reference-dependencies` support to the generator so only these two services get it.

## Testing

- RDS and DSQL unit tests pass on net472, netcoreapp3.1, and net8.0.
- Affected packages and the generator build clean.

Opened as a draft against `development`.
