### PR TITLE
fix(Core): sign multi-value headers with the ", " wire form (#4493)

### DIFF
--- a/generator/.DevConfigs/771dedbe-fcc5-48bb-9bd9-15adbf999fa1.json
+++ b/generator/.DevConfigs/771dedbe-fcc5-48bb-9bd9-15adbf999fa1.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fixed `SigV4SigningHandler` producing an invalid signature for requests carrying a multi-value header. The values were joined with `,` when building the string-to-sign, but `HttpClient` sends them on the wire joined with `, ` (comma + space); they are now joined with `, ` to match, so the service-computed signature matches. Fixes #4493."
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Signing/SigV4SigningHandler.cs
@@ -307,11 +307,19 @@ namespace Amazon.Runtime.Signing
 #endif
 
         // Flatten the request and content headers into the single-value-per-name shape AWSSigningRequest
-        // expects, adding them to its (case-insensitive, get-only) Headers collection. A multi-valued header
-        // is joined with commas, each value trimmed, per the SigV4 canonical form documented on
-        // AWSSigningRequest.Headers. When the same header name appears on both the request and the content,
-        // HttpClient sends both values (request first, then content) as one comma-joined line, so the
-        // signature must cover that same combined value rather than only the content value.
+        // expects, adding them to its (case-insensitive, get-only) Headers collection.
+        //
+        // Two distinct multi-value cases exist, and they are joined differently because the service
+        // canonicalizes what it receives on the wire and the signature must cover that same value:
+        //
+        //   * A header name carrying multiple values (e.g. { "foo", ["bar", "baz"] }) is emitted by
+        //     HttpClient as a SINGLE wire line with the values joined by ", " (comma + space). The service
+        //     canonicalizes that one line to "bar, baz" (the single space is preserved), so JoinValues must
+        //     join with ", " — joining with "," produces a signature the service rejects (see issue #4493).
+        //
+        //   * The same header name appearing on BOTH the request and the content is sent as TWO wire lines
+        //     (request value first, then content value). SigV4 canonicalizes repeated header lines by joining
+        //     them with "," (no space), so the two already-joined values are combined here with "," to match.
         private static void CollectHeaders(HttpRequestMessage request, IDictionary<string, string> headers)
         {
             foreach (var header in request.Headers)
@@ -329,9 +337,13 @@ namespace Amazon.Runtime.Signing
             }
         }
 
+        // Join the values of a single multi-valued header the way HttpClient serializes them on the wire:
+        // with ", " (comma + space), each value trimmed. This must match the wire form exactly because the
+        // service canonicalizes the header line it receives and validates the signature against it; joining
+        // with "," alone (while HttpClient sends ", ") is what caused invalid signatures in issue #4493.
         private static string JoinValues(IEnumerable<string> values)
         {
-            return string.Join(",", values.Select(v => v == null ? string.Empty : v.Trim()));
+            return string.Join(", ", values.Select(v => v == null ? string.Empty : v.Trim()));
         }
 
         private static bool HasContentSha256Header(HttpRequestMessage request)

--- a/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Signing/SigV4SigningHandlerTests.cs
@@ -333,6 +333,82 @@ namespace AWSSDK.UnitTests.Signing
             StringAssert.Contains(auth, "x-custom");
         }
 
