### PR TITLE
Reduce allocations from clock skew helper

### DIFF
--- a/generator/.DevConfigs/7a478b25-01e0-4c26-8cd7-3ecb96e3f61f.json
+++ b/generator/.DevConfigs/7a478b25-01e0-4c26-8cd7-3ecb96e3f61f.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "changeLogMessages": [
+      "Reduced allocations in the clock skew correction pipeline by avoiding boxing of TimeSpan values and repeated Uri.ToString() calls for the request endpoint."
+    ],
+    "type": "patch",
+    "updateMinimum": false
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs
@@ -181,7 +181,7 @@ namespace Amazon.Runtime.Internal.Auth
             // resulting exception) is unchanged from the pre-refactor flow, which validated first.
             ValidateRequest(request);
             return SignRequest(request, clientConfig, metrics, awsAccessKeyId, awsSecretAccessKey,
-                               CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString(), clientConfig));
+                               CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.GetEndpointString(), clientConfig));
         }
 
         /// <summary>
@@ -1239,7 +1239,7 @@ namespace Amazon.Runtime.Internal.Auth
                                                  string overrideSigningRegion)
         {
             return SignRequest(request, clientConfig, metrics, awsAccessKeyId, awsSecretAccessKey, service, overrideSigningRegion,
-                               CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString(), clientConfig));
+                               CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.GetEndpointString(), clientConfig));
         }
 
         /// <summary>

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/CloudFrontSigner.cs
@@ -47,7 +47,7 @@ namespace Amazon.Runtime.Internal.Auth
                 throw new ArgumentOutOfRangeException("awsAccessKeyId", "The AWS Access Key ID cannot be NULL or a Zero length string");
             }
 
-            DateTime dateTime = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString(), clientConfig);
+            DateTime dateTime = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.GetEndpointString(), clientConfig);
             request.SignedAt = dateTime;
             string dateTimeString = dateTime.ToString(AWSSDKUtils.RFC822DateFormat, CultureInfo.InvariantCulture);
             request.Headers.Add(HeaderKeys.XAmzDateHeader, dateTimeString);

--- a/sdk/src/Core/Amazon.Runtime/Internal/Auth/QueryStringSigner.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Auth/QueryStringSigner.cs
@@ -59,7 +59,7 @@ namespace Amazon.Runtime.Internal.Auth
             request.Parameters["SignatureVersion"] = SignatureVersion2;
             request.Parameters["SignatureMethod"] = clientConfig.SignatureMethod.ToString();
             request.Parameters["Timestamp"] = AWSSDKUtils.GetFormattedTimestampISO8601(clientConfig, request.OriginalRequest);
-            request.SignedAt = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.Endpoint.ToString(), clientConfig);
+            request.SignedAt = CorrectClockSkew.GetCorrectedUtcNowForEndpoint(request.GetEndpointString(), clientConfig);
             // remove Signature parameter, in case this is a retry
             request.Parameters.Remove("Signature");
 

--- a/sdk/src/Core/Amazon.Runtime/Internal/ClockSkewPipelineHelper.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/ClockSkewPipelineHelper.cs
@@ -105,12 +105,11 @@ namespace Amazon.Runtime.Internal
                 : (DateTime?)null;
             bool hasAgeHeader = response.IsHeaderPresent(HeaderKeys.AgeHeader);
 
-            var contextAttributes = executionContext.RequestContext.ContextAttributes;
             if (ClockSkewCalculator.TryComputeCandidateSkew(serverTime, sentAtUtc.Value, receivedUtc, hasAgeHeader, out var candidate))
             {
-                var endpoint = executionContext.RequestContext.Request.Endpoint.ToString();
+                var endpoint = executionContext.RequestContext.Request.GetEndpointString();
                 CorrectClockSkew.SetClockCorrectionForEndpoint(endpoint, candidate);
-                contextAttributes[AttemptSkewCandidateKey] = candidate;
+                SetAttemptSkewCandidate(executionContext.RequestContext, candidate);
 
                 // Emit a detailed diagnostic only when the measured skew is large enough to
                 // plausibly be the cause of auth/retry failures. Gated on the detection
@@ -124,8 +123,30 @@ namespace Amazon.Runtime.Internal
             }
             else
             {
-                contextAttributes.Remove(AttemptSkewCandidateKey);
+                SetAttemptSkewCandidate(executionContext.RequestContext, null);
             }
+        }
+
+        /// <summary>
+        /// Stores (or clears) the latest attempt's candidate skew. <see cref="RequestContext"/> is
+        /// the only <see cref="IRequestContext"/> implementation in the SDK, so the common case
+        /// writes the typed <see cref="RequestContext.ClockSkewAttemptCandidate"/> field, avoiding
+        /// the box that storing a <see cref="TimeSpan"/> in the <c>object</c>-valued
+        /// <see cref="IRequestContext.ContextAttributes"/> dictionary would otherwise cost on every
+        /// response. Any other implementation falls back to the dictionary so behavior is unchanged.
+        /// </summary>
+        private static void SetAttemptSkewCandidate(IRequestContext requestContext, TimeSpan? candidate)
+        {
+            if (requestContext is RequestContext concreteContext)
+            {
+                concreteContext.ClockSkewAttemptCandidate = candidate;
+                return;
+            }
+
+            if (candidate is { } value)
+                requestContext.ContextAttributes[AttemptSkewCandidateKey] = value;
+            else
+                requestContext.ContextAttributes.Remove(AttemptSkewCandidateKey);
         }
 
         /// <summary>
