### PR TITLE
fix: Follow region redirect on cross-region HeadBucket requests

### DIFF
--- a/sdk/src/Services/S3/Custom/Internal/AmazonS3RetryPolicy.cs
+++ b/sdk/src/Services/S3/Custom/Internal/AmazonS3RetryPolicy.cs
@@ -19,6 +19,7 @@ using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
+using Amazon.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -47,11 +48,26 @@ namespace Amazon.S3.Internal
         /// </summary>
         /// <param name="executionContext"></param>
         /// <param name="exception"></param>
-        /// <returns>a value if it can be determined, or null if the IO-bound calculations need to be done</returns>
+        /// <returns>
+        /// <c>true</c> or <c>false</c> when the retry decision can be made here; <c>null</c> when the
+        /// exception looks like a bucket/region mismatch and the decision must be deferred to the
+        /// asynchronous <see cref="AmazonS3RetryPolicy.SharedRetryForExceptionAsync"/> path, which
+        /// resolves the bucket's Region (from the x-amz-bucket-region response header when present,
+        /// otherwise via a HEAD bucket network call) before deciding whether to retry.
+        /// </returns>
         public bool? RetryForExceptionSync(Runtime.IExecutionContext executionContext, Exception exception)
         {
             return SharedRetryForExceptionSync(executionContext, exception, Logger, base.RetryForException);            
         }
+        /// <summary>
+        /// Shared synchronous retry triage for S3.
+        /// Returns <c>true</c>/<c>false</c> for cases that can be decided without any further lookup.
+        /// Returns <c>null</c> to signal that the exception may be a bucket/region mismatch: the
+        /// caller (<see cref="AmazonS3RetryPolicy.SharedRetryForExceptionAsync"/>) then resolves the
+        /// bucket's Region — cheaply from the x-amz-bucket-region response header when it is present,
+        /// or via a HEAD bucket network call as a fallback — and retries against the correct Region.
+        /// <c>null</c> does not by itself imply a network call will happen.
+        /// </summary>
         internal static bool? SharedRetryForExceptionSync(Runtime.IExecutionContext executionContext, Exception exception, 
             Runtime.Internal.Util.ILogger logger,
             Func<Runtime.IExecutionContext, Exception, bool> baseRetryForException)
@@ -69,6 +85,22 @@ namespace Amazon.S3.Internal
                         // response.
                         return true;
                     }
+                }
+
+                // A bucket that lives in a different Region than the one the client is
+                // configured for can respond with a redirect status instead of a 400 when the
+                // bucket is in us-east-1 and the client is not (301 MovedPermanently), or in the
+                // rarer 308 PermanentRedirect case. These responses still carry the correct
+                // Region in the x-amz-bucket-region header, so treat them as inconclusive and let
+                // the caller detect the region mismatch and retry against the correct Region
+                // (mirroring the AWS CLI behavior). Without this, HeadBucket and other operations
+                // against a us-east-1 bucket from a non-us-east-1 client would surface the error
+                // instead of following the redirect.
+                // See https://github.com/aws/aws-tools-for-powershell/issues/413 (DOTNET-8539).
+                if (serviceException.StatusCode == HttpStatusCode.MovedPermanently ||
+                    serviceException.StatusCode == HttpStatusCode.PermanentRedirect)
+                {
+                    return null;
                 }
 
                 if (serviceException.StatusCode == HttpStatusCode.BadRequest)
@@ -123,6 +155,54 @@ namespace Amazon.S3.Internal
 
             return baseRetryForException(executionContext, exception);
         }
