### PR TITLE
Remove unnecessary delays from tests

### DIFF
--- a/generator/.DevConfigs/1e01f352-9458-497a-a8ec-5f39959b2866.json
+++ b/generator/.DevConfigs/1e01f352-9458-497a-a8ec-5f39959b2866.json
@@ -1,9 +1,0 @@
-{
-  "core": {
-    "updateMinimum": false,
-    "type": "patch",
-    "changeLogMessages": [
-      "Placeholder for dry-run"
-    ]
-  }
-}

--- a/generator/.DevConfigs/1e01f352-9458-497a-a8ec-5f39959b2866.json
+++ b/generator/.DevConfigs/1e01f352-9458-497a-a8ec-5f39959b2866.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "updateMinimum": false,
+    "type": "patch",
+    "changeLogMessages": [
+      "Placeholder for dry-run"
+    ]
+  }
+}

--- a/sdk/test/IntegrationTests/Tests/General.cs
+++ b/sdk/test/IntegrationTests/Tests/General.cs
@@ -308,7 +308,11 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
         [Fact]
         public void TestLargeRetryCount()
         {
-            var maxRetries = 1000;
+            // Verifies the backoff computation doesn't overflow at large retry counts.
+            // Sampling retry counts is enough to prove that; iterating every value from
+            // 0 to 1000 just multiplies Thread.Sleep calls (each costing ~15ms of timer
+            // resolution regardless of MaxBackoffInMilliseconds).
+            var retryCounts = new[] { 0, 1, 10, 30, 31, 32, 63, 64, 100, 500, 999, 1000, int.MaxValue };
             var maxMilliseconds = 1;
             ClientConfig config = new AmazonDynamoDBConfig();
             config.MaxErrorRetry = 100;
@@ -322,9 +326,9 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             };
 
             var context = new Amazon.Runtime.Internal.ExecutionContext(new RequestContext(false, new NullSigner()), null);
-            for (int i = 0; i < maxRetries; i++)
+            foreach (var retries in retryCounts)
             {
-                context.RequestContext.Retries = i;
+                context.RequestContext.Retries = retries;
                 coreRetryPolicy.WaitBeforeRetry(context);
                 ddbRetryPolicy.WaitBeforeRetry(context);
             }

--- a/sdk/test/Services/S3/IntegrationTests/CapacityManagerTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CapacityManagerTests.cs
@@ -1,3 +1,4 @@
+using Amazon.Runtime.Internal;
 using Amazon.S3;
 using AWSSDK_DotNet.CommonTest.Utils;
 using System;
@@ -76,8 +77,8 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                     }
                 };
 
-                using (var client = new AmazonS3Client(new AmazonS3Config 
-                { 
+                using (var client = new MinimalBackoffS3Client(new AmazonS3Config
+                {
                     ServiceURL = "http://localhost:" + servlet.Port,
                     MaxErrorRetry = 1
                 }))
@@ -93,6 +94,27 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                     retryFlag = true;
                     requestCount = 0;
                     FailureRetryRequests(TotalRequests, RetryRequests, ExtraRequests, client);
+                }
+            }
+        }
+
+        /// <summary>
+        /// S3 client whose retry policy sleeps at most 1ms between retries. Capacity
+        /// accounting is independent of backoff duration; without this the ~1000
+        /// retries against the local servlet each sleep a real backoff.
+        /// </summary>
+        private class MinimalBackoffS3Client : AmazonS3Client
+        {
+            public MinimalBackoffS3Client(AmazonS3Config config) : base(config) { }
+
+            protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
+            {
+                base.CustomizeRuntimePipeline(pipeline);
+
+                var retryHandler = pipeline.Handlers.Find(h => h is RetryHandler) as RetryHandler;
+                if (retryHandler.RetryPolicy is StandardRetryPolicy standardPolicy)
+                {
+                    standardPolicy.MaxBackoffInMilliseconds = 1;
                 }
             }
         }

--- a/sdk/test/Services/S3/IntegrationTests/CapacityManagerTests.cs
+++ b/sdk/test/Services/S3/IntegrationTests/CapacityManagerTests.cs
@@ -112,10 +112,19 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 base.CustomizeRuntimePipeline(pipeline);
 
                 var retryHandler = pipeline.Handlers.Find(h => h is RetryHandler) as RetryHandler;
-                if (retryHandler.RetryPolicy is StandardRetryPolicy standardPolicy)
+                if (retryHandler == null)
                 {
-                    standardPolicy.MaxBackoffInMilliseconds = 1;
+                    throw new InvalidOperationException(
+                        "CapacityManagerTests expected a RetryHandler in the runtime pipeline so retry backoff could be reduced for deterministic test performance.");
                 }
