### PR TITLE
Fix regression for null attribute names in document model

### DIFF
--- a/generator/.DevConfigs/198a8ea9-1ff2-4205-8ad3-226ff2052df4.json
+++ b/generator/.DevConfigs/198a8ea9-1ff2-4205-8ad3-226ff2052df4.json
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "serviceName": "DynamoDBv2",
+      "type": "patch",
+      "changeLogMessages": [
+        "Fix regression for null `ExpressionAttributeNames` in document model"
+      ]
+    }
+  ]
+}

--- a/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
+++ b/sdk/src/Services/DynamoDBv2/Custom/DocumentModel/Expression.cs
@@ -159,7 +159,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         private void MergeAttributes(UpdateItemRequest request, Table table)
         {
-            var convertToAttributeValues  = ConvertToAttributeValues(this.ExpressionAttributeValues, table);
+            var convertToAttributeValues = ConvertToAttributeValues(this.ExpressionAttributeValues, table);
             if (convertToAttributeValues != null)
             {
                 request.ExpressionAttributeValues ??= new Dictionary<string, AttributeValue>(StringComparer.Ordinal);
@@ -185,13 +185,19 @@ namespace Amazon.DynamoDBv2.DocumentModel
         internal void ApplyExpression(GetItemRequest request, Table table)
         {
             request.ProjectionExpression = ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
         internal void ApplyExpression(Get request, Table table)
         {
             request.ProjectionExpression = ExpressionStatement;
-            request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            if (this.ExpressionAttributeNames?.Count > 0)
+            {
+                request.ExpressionAttributeNames = new Dictionary<string, string>(this.ExpressionAttributeNames);
+            }
         }
 
         internal void ApplyExpression(Put request, Table table)
@@ -311,7 +317,7 @@ namespace Amazon.DynamoDBv2.DocumentModel
 
         private Dictionary<string, string> MergeExpressionAttributeNames(Dictionary<string, string> requestExpressionAttributeNames)
         {
-            if (this.ExpressionAttributeNames?.Count <= 0)
+            if (this.ExpressionAttributeNames == null || this.ExpressionAttributeNames.Count <= 0)
             {
                 return requestExpressionAttributeNames;
             }

--- a/sdk/test/Services/DynamoDBv2/UnitTests/Custom/SearchTests.cs
+++ b/sdk/test/Services/DynamoDBv2/UnitTests/Custom/SearchTests.cs
@@ -639,6 +639,88 @@ namespace AWSSDK_DotNet.UnitTests
             Assert.AreEqual(1, captured.Segment);
         }
 
+        // Regression test for https://github.com/aws/aws-sdk-net/issues/4489
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public async Task GetNextSetHelper_Scan_FilterExpression_NullNames_DoesNotThrow()
+        {
+            ScanRequest captured = null;
+            var filterExpression = new Expression
+            {
+                ExpressionStatement = "Price > :price",
+                ExpressionAttributeNames = null,
+                ExpressionAttributeValues = new Dictionary<string, DynamoDBEntry> { { ":price", new Primitive("10", true) } }
+            };
+
+            var scanSearch = new Search(SearchType.Scan)
+            {
+                SourceTable = _mockTable,
+                TableName = "TestTable",
+                CollectResults = true,
+                Filter = null,
+                FilterExpression = filterExpression
+            };
+
+            var mockScanResponse = new ScanResponse
+            {
+                Items = new List<Dictionary<string, AttributeValue>>(),
+                LastEvaluatedKey = null
+            };
+
+            _mockDynamoDBClient
+                .Setup(client => client.ScanAsync(It.IsAny<ScanRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<ScanRequest, CancellationToken>((req, ct) => captured = req)
+                .ReturnsAsync(mockScanResponse);
+
+            _ = await scanSearch.GetNextSetHelperAsync(CancellationToken.None);
+            Assert.IsNotNull(captured, "Expected ScanRequest to be captured.");
+            Assert.AreEqual("Price > :price", captured.FilterExpression);
+            Assert.IsNull(captured.ExpressionAttributeNames);
+            Assert.IsNotNull(captured.ExpressionAttributeValues);
+            Assert.IsTrue(captured.ExpressionAttributeValues.ContainsKey(":price"));
+        }
+
+        // Regression test for https://github.com/aws/aws-sdk-net/issues/4489
+        [TestMethod]
+        [TestCategory("DynamoDBv2")]
+        public async Task GetNextSetHelper_Scan_FilterExpressionNullNames_MergesWithAttributesToGet()
+        {
+            ScanRequest captured = null;
+            var filterExpression = new Expression
+            {
+                ExpressionStatement = "Price > :price",
+                ExpressionAttributeNames = null,
+                ExpressionAttributeValues = new Dictionary<string, DynamoDBEntry> { { ":price", new Primitive("10", true) } }
+            };
+
+            var scanSearch = new Search(SearchType.Scan)
+            {
+                SourceTable = _mockTable,
+                TableName = "TestTable",
+                CollectResults = true,
+                Filter = null,
+                FilterExpression = filterExpression,
+                AttributesToGet = new List<string> { "Id", "Status" }
+            };
+
+            var mockScanResponse = new ScanResponse
+            {
+                Items = new List<Dictionary<string, AttributeValue>>(),
+                LastEvaluatedKey = null
+            };
+
+            _mockDynamoDBClient
+                .Setup(client => client.ScanAsync(It.IsAny<ScanRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<ScanRequest, CancellationToken>((req, ct) => captured = req)
+                .ReturnsAsync(mockScanResponse);
+
+            _ = await scanSearch.GetNextSetHelperAsync(CancellationToken.None);
+            Assert.IsNotNull(captured, "Expected ScanRequest to be captured.");
+            Assert.IsNotNull(captured.ExpressionAttributeNames);
+            Assert.IsTrue(captured.ExpressionAttributeNames.ContainsValue("Id"));
+            Assert.IsTrue(captured.ExpressionAttributeNames.ContainsValue("Status"));
+        }
+
 #if NETFRAMEWORK
         [TestMethod]
         [TestCategory("DynamoDBv2")]


### PR DESCRIPTION
Fixes #4489 (side note: I think we need to do a sweep of the DDB hand-written code - this is the 3rd or 4th issue related to null vs empty collections... - we have a lot of tests but they're not catching regressions before breaking customers).

## Testing
Ran added unit tests before (confirming they failed as expected) and after the fix.

### Dry-runs
- **DotNet Dry-run ID:** `053ed982-d70c-4ef0-abcb-73bbca143156`
  - [X] Completed
- **PowerShell Dry-run ID:** `edd259a6-cef5-4953-bf64-40db867c3e87`
  - [X] Completed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license