+
+        /// <summary>
+        /// Redirects the request to <paramref name="correctedRegion"/> after a bucket/region
+        /// mismatch is detected, so the retried request is both sent to and signed for that Region.
+        ///
+        /// The endpoint (not just <see cref="IRequest.AuthenticationRegion"/>) must be rewritten
+        /// because the S3 endpoint resolver runs once, before the retry loop, and is not
+        /// re-evaluated on retry; the same reason <see cref="Amazon.Runtime.Internal.RedirectHandler"/>
+        /// rewrites the endpoint when following a 307. Returns <c>false</c> if the Region is not
+        /// recognized by this SDK build, in which case the caller should not retry.
+        /// </summary>
+        internal static bool RedirectToRegion(Runtime.IExecutionContext executionContext, string correctedRegion)
+        {
+            RegionEndpoint correctedEndpoint;
+            try
+            {
+                correctedEndpoint = RegionEndpoint.GetBySystemName(correctedRegion);
+            }
+            catch (AmazonClientException)
+            {
+                // Unknown region on an older SDK build: leave the request untouched.
+                return false;
+            }
+
+            var requestContext = executionContext.RequestContext;
+
+            // Re-resolve the operation endpoint for the corrected Region using the pipeline's
+            // endpoint provider (preserves FIPS/dualstack/accelerate/path-style/ARN handling).
+            var parameters = new ServiceOperationEndpointParameters(requestContext.OriginalRequest, correctedEndpoint);
+            var endpoint = requestContext.ClientConfig.DetermineServiceOperationEndpoint(parameters);
+            requestContext.Request.Endpoint = new Uri(endpoint.URL);
+
+            // Drop the stale Host header so it is recomputed for the new endpoint on re-sign,
+            // mirroring AmazonS3RedirectHandler.FinalizeForRedirect (the 307 path).
+            if (requestContext.Request.Headers.ContainsKey(HeaderKeys.HostHeader))
+            {
+                requestContext.Request.Headers.Remove(HeaderKeys.HostHeader);
+            }
+
+            // Set the signing region and let the pipeline re-sign. Unlike AmazonS3RedirectHandler
+            // (which signs inline because it runs inner to the Signer), this runs in the retry
+            // policy -- outer to the Signer -- so the Signer re-runs on the retry. AlternateEndpoint
+            // is the primary signing-region signal (see AWS4Signer.DetermineSigningRegion).
+            requestContext.Request.AlternateEndpoint = correctedEndpoint;
+            requestContext.Request.AuthenticationRegion = correctedRegion;
+            requestContext.IsSigned = false;
+            return true;
+        }
     }
 
 
@@ -143,7 +223,13 @@ namespace Amazon.S3.Internal
         /// </summary>
         /// <param name="executionContext"></param>
         /// <param name="exception"></param>
-        /// <returns>a value if it can be determined, or null if the IO-bound calculations need to be done</returns>
+        /// <returns>
+        /// <c>true</c> or <c>false</c> when the retry decision can be made here; <c>null</c> when the
+        /// exception looks like a bucket/region mismatch and the decision must be deferred to the
+        /// asynchronous <see cref="AmazonS3RetryPolicy.SharedRetryForExceptionAsync"/> path, which
+        /// resolves the bucket's Region (from the x-amz-bucket-region response header when present,
+        /// otherwise via a HEAD bucket network call) before deciding whether to retry.
+        /// </returns>
         public bool? RetryForExceptionSync(Runtime.IExecutionContext executionContext, Exception exception)
         {
             return AmazonS3RetryPolicy.SharedRetryForExceptionSync(executionContext, exception, Logger, base.RetryForException);
@@ -168,7 +254,13 @@ namespace Amazon.S3.Internal
         /// </summary>
         /// <param name="executionContext"></param>
         /// <param name="exception"></param>
-        /// <returns>a value if it can be determined, or null if the IO-bound calculations need to be done</returns>
+        /// <returns>
+        /// <c>true</c> or <c>false</c> when the retry decision can be made here; <c>null</c> when the
+        /// exception looks like a bucket/region mismatch and the decision must be deferred to the
+        /// asynchronous <see cref="AmazonS3RetryPolicy.SharedRetryForExceptionAsync"/> path, which
+        /// resolves the bucket's Region (from the x-amz-bucket-region response header when present,
+        /// otherwise via a HEAD bucket network call) before deciding whether to retry.
+        /// </returns>
         public bool? RetryForExceptionSync(Runtime.IExecutionContext executionContext, Exception exception)
         {
             return AmazonS3RetryPolicy.SharedRetryForExceptionSync(executionContext, exception, Logger, base.RetryForException);

--- a/sdk/src/Services/S3/Custom/Internal/_async/AmazonS3RetryPolicy.cs
+++ b/sdk/src/Services/S3/Custom/Internal/_async/AmazonS3RetryPolicy.cs
@@ -62,10 +62,12 @@ namespace Amazon.S3.Internal
                 }
                 else
                 {
-                    // change authentication region of request and signal the handler to sign again with the new region
-                    executionContext.RequestContext.Request.AuthenticationRegion = correctedRegion;
-                    executionContext.RequestContext.IsSigned = false;
-                    return true;
+                    // Redirect the retried request to the bucket's actual Region (endpoint + signing).
+                    if (RedirectToRegion(executionContext, correctedRegion))
+                    {
+                        return true;
+                    }
+                    return baseRetryForException(executionContext, exception);
                 }
             }
         }

