### PR TITLE
Encode entire MemoryStream in `StringUtils.FromMemoryStream`

### DIFF
--- a/generator/.DevConfigs/8f3a2b1c-4d5e-4f6a-9b7c-1e2d3c4b5a69.json
+++ b/generator/.DevConfigs/8f3a2b1c-4d5e-4f6a-9b7c-1e2d3c4b5a69.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": true,
+    "type": "patch",
+    "changeLogMessages": [
+      "Fixed `StringUtils.FromMemoryStream` to always encode the entire stream contents regardless of the stream's current `Position`, making it consistent with streams whose buffers are exposable"
+    ]
+  }
+}

--- a/sdk/src/Core/Amazon.Runtime/Internal/Util/StringUtils.cs
+++ b/sdk/src/Core/Amazon.Runtime/Internal/Util/StringUtils.cs
@@ -49,6 +49,18 @@ namespace Amazon.Runtime.Internal.Util
             return value == null ? "" : value.Intern().Value;
         }
 
+        /// <summary>
+        /// Returns the contents of a MemoryStream as a Base64-encoded string.
+        /// </summary>
+        /// <remarks>
+        /// This method always encodes the entire contents of the MemoryStream, regardless of
+        /// the current <see cref="MemoryStream.Position"/>. When <see cref="MemoryStream.TryGetBuffer"/>
+        /// succeeds, the underlying buffer is accessed directly without modifying the stream.
+        /// When TryGetBuffer fails (e.g., for MemoryStreams wrapping a byte array), the stream's
+        /// <see cref="MemoryStream.Position"/> is reset to 0 before reading. In this fallback case,
+        /// the caller's stream position will be modified as a side effect.
+        /// </remarks>
+        /// <param name="value">The MemoryStream containing the binary data to encode.</param>
         public static string FromMemoryStream(MemoryStream value)
         {
             if (value.TryGetBuffer(out var buffer))
@@ -60,6 +72,7 @@ namespace Amazon.Runtime.Internal.Util
                 var array = ArrayPool<byte>.Shared.Rent((int)value.Length);
                 try
                 {
+                    value.Position = 0;
                     value.Read(array, 0, (int)value.Length);
                     return Convert.ToBase64String(array, 0, (int)value.Length);
                 }

--- a/sdk/test/UnitTests/Custom/Runtime/StringUtilsTests.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/StringUtilsTests.cs
@@ -127,5 +127,23 @@ namespace AWSSDK.UnitTests
         {
             Assert.AreEqual(expectedHeader, StringUtils.FromList(values));
         }
+
+        [TestMethod]
+        [TestCategory("UnitTest")]
+        [TestCategory("Runtime")]
+        public void FromMemoryStreamEncodesEntireStreamRegardlessOfPosition()
+        {
+            // Repro for https://github.com/aws/aws-sdk-net/issues/4502: MemoryStream(byte[]) does not
+            // expose its buffer, forcing the ArrayPool fallback path, which read from the current
+            // Position and returned stale pooled bytes on a second conversion of the same stream.
+            var payloadA = Encoding.UTF8.GetBytes("REAL-PAYLOAD-AAAAAAAAAAAAAAAAAA");
+            var payloadB = Encoding.UTF8.GetBytes("DECOY-FROM-UNRELATED-CALL-BBBBB");
+            var streamA = new MemoryStream(payloadA, writable: false);
+            var streamB = new MemoryStream(payloadB, writable: false);
+
+            Assert.AreEqual(Convert.ToBase64String(payloadA), StringUtils.FromMemoryStream(streamA));
+            Assert.AreEqual(Convert.ToBase64String(payloadB), StringUtils.FromMemoryStream(streamB));
+            Assert.AreEqual(Convert.ToBase64String(payloadA), StringUtils.FromMemoryStream(streamA));
+        }
     }
 }


### PR DESCRIPTION
Fixes #4502

<!--- Provide DotNet and PS dry-run IDs and check the appropriate status for each -->
- **DotNet Dry-run ID:** `43629d04-8049-4b41-8723-8aa84b667e1a`
  - [X] Completed
- **PowerShell Dry-run ID:** `b316399e-285e-4b60-9526-8b95d2a1bbe9`
  - [X] Completed

## Breaking Changes Assessment
Added Norm as a reviewer (this is an internal method, but it's a behavior change).

## License
- [X] I confirm that this pull request can be released under the Apache 2 license