+        [TestMethod]
+        public async Task Send_MultiValueHeader_SignsWireFormWithCommaSpace()
+        {
+            // A single header name carrying multiple values is emitted by HttpClient on ONE wire line with the
+            // values joined by ", " (comma + space). The service canonicalizes that received line verbatim, so
+            // the signature must be computed over "bar, baz" — not "bar,baz". This is the regression from
+            // issue #4493: joining with "," alone produced an Authorization the service rejected.
+            //
+            // Cross-check strategy (no golden string, no network): sign the same request two ways with a fixed
+            // SignedAt so the results are deterministic and directly comparable.
+            //   1. The handler path: a request with foo = ["bar", "baz"], captured after signing.
+            //   2. The facade path (AWSSigV4Signer.Sign), whose Headers take one already-joined value per name
+            //      "in the same order and form they are sent on the wire". Both paths add host, x-amz-date, and
+            //      x-amz-content-sha256 identically, so the ONLY thing that can differ between them is the value
+            //      signed for foo. Therefore the handler's Authorization must equal the facade signing foo as
+            //      "bar, baz" and must NOT equal the facade signing foo as "bar,baz".
+            var signedAt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+            var credentials = new BasicAWSCredentials(AccessKey, SecretKey);
+            const string uri = "https://example.execute-api.us-east-1.amazonaws.com/items";
+
+            var inner = new CapturingInnerHandler();
+            var handler = new SigV4SigningHandler(new AWSSigV4Parameters
+            {
+                Credentials = credentials,
+                Region = Region,
+                Service = Service,
+                SignedAt = signedAt,
+            })
+            {
+                InnerHandler = inner,
+            };
+            var invoker = new HttpMessageInvoker(handler);
+            var message = new HttpRequestMessage(HttpMethod.Get, uri);
+            message.Headers.TryAddWithoutValidation("foo", "bar");
+            message.Headers.TryAddWithoutValidation("foo", "baz");
+            await invoker.SendAsync(message, CancellationToken.None);
+
+            var handlerAuth = inner.LastRequest.Headers.GetValues(HeaderKeys.AuthorizationHeader).Single();
+
+            // foo must be part of the signed headers, or this comparison would prove nothing.
+            StringAssert.Contains(handlerAuth, "foo");
+
+            var wireFormAuth = SignFoo("bar, baz", credentials, signedAt, uri);
+            var noSpaceAuth = SignFoo("bar,baz", credentials, signedAt, uri);
+
+            // Sanity: the two facade signatures differ, so the assertion below can distinguish them.
+            Assert.AreNotEqual(wireFormAuth, noSpaceAuth);
+
+            Assert.AreEqual(wireFormAuth, handlerAuth,
+                "The handler must sign a multi-value header as its wire form \"bar, baz\" (comma + space).");
+            Assert.AreNotEqual(noSpaceAuth, handlerAuth,
+                "The handler must not sign a multi-value header as \"bar,baz\" (no space) — that is the #4493 bug.");
+        }
+
+        // Signs a GET to the given URI with a single foo header value via the neutral facade, returning the
+        // Authorization value. Uses the same credentials/region/service/SignedAt as the handler path so the
+        // only variable is the foo value.
+        private static string SignFoo(string fooValue, AWSCredentials credentials, DateTime signedAt, string uri)
+        {
+            var request = new AWSSigningRequest
+            {
+                HttpMethod = HttpMethod.Get,
+                RequestUri = new Uri(uri),
+            };
+            request.Headers["foo"] = fooValue;
+
+            var result = AWSSigV4Signer.Sign(request, new AWSSigV4Parameters
+            {
+                Credentials = credentials,
+                Region = Region,
+                Service = Service,
+                SignedAt = signedAt,
+            });
+            return result.Headers[HeaderKeys.AuthorizationHeader];
+        }
+
         // -----------------------------------------------------------------------
         // Per-request overrides via Options / Properties.
         // -----------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #4493.

`SigV4SigningHandler` produced an invalid signature (`SignatureDoesNotMatch`) for any request carrying a **multi-value header** — a single header name with more than one value.

When building the string-to-sign, `JoinValues` joined the values with `,` (no space). But `HttpClient` serializes a multi-value header onto the wire as a **single line** with the values joined by `, ` (comma **+ space**). AWS canonicalizes the header line it actually receives, so the signature was computed over `bar,baz` while the service computed it over `bar, baz` — a mismatch, and the request was rejected.

## Fix

`JoinValues` now joins with `", "` to match the wire form HttpClient emits.

The separate case — the **same header name on both the request and the content** — is intentionally left joining with `","` (no space). That case is sent as *two* wire lines, which SigV4 canonicalizes by joining repeated header lines with `,` (no space), so it must stay as-is. The two cases are now documented in the code.

```
- return string.Join(",", values.Select(v => v == null ? string.Empty : v.Trim()));
+ return string.Join(", ", values.Select(v => v == null ? string.Empty : v.Trim()));
```

## Testing

**Unit test** — added `Send_MultiValueHeader_SignsWireFormWithCommaSpace` to `SigV4SigningHandlerTests`. With a fixed `SignedAt` it signs `foo: [bar, baz]` through the handler and cross-checks the resulting `Authorization` against the neutral `AWSSigV4Signer` facade: it must equal signing `foo = "bar, baz"` and must **not** equal signing `foo = "bar,baz"`. All 21 tests in the class pass (net8.0).

**End-to-end (manual)** — signed a real STS `GetCallerIdentity` GET through the handler with a multi-value header:
- With the fix: **HTTP 200**.
- Reverting the fix (join `","`): **HTTP 403 SignatureDoesNotMatch** (confirms the change is what makes the service accept the request).

## Change file

Includes a dev config change file under `generator/.DevConfigs/` describing this as a patch to `AWSSDK.Core`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