+
+                if (!(retryHandler.RetryPolicy is StandardRetryPolicy standardPolicy))
+                {
+                    throw new InvalidOperationException(
+                        "CapacityManagerTests expected RetryHandler.RetryPolicy to be StandardRetryPolicy so retry backoff could be reduced for deterministic test performance.");
+                }
+
+                standardPolicy.MaxBackoffInMilliseconds = 1;
             }
         }
 

--- a/sdk/test/Services/SQS/IntegrationTests/SQS.cs
+++ b/sdk/test/Services/SQS/IntegrationTests/SQS.cs
@@ -6,7 +6,6 @@ using AWSSDK_DotNet.IntegrationTests.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -246,6 +245,23 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             Assert.NotNull(result.QueueUrl);
             _createdQueueUrls.Add(result.QueueUrl);
 
+            // CreateQueue's contract allows up to a second before a new queue is usable.
+            // Poll a queue-addressed call until the queue resolves rather than gating on
+            // ListQueues visibility, which is eventually consistent and can lag creation
+            // by 30+ seconds (and which no caller asserts on).
+            for (int i = 0; ; i++)
+            {
+                try
+                {
+                    await _client.GetQueueUrlAsync(new GetQueueUrlRequest { QueueName = name });
+                    break;
+                }
+                catch (QueueDoesNotExistException) when (i < 30)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+            }
+
             var attrResults = await _client.GetQueueAttributesAsync(new GetQueueAttributesRequest
             {
                 QueueUrl = result.QueueUrl,
@@ -260,19 +276,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests
             Assert.False(attrResults.ContentBasedDeduplication.HasValue);
             Assert.Null(attrResults.ContentBasedDeduplication);
 
-            for (int i = 0; i < 30; i++)
-            {
-                var listResult = await _client.ListQueuesAsync(new ListQueuesRequest { QueueNamePrefix = prefix });
-                if (listResult.QueueUrls.FirstOrDefault(x => x == result.QueueUrl) != null)
-                {
-                    return result.QueueUrl;
-                }
-
-                await Task.Delay(TimeSpan.FromSeconds(2));
-            }
-
-            Assert.Fail("Queue never created");
-            return "fail";
+            return result.QueueUrl;
         }
 
         [Fact]

--- a/sdk/test/UnitTests/Custom/Runtime/Credentials/ProcessAWSCredentialsTest.cs
+++ b/sdk/test/UnitTests/Custom/Runtime/Credentials/ProcessAWSCredentialsTest.cs
@@ -91,8 +91,10 @@ namespace AWSSDK.UnitTests
 
         /// <summary>
         /// The test validates the credential refresh logic for session credentials.
-        /// The executable generates mock creds and Guid tokens with an expiration of
-        /// 1 min. Hence a delay of 1 min is added to allow successful credential refresh.
+        /// DetermineProcessCredential runs the credential process on every call (it does
+        /// not cache) and the executable generates a new Guid token per run, so a
+        /// refresh must yield a different token without waiting for the 1 minute
+        /// expiration the executable sets.
         /// </summary>
         [TestMethod]
         public void ValidateCredentialRefresh()
@@ -100,9 +102,9 @@ namespace AWSSDK.UnitTests
             var processCredential = new ProcessAWSCredentials($"{Executable} {ArgumentsSession} {ValidVersionNumber}");
             var credentialsRefreshState = processCredential.DetermineProcessCredential();
             var oldToken = credentialsRefreshState.Credentials.Token;
-            
-            Thread.Sleep(TimeSpan.FromSeconds(60));
-            
+
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+
             credentialsRefreshState = processCredential.DetermineProcessCredential();
             Assert.AreNotEqual(oldToken, credentialsRefreshState.Credentials.Token);
         }


### PR DESCRIPTION
We have a few integration tests (and one unit test) that had unnecessary delays (which impacted the release and preview build times). This small PR refactors them to validate the same behavior in a more efficient way - note these aren't the only tests with `Thread.Sleep` / `Task.Delay` but they were the longest ones in terms of duration.

| Test project | Framework | Before (9/10 release) | After (dry-run) |
|---|---|---|---|
| AWSSDK.UnitTests.NetFramework | net472 | 3m 41s | 2m 48s |
| AWSSDK.IntegrationTests | net472 | 5m 42s | 4m 59s |
| AWSSDK.UnitTests.NetStandard | net8.0 | 3m 05s | 2m 07s |
| AWSSDK.IntegrationTests | net8.0 | 3m 20s | 2m 17s |

### Dry-runs
- **DotNet Dry-run ID:** `19a272d7-370c-41f3-8d71-81e8127f8a9b`
  - [X] Completed successfully
- **PowerShell Dry-run ID:** `f9876400-a23b-4e16-929a-91c491f7688a`
  - [X] Completed successfully

## Breaking Changes Assessment
N/A

## License
- [X] I confirm that this pull request can be released under the Apache 2 license