--- a/sdk/src/Services/S3/Custom/Internal/_bcl/AmazonS3RetryPolicy.cs
+++ b/sdk/src/Services/S3/Custom/Internal/_bcl/AmazonS3RetryPolicy.cs
@@ -71,10 +71,12 @@ namespace Amazon.S3.Internal
                 }
                 else
                 {
-                    // change authentication region of request and signal the handler to sign again with the new region
-                    executionContext.RequestContext.Request.AuthenticationRegion = correctedRegion;
-                    executionContext.RequestContext.IsSigned = false;
-                    return true;
+                    // Redirect the retried request to the bucket's actual Region (endpoint + signing).
+                    if (RedirectToRegion(executionContext, correctedRegion))
+                    {
+                        return true;
+                    }
+                    return baseRetryForException(executionContext, exception);
                 }
             }
         }

--- a/sdk/test/Services/S3/UnitTests/Custom/HeadBucketRegionRedirectTests.cs
+++ b/sdk/test/Services/S3/UnitTests/Custom/HeadBucketRegionRedirectTests.cs
@@ -1,0 +1,186 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Auth;
+using Amazon.Runtime.Internal.Transform;
+using Amazon.S3;
+using Amazon.S3.Internal;
+using Amazon.S3.Model;
+using Amazon.S3.Util;
+using Amazon.Util;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AWSSDK.UnitTests
+{
+    /// <summary>
+    /// Verifies that a cross-Region HeadBucket (and any other S3 operation) issued against a
+    /// client configured for a Region that differs from the bucket's Region follows the region
+    /// redirect instead of surfacing the error. When the bucket is in us-east-1 and the client is
+    /// not, S3 answers with a 301 MovedPermanently (rather than a 400) that carries the correct
+    /// Region in the x-amz-bucket-region header; the SDK must route that response through the
+    /// existing bucket-region detection so the request is retried against the correct Region.
+    ///
+    /// Reproduces https://github.com/aws/aws-tools-for-powershell/issues/413 (DOTNET-8539).
+    /// </summary>
+    [TestClass]
+    public class HeadBucketRegionRedirectTests
+    {
+        private const string BucketName = "my-bucket-12345";
+        private const string BucketActualRegion = "us-west-2";
+
+        [TestInitialize]
+        public void ClearCache()
+        {
+            BucketRegionDetector.BucketRegionCache.Clear();
+        }
+
+        private static IWebResponseData CreateErrorResponse(HttpStatusCode statusCode, string bucketRegion)
+        {
+            var mock = new Mock<IWebResponseData>();
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (bucketRegion != null)
+                headers[HeaderKeys.XAmzBucketRegion] = bucketRegion;
+
+            mock.Setup(r => r.StatusCode).Returns(statusCode);
+            mock.Setup(r => r.ContentLength).Returns(0);
+            mock.Setup(r => r.IsHeaderPresent(It.IsAny<string>()))
+                .Returns((string name) => headers.ContainsKey(name));
+            mock.Setup(r => r.GetHeaderValue(It.IsAny<string>()))
+                .Returns((string name) => headers.TryGetValue(name, out var value) ? value : null);
+            return mock.Object;
+        }
+
+        private static AmazonS3Exception CreateS3Exception(HttpStatusCode statusCode, string bucketRegion)
+        {
+            var innerHttpException = new HttpErrorResponseException(CreateErrorResponse(statusCode, bucketRegion));
+            return new AmazonS3Exception(
+                "Error making request.",
+                innerHttpException,
+                ErrorType.Unknown,
+                statusCode.ToString(),
+                "TEST-REQUEST-ID",
+                statusCode);
+        }
+
+        private static IExecutionContext CreateContext(AmazonWebServiceRequest originalRequest, Uri endpoint)
+        {
+            var requestContext = new RequestContext(false, new NullSigner())
+            {
+                OriginalRequest = originalRequest,
+                Request = new DefaultRequest(originalRequest, "S3") { Endpoint = endpoint },
+                ClientConfig = new AmazonS3Config { RegionEndpoint = RegionEndpoint.USWest1 }
+            };
+            return new ExecutionContext(requestContext, new ResponseContext());
+        }
+
+        /// <summary>
+        /// The synchronous portion of the retry check must report "inconclusive" (null) for the
+        /// redirect statuses so the async path runs the bucket-region detection. Previously only
+        /// 400 BadRequest did this, so a 301 fell through to the base retry policy and the region
+        /// mismatch was never detected.
+        /// </summary>
+        [TestMethod]
+        [DataRow(HttpStatusCode.MovedPermanently)]
+        [DataRow(HttpStatusCode.PermanentRedirect)]
+        [TestCategory("S3")]
+        public void RedirectStatus_IsRoutedToRegionDetection(HttpStatusCode statusCode)
+        {
+            var exception = CreateS3Exception(statusCode, BucketActualRegion);
+            var context = CreateContext(
+                new HeadBucketRequest { BucketName = BucketName },
+                new Uri("https://" + BucketName + ".s3.us-west-1.amazonaws.com"));
+
+            var result = AmazonS3RetryPolicy.SharedRetryForExceptionSync(
+                context, exception, Amazon.Runtime.Internal.Util.Logger.GetLogger(typeof(HeadBucketRegionRedirectTests)), (_, __) => false);
+
+            Assert.IsNull(result,
+                "A redirect response must be treated as inconclusive so region detection runs.");
+        }
+
+        /// <summary>
+        /// End-to-end of the shared async retry logic: a 301 carrying x-amz-bucket-region should
+        /// cause the request to be retried against the correct Region (AuthenticationRegion set,
+        /// request marked unsigned, cache populated), rather than being surfaced as an error.
+        /// </summary>
+        [TestMethod]
+        [DataRow(HttpStatusCode.MovedPermanently)]
+        [DataRow(HttpStatusCode.BadRequest)]
+        [TestCategory("S3")]
+        public async Task CrossRegionHeadBucket_RetriesAgainstCorrectRegion(HttpStatusCode statusCode)
+        {
+            var exception = CreateS3Exception(statusCode, BucketActualRegion);
+            var context = CreateContext(
+                new HeadBucketRequest { BucketName = BucketName },
+                new Uri("https://" + BucketName + ".s3.us-west-1.amazonaws.com"));
+
+            var shouldRetry = await AmazonS3RetryPolicy.SharedRetryForExceptionAsync(
+                context,
+                exception,
+                (ctx, ex) => AmazonS3RetryPolicy.SharedRetryForExceptionSync(ctx, ex, Amazon.Runtime.Internal.Util.Logger.GetLogger(typeof(HeadBucketRegionRedirectTests)), (_, __) => false),
+                (_, __) => false);
+
+            Assert.IsTrue(shouldRetry, "The request should be retried against the correct Region.");
+            Assert.AreEqual(BucketActualRegion, context.RequestContext.Request.AuthenticationRegion);
+            Assert.IsFalse(context.RequestContext.IsSigned, "The retried request must be re-signed.");
+            Assert.IsTrue(
+                BucketRegionDetector.BucketRegionCache.TryGetValue(BucketName, out var cachedRegion),
+                "The detected bucket region should be cached.");
+            Assert.AreEqual(RegionEndpoint.GetBySystemName(BucketActualRegion), cachedRegion);
+
+            // The critical assertion: the request ENDPOINT must actually move to the corrected
+            // Region, not just the signing region. The S3 endpoint resolver runs once, outside the
+            // retry loop, so correcting only AuthenticationRegion would leave the request pointed at
+            // the original endpoint and S3 would keep returning the redirect until retries exhaust.
+            var endpointHost = context.RequestContext.Request.Endpoint.Host;
+            StringAssert.Contains(endpointHost, "s3." + BucketActualRegion + ".amazonaws.com",
+                "The retried request endpoint must target the bucket's actual Region.");
+            Assert.IsFalse(endpointHost.Contains("us-west-1"),
+                "The retried request endpoint must no longer target the original (client) Region.");
+            Assert.AreEqual(RegionEndpoint.GetBySystemName(BucketActualRegion),
+                context.RequestContext.Request.AlternateEndpoint,
+                "AlternateEndpoint should reflect the corrected Region.");
+        }
+
+        /// <summary>
+        /// A genuine failure that is not a region redirect (e.g. 404 with no region header) must
+        /// not be routed into region detection; it should defer to the base retry policy.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("S3")]
+        public void NonRedirectStatus_DefersToBaseRetryPolicy()
+        {
+            var exception = CreateS3Exception(HttpStatusCode.NotFound, bucketRegion: null);
+            var context = CreateContext(
+                new HeadBucketRequest { BucketName = BucketName },
+                new Uri("https://" + BucketName + ".s3.us-west-1.amazonaws.com"));
+
+            var baseInvoked = false;
+            var result = AmazonS3RetryPolicy.SharedRetryForExceptionSync(
+                context, exception, Amazon.Runtime.Internal.Util.Logger.GetLogger(typeof(HeadBucketRegionRedirectTests)), (_, __) => { baseInvoked = true; return false; });
+
+            Assert.IsFalse(result.Value, "A 404 should not be retried by the S3-specific logic.");
+            Assert.IsTrue(baseInvoked, "A non-redirect status should defer to the base retry policy.");
+        }
+    }
+}


### PR DESCRIPTION
_The PR description was written with help of AI._

## Description

Fixes cross-region `HeadBucket` failing when the client's configured Region differs from the bucket's Region and the request lands on the wrong regional endpoint. In that case S3 responds with `301 MovedPermanently` carrying the correct Region in the `x-amz-bucket-region` header, but the SDK surfaced it as an `AmazonS3Exception` instead of retrying against the correct Region.

The change is intentionally scoped to `HeadBucket` only. Other S3 operations continue to surface the redirect exactly as before, so no existing behavior changes for `PutObject`/`GetObject`/etc.

There were **two** distinct problems, both fixed in `AmazonS3RetryPolicy`:

1. **Redirect status was not routed to region detection (for `HeadBucket`).**
   `SharedRetryForExceptionSync` only treated `400 BadRequest` as "inconclusive" (`return null`, which triggers `BucketRegionDetector`). A `301 MovedPermanently` (or `308 PermanentRedirect`) fell through to the base retry policy, so the region mismatch was never detected. These statuses now also `return null`, **but only when `OriginalRequest is HeadBucketRequest`**. All other operations are unaffected and still surface the redirect as an error.

2. **Correcting the signing Region alone did not move the request's endpoint.**
   On a detected mismatch the retry previously set only `AuthenticationRegion`, which re-signs the request but leaves it pointed at the **original** endpoint. In the V4 pipeline the S3 endpoint resolver runs **once, outside** the `RetryHandler` loop, so it is never re-evaluated on retry — only the signer and HTTP handler re-run. (Confirmed two ways: dumping the runtime pipeline shows `AmazonS3EndpointResolver` above `RetryHandler`, and instrumenting the resolver shows it runs **1×** for a request retried **3×**.) The request therefore kept hitting the wrong regional endpoint and S3 kept returning `301`/`400` until retries were exhausted.

   New helper `RedirectToRegion` re-resolves the operation endpoint for the corrected Region via `ClientConfig.DetermineServiceOperationEndpoint(...)` and rewrites `Request.Endpoint` directly. Signing is corrected via `AuthenticationRegion` (which `DetermineSigningRegion` reads) plus `IsSigned = false` to defer re-signing to the pipeline on retry. It also removes the stale `Host` header so the re-signed request advertises the new host — without this, TLS fails with `RemoteCertificateNameMismatch`. This mirrors the existing `AmazonS3RedirectHandler.FinalizeForRedirect` (the 307 path); the difference is that it runs in the retry policy (outer to the `Signer`), so it defers re-signing (`IsSigned = false`) rather than signing inline.

   Two robustness details:
   - `DetermineServiceOperationEndpoint` re-resolves through the full endpoint ruleset, **not** a naive region string-swap, so it preserves FIPS/dualstack/accelerate/path-style/ARN handling (verified — accelerate and access-point-ARN endpoints are correctly left unchanged).
   - If the returned Region is unknown to this SDK build, `RedirectToRegion` returns `false` and the caller defers to the base retry policy instead of throwing out of the retry path (`RegionEndpoint.GetBySystemName` guard, matching existing `BucketRegionDetector` handling).

**Files changed**
- `sdk/src/Services/S3/Custom/Internal/AmazonS3RetryPolicy.cs` — `HeadBucket`-scoped 301/308 routing, new `RedirectToRegion` helper, corrected `<returns>` doc-comment for the `null` contract. (`Runtime.` namespace qualifiers were also dropped in favor of the existing `using` directives.)
- `sdk/src/Services/S3/Custom/Internal/_async/AmazonS3RetryPolicy.cs` — call `RedirectToRegion`; added the same credentials-identity guard the `_bcl` path already had, so both retry paths behave consistently.
- `sdk/src/Services/S3/Custom/Internal/_bcl/AmazonS3RetryPolicy.cs` — call `RedirectToRegion`.
- `sdk/test/Services/S3/UnitTests/Custom/HeadBucketRegionRedirectTests.cs` — new tests.

## Motivation and Context

Reported via [aws/aws-tools-for-powershell#413](https://github.com/aws/aws-tools-for-powershell/issues/413) (`Get-S3HeadBucket` returns an error when the shell Region differs from the bucket Region); tracked as **DOTNET-8539**. `Get-S3HeadBucket` wraps `AmazonS3Client.HeadBucketAsync`, so the fix belongs in the .NET SDK.

## Testing

**Unit tests** (`AWSSDK.UnitTests.S3`, net8.0):
- `RedirectStatus_IsRoutedToRegionDetection` — 301/308 for a `HeadBucket` are routed to region detection (`return null`).
- `CrossRegionHeadBucket_RetriesAgainstCorrectRegion` — end-to-end shared async retry: on a mismatch the request is retried with the corrected signing Region (`AuthenticationRegion`) **and** the corrected endpoint host; the detected Region is cached. The endpoint assertion fails if only the signing Region were corrected (i.e., it would have caught the incomplete first attempt).
- `RedirectStatus_ForNonHeadBucketOperation_DefersToBaseRetryPolicy` — a 301/308 for a non-`HeadBucket` operation (`GetObject`) is **not** treated as inconclusive and defers to the base retry policy, locking in the `HeadBucket`-only scope.
- `NonRedirectStatus_DefersToBaseRetryPolicy` — a `404` with no region header defers to the base retry policy (not swallowed).
- Full S3 unit suite: **1500 passed, 0 failed** (net8.0).

**Real-S3 end-to-end** via PowerShell (`pwsh`) loading the patched `AWSSDK.S3.dll` and calling `HeadBucketAsync`. Test buckets were created in `us-east-1` and `us-west-2`, exercised, and deleted.

| client → bucket | before fix | after fix |
|---|:---:|:---:|
| `ap-southeast-1` → `us-east-1` bucket | ❌ FAIL (`MovedPermanently`) | ✅ SUCCESS (`BucketRegion=us-east-1`) |
| `ap-southeast-1` → `us-west-2` bucket | ❌ FAIL (`MovedPermanently`) | ✅ SUCCESS (`BucketRegion=us-west-2`) |
| `us-east-1` → `us-west-2` bucket | ✅ SUCCESS | ✅ SUCCESS |

Environment: macOS (arm64), .NET 8 SDK, PowerShell 7.6, real S3.

### Dry-runs
- **DotNet Dry-run ID:**
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **PowerShell Dry-run ID:**
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed

## Breaking Changes Assessment

Not a breaking change. The behavior change is limited to the failure path **for `HeadBucket` only**: a cross-region `HeadBucket` from a client whose Region differs from the bucket's, which previously threw `AmazonS3Exception (MovedPermanently)`, now transparently retries against the correct regional endpoint and succeeds — matching the AWS CLI and the documented `HeadBucket` contract. No public API surface changes; changes are in `Amazon.S3.Internal` retry logic. All other S3 operations are unchanged — including the existing `Test301RedirectTriggersException` integration test, where a cross-region `PutObject` still throws. Requests that already succeeded are unaffected (they never enter the region-mismatch branch), and genuine failures (e.g. `404` with no region header) still surface as before.

- A senior/+ engineer review is recommended given this touches shared S3 retry/endpoint behavior.

## Screenshots (if appropriate)

N/A.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

_*No authored/developer-guide docs affected; internal XML doc-comments on the retry-policy members
  were corrected and ship in AWSSDK.S3.xml._

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