@@ -142,7 +163,7 @@ namespace Amazon.Runtime.Internal
             if (webData != null)
                 RecordFromResponse(executionContext, sentAtUtc, webData);
             else
-                executionContext.RequestContext.ContextAttributes.Remove(AttemptSkewCandidateKey);
+                SetAttemptSkewCandidate(executionContext.RequestContext, null);
         }
 
         /// <summary>
@@ -152,14 +173,37 @@ namespace Amazon.Runtime.Internal
         /// </summary>
         internal static bool AttemptSkewExceedsThreshold(IExecutionContext executionContext)
         {
-            if (executionContext.RequestContext.ContextAttributes.TryGetValue(AttemptSkewCandidateKey, out var value)
-                && value is TimeSpan candidate)
+            var requestContext = executionContext.RequestContext;
+            TimeSpan? candidate;
+
+            if (requestContext is RequestContext concreteContext)
             {
-                var absolute = candidate.Ticks < 0 ? candidate.Negate() : candidate;
-                return absolute > ClockSkewCalculator.SkewDetectionThreshold;
+                // Normal flow: RecordFromResponse/RecordFromException already wrote this field, so
+                // the common case resolves here without ever touching ContextAttributes. Only fall
+                // back to it (via the non-creating accessor, so we don't allocate a dictionary the
+                // field-based path doesn't need) when something set the key directly instead, e.g.
+                // a test or another pipeline handler bypassing the normal recording path.
+                candidate = concreteContext.ClockSkewAttemptCandidate;
+                if (!candidate.HasValue &&
+                    concreteContext.ContextAttributesIfCreated is { } attributes &&
+                    attributes.TryGetValue(AttemptSkewCandidateKey, out var directValue) &&
+                    directValue is TimeSpan directCandidate)
+                {
+                    candidate = directCandidate;
+                }
+            }
+            else
+            {
+                candidate = requestContext.ContextAttributes.TryGetValue(AttemptSkewCandidateKey, out var boxedValue) && boxedValue is TimeSpan boxed
+                    ? boxed
+                    : (TimeSpan?)null;
             }
 
-            return false;
+            if (candidate is not { } value)
+                return false;
+
+            var absolute = value.Ticks < 0 ? value.Negate() : value;
+            return absolute > ClockSkewCalculator.SkewDetectionThreshold;
         }
 
         private static IWebResponseData GetWebData(Exception exception)

--- a/sdk/src/Core/Amazon.Runtime/Internal/DefaultRequest.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/DefaultRequest.cs
@@ -43,6 +43,7 @@ namespace Amazon.Runtime.Internal
         readonly List<EventStreamHeader> eventHeaders = new List<EventStreamHeader>();
 
         Uri endpoint;
+        string endpointString;
         string resourcePath;
         string serviceName;
         readonly AmazonWebServiceRequest originalRequest;
@@ -239,8 +240,19 @@ namespace Amazon.Runtime.Internal
             set
             {
                 this.endpoint = value;
+                this.endpointString = null;
             }
         }
+
+        /// <summary>
+        /// The <see cref="Endpoint"/>, materialized to a string and cached for the lifetime of
+        /// this request instance (invalidated whenever <see cref="Endpoint"/> is reassigned).
+        /// Signing, retry logging and clock skew tracking all need the endpoint as a string at
+        /// least once per attempt; <see cref="Uri.ToString()"/> recomputes it on every call, so
+        /// callers on those hot paths should use this instead of calling
+        /// <c>Endpoint.ToString()</c> themselves. Internal use only, via <see cref="RequestExtensions.GetEndpointString"/>.
+        /// </summary>
+        internal string EndpointString => this.endpointString ?? (this.endpointString = this.endpoint.ToString());
 
         /// <summary>
         /// Gets and Sets the resource path added on to the endpoint.

--- a/sdk/src/Core/Amazon.Runtime/Internal/RequestExtensions.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/RequestExtensions.cs
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon.Runtime.Internal
+{
+    internal static class RequestExtensions
+    {
+        /// <summary>
+        /// Returns the request's endpoint as a string, using <see cref="DefaultRequest.EndpointString"/>'s
+        /// per-instance cache when available instead of allocating a new string via
+        /// <see cref="System.Uri.ToString()"/> on every call. <see cref="DefaultRequest"/> is the only
+        /// <see cref="IRequest"/> implementation in the SDK; any other implementation falls back to
+        /// <c>Endpoint.ToString()</c> so behavior is unchanged.
+        /// </summary>
+        internal static string GetEndpointString(this IRequest request)
+        {
+            return request is DefaultRequest defaultRequest
+                ? defaultRequest.EndpointString
+                : request.Endpoint.ToString();
+        }
+    }
+}

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/Contexts.cs
@@ -80,6 +80,14 @@ namespace Amazon.Runtime.Internal
         private IDictionary<string, object> _contextAttributes;
         private UserAgentDetails _userAgentDetails;
 
+        /// <summary>
+        /// Fast-path storage for the Clock Skew Correction specification's per-attempt candidate
+        /// skew (see <see cref="ClockSkewPipelineHelper"/>). Recorded from every response, so it
+        /// is kept as a typed field rather than boxed into <see cref="ContextAttributes"/> to
+        /// avoid a per-request heap allocation.
+        /// </summary>
+        internal TimeSpan? ClockSkewAttemptCandidate;
+
         public RequestContext(bool enableMetric)
             : this(enableMetric, null)
         {
@@ -167,6 +175,16 @@ namespace Amazon.Runtime.Internal
                 return _contextAttributes;
             }
         }
+
+        /// <summary>
+        /// Returns the backing <see cref="ContextAttributes"/> dictionary without forcing it to be
+        /// created, or null if nothing has used it yet. Lets <see cref="ClockSkewPipelineHelper"/>
+        /// check for a directly-set <see cref="ClockSkewPipelineHelper.AttemptSkewCandidateKey"/>
+        /// entry (e.g. from tests, or other pipeline handlers) without allocating a dictionary that
+        /// the normal request flow, which uses <see cref="ClockSkewAttemptCandidate"/> instead,
+        /// would otherwise never need.
+        /// </summary>
+        internal IDictionary<string, object> ContextAttributesIfCreated => _contextAttributes;
 
         public IHttpRequestStreamHandle RequestStreamHandle { get; set; }
     }

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryHandler.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryHandler.cs
@@ -309,7 +309,7 @@ namespace Amazon.Runtime.Internal
                 Logger.InfoFormat("WebException ({1}) making request {2} to {3}. Attempting retry {4} of {5}.",
                           webException.Status,
                           requestContext.RequestName,
-                          requestContext.Request.Endpoint.ToString(),
+                          requestContext.Request.GetEndpointString(),
                           requestContext.Retries,
                           this.RetryPolicy.MaxRetries);
             }
@@ -319,7 +319,7 @@ namespace Amazon.Runtime.Internal
                 Logger.InfoFormat("{0} making request {1} to {2}. Attempting retry {3} of {4}.",
                               exception.GetType().Name,
                               requestContext.RequestName,
-                              requestContext.Request.Endpoint.ToString(),
+                              requestContext.Request.GetEndpointString(),
                               requestContext.Retries,
                               this.RetryPolicy.MaxRetries);
 #if !NETSTANDARD
@@ -332,7 +332,7 @@ namespace Amazon.Runtime.Internal
             Logger.Error(exception, "{0} making request {1} to {2}. Attempt {3}.",
                           exception.GetType().Name,
                           requestContext.RequestName,
-                          requestContext.Request.Endpoint.ToString(),
+                          requestContext.Request.GetEndpointString(),
                           requestContext.Retries + 1);
         }
 

--- a/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
+++ b/sdk/src/Core/Amazon.Runtime/Pipeline/RetryHandler/RetryPolicy.cs
@@ -539,9 +539,10 @@ namespace Amazon.Runtime
             if (!ClockSkewPipelineHelper.AttemptSkewExceedsThreshold(executionContext))
                 return false;
 
+            var endpointString = executionContext.RequestContext.Request.GetEndpointString();
             Logger.InfoFormat(clockSkewUpdatedFormat,
-                CorrectClockSkew.GetClockCorrectionForEndpoint(executionContext.RequestContext.Request.Endpoint.ToString()),
-                executionContext.RequestContext.Request.Endpoint.ToString());
+                CorrectClockSkew.GetClockCorrectionForEndpoint(endpointString),
+                endpointString);
             executionContext.RequestContext.IsSigned = false;
             return true;
         }


### PR DESCRIPTION
## Description

- Avoid allocations from boxing a `TimeSpan` value when accounting for clock skew (from e4acdd609a2d09145eb13a4d23b4fdcf78390517).
- Avoid repeated `Uri.ToString()` allocations for the request URL for the same request object.

## Motivation and Context

I have some benchmarks that track the performance of the OpenTelemetry .NET SDK, and I noticed a regression in memory allocations between the 4.0.102.1 and 4.0.102.3 releases as shown by the purple box below:

<img width="700" height="450" alt="image" src="https://github.com/user-attachments/assets/2774ffb7-3062-4edd-8315-0b84c43e182e" />

I had Claude Code investigate the source of the regression, which tied it to the changes for all requests to account for clock skew and boxing of a `TimeSpan` value into the `ContextAttributes` dictionary.

N.B.: The larger increase earlier on the graph is #4501. I have also not integrated these changes into the original benchmarks to quantify any reduction in allocations.

## Testing

Existing unit tests.

### Dry-runs

- **DotNet Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [ ] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

See above.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement